### PR TITLE
modernize stack references: read > create

### DIFF
--- a/.changes/unreleased/runtime-Improvements-281.yaml
+++ b/.changes/unreleased/runtime-Improvements-281.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Implment pulumi_stack_reference as a Read instead of a Create
+time: 2026-06-22T10:44:10.65913+02:00
+custom:
+    Component: runtime
+    PR: "281"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -69,6 +69,11 @@ type ResourceMonitor interface {
 	// RegisterResource registers a resource with Pulumi.
 	RegisterResource(ctx context.Context, req RegisterResourceRequest) (*RegisterResourceResponse, error)
 
+	// ReadResource reads the state of an existing resource. This is the
+	// registration form used for stack references, which the engine resolves
+	// against the backend rather than creating.
+	ReadResource(ctx context.Context, req ReadResourceRequest) (*ReadResourceResponse, error)
+
 	// Invoke invokes a provider function.
 	Invoke(ctx context.Context, req InvokeRequest) (*InvokeResponse, error)
 
@@ -180,6 +185,32 @@ type RegisterResourceRequest struct {
 
 // RegisterResourceResponse contains the result of registering a resource.
 type RegisterResourceResponse struct {
+	URN     urn.URN
+	ID      string
+	Outputs property.Map
+}
+
+// ReadResourceRequest contains the parameters for reading an existing resource.
+// A read honors only the subset of resource options the engine's ReadResource
+// RPC accepts; options that imply lifecycle management (Protect, IgnoreChanges,
+// CustomTimeouts, ...) have no meaning for a read and are not carried.
+type ReadResourceRequest struct {
+	Type                    string
+	Name                    string
+	ID                      string
+	Inputs                  property.Map
+	Parent                  urn.URN
+	Dependencies            []string
+	Provider                string
+	Version                 string
+	AdditionalSecretOutputs []string
+	PluginDownloadURL       string
+	PackageRef              PackageRef
+}
+
+// ReadResourceResponse contains the result of reading a resource. ID echoes the
+// requested ID, since a read identifies the resource rather than minting one.
+type ReadResourceResponse struct {
 	URN     urn.URN
 	ID      string
 	Outputs property.Map
@@ -2398,6 +2429,10 @@ func (e *Engine) registerResource(
 ) (urn.URN, string, property.Map, error) {
 	inputs = lowerTerraformDataInputs(tfType, inputs, opts)
 
+	if typeToken == stackReferenceType {
+		return e.readResource(ctx, typeToken, name, inputs, opts)
+	}
+
 	// Register with the resource monitor
 	resp, err := e.resmon.RegisterResource(ctx, RegisterResourceRequest{
 		Type:                    typeToken,
@@ -2435,6 +2470,47 @@ func (e *Engine) registerResource(
 	}
 
 	return resp.URN, resp.ID, lowerTerraformDataOutputs(tfType, resp.Outputs, opts), nil
+}
+
+// stackReferenceType is the builtin resource the engine resolves against the
+// backend. It is registered with a Read rather than a Create: the modern Pulumi
+// SDKs read stack references (Go's ReadResource, Node's id-bearing
+// CustomResource), and Create is deprecated for this type.
+const stackReferenceType = "pulumi:pulumi:StackReference"
+
+// readResource registers a resource via a Read. The ID is taken from the "name"
+// input (the fully-qualified stack name), matching how the SDKs identify a
+// stack reference.
+func (e *Engine) readResource(
+	ctx context.Context,
+	typeToken string,
+	name string,
+	inputs property.Map,
+	opts *ResourceOptions,
+) (urn.URN, string, property.Map, error) {
+	nameVal, ok := inputs.GetOk("name")
+	if !ok || !nameVal.IsString() {
+		return "", "", property.Map{}, fmt.Errorf("%s %q requires a string \"name\" input", typeToken, name)
+	}
+
+	resp, err := e.resmon.ReadResource(ctx, ReadResourceRequest{
+		Type:                    typeToken,
+		Name:                    name,
+		ID:                      nameVal.AsString(),
+		Inputs:                  inputs,
+		Parent:                  opts.Parent,
+		Dependencies:            opts.DependsOn,
+		Provider:                opts.Provider,
+		Version:                 opts.Version,
+		AdditionalSecretOutputs: opts.AdditionalSecretOutputs,
+		PluginDownloadURL:       opts.PluginDownloadURL,
+		PackageRef:              opts.PackageRef,
+	})
+	if err != nil {
+		return "", "", property.Map{}, err
+	}
+
+	return resp.URN, resp.ID, resp.Outputs, nil
 }
 
 // processDataSource processes a data source definition.

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -107,6 +107,64 @@ resource "aws_instance" "web" {
 	}
 }
 
+func TestEngine_StackReferenceUsesRead(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "pulumi_stack_reference" "ref" {
+  name = "org/project/stack"
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.Empty(t, diags)
+
+	// "pulumi" is a reserved package name, so it must be bound with
+	// AllowPulumiPackage rather than through schemaloader.New.
+	pulumiPkg, diag, err := schema.BindSpec(schema.PackageSpec{
+		Name: "pulumi",
+		Resources: map[string]schema.ResourceSpec{
+			"pulumi:pulumi:StackReference": {
+				InputProperties: map[string]schema.PropertySpec{
+					"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}, nil, schema.ValidationOptions{AllowPulumiPackage: true})
+	require.NoError(t, err)
+	require.Empty(t, diag)
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader:    schemaloader.Mock{"pulumi": pulumiPkg},
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	// The stack reference must be resolved with a Read, not a Create: only the
+	// stack (a Create) should appear among registrations.
+	require.Len(t, mock.RegisteredResources, 1)
+	assert.Equal(t, "pulumi:pulumi:Stack", mock.RegisteredResources[0].Type)
+
+	require.Len(t, mock.ReadResources, 1)
+	read := mock.ReadResources[0]
+	assert.Equal(t, "pulumi:pulumi:StackReference", read.Type)
+	assert.Equal(t, "ref", read.Name)
+	assert.Equal(t, "org/project/stack", read.ID)
+	assert.Equal(t, "org/project/stack", read.Inputs.Get("name").AsString())
+}
+
 func TestEngine_PulumiResourceNameRejectsWrappedResource(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -545,6 +545,58 @@ func (m *constructResourceMonitor) RegisterResource(
 	}, nil
 }
 
+// ReadResource reads the state of an existing resource.
+func (m *constructResourceMonitor) ReadResource(
+	ctx context.Context,
+	req run.ReadResourceRequest,
+) (*run.ReadResourceResponse, error) {
+	properties, err := plugin.MarshalProperties(resource.ToResourcePropertyMap(req.Inputs), plugin.MarshalOptions{
+		KeepSecrets:   true,
+		KeepResources: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling inputs: %w", err)
+	}
+
+	parent := req.Parent
+	if parent == "" {
+		parent = m.componentURN
+	}
+
+	resp, err := m.client.ReadResource(ctx, &pulumirpc.ReadResourceRequest{
+		Id:                      req.ID,
+		Type:                    req.Type,
+		Name:                    m.componentName + "-" + req.Name,
+		Parent:                  string(parent),
+		Properties:              properties,
+		Dependencies:            req.Dependencies,
+		Provider:                req.Provider,
+		Version:                 req.Version,
+		AdditionalSecretOutputs: req.AdditionalSecretOutputs,
+		PluginDownloadURL:       req.PluginDownloadURL,
+		PackageRef:              string(req.PackageRef),
+		AcceptSecrets:           true,
+		AcceptResources:         true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	outputs, err := plugin.UnmarshalProperties(resp.Properties, plugin.MarshalOptions{
+		KeepSecrets:   true,
+		KeepResources: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unmarshaling outputs: %w", err)
+	}
+
+	return &run.ReadResourceResponse{
+		URN:     urn.URN(resp.Urn),
+		ID:      req.ID,
+		Outputs: resource.FromResourcePropertyMap(outputs),
+	}, nil
+}
+
 // RegisterResourceOutputs registers resource outputs.
 func (m *constructResourceMonitor) RegisterResourceOutputs(
 	ctx context.Context,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1250,6 +1250,47 @@ func (r *resourceMonitorAdapter) RegisterResource(
 	}, nil
 }
 
+// ReadResource reads the state of an existing resource.
+func (r *resourceMonitorAdapter) ReadResource(
+	ctx context.Context,
+	req run.ReadResourceRequest,
+) (*run.ReadResourceResponse, error) {
+	inputsStruct, err := plugin.MarshalProperties(resource.ToResourcePropertyMap(req.Inputs), r.pluginOptions())
+	if err != nil {
+		return nil, fmt.Errorf("marshaling inputs: %w", err)
+	}
+
+	resp, err := r.monitorClient.ReadResource(ctx, &pulumirpc.ReadResourceRequest{
+		Id:                      req.ID,
+		Type:                    req.Type,
+		Name:                    req.Name,
+		Parent:                  string(req.Parent),
+		Properties:              inputsStruct,
+		Dependencies:            req.Dependencies,
+		Provider:                req.Provider,
+		Version:                 req.Version,
+		AcceptSecrets:           true,
+		AdditionalSecretOutputs: req.AdditionalSecretOutputs,
+		AcceptResources:         true,
+		PluginDownloadURL:       req.PluginDownloadURL,
+		PackageRef:              string(req.PackageRef),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading resource: %w", err)
+	}
+
+	outputs, err := plugin.UnmarshalProperties(resp.Properties, r.pluginOptions())
+	if err != nil {
+		return nil, fmt.Errorf("unmarshaling outputs: %w", err)
+	}
+
+	return &run.ReadResourceResponse{
+		URN:     urn.URN(resp.Urn),
+		ID:      req.ID,
+		Outputs: resource.FromResourcePropertyMap(outputs),
+	}, nil
+}
+
 // Invoke invokes a provider function.
 func (r *resourceMonitorAdapter) Invoke(
 	ctx context.Context,

--- a/tests/testutil/monitor.go
+++ b/tests/testutil/monitor.go
@@ -29,6 +29,7 @@ import (
 type MockResourceMonitor struct {
 	mu                  sync.Mutex
 	RegisteredResources []run.RegisterResourceRequest
+	ReadResources       []run.ReadResourceRequest
 	InvokedFunctions    []run.InvokeRequest
 	Warnings            []string
 	StackOutputs        property.Map
@@ -43,6 +44,9 @@ type MockResourceMonitor struct {
 
 	// RegisterResourceHandler, if  set, is  called for each  RegisterResource instead of the default behavior.
 	RegisterResourceHandler func(ctx context.Context, req run.RegisterResourceRequest) (*run.RegisterResourceResponse, error)
+
+	// ReadResourceHandler, if set, is called for each ReadResource instead of the default behavior.
+	ReadResourceHandler func(ctx context.Context, req run.ReadResourceRequest) (*run.ReadResourceResponse, error)
 }
 
 type registeredHook struct {
@@ -101,6 +105,24 @@ func (m *MockResourceMonitor) RegisterResource(ctx context.Context, req run.Regi
 	}
 
 	return resp, nil
+}
+
+func (m *MockResourceMonitor) ReadResource(ctx context.Context, req run.ReadResourceRequest) (*run.ReadResourceResponse, error) {
+	m.mu.Lock()
+	m.ReadResources = append(m.ReadResources, req)
+	handler := m.ReadResourceHandler
+	m.mu.Unlock()
+
+	if handler != nil {
+		return handler(ctx, req)
+	}
+
+	resURN := urn.URN("urn:pulumi:test::project::" + req.Type + "::" + req.Name)
+	return &run.ReadResourceResponse{
+		URN:     resURN,
+		ID:      req.ID,
+		Outputs: req.Inputs,
+	}, nil
 }
 
 func (m *MockResourceMonitor) runHooks(


### PR DESCRIPTION
Implement `pulumi_stack_reference` with a read under the hood, instead of the standard register. This removes a deprecation warning.

Existing users will see a benign replace.