### PR TITLE
Expose Multi-Language Component inputs and outputs as camelCase

### DIFF
--- a/.changes/unreleased/language-host-improvements-274.yaml
+++ b/.changes/unreleased/language-host-improvements-274.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Expose Multi-Language Component inputs and outputs under camelCase names
+time: 2026-06-16T23:41:33Z
+custom:
+    Component: language-host
+    PR: "274"

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -583,29 +583,24 @@ func convertPropertyNames(v property.Value, spec *PropertySpec, toPulumi bool) p
 				out[dst] = convertPropertyNames(fv, fieldSpec, toPulumi)
 			}
 		}
-		return withAttrs(v, property.New(out))
+		return property.WithGoValue(v, out)
 	case spec.AdditionalProperties != nil && v.IsMap():
 		obj := v.AsMap()
 		out := make(map[string]property.Value, obj.Len())
 		for k, mv := range obj.All {
 			out[k] = convertPropertyNames(mv, spec.AdditionalProperties, toPulumi)
 		}
-		return withAttrs(v, property.New(out))
+		return property.WithGoValue(v, out)
 	case spec.Items != nil && v.IsArray():
 		arr := v.AsArray()
 		out := make([]property.Value, arr.Len())
 		for i, e := range arr.All {
 			out[i] = convertPropertyNames(e, spec.Items, toPulumi)
 		}
-		return withAttrs(v, property.New(out))
+		return property.WithGoValue(v, out)
 	default:
 		return v
 	}
-}
-
-// withAttrs copies orig's secret flag and dependencies onto a rebuilt value.
-func withAttrs(orig, rebuilt property.Value) property.Value {
-	return rebuilt.WithSecret(orig.Secret()).WithDependencies(orig.Dependencies())
 }
 
 // ToPulumiPackageSchema converts the module schema to a full Pulumi package

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -29,8 +29,8 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
 	pulumischema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -520,11 +520,16 @@ func (s *ModuleSchema) ToJSON() ([]byte, error) {
 	return json.MarshalIndent(s, "", "  ")
 }
 
-// pulumiName converts a snake_case HCL identifier (a variable or output name) to
-// the camelCase name Pulumi conventionally uses for the corresponding schema
-// property. The runtime boundary (Construct) reverses this with
-// transform.SnakeCaseFromPulumiCase to recover the HCL name.
-func pulumiName(snake string) string {
+// pulumiCase converts a snake_case HCL identifier (a variable, output, or object
+// field name) to the camelCase name Pulumi conventionally uses for the schema
+// property. props is nil because an MLC module has no provider property list to
+// resolve against — the convention is the definition of the camelCase name.
+//
+// This conversion is only ever applied in the snake→camel direction, and the
+// snake_case name is always retained as the source of truth (the boundary
+// converters below iterate the snake-keyed spec rather than inverting a
+// camelCase name), so the lossy camel→snake inverse is never relied upon.
+func pulumiCase(snake string) string {
 	name, _ := transform.PulumiCaseFromSnakeCase(snake, nil)
 	return name
 }
@@ -532,122 +537,125 @@ func pulumiName(snake string) string {
 // InputsToHCL maps component inputs — keyed by their camelCase schema property
 // names — to the snake_case names the HCL module declares, recursively renaming
 // object fields at every depth. Map keys are user data and are left unchanged.
-func (s *ModuleSchema) InputsToHCL(inputs resource.PropertyMap) resource.PropertyMap {
-	out := make(resource.PropertyMap, len(inputs))
-	for k, v := range inputs {
-		snake := transform.SnakeCaseFromPulumiCase(string(k))
-		out[resource.PropertyKey(snake)] = convertPropertyNames(v, s.InputProperties[snake], false)
+// It iterates the snake-keyed input spec and looks up each input by its derived
+// camelCase name, so the mapping never depends on inverting a camelCase name.
+func (s *ModuleSchema) InputsToHCL(inputs property.Map) property.Map {
+	out := make(map[string]property.Value, inputs.Len())
+	for snake, spec := range s.InputProperties {
+		if v, ok := inputs.GetOk(pulumiCase(snake)); ok {
+			out[snake] = convertPropertyNames(v, spec, false)
+		}
 	}
-	return out
+	return property.NewMap(out)
 }
 
 // OutputsToPulumi maps the module's outputs — keyed by their snake_case HCL
 // names — to the camelCase schema property names, recursively renaming object
 // fields at every depth. Map keys are left unchanged.
-func (s *ModuleSchema) OutputsToPulumi(outputs resource.PropertyMap) resource.PropertyMap {
-	out := make(resource.PropertyMap, len(outputs))
-	for k, v := range outputs {
-		out[resource.PropertyKey(pulumiName(string(k)))] = convertPropertyNames(v, s.OutputProperties[string(k)], true)
+func (s *ModuleSchema) OutputsToPulumi(outputs property.Map) property.Map {
+	out := make(map[string]property.Value, outputs.Len())
+	for snake, v := range outputs.All {
+		out[pulumiCase(snake)] = convertPropertyNames(v, s.OutputProperties[snake], true)
 	}
-	return out
+	return property.NewMap(out)
 }
 
 // convertPropertyNames recursively renames object-field names in v according to
 // spec, which describes v's type. Object fields (spec.Properties, snake_case)
 // are renamed between snake_case and camelCase; the dynamic keys of a map
 // (spec.AdditionalProperties) are user data and left unchanged. toPulumi selects
-// the direction: snake_case→camelCase when true, the reverse when false.
-func convertPropertyNames(v resource.PropertyValue, spec *PropertySpec, toPulumi bool) resource.PropertyValue {
-	switch {
-	case spec == nil:
+// the direction: snake_case→camelCase when true, the reverse when false. A
+// value's secret flag and dependencies are preserved across the rename.
+func convertPropertyNames(v property.Value, spec *PropertySpec, toPulumi bool) property.Value {
+	if spec == nil || v.IsNull() || v.IsComputed() {
 		return v
-	case v.IsSecret():
-		return resource.MakeSecret(convertPropertyNames(v.SecretValue().Element, spec, toPulumi))
-	case v.IsOutput():
-		o := v.OutputValue()
-		o.Element = convertPropertyNames(o.Element, spec, toPulumi)
-		return resource.NewOutputProperty(o)
-	case len(spec.Properties) > 0 && v.IsObject():
-		obj := v.ObjectValue()
-		out := make(resource.PropertyMap, len(obj))
+	}
+	switch {
+	case len(spec.Properties) > 0 && v.IsMap():
+		obj := v.AsMap()
+		out := make(map[string]property.Value, obj.Len())
 		for snake, fieldSpec := range spec.Properties {
-			src, dst := resource.PropertyKey(pulumiName(snake)), resource.PropertyKey(snake)
+			src, dst := pulumiCase(snake), snake
 			if toPulumi {
 				src, dst = dst, src
 			}
-			if fv, ok := obj[src]; ok {
+			if fv, ok := obj.GetOk(src); ok {
 				out[dst] = convertPropertyNames(fv, fieldSpec, toPulumi)
 			}
 		}
-		return resource.NewObjectProperty(out)
-	case spec.AdditionalProperties != nil && v.IsObject():
-		obj := v.ObjectValue()
-		out := make(resource.PropertyMap, len(obj))
-		for k, mv := range obj {
+		return withAttrs(v, property.New(out))
+	case spec.AdditionalProperties != nil && v.IsMap():
+		obj := v.AsMap()
+		out := make(map[string]property.Value, obj.Len())
+		for k, mv := range obj.All {
 			out[k] = convertPropertyNames(mv, spec.AdditionalProperties, toPulumi)
 		}
-		return resource.NewObjectProperty(out)
+		return withAttrs(v, property.New(out))
 	case spec.Items != nil && v.IsArray():
-		arr := v.ArrayValue()
-		out := make([]resource.PropertyValue, len(arr))
-		for i, e := range arr {
+		arr := v.AsArray()
+		out := make([]property.Value, arr.Len())
+		for i, e := range arr.All {
 			out[i] = convertPropertyNames(e, spec.Items, toPulumi)
 		}
-		return resource.NewArrayProperty(out)
+		return withAttrs(v, property.New(out))
 	default:
 		return v
 	}
 }
 
-// ToPulumiPackageSchema converts the module schema to a full Pulumi package
-// schema format. Variable and output names, which are snake_case in HCL, are
-// exposed under their camelCase Pulumi property names. Object types are emitted
-// as named types in the `types` section and referenced via `$ref`, so a consumer
-// binds them as proper object types (a property's inline type spec cannot carry
-// `properties`).
-func (s *ModuleSchema) ToPulumiPackageSchema() map[string]any {
-	componentToken := fmt.Sprintf("%s:%s:%s", s.PackageName, s.Module, s.ComponentName)
-	types := make(map[string]any)
+// withAttrs copies orig's secret flag and dependencies onto a rebuilt value.
+func withAttrs(orig, rebuilt property.Value) property.Value {
+	return rebuilt.WithSecret(orig.Secret()).WithDependencies(orig.Dependencies())
+}
 
-	inputProps := make(map[string]any)
+// ToPulumiPackageSchema converts the module schema to a full Pulumi package
+// schema. Variable and output names, which are snake_case in HCL, are exposed
+// under their camelCase Pulumi property names. Object types are emitted as named
+// types in the `types` section and referenced via `$ref`, so a consumer binds
+// them as proper object types (a property's inline type spec cannot carry
+// `properties`).
+func (s *ModuleSchema) ToPulumiPackageSchema() pulumischema.PackageSpec {
+	componentToken := fmt.Sprintf("%s:%s:%s", s.PackageName, s.Module, s.ComponentName)
+	types := make(map[string]pulumischema.ComplexTypeSpec)
+
+	inputProps := make(map[string]pulumischema.PropertySpec)
 	for name, prop := range s.InputProperties {
-		inputProps[pulumiName(name)] = s.schemaProperty(prop, pascalCase(pulumiName(name)), types)
+		inputProps[pulumiCase(name)] = s.schemaProperty(prop, pascalCase(pulumiCase(name)), types)
 	}
 
 	// Output properties are the inputs plus the declared outputs.
-	outputProps := make(map[string]any)
+	outputProps := make(map[string]pulumischema.PropertySpec)
 	for name, prop := range s.InputProperties {
-		outputProps[pulumiName(name)] = s.schemaProperty(prop, pascalCase(pulumiName(name)), types)
+		outputProps[pulumiCase(name)] = s.schemaProperty(prop, pascalCase(pulumiCase(name)), types)
 	}
 	for name, prop := range s.OutputProperties {
-		outputProps[pulumiName(name)] = s.schemaProperty(prop, pascalCase(pulumiName(name)), types)
+		outputProps[pulumiCase(name)] = s.schemaProperty(prop, pascalCase(pulumiCase(name)), types)
 	}
 
-	var requiredInputs []string
+	requiredInputs := make([]string, 0, len(s.RequiredInputs))
 	for _, name := range s.RequiredInputs {
-		requiredInputs = append(requiredInputs, pulumiName(name))
+		requiredInputs = append(requiredInputs, pulumiCase(name))
 	}
 	sort.Strings(requiredInputs)
 
-	result := map[string]any{
-		"name":        s.PackageName,
-		"version":     s.Version,
-		"description": s.Description,
-		"resources": map[string]any{
-			componentToken: map[string]any{
-				"isComponent":     true,
-				"description":     s.Description,
-				"inputProperties": inputProps,
-				"requiredInputs":  requiredInputs,
-				"properties":      outputProps,
-				"type":            "object",
+	return pulumischema.PackageSpec{
+		Name:        s.PackageName,
+		Version:     s.Version,
+		Description: s.Description,
+		Types:       types,
+		Resources: map[string]pulumischema.ResourceSpec{
+			componentToken: {
+				ObjectTypeSpec: pulumischema.ObjectTypeSpec{
+					Type:        "object",
+					Description: s.Description,
+					Properties:  outputProps,
+				},
+				IsComponent:     true,
+				InputProperties: inputProps,
+				RequiredInputs:  requiredInputs,
 			},
 		},
 	}
-	if len(types) > 0 {
-		result["types"] = types
-	}
-	return result
 }
 
 // pascalCase upper-cases the first letter of a camelCase name, for use in a type
@@ -659,41 +667,45 @@ func pascalCase(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
-// schemaProperty converts a PropertySpec to a Pulumi property type spec. An
-// object type is registered as a named type (keyed by a token derived from
-// typeName) in types and referenced via `$ref`; the dynamic keys of a map are
-// not named, so its value type recurses without registering field names.
-func (s *ModuleSchema) schemaProperty(prop *PropertySpec, typeName string, types map[string]any) map[string]any {
-	result := make(map[string]any)
+// schemaProperty converts a PropertySpec to a Pulumi PropertySpec, carrying the
+// property-level description, secret flag, and default over the underlying type.
+func (s *ModuleSchema) schemaProperty(
+	prop *PropertySpec, typeName string, types map[string]pulumischema.ComplexTypeSpec,
+) pulumischema.PropertySpec {
+	return pulumischema.PropertySpec{
+		TypeSpec:    s.schemaType(prop, typeName, types),
+		Description: prop.Description,
+		Secret:      prop.Secret,
+		Default:     prop.Default,
+	}
+}
 
+// schemaType converts a PropertySpec to a Pulumi TypeSpec. An object type is
+// registered as a named type (keyed by a token derived from typeName) in types
+// and referenced via `$ref`; the dynamic keys of a map are not named, so its
+// value type recurses without registering field names.
+func (s *ModuleSchema) schemaType(
+	prop *PropertySpec, typeName string, types map[string]pulumischema.ComplexTypeSpec,
+) pulumischema.TypeSpec {
 	switch {
 	case len(prop.Properties) > 0:
 		token := fmt.Sprintf("%s:%s:%s", s.PackageName, s.Module, typeName)
-		fields := make(map[string]any)
+		fields := make(map[string]pulumischema.PropertySpec, len(prop.Properties))
 		for name, field := range prop.Properties {
-			camel := pulumiName(name)
+			camel := pulumiCase(name)
 			fields[camel] = s.schemaProperty(field, typeName+pascalCase(camel), types)
 		}
-		types[token] = map[string]any{"type": "object", "properties": fields}
-		result["$ref"] = "#/types/" + token
+		types[token] = pulumischema.ComplexTypeSpec{
+			ObjectTypeSpec: pulumischema.ObjectTypeSpec{Type: "object", Properties: fields},
+		}
+		return pulumischema.TypeSpec{Ref: "#/types/" + token}
 	case prop.AdditionalProperties != nil:
-		result["type"] = "object"
-		result["additionalProperties"] = s.schemaProperty(prop.AdditionalProperties, typeName+"Value", types)
+		elem := s.schemaType(prop.AdditionalProperties, typeName+"Value", types)
+		return pulumischema.TypeSpec{Type: "object", AdditionalProperties: &elem}
 	case prop.Items != nil:
-		result["type"] = "array"
-		result["items"] = s.schemaProperty(prop.Items, typeName+"Item", types)
-	case prop.Type != "":
-		result["type"] = prop.Type
+		elem := s.schemaType(prop.Items, typeName+"Item", types)
+		return pulumischema.TypeSpec{Type: "array", Items: &elem}
+	default:
+		return pulumischema.TypeSpec{Type: prop.Type}
 	}
-
-	if prop.Description != "" {
-		result["description"] = prop.Description
-	}
-	if prop.Secret {
-		result["secret"] = true
-	}
-	if prop.Default != nil {
-		result["default"] = prop.Default
-	}
-	return result
 }

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -518,24 +518,41 @@ func (s *ModuleSchema) ToJSON() ([]byte, error) {
 	return json.MarshalIndent(s, "", "  ")
 }
 
-// ToPulumiPackageSchema converts the module schema to a full Pulumi package schema format.
+// pulumiName converts a snake_case HCL identifier (a variable or output name) to
+// the camelCase name Pulumi conventionally uses for the corresponding schema
+// property. The runtime boundary (Construct) reverses this with
+// transform.SnakeCaseFromPulumiCase to recover the HCL name.
+func pulumiName(snake string) string {
+	name, _ := transform.PulumiCaseFromSnakeCase(snake, nil)
+	return name
+}
+
+// ToPulumiPackageSchema converts the module schema to a full Pulumi package
+// schema format. Variable and output names, which are snake_case in HCL, are
+// exposed under their camelCase Pulumi property names.
 func (s *ModuleSchema) ToPulumiPackageSchema() map[string]any {
 	componentToken := fmt.Sprintf("%s:%s:%s", s.PackageName, s.Module, s.ComponentName)
 
 	// Build input properties
 	inputProps := make(map[string]any)
 	for name, prop := range s.InputProperties {
-		inputProps[name] = propertySpecToSchemaProperty(prop)
+		inputProps[pulumiName(name)] = propertySpecToSchemaProperty(prop)
 	}
 
 	// Build output properties (inputs + outputs)
 	outputProps := make(map[string]any)
 	for name, prop := range s.InputProperties {
-		outputProps[name] = propertySpecToSchemaProperty(prop)
+		outputProps[pulumiName(name)] = propertySpecToSchemaProperty(prop)
 	}
 	for name, prop := range s.OutputProperties {
-		outputProps[name] = propertySpecToSchemaProperty(prop)
+		outputProps[pulumiName(name)] = propertySpecToSchemaProperty(prop)
 	}
+
+	var requiredInputs []string
+	for _, name := range s.RequiredInputs {
+		requiredInputs = append(requiredInputs, pulumiName(name))
+	}
+	sort.Strings(requiredInputs)
 
 	return map[string]any{
 		"name":        s.PackageName,
@@ -546,7 +563,7 @@ func (s *ModuleSchema) ToPulumiPackageSchema() map[string]any {
 				"isComponent":     true,
 				"description":     s.Description,
 				"inputProperties": inputProps,
-				"requiredInputs":  s.RequiredInputs,
+				"requiredInputs":  requiredInputs,
 				"properties":      outputProps,
 				"type":            "object",
 			},

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -22,12 +22,14 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/bridge"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
 	pulumischema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -527,25 +529,98 @@ func pulumiName(snake string) string {
 	return name
 }
 
+// InputsToHCL maps component inputs — keyed by their camelCase schema property
+// names — to the snake_case names the HCL module declares, recursively renaming
+// object fields at every depth. Map keys are user data and are left unchanged.
+func (s *ModuleSchema) InputsToHCL(inputs resource.PropertyMap) resource.PropertyMap {
+	out := make(resource.PropertyMap, len(inputs))
+	for k, v := range inputs {
+		snake := transform.SnakeCaseFromPulumiCase(string(k))
+		out[resource.PropertyKey(snake)] = convertPropertyNames(v, s.InputProperties[snake], false)
+	}
+	return out
+}
+
+// OutputsToPulumi maps the module's outputs — keyed by their snake_case HCL
+// names — to the camelCase schema property names, recursively renaming object
+// fields at every depth. Map keys are left unchanged.
+func (s *ModuleSchema) OutputsToPulumi(outputs resource.PropertyMap) resource.PropertyMap {
+	out := make(resource.PropertyMap, len(outputs))
+	for k, v := range outputs {
+		out[resource.PropertyKey(pulumiName(string(k)))] = convertPropertyNames(v, s.OutputProperties[string(k)], true)
+	}
+	return out
+}
+
+// convertPropertyNames recursively renames object-field names in v according to
+// spec, which describes v's type. Object fields (spec.Properties, snake_case)
+// are renamed between snake_case and camelCase; the dynamic keys of a map
+// (spec.AdditionalProperties) are user data and left unchanged. toPulumi selects
+// the direction: snake_case→camelCase when true, the reverse when false.
+func convertPropertyNames(v resource.PropertyValue, spec *PropertySpec, toPulumi bool) resource.PropertyValue {
+	switch {
+	case spec == nil:
+		return v
+	case v.IsSecret():
+		return resource.MakeSecret(convertPropertyNames(v.SecretValue().Element, spec, toPulumi))
+	case v.IsOutput():
+		o := v.OutputValue()
+		o.Element = convertPropertyNames(o.Element, spec, toPulumi)
+		return resource.NewOutputProperty(o)
+	case len(spec.Properties) > 0 && v.IsObject():
+		obj := v.ObjectValue()
+		out := make(resource.PropertyMap, len(obj))
+		for snake, fieldSpec := range spec.Properties {
+			src, dst := resource.PropertyKey(pulumiName(snake)), resource.PropertyKey(snake)
+			if toPulumi {
+				src, dst = dst, src
+			}
+			if fv, ok := obj[src]; ok {
+				out[dst] = convertPropertyNames(fv, fieldSpec, toPulumi)
+			}
+		}
+		return resource.NewObjectProperty(out)
+	case spec.AdditionalProperties != nil && v.IsObject():
+		obj := v.ObjectValue()
+		out := make(resource.PropertyMap, len(obj))
+		for k, mv := range obj {
+			out[k] = convertPropertyNames(mv, spec.AdditionalProperties, toPulumi)
+		}
+		return resource.NewObjectProperty(out)
+	case spec.Items != nil && v.IsArray():
+		arr := v.ArrayValue()
+		out := make([]resource.PropertyValue, len(arr))
+		for i, e := range arr {
+			out[i] = convertPropertyNames(e, spec.Items, toPulumi)
+		}
+		return resource.NewArrayProperty(out)
+	default:
+		return v
+	}
+}
+
 // ToPulumiPackageSchema converts the module schema to a full Pulumi package
 // schema format. Variable and output names, which are snake_case in HCL, are
-// exposed under their camelCase Pulumi property names.
+// exposed under their camelCase Pulumi property names. Object types are emitted
+// as named types in the `types` section and referenced via `$ref`, so a consumer
+// binds them as proper object types (a property's inline type spec cannot carry
+// `properties`).
 func (s *ModuleSchema) ToPulumiPackageSchema() map[string]any {
 	componentToken := fmt.Sprintf("%s:%s:%s", s.PackageName, s.Module, s.ComponentName)
+	types := make(map[string]any)
 
-	// Build input properties
 	inputProps := make(map[string]any)
 	for name, prop := range s.InputProperties {
-		inputProps[pulumiName(name)] = propertySpecToSchemaProperty(prop)
+		inputProps[pulumiName(name)] = s.schemaProperty(prop, pascalCase(pulumiName(name)), types)
 	}
 
-	// Build output properties (inputs + outputs)
+	// Output properties are the inputs plus the declared outputs.
 	outputProps := make(map[string]any)
 	for name, prop := range s.InputProperties {
-		outputProps[pulumiName(name)] = propertySpecToSchemaProperty(prop)
+		outputProps[pulumiName(name)] = s.schemaProperty(prop, pascalCase(pulumiName(name)), types)
 	}
 	for name, prop := range s.OutputProperties {
-		outputProps[pulumiName(name)] = propertySpecToSchemaProperty(prop)
+		outputProps[pulumiName(name)] = s.schemaProperty(prop, pascalCase(pulumiName(name)), types)
 	}
 
 	var requiredInputs []string
@@ -554,7 +629,7 @@ func (s *ModuleSchema) ToPulumiPackageSchema() map[string]any {
 	}
 	sort.Strings(requiredInputs)
 
-	return map[string]any{
+	result := map[string]any{
 		"name":        s.PackageName,
 		"version":     s.Version,
 		"description": s.Description,
@@ -569,15 +644,48 @@ func (s *ModuleSchema) ToPulumiPackageSchema() map[string]any {
 			},
 		},
 	}
+	if len(types) > 0 {
+		result["types"] = types
+	}
+	return result
 }
 
-// propertySpecToSchemaProperty converts a PropertySpec to a Pulumi schema property format.
-func propertySpecToSchemaProperty(prop *PropertySpec) map[string]any {
+// pascalCase upper-cases the first letter of a camelCase name, for use in a type
+// token.
+func pascalCase(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// schemaProperty converts a PropertySpec to a Pulumi property type spec. An
+// object type is registered as a named type (keyed by a token derived from
+// typeName) in types and referenced via `$ref`; the dynamic keys of a map are
+// not named, so its value type recurses without registering field names.
+func (s *ModuleSchema) schemaProperty(prop *PropertySpec, typeName string, types map[string]any) map[string]any {
 	result := make(map[string]any)
 
-	if prop.Type != "" {
+	switch {
+	case len(prop.Properties) > 0:
+		token := fmt.Sprintf("%s:%s:%s", s.PackageName, s.Module, typeName)
+		fields := make(map[string]any)
+		for name, field := range prop.Properties {
+			camel := pulumiName(name)
+			fields[camel] = s.schemaProperty(field, typeName+pascalCase(camel), types)
+		}
+		types[token] = map[string]any{"type": "object", "properties": fields}
+		result["$ref"] = "#/types/" + token
+	case prop.AdditionalProperties != nil:
+		result["type"] = "object"
+		result["additionalProperties"] = s.schemaProperty(prop.AdditionalProperties, typeName+"Value", types)
+	case prop.Items != nil:
+		result["type"] = "array"
+		result["items"] = s.schemaProperty(prop.Items, typeName+"Item", types)
+	case prop.Type != "":
 		result["type"] = prop.Type
 	}
+
 	if prop.Description != "" {
 		result["description"] = prop.Description
 	}
@@ -587,22 +695,5 @@ func propertySpecToSchemaProperty(prop *PropertySpec) map[string]any {
 	if prop.Default != nil {
 		result["default"] = prop.Default
 	}
-	if prop.Items != nil {
-		result["items"] = propertySpecToSchemaProperty(prop.Items)
-	}
-	if prop.AdditionalProperties != nil {
-		result["additionalProperties"] = propertySpecToSchemaProperty(prop.AdditionalProperties)
-	}
-	if len(prop.Properties) > 0 {
-		props := make(map[string]any)
-		for name, p := range prop.Properties {
-			props[name] = propertySpecToSchemaProperty(p)
-		}
-		result["properties"] = props
-	}
-	if prop.Ref != "" {
-		result["$ref"] = prop.Ref
-	}
-
 	return result
 }

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/bridge"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	pulumiSchema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -338,6 +339,48 @@ output "z" {
 	}
 	_, err := GenerateModuleSchema(t.Context(), root, binder, "pkg", "0.0.0-dev", "pkg", "index")
 	require.Error(t, err)
+}
+
+// TestBoundaryNameConversion shows that the Construct boundary renames object
+// field names (snake_case ↔ camelCase) at every depth in both directions, while
+// leaving the dynamic keys of a map untouched.
+func TestBoundaryNameConversion(t *testing.T) {
+	t.Parallel()
+
+	s := &ModuleSchema{
+		InputProperties: map[string]*PropertySpec{
+			"object_in": {Type: "object", Properties: map[string]*PropertySpec{
+				"field_one": {Type: "string"},
+			}},
+			"map_in": {Type: "object", AdditionalProperties: &PropertySpec{Type: "string"}},
+		},
+		OutputProperties: map[string]*PropertySpec{
+			"object_out": {Type: "object", Properties: map[string]*PropertySpec{
+				"field_two": {Type: "string"},
+			}},
+			"map_out": {Type: "object", AdditionalProperties: &PropertySpec{Type: "string"}},
+		},
+	}
+
+	// Inputs arrive camelCase (top-level names and object fields). A map's keys
+	// are user data, so a key that looks like snake_case stays verbatim.
+	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]any{
+		"object_in": map[string]any{"field_one": "a"},
+		"map_in":    map[string]any{"user_key": "b"},
+	}), s.InputsToHCL(resource.NewPropertyMapFromMap(map[string]any{
+		"objectIn": map[string]any{"fieldOne": "a"},
+		"mapIn":    map[string]any{"user_key": "b"},
+	})))
+
+	// Outputs arrive snake_case from HCL; object fields become camelCase, map
+	// keys are preserved verbatim.
+	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]any{
+		"objectOut": map[string]any{"fieldTwo": "c"},
+		"mapOut":    map[string]any{"user_key": "d"},
+	}), s.OutputsToPulumi(resource.NewPropertyMapFromMap(map[string]any{
+		"object_out": map[string]any{"field_two": "c"},
+		"map_out":    map[string]any{"user_key": "d"},
+	})))
 }
 
 // errLoader is a schema.Loader that fails if asked to load any package. The

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -29,6 +29,7 @@ import (
 	pulumiSchema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,9 +82,7 @@ func TestGenerateModuleSchemaGolden(t *testing.T) {
 			// Bind the generated schema against the Pulumi package metaschema so
 			// that an invalid spec (e.g. a constant default on a non-primitive
 			// property) fails the test rather than only `pulumi schema check`.
-			var spec pulumiSchema.PackageSpec
-			require.NoError(t, json.Unmarshal(got, &spec))
-			_, bindDiags, err := pulumiSchema.BindSpec(spec, errLoader{}, pulumiSchema.ValidationOptions{})
+			_, bindDiags, err := pulumiSchema.BindSpec(pkgSpec, errLoader{}, pulumiSchema.ValidationOptions{})
 			require.NoError(t, err)
 			require.False(t, bindDiags.HasErrors(), bindDiags.Error())
 
@@ -362,22 +361,26 @@ func TestBoundaryNameConversion(t *testing.T) {
 		},
 	}
 
+	propMap := func(m map[string]any) property.Map {
+		return resource.FromResourcePropertyMap(resource.NewPropertyMapFromMap(m))
+	}
+
 	// Inputs arrive camelCase (top-level names and object fields). A map's keys
 	// are user data, so a key that looks like snake_case stays verbatim.
-	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]any{
+	assert.Equal(t, propMap(map[string]any{
 		"object_in": map[string]any{"field_one": "a"},
 		"map_in":    map[string]any{"user_key": "b"},
-	}), s.InputsToHCL(resource.NewPropertyMapFromMap(map[string]any{
+	}), s.InputsToHCL(propMap(map[string]any{
 		"objectIn": map[string]any{"fieldOne": "a"},
 		"mapIn":    map[string]any{"user_key": "b"},
 	})))
 
 	// Outputs arrive snake_case from HCL; object fields become camelCase, map
 	// keys are preserved verbatim.
-	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]any{
+	assert.Equal(t, propMap(map[string]any{
 		"objectOut": map[string]any{"fieldTwo": "c"},
 		"mapOut":    map[string]any{"user_key": "d"},
-	}), s.OutputsToPulumi(resource.NewPropertyMapFromMap(map[string]any{
+	}), s.OutputsToPulumi(propMap(map[string]any{
 		"object_out": map[string]any{"field_two": "c"},
 		"map_out":    map[string]any{"user_key": "d"},
 	})))

--- a/pkg/hcl/schema/testdata/collections/schema.json
+++ b/pkg/hcl/schema/testdata/collections/schema.json
@@ -5,19 +5,19 @@
     "collections:infra:widget": {
       "description": "",
       "inputProperties": {
-        "list_of_string": {
+        "listOfString": {
           "items": {
             "type": "string"
           },
           "type": "array"
         },
-        "map_of_string": {
+        "mapOfString": {
           "additionalProperties": {
             "type": "string"
           },
           "type": "object"
         },
-        "object_value": {
+        "objectValue": {
           "properties": {
             "bool_field": {
               "type": "boolean"
@@ -28,7 +28,7 @@
           },
           "type": "object"
         },
-        "set_of_number": {
+        "setOfNumber": {
           "items": {
             "type": "number"
           },
@@ -37,31 +37,31 @@
       },
       "isComponent": true,
       "properties": {
-        "list_of_string": {
+        "listOfString": {
           "items": {
             "type": "string"
           },
           "type": "array"
         },
-        "list_of_string_output": {
+        "listOfStringOutput": {
           "items": {
             "type": "string"
           },
           "type": "array"
         },
-        "map_of_string": {
+        "mapOfString": {
           "additionalProperties": {
             "type": "string"
           },
           "type": "object"
         },
-        "map_of_string_output": {
+        "mapOfStringOutput": {
           "additionalProperties": {
             "type": "string"
           },
           "type": "object"
         },
-        "object_value": {
+        "objectValue": {
           "properties": {
             "bool_field": {
               "type": "boolean"
@@ -72,7 +72,7 @@
           },
           "type": "object"
         },
-        "set_of_number": {
+        "setOfNumber": {
           "items": {
             "type": "number"
           },

--- a/pkg/hcl/schema/testdata/collections/schema.json
+++ b/pkg/hcl/schema/testdata/collections/schema.json
@@ -1,72 +1,7 @@
 {
-  "description": "",
   "name": "collections",
-  "resources": {
-    "collections:infra:widget": {
-      "description": "",
-      "inputProperties": {
-        "listOfString": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "mapOfString": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": "object"
-        },
-        "objectValue": {
-          "$ref": "#/types/collections:infra:ObjectValue"
-        },
-        "setOfNumber": {
-          "items": {
-            "type": "number"
-          },
-          "type": "array"
-        }
-      },
-      "isComponent": true,
-      "properties": {
-        "listOfString": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "listOfStringOutput": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "mapOfString": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": "object"
-        },
-        "mapOfStringOutput": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "type": "object"
-        },
-        "objectValue": {
-          "$ref": "#/types/collections:infra:ObjectValue"
-        },
-        "setOfNumber": {
-          "items": {
-            "type": "number"
-          },
-          "type": "array"
-        }
-      },
-      "requiredInputs": null,
-      "type": "object"
-    }
-  },
+  "version": "0.0.0-dev",
+  "config": {},
   "types": {
     "collections:infra:ObjectValue": {
       "properties": {
@@ -80,5 +15,69 @@
       "type": "object"
     }
   },
-  "version": "0.0.0-dev"
+  "provider": {},
+  "resources": {
+    "collections:infra:widget": {
+      "properties": {
+        "listOfString": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "listOfStringOutput": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mapOfString": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "mapOfStringOutput": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "objectValue": {
+          "$ref": "#/types/collections:infra:ObjectValue"
+        },
+        "setOfNumber": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
+      },
+      "type": "object",
+      "inputProperties": {
+        "listOfString": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mapOfString": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "objectValue": {
+          "$ref": "#/types/collections:infra:ObjectValue"
+        },
+        "setOfNumber": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
+      },
+      "isComponent": true
+    }
+  }
 }

--- a/pkg/hcl/schema/testdata/collections/schema.json
+++ b/pkg/hcl/schema/testdata/collections/schema.json
@@ -18,15 +18,7 @@
           "type": "object"
         },
         "objectValue": {
-          "properties": {
-            "bool_field": {
-              "type": "boolean"
-            },
-            "string_field": {
-              "type": "string"
-            }
-          },
-          "type": "object"
+          "$ref": "#/types/collections:infra:ObjectValue"
         },
         "setOfNumber": {
           "items": {
@@ -62,15 +54,7 @@
           "type": "object"
         },
         "objectValue": {
-          "properties": {
-            "bool_field": {
-              "type": "boolean"
-            },
-            "string_field": {
-              "type": "string"
-            }
-          },
-          "type": "object"
+          "$ref": "#/types/collections:infra:ObjectValue"
         },
         "setOfNumber": {
           "items": {
@@ -80,6 +64,19 @@
         }
       },
       "requiredInputs": null,
+      "type": "object"
+    }
+  },
+  "types": {
+    "collections:infra:ObjectValue": {
+      "properties": {
+        "boolField": {
+          "type": "boolean"
+        },
+        "stringField": {
+          "type": "string"
+        }
+      },
       "type": "object"
     }
   },

--- a/pkg/hcl/schema/testdata/inference/schema.json
+++ b/pkg/hcl/schema/testdata/inference/schema.json
@@ -5,19 +5,19 @@
     "inference:index:inference": {
       "description": "",
       "inputProperties": {
-        "string_value": {
+        "stringValue": {
           "type": "string"
         }
       },
       "isComponent": true,
       "properties": {
-        "number_output": {
+        "numberOutput": {
           "type": "number"
         },
-        "string_output": {
+        "stringOutput": {
           "type": "string"
         },
-        "string_value": {
+        "stringValue": {
           "type": "string"
         }
       },

--- a/pkg/hcl/schema/testdata/inference/schema.json
+++ b/pkg/hcl/schema/testdata/inference/schema.json
@@ -1,15 +1,10 @@
 {
-  "description": "",
   "name": "inference",
+  "version": "0.0.0-dev",
+  "config": {},
+  "provider": {},
   "resources": {
     "inference:index:inference": {
-      "description": "",
-      "inputProperties": {
-        "stringValue": {
-          "type": "string"
-        }
-      },
-      "isComponent": true,
       "properties": {
         "numberOutput": {
           "type": "number"
@@ -21,9 +16,13 @@
           "type": "string"
         }
       },
-      "requiredInputs": null,
-      "type": "object"
+      "type": "object",
+      "inputProperties": {
+        "stringValue": {
+          "type": "string"
+        }
+      },
+      "isComponent": true
     }
-  },
-  "version": "0.0.0-dev"
+  }
 }

--- a/pkg/hcl/schema/testdata/primitives/schema.json
+++ b/pkg/hcl/schema/testdata/primitives/schema.json
@@ -1,50 +1,50 @@
 {
-  "description": "",
   "name": "primitives",
+  "version": "1.2.3",
+  "config": {},
+  "provider": {},
   "resources": {
     "primitives:index:primitives": {
-      "description": "",
-      "inputProperties": {
-        "boolValue": {
-          "default": true,
-          "type": "boolean"
-        },
-        "numberValue": {
-          "default": 1,
-          "type": "number"
-        },
-        "stringValue": {
-          "description": "The resource name.",
-          "type": "string"
-        }
-      },
-      "isComponent": true,
       "properties": {
         "boolValue": {
-          "default": true,
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "numberValue": {
-          "default": 1,
-          "type": "number"
+          "type": "number",
+          "default": 1
         },
         "stringOutput": {
-          "description": "The generated identifier.",
-          "type": "string"
+          "type": "string",
+          "description": "The generated identifier."
         },
         "stringValue": {
-          "description": "The resource name.",
-          "type": "string"
+          "type": "string",
+          "description": "The resource name."
         },
         "templateOutput": {
           "type": "string"
         }
       },
+      "type": "object",
+      "inputProperties": {
+        "boolValue": {
+          "type": "boolean",
+          "default": true
+        },
+        "numberValue": {
+          "type": "number",
+          "default": 1
+        },
+        "stringValue": {
+          "type": "string",
+          "description": "The resource name."
+        }
+      },
       "requiredInputs": [
         "stringValue"
       ],
-      "type": "object"
+      "isComponent": true
     }
-  },
-  "version": "1.2.3"
+  }
 }

--- a/pkg/hcl/schema/testdata/primitives/schema.json
+++ b/pkg/hcl/schema/testdata/primitives/schema.json
@@ -5,43 +5,43 @@
     "primitives:index:primitives": {
       "description": "",
       "inputProperties": {
-        "bool_value": {
+        "boolValue": {
           "default": true,
           "type": "boolean"
         },
-        "number_value": {
+        "numberValue": {
           "default": 1,
           "type": "number"
         },
-        "string_value": {
+        "stringValue": {
           "description": "The resource name.",
           "type": "string"
         }
       },
       "isComponent": true,
       "properties": {
-        "bool_value": {
+        "boolValue": {
           "default": true,
           "type": "boolean"
         },
-        "number_value": {
+        "numberValue": {
           "default": 1,
           "type": "number"
         },
-        "string_output": {
+        "stringOutput": {
           "description": "The generated identifier.",
           "type": "string"
         },
-        "string_value": {
+        "stringValue": {
           "description": "The resource name.",
           "type": "string"
         },
-        "template_output": {
+        "templateOutput": {
           "type": "string"
         }
       },
       "requiredInputs": [
-        "string_value"
+        "stringValue"
       ],
       "type": "object"
     }

--- a/pkg/hcl/schema/testdata/required/schema.json
+++ b/pkg/hcl/schema/testdata/required/schema.json
@@ -1,25 +1,10 @@
 {
-  "description": "",
   "name": "required",
+  "version": "0.0.0-dev",
+  "config": {},
+  "provider": {},
   "resources": {
     "required:index:required": {
-      "description": "",
-      "inputProperties": {
-        "stringA": {
-          "type": "string"
-        },
-        "stringB": {
-          "type": "string"
-        },
-        "stringC": {
-          "type": "string"
-        },
-        "stringWithDefault": {
-          "default": "ok",
-          "type": "string"
-        }
-      },
-      "isComponent": true,
       "properties": {
         "stringA": {
           "type": "string"
@@ -31,8 +16,24 @@
           "type": "string"
         },
         "stringWithDefault": {
-          "default": "ok",
+          "type": "string",
+          "default": "ok"
+        }
+      },
+      "type": "object",
+      "inputProperties": {
+        "stringA": {
           "type": "string"
+        },
+        "stringB": {
+          "type": "string"
+        },
+        "stringC": {
+          "type": "string"
+        },
+        "stringWithDefault": {
+          "type": "string",
+          "default": "ok"
         }
       },
       "requiredInputs": [
@@ -40,8 +41,7 @@
         "stringB",
         "stringC"
       ],
-      "type": "object"
+      "isComponent": true
     }
-  },
-  "version": "0.0.0-dev"
+  }
 }

--- a/pkg/hcl/schema/testdata/required/schema.json
+++ b/pkg/hcl/schema/testdata/required/schema.json
@@ -5,40 +5,40 @@
     "required:index:required": {
       "description": "",
       "inputProperties": {
-        "string_a": {
+        "stringA": {
           "type": "string"
         },
-        "string_b": {
+        "stringB": {
           "type": "string"
         },
-        "string_c": {
+        "stringC": {
           "type": "string"
         },
-        "string_with_default": {
+        "stringWithDefault": {
           "default": "ok",
           "type": "string"
         }
       },
       "isComponent": true,
       "properties": {
-        "string_a": {
+        "stringA": {
           "type": "string"
         },
-        "string_b": {
+        "stringB": {
           "type": "string"
         },
-        "string_c": {
+        "stringC": {
           "type": "string"
         },
-        "string_with_default": {
+        "stringWithDefault": {
           "default": "ok",
           "type": "string"
         }
       },
       "requiredInputs": [
-        "string_a",
-        "string_b",
-        "string_c"
+        "stringA",
+        "stringB",
+        "stringC"
       ],
       "type": "object"
     }

--- a/pkg/hcl/schema/testdata/sensitive/schema.json
+++ b/pkg/hcl/schema/testdata/sensitive/schema.json
@@ -5,32 +5,32 @@
     "sensitive:index:sensitive": {
       "description": "",
       "inputProperties": {
-        "sensitive_string": {
+        "sensitiveString": {
           "secret": true,
           "type": "string"
         },
-        "untyped_value": {
+        "untypedValue": {
           "description": "No type constraint, so it defaults to the object (any) type.",
           "type": "object"
         }
       },
       "isComponent": true,
       "properties": {
-        "sensitive_output": {
+        "sensitiveOutput": {
           "secret": true,
           "type": "string"
         },
-        "sensitive_string": {
+        "sensitiveString": {
           "secret": true,
           "type": "string"
         },
-        "untyped_value": {
+        "untypedValue": {
           "description": "No type constraint, so it defaults to the object (any) type.",
           "type": "object"
         }
       },
       "requiredInputs": [
-        "sensitive_string"
+        "sensitiveString"
       ],
       "type": "object"
     }

--- a/pkg/hcl/schema/testdata/sensitive/schema.json
+++ b/pkg/hcl/schema/testdata/sensitive/schema.json
@@ -1,39 +1,39 @@
 {
-  "description": "",
   "name": "sensitive",
+  "version": "0.0.0-dev",
+  "config": {},
+  "provider": {},
   "resources": {
     "sensitive:index:sensitive": {
-      "description": "",
-      "inputProperties": {
-        "sensitiveString": {
-          "secret": true,
-          "type": "string"
-        },
-        "untypedValue": {
-          "description": "No type constraint, so it defaults to the object (any) type.",
-          "type": "object"
-        }
-      },
-      "isComponent": true,
       "properties": {
         "sensitiveOutput": {
-          "secret": true,
-          "type": "string"
+          "type": "string",
+          "secret": true
         },
         "sensitiveString": {
-          "secret": true,
-          "type": "string"
+          "type": "string",
+          "secret": true
         },
         "untypedValue": {
-          "description": "No type constraint, so it defaults to the object (any) type.",
-          "type": "object"
+          "type": "object",
+          "description": "No type constraint, so it defaults to the object (any) type."
+        }
+      },
+      "type": "object",
+      "inputProperties": {
+        "sensitiveString": {
+          "type": "string",
+          "secret": true
+        },
+        "untypedValue": {
+          "type": "object",
+          "description": "No type constraint, so it defaults to the object (any) type."
         }
       },
       "requiredInputs": [
         "sensitiveString"
       ],
-      "type": "object"
+      "isComponent": true
     }
-  },
-  "version": "0.0.0-dev"
+  }
 }

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -327,7 +327,8 @@ func (p *HCLProvider) Construct(ctx context.Context, req *pulumirpc.ConstructReq
 	// camelCase object fields); map them to the snake_case names the HCL module
 	// declares, at every nesting depth.
 	config := make(map[string]string)
-	for k, v := range p.schema.InputsToHCL(inputs) {
+	hclInputs := resource.ToResourcePropertyMap(p.schema.InputsToHCL(resource.FromResourcePropertyMap(inputs)))
+	for k, v := range hclInputs {
 		configKey := req.Project + ":" + string(k)
 		if v.IsString() {
 			config[configKey] = v.StringValue()
@@ -555,8 +556,7 @@ func (m *constructResourceMonitor) RegisterResourceOutputs(
 	// names the schema declares, at every nesting depth. Child resources already
 	// carry their own correctly-cased property names.
 	if urn == m.componentURN {
-		converted := m.moduleSchema.OutputsToPulumi(resource.ToResourcePropertyMap(outputs))
-		outputs = resource.FromResourcePropertyMap(converted)
+		outputs = m.moduleSchema.OutputsToPulumi(outputs)
 		m.outputs = outputs
 	}
 

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/run"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/schema"
-	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
 	pulumiSchema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -320,18 +319,20 @@ func (p *HCLProvider) Construct(ctx context.Context, req *pulumirpc.ConstructReq
 		replaceWith:             req.ReplaceWith,
 		customTimeouts:          req.CustomTimeouts,
 		replacementTrigger:      req.ReplacementTrigger,
+		moduleSchema:            p.schema,
 	}
 
 	// Set up config from inputs, prefixing with project name as the engine
-	// expects. Inputs arrive under their camelCase schema property names; recover
-	// the snake_case HCL variable name the module declares.
+	// expects. Inputs arrive under their camelCase schema property names (with
+	// camelCase object fields); map them to the snake_case names the HCL module
+	// declares, at every nesting depth.
 	config := make(map[string]string)
-	for k, v := range inputs {
-		configKey := req.Project + ":" + transform.SnakeCaseFromPulumiCase(string(k))
+	for k, v := range p.schema.InputsToHCL(inputs) {
+		configKey := req.Project + ":" + string(k)
 		if v.IsString() {
 			config[configKey] = v.StringValue()
 		} else {
-			jsonVal, _ := json.Marshal(v.V)
+			jsonVal, _ := json.Marshal(v.Mappable())
 			config[configKey] = string(jsonVal)
 		}
 	}
@@ -423,6 +424,10 @@ type constructResourceMonitor struct {
 
 	componentURN urn.URN
 	outputs      property.Map
+
+	// moduleSchema maps the component's snake_case HCL output names to the
+	// camelCase schema property names when registering its outputs.
+	moduleSchema *schema.ModuleSchema
 }
 
 // RegisterResource registers a resource.
@@ -546,15 +551,12 @@ func (m *constructResourceMonitor) RegisterResourceOutputs(
 	outputs property.Map,
 ) error {
 	// The component's outputs are keyed by the HCL module's snake_case output
-	// names; expose them under the camelCase names the schema declares. Child
-	// resources already carry their own correctly-cased property names.
+	// names (with snake_case object fields); expose them under the camelCase
+	// names the schema declares, at every nesting depth. Child resources already
+	// carry their own correctly-cased property names.
 	if urn == m.componentURN {
-		converted := make(map[string]property.Value, outputs.Len())
-		for k, v := range outputs.AsMap() {
-			camel, _ := transform.PulumiCaseFromSnakeCase(k, nil)
-			converted[camel] = v
-		}
-		outputs = property.NewMap(converted)
+		converted := m.moduleSchema.OutputsToPulumi(resource.ToResourcePropertyMap(outputs))
+		outputs = resource.FromResourcePropertyMap(converted)
 		m.outputs = outputs
 	}
 

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/run"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/schema"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
 	pulumiSchema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -321,10 +322,12 @@ func (p *HCLProvider) Construct(ctx context.Context, req *pulumirpc.ConstructReq
 		replacementTrigger:      req.ReplacementTrigger,
 	}
 
-	// Set up config from inputs, prefixing with project name as the engine expects.
+	// Set up config from inputs, prefixing with project name as the engine
+	// expects. Inputs arrive under their camelCase schema property names; recover
+	// the snake_case HCL variable name the module declares.
 	config := make(map[string]string)
 	for k, v := range inputs {
-		configKey := req.Project + ":" + string(k)
+		configKey := req.Project + ":" + transform.SnakeCaseFromPulumiCase(string(k))
 		if v.IsString() {
 			config[configKey] = v.StringValue()
 		} else {
@@ -542,8 +545,16 @@ func (m *constructResourceMonitor) RegisterResourceOutputs(
 	urn urn.URN,
 	outputs property.Map,
 ) error {
-	// Track outputs for the component
+	// The component's outputs are keyed by the HCL module's snake_case output
+	// names; expose them under the camelCase names the schema declares. Child
+	// resources already carry their own correctly-cased property names.
 	if urn == m.componentURN {
+		converted := make(map[string]property.Value, outputs.Len())
+		for k, v := range outputs.AsMap() {
+			camel, _ := transform.PulumiCaseFromSnakeCase(k, nil)
+			converted[camel] = v
+		}
+		outputs = property.NewMap(converted)
 		m.outputs = outputs
 	}
 

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -167,18 +167,25 @@ func TestSmokeModule(t *testing.T) {
 	runPulumi(t, "package", "add", "../randommodule")
 
 	// The pet name flows from a not-yet-created `random_pet` inside the
-	// component, so the root output is unknown during preview.
-	require.Regexp(t, regexp.MustCompile(`pet: \[unknown\]`), string(runPulumi(t, "preview")),
-		"pet output should be unknown at preview")
+	// component, so that output is unknown during preview.
+	require.Regexp(t, regexp.MustCompile(`pet_name\s*: \[unknown\]`), string(runPulumi(t, "preview")),
+		"pet_name output should be unknown at preview")
 
 	runPulumi(t, "up", "--yes", "--skip-preview")
 
-	// `length = 3` produces "<word>-<word>-<word>" (lowercase letters only).
+	// The multi-word `pet_length`, nested object field `string_field`, and map
+	// value `user_key` all round-trip through the component, which only works if
+	// the boundary translates object/field names (but not map keys) in both
+	// directions: a snake_case HCL module exposed under a camelCase schema.
 	outputs := parseStackOutput(t, runPulumi(t, "stack", "output", "--json"))
-	pet, ok := outputs["pet"].(string)
-	require.True(t, ok, "pet output must be a string, got %T (%v)", outputs["pet"], outputs["pet"])
-	require.Regexp(t, regexp.MustCompile(`^[a-z]+-[a-z]+-[a-z]+$`), pet,
-		"pet output should match '<word>-<word>-<word>'")
+
+	petName, ok := outputs["pet_name"].(string)
+	require.True(t, ok, "pet_name must be a string, got %T (%v)", outputs["pet_name"], outputs["pet_name"])
+	require.Regexp(t, regexp.MustCompile(`^[a-z]+-[a-z]+-[a-z]+$`), petName,
+		"pet_length = 3 should yield a three-word pet name")
+
+	require.Equal(t, "hello", outputs["object_field"], "object field value should round-trip")
+	require.Equal(t, "world", outputs["map_field"], "map value (keyed by a preserved key) should round-trip")
 
 	runPulumi(t, "destroy", "--yes", "--skip-preview")
 }

--- a/tests/smoke/testdata/module/program/main.tf
+++ b/tests/smoke/testdata/module/program/main.tf
@@ -1,7 +1,21 @@
 resource "randommodule" "pet" {
-  length = 3
+  pet_length = 3
+  object_value = {
+    string_field = "hello"
+  }
+  map_value = {
+    user_key = "world"
+  }
 }
 
-output "pet" {
-  value = randommodule.pet.pet
+output "pet_name" {
+  value = randommodule.pet.pet_name
+}
+
+output "object_field" {
+  value = randommodule.pet.echo_object.string_field
+}
+
+output "map_field" {
+  value = randommodule.pet.echo_map.user_key
 }

--- a/tests/smoke/testdata/module/randommodule/main.tf
+++ b/tests/smoke/testdata/module/randommodule/main.tf
@@ -7,14 +7,35 @@ terraform {
   }
 }
 
-variable "length" {
+# Multi-word and nested names exercise the snake_case<->camelCase translation at
+# the component boundary: the schema exposes camelCase, the HCL module is
+# snake_case. Object fields are renamed; the dynamic keys of a map are not.
+variable "pet_length" {
   type = number
 }
 
-resource "random_pet" "name" {
-  length = var.length
+variable "object_value" {
+  type = object({
+    string_field = string
+  })
 }
 
-output "pet" {
+variable "map_value" {
+  type = map(string)
+}
+
+resource "random_pet" "name" {
+  length = var.pet_length
+}
+
+output "pet_name" {
   value = random_pet.name.id
+}
+
+output "echo_object" {
+  value = var.object_value
+}
+
+output "echo_map" {
+  value = var.map_value
 }


### PR DESCRIPTION
## What

An HCL `variable` or `output` name is snake_case (e.g. `list_of_string`), but Pulumi conventionally names component properties in camelCase (`listOfString`). This exposes a file-based Multi-Language Component's inputs and outputs under camelCase property names, while the HCL module continues to use its native snake_case names internally.

## How

The conversion is confined to the engine↔module boundary:

- **Schema** (`ToPulumiPackageSchema`): input properties, output properties, and `requiredInputs` are emitted under their camelCase names (via `transform.PulumiCaseFromSnakeCase`). The internal `ModuleSchema` stays snake_case.
- **Construct** (`provider.go`): an incoming input — keyed by its camelCase schema property name — is mapped back to the snake_case HCL `variable` name (`transform.SnakeCaseFromPulumiCase`) when building the engine config; the module's snake_case `output` values are re-keyed to camelCase before they're returned as the component's outputs.

`run.go` and the HCL evaluation scope are untouched and remain snake_case-native. Names without underscores (e.g. `length`, `pet`) are unchanged.

## Scope

Top-level input/output names only. **Nested object-field names stay snake_case** — converting them (e.g. `object({ string_field = … })` → `stringField`) would require recursively translating the field keys *within* property values at Construct, not just the schema; that's a separate change.

## Tests

The golden fixtures (`pkg/hcl/schema/testdata/`) now show camelCase property names and still bind against the Pulumi metaschema. The full `pkg/hcl/...` and `pkg/server` suites pass.