### PR TITLE
Sequence variables after their validation references

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-279.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-279.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Sequence a `variable` after the values its `validation` references
+time: 2026-06-17T20:35:17Z
+custom:
+    Component: runtime
+    PR: "279"

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -326,13 +326,14 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 		}, nil),
 	), "nodes without dependencies cannot error")
 
-	// Add variable nodes (no dependencies, they come from outside)
+	// Variable values come from outside, so a variable depends only on whatever
+	// its validation rules reference (e.g. another variable).
 	for name, v := range config.Variables {
 		err := g.AddNode(&Node{
 			Key:      "var." + name,
 			Type:     NodeTypeVariable,
 			Variable: v,
-		}, nil)
+		}, g.variableValidationDeps(v, "var."+name, ""))
 		if err != nil {
 			return nil, err
 		}
@@ -692,6 +693,20 @@ func (g *Graph) outputDeps(output *ast.Output, prefix string) []pdag.Node {
 	return deps
 }
 
+// variableValidationDeps gathers the graph dependencies of a variable's
+// `validation` rules — the condition and error-message expressions — minus a
+// self-reference to the variable being validated, which is always in scope and
+// would otherwise form a cycle.
+func (g *Graph) variableValidationDeps(v *ast.Variable, key, prefix string) []pdag.Node {
+	_, self := g.newNode(key)
+	var deps []pdag.Node
+	for _, rule := range v.Validations {
+		deps = append(deps, g.exprDeps(rule.Condition, prefix)...)
+		deps = append(deps, g.exprDeps(rule.ErrorMessage, prefix)...)
+	}
+	return slices.DeleteFunc(deps, func(n pdag.Node) bool { return n == self })
+}
+
 // exprDeps extracts all dependencies from an expression, applying prefix to resolved keys.
 func (g *Graph) exprDeps(expr hcl.Expression, prefix string) []pdag.Node {
 	return g.exprDepsExcluding(expr, prefix, nil)
@@ -933,6 +948,7 @@ func (g *Graph) inlineModule(
 		if inputAttr, ok := moduleInputAttrs[varName]; ok {
 			varDeps = append(varDeps, g.exprDeps(inputAttr.Expr, parentPrefix)...)
 		}
+		varDeps = append(varDeps, g.variableValidationDeps(v, prefix+"var."+varName, prefix)...)
 		if err := g.AddNode(&Node{
 			Key:        prefix + "var." + varName,
 			Type:       NodeTypeVariable,

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -1419,6 +1419,59 @@ variable "instance_type" {
 	}
 }
 
+// A variable's validation condition may reference another variable; the
+// referencing variable must be sequenced after the one it reads, so the rule
+// evaluates deterministically rather than racing the dependency.
+func TestEngine_VariableValidationCrossReference(t *testing.T) {
+	t.Parallel()
+
+	runProgram := func(t *testing.T, name string) error {
+		src := []byte(`
+variable "min" {
+  type    = number
+  default = 3
+}
+
+variable "name" {
+  type    = string
+  default = "` + name + `"
+
+  validation {
+    condition     = length(var.name) >= var.min
+    error_message = "name is shorter than min"
+  }
+}
+
+output "name" {
+  value = var.name
+}
+`)
+		config, diags := parser.NewParser().ParseSource("test.hcl", src)
+		require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ProjectName:     "test-project",
+			StackName:       "dev",
+			ResourceMonitor: &testutil.MockResourceMonitor{},
+			WorkDir:         t.TempDir(),
+			RootDir:         t.TempDir(),
+			SchemaLoader:    schemaloader.New(t, schema.PackageSpec{Name: "empty"}),
+		})
+		return engine.Run(t.Context())
+	}
+
+	t.Run("pass", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, runProgram(t, "widget"))
+	})
+
+	t.Run("fail", func(t *testing.T) {
+		t.Parallel()
+		assert.EqualError(t, runProgram(t, "xy"),
+			`validation failed for variable "name": name is shorter than min`+"\ncontext canceled")
+	})
+}
+
 func TestEngine_VariableValidationFail_SensitiveErrorMessage(t *testing.T) {
 	t.Parallel()
 

--- a/tests/tfcompat/variable_validation_xref_test.go
+++ b/tests/tfcompat/variable_validation_xref_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1VariableValidationCrossReference asserts that a `variable`'s
+// `validation` condition may reference another variable, and that a failing
+// cross-referencing rule makes both runtimes fail with the configured error
+// message, matching OpenTofu.
+func TestL1VariableValidationCrossReference(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_variable_validation_xref", tfcompat.Case{
+		Stages: []tfcompat.Stage{{
+			Files: map[string]string{"main.tf": `
+variable "min" {
+  type    = number
+  default = 3
+}
+
+variable "name" {
+  type    = string
+  default = "xy"
+
+  validation {
+    condition     = length(var.name) >= var.min
+    error_message = "XREF_VALIDATION_FAILED"
+  }
+}
+
+output "name" {
+  value = var.name
+}
+`},
+			ExpectErr: "XREF_VALIDATION_FAILED",
+		}},
+	})
+}
+
+// TestL2ModuleVariableValidationCrossReference asserts the same for a variable
+// declared in a child module whose validation references another of the
+// module's variables.
+func TestL2ModuleVariableValidationCrossReference(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_variable_validation_xref", tfcompat.Case{
+		Stages: []tfcompat.Stage{{
+			Files: map[string]string{
+				"main.tf": `
+module "child" {
+  source = "./child"
+}
+
+output "name" {
+  value = module.child.name
+}
+`,
+				"child/main.tf": `
+variable "min" {
+  type    = number
+  default = 3
+}
+
+variable "name" {
+  type    = string
+  default = "xy"
+
+  validation {
+    condition     = length(var.name) >= var.min
+    error_message = "MODULE_XREF_VALIDATION_FAILED"
+  }
+}
+
+output "name" {
+  value = var.name
+}
+`,
+			},
+			ExpectErr: "MODULE_XREF_VALIDATION_FAILED",
+		}},
+	})
+}


### PR DESCRIPTION
## Problem

A `variable`'s `validation` condition may reference another variable (OpenTofu's cross-variable validation, also locals/data/resources):

```hcl
variable "min" {
  type    = number
  default = 3
}

variable "name" {
  type    = string
  default = "xy"
  validation {
    condition     = length(var.name) >= var.min
    error_message = "XREF_VALIDATION_FAILED"
  }
}
```

OpenTofu fails the apply with `XREF_VALIDATION_FAILED`. pulumi-hcl gave variable nodes no dependency on the values their validation reads, so `var.name` could be processed before `var.min`. The condition then read an unset `var.min` and failed with the wrong error — **non-deterministically**: a 10× run of the repro test on `master` came up 6 passed / 4 failed.

## Fix

Add the `condition` and `error_message` expression references of every validation rule to the variable node's graph dependencies, on both the root and module paths (`variableValidationDeps`). A self-reference to the variable being validated is filtered out — it is always in scope and would otherwise form a cycle, which is also what keeps the existing self-only validations (`length(var.name) > 3`) working.

The fix is general: a validation that reads a `local`, `data` source, or resource is sequenced after it too, since `exprDeps` already resolves those namespaces.

## Sweep

- **Output `precondition`** had the analogous dep gap and is fixed in #278.
- **Resource `precondition`/`postcondition`** already contribute graph deps via `bodyDeps` recursion into the lifecycle block.
- **`check` blocks** run after the program settles (`evaluateChecks`), so they need no ordering edge.

## Tests

- `tests/tfcompat/variable_validation_xref_test.go` — `TestL1VariableValidationCrossReference` (top level) and `TestL2ModuleVariableValidationCrossReference` (child module). Flaky on `master`, deterministically pass with the fix.
- `TestEngine_VariableValidationCrossReference` in `pkg/hcl/run/run_test.go` — engine unit coverage (pass + fail), verified deterministic across repeated runs.

All `pkg/hcl/...`, `pkg/server`, and `tests/tfcompat` suites pass.