### PR TITLE
Enforce output precondition blocks

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-278.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-278.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Enforce an `output`'s `precondition` blocks
+time: 2026-06-17T19:33:11Z
+custom:
+    Component: runtime
+    PR: "278"

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -406,7 +406,7 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 
 	// Add output nodes
 	for name, output := range config.Outputs {
-		deps := g.exprDeps(output.Value, "")
+		deps := g.outputDeps(output, "")
 		err := g.AddNode(&Node{
 			Key:    "output." + name,
 			Type:   NodeTypeOutput,
@@ -678,6 +678,18 @@ func (g *Graph) bodyDeps(body hcl.Body, prefix string, exclude map[string]bool) 
 	}
 
 	return slices.Collect(maps.Keys(seen))
+}
+
+// outputDeps gathers an output node's dependencies: its value expression plus
+// the condition and error-message expressions of every precondition, so an
+// output is sequenced after everything its precondition references.
+func (g *Graph) outputDeps(output *ast.Output, prefix string) []pdag.Node {
+	deps := g.exprDeps(output.Value, prefix)
+	for _, rule := range output.Preconditions {
+		deps = append(deps, g.exprDeps(rule.Condition, prefix)...)
+		deps = append(deps, g.exprDeps(rule.ErrorMessage, prefix)...)
+	}
+	return deps
 }
 
 // exprDeps extracts all dependencies from an expression, applying prefix to resolved keys.
@@ -1023,7 +1035,7 @@ func (g *Graph) inlineModule(
 
 	// Outputs
 	for outputName, output := range loaded.Config.Outputs {
-		deps := g.exprDeps(output.Value, prefix)
+		deps := g.outputDeps(output, prefix)
 		deps = append(deps, initIdx)
 		if err := g.AddNode(&Node{
 			Key:        prefix + "output." + outputName,

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -3197,6 +3197,9 @@ func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error 
 	isForEach := mod.ForEach != nil
 
 	err := e.forEachModuleInstance(node, func(inst *moduleInstance) error {
+		if err := runOutputPreconditions(output, inst.EvalCtx.HCLContext(), outputName); err != nil {
+			return err
+		}
 		val, diags := output.Value.Value(inst.EvalCtx.HCLContext())
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating module output %s: %s", outputName, diags.Error())
@@ -3420,6 +3423,10 @@ func (e *Engine) registerComponentResource(
 
 // processOutput processes an output definition.
 func (e *Engine) processOutput(_ context.Context, name string, output *ast.Output) error {
+	if err := runOutputPreconditions(output, e.evaluator.Context().HCLContext(), name); err != nil {
+		return err
+	}
+
 	// Evaluate the output value, intercepting can() calls.
 	val, diags := e.evaluator.EvaluateExpression(output.Value)
 	if diags.HasErrors() {
@@ -3659,6 +3666,18 @@ func conditionResultToBool(v cty.Value) (bool, error) {
 		return false, fmt.Errorf("condition must return either true or false, not null")
 	}
 	return converted.True(), nil
+}
+
+// runOutputPreconditions evaluates an output's `precondition` rules against
+// hclCtx and returns an error for the first rule whose condition is known and
+// false; unknown conditions are deferred.
+func runOutputPreconditions(output *ast.Output, hclCtx *hcl.EvalContext, name string) error {
+	for i, rule := range output.Preconditions {
+		if err := evaluatePrecondition(rule, hclCtx, i+1, fmt.Sprintf("output %q", name)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // evaluatePrecondition returns nil when the rule holds or its condition is

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/run"
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil"
@@ -1135,6 +1136,117 @@ output "name" {
 		assert.EqualError(t, err,
 			`validation failed for variable "name": name must be longer than three characters`+
 				"\ncontext canceled")
+	})
+}
+
+func TestEngine_OutputPrecondition(t *testing.T) {
+	t.Parallel()
+
+	newEngine := func(t *testing.T, config *ast.Config, workDir string) (*testutil.MockResourceMonitor, *run.Engine) {
+		mock := &testutil.MockResourceMonitor{}
+		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ProjectName:     "test-project",
+			StackName:       "dev",
+			ResourceMonitor: mock,
+			WorkDir:         workDir,
+			RootDir:         workDir,
+			SchemaLoader:    schemaloader.New(t, schema.PackageSpec{Name: "empty"}),
+		})
+		return mock, engine
+	}
+
+	t.Run("root_pass", func(t *testing.T) {
+		t.Parallel()
+
+		src := []byte(`
+variable "enabled" {
+  type    = bool
+  default = true
+}
+
+output "result" {
+  value = "ok"
+
+  precondition {
+    condition     = var.enabled
+    error_message = "must be enabled"
+  }
+}
+`)
+		config, diags := parser.NewParser().ParseSource("test.hcl", src)
+		require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+		mock, engine := newEngine(t, config, t.TempDir())
+		require.NoError(t, engine.Run(t.Context()))
+
+		output, ok := mock.StackOutputs.GetOk("result")
+		require.True(t, ok, "expected result output")
+		assert.Equal(t, "ok", output.AsString())
+	})
+
+	t.Run("root_fail", func(t *testing.T) {
+		t.Parallel()
+
+		src := []byte(`
+variable "enabled" {
+  type    = bool
+  default = false
+}
+
+output "result" {
+  value = "ok"
+
+  precondition {
+    condition     = var.enabled
+    error_message = "must be enabled"
+  }
+}
+`)
+		config, diags := parser.NewParser().ParseSource("test.hcl", src)
+		require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+		_, engine := newEngine(t, config, t.TempDir())
+		assert.EqualError(t, engine.Run(t.Context()),
+			`processing output result: precondition for output "result": must be enabled`)
+	})
+
+	t.Run("module_fail", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		moduleDir := tmpDir + "/modules/child"
+		require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+		require.NoError(t, os.WriteFile(moduleDir+"/main.tf", []byte(`
+variable "ok" {
+  type    = bool
+  default = false
+}
+
+output "result" {
+  value = "ok"
+
+  precondition {
+    condition     = var.ok
+    error_message = "child output not ok"
+  }
+}
+`), 0o644))
+		require.NoError(t, os.WriteFile(tmpDir+"/main.tf", []byte(`
+module "child" {
+  source = "./modules/child"
+}
+
+output "child_result" {
+  value = module.child.result
+}
+`), 0o644))
+
+		config, diags := parser.NewParser().ParseDirectory(tmpDir)
+		require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+		_, engine := newEngine(t, config, tmpDir)
+		assert.EqualError(t, engine.Run(t.Context()),
+			`precondition for output "result": child output not ok`+"\ncontext canceled")
 	})
 }
 

--- a/tests/tfcompat/output_precondition_test.go
+++ b/tests/tfcompat/output_precondition_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1OutputPrecondition asserts that a failing `precondition` on a top-level
+// output makes both runtimes fail with the configured error message, matching
+// OpenTofu.
+func TestL1OutputPrecondition(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_output_precondition", tfcompat.Case{
+		Stages: []tfcompat.Stage{{
+			Files: map[string]string{"main.tf": `
+variable "enabled" {
+  type    = bool
+  default = false
+}
+
+output "result" {
+  value = "ok"
+
+  precondition {
+    condition     = var.enabled
+    error_message = "OUTPUT_PRECONDITION_FAILED"
+  }
+}
+`},
+			ExpectErr: "OUTPUT_PRECONDITION_FAILED",
+		}},
+	})
+}
+
+// TestL2ModuleOutputPrecondition asserts that a failing `precondition` on a
+// child module's output makes both runtimes fail with the configured error
+// message, matching OpenTofu.
+func TestL2ModuleOutputPrecondition(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_output_precondition", tfcompat.Case{
+		Stages: []tfcompat.Stage{{
+			Files: map[string]string{
+				"main.tf": `
+module "child" {
+  source = "./child"
+}
+
+output "child_result" {
+  value = module.child.result
+}
+`,
+				"child/main.tf": `
+variable "ok" {
+  type    = bool
+  default = false
+}
+
+output "result" {
+  value = "ok"
+
+  precondition {
+    condition     = var.ok
+    error_message = "MODULE_OUTPUT_PRECONDITION_FAILED"
+  }
+}
+`,
+			},
+			ExpectErr: "MODULE_OUTPUT_PRECONDITION_FAILED",
+		}},
+	})
+}


### PR DESCRIPTION
## Problem

A `precondition` block on an `output` was parsed (`ast.Output.Preconditions`) but never evaluated, so a failing precondition did not stop the operation. OpenTofu fails the apply:

```hcl
output "result" {
  value = "ok"
  precondition {
    condition     = var.enabled   # false
    error_message = "OUTPUT_PRECONDITION_FAILED"
  }
}
```

```
$ tofu apply
Error: Module output value precondition failed
OUTPUT_PRECONDITION_FAILED
```

pulumi-hcl applied cleanly, ignoring the check — at the top level and inside modules.

## Fix

- Evaluate output preconditions on both output paths (`processOutput` and `processModuleOutput`) via a shared `runOutputPreconditions` helper that reuses the existing `evaluatePrecondition` (so unknown-condition deferral, bool coercion, and sensitive error-message rendering all match the resource-condition path). The module path evaluates each rule against the module instance's own context.
- Add the precondition `condition` and `error_message` expression references to each output node's graph dependencies (`outputDeps`, applied at both the root and module output sites). A precondition can reference values the output value expression does not; without these edges the nested-module case raced — the output was processed before the variable its precondition reads, so `var.ok` resolved as "unsupported attribute" instead of failing the precondition.

## Sweep

- **Resource `precondition`/`postcondition`** already evaluate and already get graph deps (via `bodyDeps` recursion into the lifecycle block); they share one `processResource` path regardless of module nesting — no asymmetry.
- **`check` blocks** are already handled by `evaluateChecks`.
- **Output `postcondition`** is not a Terraform concept, so only preconditions apply.
- **Variable `validation`** conditions that reference symbols beyond the variable itself still contribute no graph-dependency edges — a separate, pre-existing gap in the validation feature, left out of this PR.

## Tests

- `tests/tfcompat/output_precondition_test.go` — `TestL1OutputPrecondition` (top level) and `TestL2ModuleOutputPrecondition` (nested module). Both failed on `master` (OpenTofu errored, pulumi did not) and pass with the fix.
- `TestEngine_OutputPrecondition` in `pkg/hcl/run/run_test.go` — engine unit coverage for root pass, root fail, and module fail.

All `pkg/hcl/...`, `pkg/server`, and `tests/tfcompat` suites pass.