### PR TITLE
Recognize `pulumi/`-sourced providers declared in child modules

### DIFF
--- a/.changes/unreleased/language-host-bug-fixes-275.yaml
+++ b/.changes/unreleased/language-host-bug-fixes-275.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Recognize `pulumi/`-sourced providers declared in child modules as needing no local SDK
+time: 2026-06-17T18:54:59Z
+custom:
+    Component: language-host
+    PR: "275"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -313,37 +312,20 @@ func readParameterizationInfos(dir string) (map[string]workspace.PackageDescript
 func missingNonPulumiSDKs(
 	ctx context.Context, config *ast.Config, sdks map[string]workspace.PackageDescriptor, workDir string,
 ) []string {
-	used := usedProviders(ctx, config, workDir)
-	pulumiSourced := map[string]bool{}
-	if config != nil && config.Terraform != nil {
-		for alias, req := range config.Terraform.RequiredProviders {
-			if req.IsPulumi() {
-				pulumiSourced[alias] = true
-			}
-		}
-	}
+	_, _, aliases := collectRequirements(ctx, config, workDir)
 	var missing []string
-	for _, alias := range used {
-		if isBuiltinProvider(alias) || pulumiSourced[alias] {
+	for _, alias := range sortedKeys(aliases) {
+		if isBuiltinProvider(alias) || aliases[alias].IsPulumi() {
 			continue
 		}
 		if _, ok := sdks[alias]; !ok {
 			missing = append(missing, alias)
 		}
 	}
-	sort.Strings(missing)
 	return missing
 }
 
 func isBuiltinProvider(alias string) bool { return alias == "pulumi" || alias == "terraform" }
-
-// usedProviders returns the sorted provider local names referenced by config
-// (required_providers, provider blocks, resource/data type prefixes). A
-// non-empty workDir enables recursion through `module` blocks.
-func usedProviders(ctx context.Context, config *ast.Config, workDir string) []string {
-	_, _, aliases := collectRequirements(ctx, config, workDir)
-	return sortedKeys(aliases)
-}
 
 // versionSet is a deduplicated set of version constraints declared for one
 // provider source. constraint() joins them in sorted order — so the emitted
@@ -369,8 +351,8 @@ func (v *versionSet) constraint() string { return strings.Join(sortedKeys(v.seen
 //   - tf: non-Pulumi sources mapped to the union of version constraints
 //     declared for them across the module tree;
 //   - pulumi: pulumi/<name>-sourced packages mapped to their version;
-//   - aliases: every provider local name referenced (the set usedProviders
-//     reports), builtins included.
+//   - aliases: every provider local name referenced, mapped to its resolved
+//     required_providers entry (nil for implicit providers), builtins included.
 //
 // Each local name is resolved to its source within the module that uses it (its
 // own required_providers, else the "hashicorp/<name>" default), so a provider

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -500,6 +500,41 @@ func TestMissingNonPulumiSDKs_BuiltinProvider(t *testing.T) {
 	assert.Empty(t, missingNonPulumiSDKs(t.Context(), cfg, nil, ""))
 }
 
+// A pulumi-sourced provider declared only in a child module must not be
+// reported missing: it needs no local SDK regardless of which module declares
+// it.
+func TestMissingNonPulumiSDKs_PulumiSourceInChildModule(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+module "deploy" {
+  source = "./deploy"
+}
+`), 0o600))
+
+	childDir := filepath.Join(dir, "deploy")
+	require.NoError(t, os.MkdirAll(childDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(childDir, "main.tf"), []byte(`
+terraform {
+  required_providers {
+    example = {
+      source = "pulumi/example"
+    }
+  }
+}
+
+provider "example" {}
+
+resource "example_resource" "hello" {}
+`), 0o600))
+
+	cfg, diags := parser.NewParser().ParseDirectory(dir)
+	require.False(t, diags.HasErrors(), "diags: %v", diags)
+
+	assert.Empty(t, missingNonPulumiSDKs(t.Context(), cfg, nil, dir))
+}
+
 // A provider local name that contains underscores (e.g. "snake_names") must
 // be resolved against the declared providers, not split at the first
 // underscore. The naive split yielded a spurious "snake" provider that was


### PR DESCRIPTION
## Problem

When a `pulumi/`-sourced provider is declared in a child module rather than the root, `pulumi up` fails with:

```
error: an unhandled error occurred: missing local SDK for non-Pulumi provider(s) [kubernetes]; run `pulumi install` to fetch them
```

`pulumi install` does not help, because a full Pulumi provider (e.g. `pulumi/kubernetes`) needs no local SDK at all.

## Root cause

`missingNonPulumiSDKs` (in `pkg/server/server.go`) enumerates the *used* providers by recursing through `module` blocks, but built its pulumi-sourced allow-set from **only the root module's** `required_providers`. A provider declared solely in a child module was therefore counted as used yet never recognized as pulumi-sourced, so it was reported as a missing non-Pulumi SDK.

## Fix

Derive the pulumi-sourced set from `collectRequirements` — the same module-recursive walk that already enumerates used providers — so each alias is checked against its *resolved* `required_providers` entry via `req.IsPulumi()`. A pulumi provider declared anywhere in the module tree is now correctly skipped. This also removes the now-orphaned `usedProviders` helper.

## Test

Added `TestMissingNonPulumiSDKs_PulumiSourceInChildModule`, which declares `pulumi/example` in a child module and asserts nothing is reported missing. It fails before the fix (`Should be empty, but was [example]`) and passes after.