### PR TITLE
Defer a data source read when a dependency has changes pending

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-266.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-266.yaml
@@ -1,6 +1,6 @@
 kind: bug-fixes
-body: Defer a `data` source read until apply when a referenced resource has changes pending
-time: 2026-06-11T11:13:06Z
+body: Defer a `data` source read until apply when a referenced resource has changes pending, and make `depends_on` on a module call wait for the module's resources
+time: 2026-06-11T11:36:38Z
 custom:
     Component: runtime
     PR: "266"

--- a/.changes/unreleased/runtime-bug-fixes-266.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-266.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Defer a `data` source read until apply when a referenced resource has changes pending
+time: 2026-06-11T11:13:06Z
+custom:
+    Component: runtime
+    PR: "266"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           go-version-file: go.mod
       - uses: pulumi/actions@v7
         with:
-          pulumi-version: pr#23453
+          pulumi-version: dev
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       - uses: opentofu/setup-opentofu@v2

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -1035,13 +1035,28 @@ func (g *Graph) inlineModule(
 		}
 	}
 
-	// Completion node: depends on all outputs + init. The completion key
-	// is the module call's identifier (without the trailing "."), so that
+	// Completion node: depends on init, all outputs, and everything in the
+	// module with side effects — resources, data sources, and nested module
+	// calls — so that `module.<name>` (the depends_on form) resolves only
+	// after the whole module has been processed. The completion key is the
+	// module call's identifier (without the trailing "."), so that
 	// expressions like `module.<name>` in the parent scope resolve to it.
 	completionKey := parentPrefix + "module." + name
 	completionDeps := []pdag.Node{initIdx}
 	for outputName := range loaded.Config.Outputs {
 		_, idx := g.newNode(prefix + "output." + outputName)
+		completionDeps = append(completionDeps, idx)
+	}
+	for key := range loaded.Config.Resources {
+		_, idx := g.newNode(prefix + key)
+		completionDeps = append(completionDeps, idx)
+	}
+	for key := range loaded.Config.DataSources {
+		_, idx := g.newNode(prefix + "data." + key)
+		completionDeps = append(completionDeps, idx)
+	}
+	for nestedName := range loaded.Config.Modules {
+		_, idx := g.newNode(prefix + "module." + nestedName)
 		completionDeps = append(completionDeps, idx)
 	}
 	if err := g.AddNode(&Node{

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -359,10 +359,14 @@ type Engine struct {
 
 	// pendingResourceChanges tracks, during preview, the managed resources
 	// whose registration indicates a change is pending (unknown id means a
-	// pending create; computed outputs mean the provider planned new values).
-	// Keyed by the resource's unexpanded graph key so a reference to any
-	// instance of a ranged resource matches. Data sources that reference or
-	// depend on such a resource defer their read to the apply phase.
+	// pending create or replace; computed outputs mean the provider planned
+	// new values). A pending resource is stored under its instance-qualified
+	// module prefix plus unexpanded resource key — so a reference to any
+	// count/for_each instance of the resource matches, while other instances
+	// of the enclosing module call don't — and under each enclosing module
+	// call's own key, so `depends_on = [module.x]` matches transitively. Data
+	// sources that reference or depend on a pending entry defer their read to
+	// the apply phase.
 	pendingResourceChanges *util.SyncMap[string, struct{}]
 
 	// graph is the resolved dependency graph for the current run. Stored on
@@ -1320,7 +1324,7 @@ func (e *Engine) registerResourceInstanceInContext(
 	}
 
 	if e.dryRun && (id == "" || property.New(outputs).HasComputed()) {
-		e.pendingResourceChanges.Set(instance.OriginalKey, struct{}{})
+		e.markPendingResourceChange(node, modInst, instance.OriginalKey)
 	}
 
 	outputs = outputs.Delete("id", "urn")
@@ -2440,6 +2444,29 @@ func (e *Engine) registerResource(
 	return resp.URN, resp.ID, lowerTerraformDataOutputs(tfType, resp.Outputs, opts), nil
 }
 
+// markPendingResourceChange records a managed resource with a change pending
+// so data sources that reference it defer their read. The resource is keyed
+// by its instance-qualified module prefix plus unexpanded resource key, and
+// every enclosing module call is keyed too so a `depends_on` naming the
+// module call defers as well.
+func (e *Engine) markPendingResourceChange(node *graph.Node, modInst *moduleInstance, originalKey string) {
+	instPath := modulepath.Root()
+	localKey := originalKey
+	if modInst != nil {
+		instPath = modInst.Path
+		localKey = strings.TrimPrefix(originalKey, node.ModuleInfo.Prefix())
+	}
+	e.pendingResourceChanges.Set(instPath.PrefixString()+localKey, struct{}{})
+	for p := instPath; ; {
+		parent, leaf, ok := p.Parent()
+		if !ok {
+			return
+		}
+		e.pendingResourceChanges.Set(parent.PrefixString()+"module."+leaf.Name(), struct{}{})
+		p = parent
+	}
+}
+
 // processDataSource processes a data source definition.
 func (e *Engine) processDataSource(ctx context.Context, node *graph.Node) error {
 	ds := node.Resource
@@ -2449,15 +2476,17 @@ func (e *Engine) processDataSource(ctx context.Context, node *graph.Node) error 
 
 	if node.ModuleInfo != nil {
 		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-			return e.processDataSourceInContext(ctx, node, ds, inst.EvalCtx)
+			return e.processDataSourceInContext(ctx, node, ds, inst.EvalCtx, inst.Path.PrefixString())
 		})
 	}
 
-	return e.processDataSourceInContext(ctx, node, ds, e.evaluator.Context())
+	return e.processDataSourceInContext(ctx, node, ds, e.evaluator.Context(), "")
 }
 
+// instPrefix is the instance-qualified module prefix of the module instance
+// being processed ("" at the root), used to match pendingResourceChanges keys.
 func (e *Engine) processDataSourceInContext(
-	ctx context.Context, node *graph.Node, ds *ast.Resource, evalCtx *eval.Context,
+	ctx context.Context, node *graph.Node, ds *ast.Resource, evalCtx *eval.Context, instPrefix string,
 ) error {
 	funcSchema, err := e.resolveFunction(ctx, ds.Type)
 	if err != nil {
@@ -2474,10 +2503,10 @@ func (e *Engine) processDataSourceInContext(
 	dsKey = strings.TrimPrefix(dsKey, "data.")
 
 	if ds.Count != nil || ds.ForEach != nil {
-		return e.processRangedDataSource(ctx, node, ds, funcSchema, evalCtx, dsKey)
+		return e.processRangedDataSource(ctx, node, ds, funcSchema, evalCtx, dsKey, instPrefix)
 	}
 
-	ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx)
+	ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx, instPrefix)
 	if err != nil {
 		return err
 	}
@@ -2491,7 +2520,7 @@ func (e *Engine) processDataSourceInContext(
 // `data.<type>.<name>[<index>|<key>].<attr>` resolves as expected.
 func (e *Engine) processRangedDataSource(
 	ctx context.Context, node *graph.Node, ds *ast.Resource, funcSchema *schema.Function,
-	evalCtx *eval.Context, dsKey string,
+	evalCtx *eval.Context, dsKey, instPrefix string,
 ) error {
 	tempEvaluator := eval.NewEvaluator(evalCtx)
 	expander := graph.NewResourceExpander()
@@ -2530,7 +2559,7 @@ func (e *Engine) processRangedDataSource(
 			evalCtx.SetEach(*instance.EachKey, *instance.EachValue)
 		}
 
-		ctyOut, invokeErr := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx)
+		ctyOut, invokeErr := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx, instPrefix)
 
 		if instance.Index != nil {
 			evalCtx.ClearCount()
@@ -2575,7 +2604,7 @@ func (e *Engine) processRangedDataSource(
 // without a separate dependency map.
 func (e *Engine) invokeDataSourceOnce(
 	ctx context.Context, node *graph.Node, ds *ast.Resource, funcSchema *schema.Function,
-	evalCtx *eval.Context,
+	evalCtx *eval.Context, instPrefix string,
 ) (cty.Value, error) {
 	hclCtx := evalCtx.HCLContext()
 
@@ -2591,10 +2620,6 @@ func (e *Engine) invokeDataSourceOnce(
 	// a change pending must defer its read to the apply phase, even when the
 	// referenced value is already known. Only direct references count:
 	// indirection through a local, variable, or module output does not defer.
-	refPrefix := ""
-	if node.ModuleInfo != nil {
-		refPrefix = node.ModuleInfo.Prefix()
-	}
 	depsPending := false
 	checkPendingDep := func(key string) {
 		if _, ok := e.pendingResourceChanges.Get(key); ok {
@@ -2610,8 +2635,14 @@ func (e *Engine) invokeDataSourceOnce(
 			if _, isIterationVar := extraVars[namespace]; isIterationVar {
 				continue
 			}
+			// A module-output reference can carry a pending resource's value
+			// without deferring; only an explicit depends_on on the module
+			// call may match its pending key.
+			if namespace == "module" {
+				continue
+			}
 			if len(parts) > 0 {
-				checkPendingDep(refPrefix + namespace + "." + parts[0])
+				checkPendingDep(instPrefix + namespace + "." + parts[0])
 			}
 		}
 	}
@@ -2703,7 +2734,7 @@ func (e *Engine) invokeDataSourceOnce(
 		if outputs, ok := e.resourceOutputs.Get(fullDepKey); ok {
 			addURN(ctyAsString(outputs.GetAttr("urn")))
 		}
-		checkPendingDep(fullDepKey)
+		checkPendingDep(instPrefix + depKey)
 	}
 
 	// Match the Node.js / Python SDK behavior: during preview, if any input
@@ -3773,7 +3804,7 @@ func (e *Engine) readScopedDataSource(ctx context.Context, ds *ast.Resource, eva
 		Type:     graph.NodeTypeDataSource,
 		Resource: ds,
 	}
-	return e.processDataSourceInContext(ctx, node, ds, evalCtx)
+	return e.processDataSourceInContext(ctx, node, ds, evalCtx, "")
 }
 
 // warnf emits a best-effort warning diagnostic. A transport failure emitting it

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -357,6 +357,14 @@ type Engine struct {
 	// Dependent nodes check this map and are skipped when a dependency failed.
 	failedNodes *util.SyncMap[string, error]
 
+	// pendingResourceChanges tracks, during preview, the managed resources
+	// whose registration indicates a change is pending (unknown id means a
+	// pending create; computed outputs mean the provider planned new values).
+	// Keyed by the resource's unexpanded graph key so a reference to any
+	// instance of a ranged resource matches. Data sources that reference or
+	// depend on such a resource defer their read to the apply phase.
+	pendingResourceChanges *util.SyncMap[string, struct{}]
+
 	// graph is the resolved dependency graph for the current run. Stored on
 	// the engine so processNode handlers can consult its topology (e.g.
 	// processProvider checks whether anything depends on a provider node
@@ -453,6 +461,7 @@ func NewEngine(ctx context.Context, config *ast.Config, opts *EngineOptions) *En
 		moduleInstances:         util.NewSyncMap[modulepath.Path, []*moduleInstance](),
 		parallel:                opts.Parallel,
 		failedNodes:             util.NewSyncMap[string, error](),
+		pendingResourceChanges:  util.NewSyncMap[string, struct{}](),
 		alwaysRegisterProviders: opts.AlwaysRegisterProviders,
 	}
 
@@ -1308,6 +1317,10 @@ func (e *Engine) registerResourceInstanceInContext(
 	if err != nil {
 		e.failedNodes.Set(instance.Key, fmt.Errorf("registering resource: %w", err))
 		return nil
+	}
+
+	if e.dryRun && (id == "" || property.New(outputs).HasComputed()) {
+		e.pendingResourceChanges.Set(instance.OriginalKey, struct{}{})
 	}
 
 	outputs = outputs.Delete("id", "urn")
@@ -2574,6 +2587,37 @@ func (e *Engine) invokeDataSourceOnce(
 		depMarks[eval.DepMark(urn)] = struct{}{}
 	}
 
+	// A data source whose config directly references a managed resource with
+	// a change pending must defer its read to the apply phase, even when the
+	// referenced value is already known. Only direct references count:
+	// indirection through a local, variable, or module output does not defer.
+	refPrefix := ""
+	if node.ModuleInfo != nil {
+		refPrefix = node.ModuleInfo.Prefix()
+	}
+	depsPending := false
+	checkPendingDep := func(key string) {
+		if _, ok := e.pendingResourceChanges.Get(key); ok {
+			depsPending = true
+		}
+	}
+	collectPendingRefs := func(expr hcl.Expression, extraVars map[string]cty.Value) {
+		if expr == nil || !e.dryRun {
+			return
+		}
+		for _, traversal := range expr.Variables() {
+			namespace, parts := eval.ParseTraversal(traversal)
+			if _, isIterationVar := extraVars[namespace]; isIterationVar {
+				continue
+			}
+			if len(parts) > 0 {
+				checkPendingDep(refPrefix + namespace + "." + parts[0])
+			}
+		}
+	}
+	collectPendingRefs(ds.Count, nil)
+	collectPendingRefs(ds.ForEach, nil)
+
 	dataSourceMapping := e.dataSourceBodyMapping(ctx, ds.Type)
 	inputs, diags := transform.EvalFunctionWithSchema(ds.Config, funcSchema, dataSourceMapping,
 		func(propKey resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
@@ -2593,6 +2637,8 @@ func (e *Engine) invokeDataSourceOnce(
 			for _, urn := range eval.CollectDepURNs(val) {
 				addURN(urn)
 			}
+
+			collectPendingRefs(expr, extraVars)
 
 			return val, diags
 		})
@@ -2657,13 +2703,15 @@ func (e *Engine) invokeDataSourceOnce(
 		if outputs, ok := e.resourceOutputs.Get(fullDepKey); ok {
 			addURN(ctyAsString(outputs.GetAttr("urn")))
 		}
+		checkPendingDep(fullDepKey)
 	}
 
 	// Match the Node.js / Python SDK behavior: during preview, if any input
 	// to the invoke is unknown, skip the provider call and synthesize an
-	// all-unknown result.
+	// all-unknown result. The same applies when the data source references or
+	// depends on a managed resource with a change pending.
 	var outputs property.Map
-	if !e.dryRun || !property.New(inputs).HasComputed() {
+	if !e.dryRun || (!property.New(inputs).HasComputed() && !depsPending) {
 		var err error
 		outputs, err = e.invokeFunction(ctx, ds.Type, invokeReq)
 		if err != nil {

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 
@@ -3170,4 +3171,132 @@ module "child" {
 		"::" + rootProvider.Name + "-id"
 	assert.Equal(t, rootRef, childResource.Provider,
 		"a child resource with no provider block must inherit the root default provider")
+}
+
+// During preview, a data source that directly references — or names in
+// depends_on — a managed resource with a change pending (unknown id) is not
+// invoked; its result is synthesized as unknown. A reference that reaches the
+// pending resource only through a local does not defer the invoke, and when
+// the dependency has no change pending (known id, known outputs) nothing
+// defers.
+func TestEngine_DataSourceDeferredWhenDependencyPending(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "aws_ec2_instance" "upstream" {
+  ami = "ami-123"
+}
+
+data "aws_ec2_vpc" "by_ref" {
+  query = aws_ec2_instance.upstream.ami
+}
+
+data "aws_ec2_vpc" "by_depends_on" {
+  query      = "static"
+  depends_on = [aws_ec2_instance.upstream]
+}
+
+locals {
+  indirect = "${aws_ec2_instance.upstream.ami}-local"
+}
+
+data "aws_ec2_vpc" "via_local" {
+  query = local.indirect
+}
+`)
+
+	runEngine := func(t *testing.T, pendingCreate bool) []run.InvokeRequest {
+		p := parser.NewParser()
+		config, diags := p.ParseSource("test.hcl", src)
+		require.False(t, diags.HasErrors(), diags.Error())
+
+		mock := &testutil.MockResourceMonitor{
+			DryRun: true,
+			RegisterResourceHandler: func(ctx context.Context, req run.RegisterResourceRequest) (*run.RegisterResourceResponse, error) {
+				id := req.Name + "-id"
+				if pendingCreate {
+					id = ""
+				}
+				return &run.RegisterResourceResponse{
+					URN:     urn.URN("urn:pulumi:test::project::" + req.Type + "::" + req.Name),
+					ID:      id,
+					Outputs: req.Inputs,
+				}, nil
+			},
+		}
+		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ProjectName:     "test-project",
+			StackName:       "dev",
+			ResourceMonitor: mock,
+			WorkDir:         t.TempDir(),
+			RootDir:         t.TempDir(),
+			DryRun:          true,
+			SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+				Name: "aws",
+				Meta: &schema.MetadataSpec{
+					ModuleFormat: `(.*)(?:/[^/]*)`,
+				},
+				Resources: map[string]schema.ResourceSpec{
+					"aws:ec2/instance:Instance": {
+						InputProperties: map[string]schema.PropertySpec{
+							"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+						ObjectTypeSpec: schema.ObjectTypeSpec{
+							Properties: map[string]schema.PropertySpec{
+								"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+							},
+						},
+					},
+				},
+				Functions: map[string]schema.FunctionSpec{
+					"aws:ec2/getVpc:getVpc": {
+						Inputs: &schema.ObjectTypeSpec{
+							Properties: map[string]schema.PropertySpec{
+								"query": {TypeSpec: schema.TypeSpec{Type: "string"}},
+							},
+						},
+						Outputs: &schema.ObjectTypeSpec{
+							Properties: map[string]schema.PropertySpec{
+								"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+							},
+						},
+					},
+				},
+			}),
+		})
+
+		require.NoError(t, engine.Run(t.Context()))
+
+		invoked := mock.InvokedFunctions
+		sort.Slice(invoked, func(i, j int) bool {
+			return invoked[i].Args.Get("query").AsString() < invoked[j].Args.Get("query").AsString()
+		})
+		return invoked
+	}
+
+	t.Run("dependency pending create", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, []run.InvokeRequest{{
+			Token: "aws:ec2/getVpc:getVpc",
+			Args:  property.NewMap(map[string]property.Value{"query": property.New("ami-123-local")}),
+		}}, runEngine(t, true))
+	})
+
+	t.Run("dependency without pending change", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, []run.InvokeRequest{
+			{
+				Token: "aws:ec2/getVpc:getVpc",
+				Args:  property.NewMap(map[string]property.Value{"query": property.New("ami-123")}),
+			},
+			{
+				Token: "aws:ec2/getVpc:getVpc",
+				Args:  property.NewMap(map[string]property.Value{"query": property.New("ami-123-local")}),
+			},
+			{
+				Token: "aws:ec2/getVpc:getVpc",
+				Args:  property.NewMap(map[string]property.Value{"query": property.New("static")}),
+			},
+		}, runEngine(t, false))
+	})
 }

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -3300,3 +3300,106 @@ data "aws_ec2_vpc" "via_local" {
 		}, runEngine(t, false))
 	})
 }
+
+// During preview, `depends_on = [module.child]` on a data source defers the
+// read while any managed resource inside that module has a change pending,
+// and does not defer once nothing is pending.
+func TestEngine_DataSourceDeferredWhenModuleDependencyPending(t *testing.T) {
+	t.Parallel()
+
+	runEngine := func(t *testing.T, pendingCreate bool) []run.InvokeRequest {
+		tmpDir := t.TempDir()
+		moduleDir := tmpDir + "/modules/child"
+		require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+		require.NoError(t, os.WriteFile(moduleDir+"/main.tf", []byte(`
+resource "aws_ec2_instance" "inner" {
+  ami = "ami-123"
+}
+`), 0o644))
+		require.NoError(t, os.WriteFile(tmpDir+"/main.tf", []byte(`
+module "child" {
+  source = "./modules/child"
+}
+
+data "aws_ec2_vpc" "after_module" {
+  query      = "static"
+  depends_on = [module.child]
+}
+`), 0o644))
+
+		p := parser.NewParser()
+		config, diags := p.ParseDirectory(tmpDir)
+		require.False(t, diags.HasErrors(), diags.Error())
+
+		mock := &testutil.MockResourceMonitor{
+			DryRun: true,
+			RegisterResourceHandler: func(ctx context.Context, req run.RegisterResourceRequest) (*run.RegisterResourceResponse, error) {
+				id := req.Name + "-id"
+				if pendingCreate && req.Type == "aws:ec2/instance:Instance" {
+					id = ""
+				}
+				return &run.RegisterResourceResponse{
+					URN:     urn.URN("urn:pulumi:test::project::" + req.Type + "::" + req.Name),
+					ID:      id,
+					Outputs: req.Inputs,
+				}, nil
+			},
+		}
+		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ProjectName:     "test-project",
+			StackName:       "dev",
+			ResourceMonitor: mock,
+			WorkDir:         tmpDir,
+			RootDir:         tmpDir,
+			DryRun:          true,
+			SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+				Name: "aws",
+				Meta: &schema.MetadataSpec{
+					ModuleFormat: `(.*)(?:/[^/]*)`,
+				},
+				Resources: map[string]schema.ResourceSpec{
+					"aws:ec2/instance:Instance": {
+						InputProperties: map[string]schema.PropertySpec{
+							"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+						ObjectTypeSpec: schema.ObjectTypeSpec{
+							Properties: map[string]schema.PropertySpec{
+								"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+							},
+						},
+					},
+				},
+				Functions: map[string]schema.FunctionSpec{
+					"aws:ec2/getVpc:getVpc": {
+						Inputs: &schema.ObjectTypeSpec{
+							Properties: map[string]schema.PropertySpec{
+								"query": {TypeSpec: schema.TypeSpec{Type: "string"}},
+							},
+						},
+						Outputs: &schema.ObjectTypeSpec{
+							Properties: map[string]schema.PropertySpec{
+								"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+							},
+						},
+					},
+				},
+			}),
+		})
+
+		require.NoError(t, engine.Run(t.Context()))
+		return mock.InvokedFunctions
+	}
+
+	t.Run("module dependency pending create", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, []run.InvokeRequest(nil), runEngine(t, true))
+	})
+
+	t.Run("module dependency without pending change", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, []run.InvokeRequest{{
+			Token: "aws:ec2/getVpc:getVpc",
+			Args:  property.NewMap(map[string]property.Value{"query": property.New("static")}),
+		}}, runEngine(t, false))
+	})
+}

--- a/tests/testutil/tfcompat/providers/simple.go
+++ b/tests/testutil/tfcompat/providers/simple.go
@@ -59,6 +59,9 @@ func SimpleProvider() *schema.Provider {
 				Schema: map[string]*schema.Schema{
 					"input_one": {Type: schema.TypeString, Optional: true},
 					"input_two": {Type: schema.TypeBool, Optional: true},
+					// Changing this forces a replacement, so tests can stage
+					// a resource with a pending replace.
+					"input_replace": {Type: schema.TypeString, Optional: true, ForceNew: true},
 					// `version` is an upstream-style attribute name used by
 					// some real TF resources (e.g. aws_rds_engine_version).
 					// Kept here so tests can assert it survives the

--- a/tests/tfcompat/l2_data_source_pending_dependency_preview_test.go
+++ b/tests/tfcompat/l2_data_source_pending_dependency_preview_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A `data` block that depends on a managed resource with changes pending must
+// not be read during the plan/preview phase, even when every input value is
+// already known: `tofu plan` defers the read to apply both for a direct
+// reference to the pending resource and for an explicit `depends_on`. Before
+// the fix, `pulumi preview` invoked both reads eagerly (the inputs are known
+// strings), recording extra data-source operations — and failing outright for
+// providers whose read requires the dependency to exist (issue #266).
+//
+// Only *direct* references defer: `via_local` reaches the pending resource
+// through a `locals` indirection, so both runtimes read it during the
+// plan/preview phase (two recorded reads: one per stage) — the recorded op
+// counts pin that boundary on both sides.
+func TestL2DataSourcePendingDependencyPreview(t *testing.T) {
+	t.Parallel()
+	files := map[string]string{"main.tf": `
+resource "simple_resource" "upstream" {
+  input_one = "a"
+  input_two = true
+}
+
+data "simple_lookup" "by_ref" {
+  query = simple_resource.upstream.input_one
+}
+
+data "simple_lookup" "by_depends_on" {
+  query      = "static"
+  depends_on = [simple_resource.upstream]
+}
+
+locals {
+  indirect = "${simple_resource.upstream.input_one}-local"
+}
+
+data "simple_lookup" "via_local" {
+  query = local.indirect
+}
+
+output "by_ref" {
+  value = data.simple_lookup.by_ref.prefix_result
+}
+
+output "by_depends_on" {
+  value = data.simple_lookup.by_depends_on.prefix_result
+}
+
+output "via_local" {
+  value = data.simple_lookup.via_local.prefix_result
+}
+`}
+	tfcompat.RunCase(t, "l2_data_source_pending_dependency_preview", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StagePreview, Files: files},
+			{Mode: tfcompat.StageApply, Files: files},
+		},
+	})
+}

--- a/tests/tfcompat/l2_data_source_pending_dependency_preview_test.go
+++ b/tests/tfcompat/l2_data_source_pending_dependency_preview_test.go
@@ -77,6 +77,171 @@ output "via_local" {
 		Stages: []tfcompat.Stage{
 			{Mode: tfcompat.StagePreview, Files: files},
 			{Mode: tfcompat.StageApply, Files: files},
+			// A clean preview after the apply: nothing is pending anymore, so
+			// neither runtime defers — all three data sources are read during
+			// the plan/preview phase.
+			{Mode: tfcompat.StagePreview, Files: files},
+		},
+	})
+}
+
+// A pending *update* must defer dependent data source reads the same way a
+// pending create does: after the first apply, changing `input_one` gives the
+// resource a pending change, and `tofu plan` defers the read of a data source
+// that references it even though the new value is already known.
+//
+// KNOWN FAILURE (https://github.com/pulumi-labs/pulumi-hcl/issues/266): an
+// update that changes only inputs is invisible to the language host — the
+// RegisterResourceResponse for an update preview carries a known id and known
+// outputs, indistinguishable from a no-op registration — so pulumi reads the
+// data source during the preview (one extra recorded read with query "b").
+// Detecting this case needs the engine to report whether a registration has a
+// change planned.
+func TestL2DataSourcePendingUpdatePreview(t *testing.T) {
+	t.Parallel()
+	program := func(inputOne string) map[string]string {
+		return map[string]string{"main.tf": `
+resource "simple_resource" "upstream" {
+  input_one = "` + inputOne + `"
+  input_two = true
+}
+
+data "simple_lookup" "by_ref" {
+  query = simple_resource.upstream.input_one
+}
+
+output "by_ref" {
+  value = data.simple_lookup.by_ref.prefix_result
+}
+`}
+	}
+	tfcompat.RunCase(t, "l2_data_source_pending_update_preview", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply, Files: program("a")},
+			{Mode: tfcompat.StagePreview, Files: program("b")},
+			{Mode: tfcompat.StageApply, Files: program("b")},
+		},
+	})
+}
+
+// A pending *replacement* (ForceNew change) must defer dependent data source
+// reads: changing `input_replace` plans a replace of the resource, so the
+// read of a data source referencing it waits for the apply phase even though
+// the referenced value (`input_one`) is unchanged and known.
+func TestL2DataSourcePendingReplacePreview(t *testing.T) {
+	t.Parallel()
+	program := func(replace string) map[string]string {
+		return map[string]string{"main.tf": `
+resource "simple_resource" "upstream" {
+  input_one     = "a"
+  input_two     = true
+  input_replace = "` + replace + `"
+}
+
+data "simple_lookup" "by_ref" {
+  query = simple_resource.upstream.input_one
+}
+
+output "by_ref" {
+  value = data.simple_lookup.by_ref.prefix_result
+}
+`}
+	}
+	tfcompat.RunCase(t, "l2_data_source_pending_replace_preview", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply, Files: program("x")},
+			{Mode: tfcompat.StagePreview, Files: program("y")},
+			{Mode: tfcompat.StageApply, Files: program("y")},
+		},
+	})
+}
+
+// `depends_on = [module.maker]` on a data source must defer the read while
+// any managed resource inside that module has a change pending, mirroring
+// the transitive walk OpenTofu performs for module references in depends_on.
+func TestL2DataSourceModuleDependsOnPendingPreview(t *testing.T) {
+	t.Parallel()
+	files := map[string]string{
+		"main.tf": `
+module "maker" {
+  source = "./mod"
+}
+
+data "simple_lookup" "after_module" {
+  query      = "static"
+  depends_on = [module.maker]
+}
+
+output "after_module" {
+  value = data.simple_lookup.after_module.prefix_result
+}
+`,
+		"mod/main.tf": `
+resource "simple_resource" "inner" {
+  input_one = "m"
+  input_two = false
+}
+`,
+	}
+	tfcompat.RunCase(t, "l2_data_source_module_depends_on_pending_preview", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StagePreview, Files: files},
+			{Mode: tfcompat.StageApply, Files: files},
+		},
+	})
+}
+
+// Pending changes are tracked per module *instance*: growing a module call
+// from count = 1 to count = 2 leaves instance [0] unchanged, so the data
+// source inside instance [0] is still read during the plan/preview phase,
+// while the one inside the new instance [1] defers until apply.
+func TestL2DataSourceModuleInstancePendingPreview(t *testing.T) {
+	t.Parallel()
+	program := func(count string) map[string]string {
+		return map[string]string{
+			"main.tf": `
+module "m" {
+  source = "./mod"
+  count  = ` + count + `
+}
+
+output "looked" {
+  value = module.m[0].looked
+}
+`,
+			"mod/main.tf": `
+resource "simple_resource" "inner" {
+  input_one = "i"
+  input_two = true
+}
+
+data "simple_lookup" "sibling" {
+  query = simple_resource.inner.input_one
+}
+
+output "looked" {
+  value = data.simple_lookup.sibling.prefix_result
+}
+`,
+		}
+	}
+	tfcompat.RunCase(t, "l2_data_source_module_instance_pending_preview", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply, Files: program("1")},
+			{Mode: tfcompat.StagePreview, Files: program("2")},
+			{Mode: tfcompat.StageApply, Files: program("2")},
 		},
 	})
 }

--- a/tests/tfcompat/l2_data_source_pending_dependency_preview_test.go
+++ b/tests/tfcompat/l2_data_source_pending_dependency_preview_test.go
@@ -90,14 +90,14 @@ output "via_local" {
 // resource a pending change, and `tofu plan` defers the read of a data source
 // that references it even though the new value is already known.
 //
-// KNOWN FAILURE (https://github.com/pulumi-labs/pulumi-hcl/issues/266): an
-// update that changes only inputs is invisible to the language host — the
-// RegisterResourceResponse for an update preview carries a known id and known
-// outputs, indistinguishable from a no-op registration — so pulumi reads the
-// data source during the preview (one extra recorded read with query "b").
-// Detecting this case needs the engine to report whether a registration has a
-// change planned.
+// Skipped: an update that changes only inputs is invisible to the language
+// host — the RegisterResourceResponse for an update preview carries a known
+// id and known outputs, indistinguishable from a no-op registration — so
+// pulumi reads the data source during the preview (one extra recorded read
+// with query "b"). Detecting this case needs the engine to report whether a
+// registration has a change planned.
 func TestL2DataSourcePendingUpdatePreview(t *testing.T) {
+	t.Skip("https://github.com/pulumi-labs/pulumi-hcl/issues/269: an input-only pending update is indistinguishable from a no-op, so the read is not deferred")
 	t.Parallel()
 	program := func(inputOne string) map[string]string {
 		return map[string]string{"main.tf": `


### PR DESCRIPTION
Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/266.

## The divergence

OpenTofu defers a data source read to the apply phase whenever the read
depends on a managed resource with a change pending, even if every argument
value is already known at plan time (`dataDependsOn` in
`internal/tofu/transform_reference.go` implicitly treats a direct reference to
a managed resource as `depends_on`, and `dependenciesHavePendingChanges`
forces the deferral). Pulumi HCL only deferred when an input *value* was
unknown, so a read like

```hcl
resource "local_file" "a" {
  filename = "${path.module}/generated.txt"
  content  = "hello"
}

data "local_file" "b" {
  filename = local_file.a.filename   # known string, pending resource
}
```

was invoked eagerly during `pulumi preview`, failing against a world where the
dependency does not exist yet (`tofu plan` shows the result as
`(known after apply)` and succeeds). The same pattern breaks real modules,
e.g. terraform-aws-modules/notify-slack.

## The fix

- During preview, record each managed resource whose registration indicates a
  pending change — an unknown `id` (pending create or replace) or computed
  output values — keyed by its instance-qualified module prefix plus
  unexpanded resource key, and additionally under each enclosing module
  call's key.
- A data source skips the provider invoke and synthesizes an all-unknown
  result (the existing unknown-input path) when its config directly
  references, or its `depends_on` names, a pending entry. `count`/`for_each`
  expressions count as references; `depends_on = [module.x]` matches the
  module-call keys, mirroring OpenTofu's transitive walk for module
  references in depends_on.
- Pending tracking is per module *instance*: growing a module call from
  `count = 1` to `2` leaves instance `[0]`'s data source reading at preview
  while the new instance `[1]` defers — OpenTofu filters out changes from
  other instances of the same module the same way.
- The module completion node (`module.<name>`) now depends on the module's
  resources, data sources, and nested module calls — previously only init and
  outputs — so anything ordered after `module.<name>` (notably a
  `depends_on = [module.x]` data read at apply time) runs after the module's
  side effects. With an output-less module, the read could previously execute
  before the module's resources were created.
- Matching OpenTofu's boundary, only *direct* references defer: reaching the
  pending resource through a `local`, variable, or module output does not.
  The tfcompat case pins this empirically on both runtimes via the recorded
  provider operations (the `via_local` data source is read during the
  plan/preview phase by both, while `by_ref` and `by_depends_on` are deferred
  by both).

## Known gap, skipped test

`TestL2DataSourcePendingUpdatePreview` documents the one residual
divergence and is skipped, tracked in
https://github.com/pulumi-labs/pulumi-hcl/issues/269: a pending update that
changes only inputs returns a known id and known outputs in
`RegisterResourceResponse`, indistinguishable from a no-op registration, so
the language host reads the data source during preview where OpenTofu
defers. `RegisterResourceResponse` carries no planned-change signal
(`result` is only success/fail/skip), so fixing this needs engine support.

## Out of scope (deliberately)

- The custom-condition case (OpenTofu widens to the full transitive
  dependency set when a data source has preconditions/postconditions) is not
  handled.

## Verification

- `TestL2DataSourcePendingDependencyPreview` (direct ref, `depends_on`,
  via-local boundary, clean-preview-after-apply) fails on master and passes
  with this change; `TestL2DataSourcePendingReplacePreview`,
  `TestL2DataSourceModuleDependsOnPendingPreview`, and
  `TestL2DataSourceModuleInstancePendingPreview` cover the corner cases.
- `TestEngine_DataSourceDeferredWhenDependencyPending` and
  `TestEngine_DataSourceDeferredWhenModuleDependencyPending` unit-cover the
  deferred/not-deferred matrix at the engine boundary.
- Full `./pkg/...` (785 tests) passes; `./tests/tfcompat/` passes (121 tests, 1 skip linked above); `make lint` is clean.