### PR TITLE
Run variable validation on module input values

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-277.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-277.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Run a `variable`'s `validation` blocks on module input values
+time: 2026-06-17T19:17:36Z
+custom:
+    Component: runtime
+    PR: "277"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -701,10 +701,16 @@ func (e *Engine) processVariable(_ context.Context, node *graph.Node) error {
 	// Store in eval context (needed for validation which may reference var.<name>)
 	e.evaluator.Context().SetVariable(varName, val)
 
-	// Run validations
-	for i, validation := range v.Validations {
-		// Evaluate condition
-		condVal, diags := e.evaluator.EvaluateExpression(validation.Condition)
+	return runVariableValidations(e.evaluator, varName, v.Validations)
+}
+
+// runVariableValidations evaluates a variable's `validation` rules against ev
+// (whose context must already hold the variable's value). It returns an error
+// for the first rule whose condition is known and false; unknown conditions are
+// deferred.
+func runVariableValidations(ev *eval.Evaluator, varName string, validations []*ast.Validation) error {
+	for i, validation := range validations {
+		condVal, diags := ev.EvaluateExpression(validation.Condition)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating validation condition %d for variable %q: %s", i+1, varName, diags.Error())
 		}
@@ -719,7 +725,7 @@ func (e *Engine) processVariable(_ context.Context, node *graph.Node) error {
 		}
 
 		if !condOK {
-			errMsgVal, diags := e.evaluator.EvaluateExpression(validation.ErrorMessage)
+			errMsgVal, diags := ev.EvaluateExpression(validation.ErrorMessage)
 			errMsg := "validation failed"
 			if !diags.HasErrors() {
 				if s := renderErrorMessage(errMsgVal); s != "" {
@@ -3029,7 +3035,8 @@ func (e *Engine) processModuleVariable(node *graph.Node) error {
 		}
 
 		inst.EvalCtx.SetVariable(varName, val)
-		return nil
+
+		return runVariableValidations(eval.NewEvaluator(inst.EvalCtx), varName, v.Validations)
 	})
 }
 

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -1067,6 +1067,77 @@ output "item_count" {
 	})
 }
 
+func TestEngine_ModuleVariableValidation(t *testing.T) {
+	t.Parallel()
+
+	const childMain = `
+variable "name" {
+  type = string
+
+  validation {
+    condition     = length(var.name) > 3
+    error_message = "name must be longer than three characters"
+  }
+}
+
+output "name" {
+  value = var.name
+}
+`
+	run := func(t *testing.T, name string) (*testutil.MockResourceMonitor, error) {
+		tmpDir := t.TempDir()
+		moduleDir := tmpDir + "/modules/child"
+		require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+		require.NoError(t, os.WriteFile(moduleDir+"/main.tf", []byte(childMain), 0o644))
+		rootMain := `
+module "child" {
+  source = "./modules/child"
+  name   = "` + name + `"
+}
+
+output "name" {
+  value = module.child.name
+}
+`
+		require.NoError(t, os.WriteFile(tmpDir+"/main.tf", []byte(rootMain), 0o644))
+
+		p := parser.NewParser()
+		config, diags := p.ParseDirectory(tmpDir)
+		require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+		mock := &testutil.MockResourceMonitor{}
+		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ProjectName:     "test-project",
+			StackName:       "dev",
+			ResourceMonitor: mock,
+			WorkDir:         tmpDir,
+			RootDir:         tmpDir,
+			SchemaLoader:    schemaloader.New(t, schema.PackageSpec{Name: "empty"}),
+		})
+		return mock, engine.Run(t.Context())
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := run(t, "widget")
+		require.NoError(t, err)
+
+		output, ok := mock.StackOutputs.GetOk("name")
+		require.True(t, ok, "expected name output")
+		assert.Equal(t, "widget", output.AsString())
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := run(t, "xy")
+		assert.EqualError(t, err,
+			`validation failed for variable "name": name must be longer than three characters`+
+				"\ncontext canceled")
+	})
+}
+
 func TestEngine_ModuleSensitiveOutput(t *testing.T) {
 	t.Parallel()
 

--- a/tests/testutil/pulexec/run.go
+++ b/tests/testutil/pulexec/run.go
@@ -65,6 +65,16 @@ func serveLanguageHost(t *testing.T) int {
 	return handle.Port
 }
 
+// languageHostGuard writes a pulumi-language-hcl executable into a fresh temp
+// dir that fails loudly when run, and returns that dir.
+func languageHostGuard(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	stub := "#!/bin/sh\necho 'should not use HCL language binary' >&2\nexit 1\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "pulumi-language-hcl"), []byte(stub), 0o755))
+	return dir
+}
+
 // Provider pairs a provider name with a way to start its in-process Pulumi
 // provider server. Use SDKv2Provider or PFProvider to build one.
 type Provider struct {
@@ -120,6 +130,9 @@ backend:
 		make([]opttest.Option, 0, 5+len(provs)),
 		opttest.Env("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true"),
 		opttest.Env("PULUMI_DEBUG_LANGUAGES", fmt.Sprintf("hcl:%d", hostPort)),
+		// The runtime under test is served in-process via PULUMI_DEBUG_LANGUAGES, so
+		// the engine must never spawn (or download) the pulumi-language-hcl binary.
+		opttest.Env("PATH", languageHostGuard(t)+string(os.PathListSeparator)+os.Getenv("PATH")),
 		opttest.TestInPlace(),
 		opttest.SkipInstall(),
 		// Cleanup destroy fails on prevent_destroy cases; temp dir is

--- a/tests/tfcompat/l2_module_variable_validation_test.go
+++ b/tests/tfcompat/l2_module_variable_validation_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL2ModuleVariableValidation asserts that a `validation` block on a child
+// module's input variable runs against the value the parent passes in: an
+// invalid value must make both runtimes fail with the configured error message,
+// matching OpenTofu.
+func TestL2ModuleVariableValidation(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_variable_validation", tfcompat.Case{
+		Stages: []tfcompat.Stage{{
+			Files: map[string]string{
+				"main.tf": `
+module "child" {
+  source = "./child"
+  name   = "x"
+}
+
+output "name" {
+  value = module.child.name
+}
+`,
+				"child/main.tf": `
+variable "name" {
+  type = string
+
+  validation {
+    condition     = length(var.name) > 3
+    error_message = "VALIDATION_FAILED_MODULE_VAR_TOO_SHORT"
+  }
+}
+
+output "name" {
+  value = var.name
+}
+`,
+			},
+			ExpectErr: "VALIDATION_FAILED_MODULE_VAR_TOO_SHORT",
+		}},
+	})
+}


### PR DESCRIPTION
## Problem

A `validation` block on a child module's input variable was silently ignored. Given:

```hcl
# root
module "child" {
  source = "./child"
  name   = "x"
}

# child
variable "name" {
  type = string
  validation {
    condition     = length(var.name) > 3
    error_message = "name must be longer than three characters"
  }
}
```

OpenTofu rejects `tofu apply` with `Invalid value for variable` / the configured error message. pulumi-hcl applied cleanly, skipping the check.

## Root cause

Root-level variables run their validation rules in `processVariable` (`pkg/hcl/run/run.go`). Module input variables take a separate path through `processModuleVariable`, which evaluated the input, applied type/`nullable` handling, and set the value — but never evaluated the `validation` rules.

## Fix

Extract the validation loop into `runVariableValidations` and call it from both paths. The module path evaluates each rule against the module instance's own evaluation context, so conditions referencing `var.<name>` resolve correctly per instance under `count`/`for_each`.

## Sweep

- **Resources** inside modules already enforce `precondition`/`postcondition` — they share the single `processResource` path regardless of nesting, so there is no asymmetry there.
- **Output `precondition`** blocks are parsed but evaluated *nowhere* (root or module). That is a distinct, pre-existing unimplemented-feature gap rather than a sibling of this root cause, so it is left out of this PR.

## Tests

- `tests/tfcompat/l2_module_variable_validation_test.go` — fails on `master` (OpenTofu errors, pulumi does not), passes with the fix.
- `TestEngine_ModuleVariableValidation` in `pkg/hcl/run/run_test.go` — unit coverage for the valid and invalid module-input cases.

The first commit on this branch hardens the tfcompat harness: it puts a `pulumi-language-hcl` stub on the engine's PATH that hard-errors if executed, so any fallback to spawning the plugin binary (instead of attaching to the in-process host via `PULUMI_DEBUG_LANGUAGES`) surfaces as a clear error rather than a confusing plugin-download failure.

All `pkg/hcl/run`, `pkg/server`, and `tests/tfcompat` suites pass.