### PR TITLE
Make `pulumi-resource-hcl` parameterizable

### DIFF
--- a/.changes/unreleased/resource-host-Improvements-283.yaml
+++ b/.changes/unreleased/resource-host-Improvements-283.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Make pulumi-resource-hcl parameterizable
+time: 2026-06-23T17:07:52.956574+02:00
+custom:
+    Component: resource-host
+    PR: "283"

--- a/cmd/pulumi-converter-hcl/main.go
+++ b/cmd/pulumi-converter-hcl/main.go
@@ -24,12 +24,24 @@ import (
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/converter"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/grpc"
 )
 
 func main() {
+	serverOpts := rpcutil.OpenTracingServerInterceptorOptions(nil)
+	if otelEndpoint := os.Getenv("PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT"); otelEndpoint != "" {
+		if err := cmdutil.InitOtelTracing("pulumi-converter-hcl", otelEndpoint); err != nil {
+			logging.V(3).Infof("failed to initialize OTel tracing: %v", err)
+		} else {
+			defer cmdutil.CloseOtelTracing()
+			serverOpts = rpcutil.OTelServerInterceptorOptions()
+		}
+	}
+
 	cancelch := make(chan bool)
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	go func() {
@@ -44,7 +56,7 @@ func main() {
 			pulumirpc.RegisterConverterServer(srv, plugin.NewConverterServer(converter.New()))
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: serverOpts,
 	})
 	if err != nil {
 		log.Fatalf("fatal: %v", err)

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/codegen"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modules"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	hclrun "github.com/pulumi-labs/pulumi-hcl/pkg/hcl/run"
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil"
@@ -1766,6 +1767,7 @@ output "instance_ami" {
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
+		ModuleLoader:    modules.NewLoader(modules.LiveResolver(t.Context())),
 		WorkDir:         t.TempDir(),
 		RootDir:         t.TempDir(),
 		SchemaLoader:    loader,
@@ -2116,6 +2118,7 @@ output "result" {
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
+		ModuleLoader:    modules.NewLoader(modules.LiveResolver(t.Context())),
 		WorkDir:         dir,
 		RootDir:         dir,
 		SchemaLoader:    loader,
@@ -2223,6 +2226,7 @@ resource "test_bucket" "bucket" {
 			StackName:       "dev",
 			ResourceMonitor: mock,
 			WorkDir:         dir,
+			ModuleLoader:    modules.NewLoader(modules.LiveResolver(t.Context())),
 			RootDir:         dir,
 			SchemaLoader:    loader,
 		})
@@ -2267,6 +2271,7 @@ data "test_getlen" "invoke_0" {
 			ProjectName:     "test-project",
 			StackName:       "dev",
 			ResourceMonitor: mock,
+			ModuleLoader:    modules.NewLoader(modules.LiveResolver(t.Context())),
 			WorkDir:         dir,
 			RootDir:         dir,
 			SchemaLoader:    loader,
@@ -2381,6 +2386,7 @@ func testConvertedPCLWithComponent(
 		StackName:       "dev",
 		ResourceMonitor: mock,
 		WorkDir:         outDir,
+		ModuleLoader:    modules.NewLoader(modules.LiveResolver(t.Context())),
 		RootDir:         outDir,
 		SchemaLoader:    loader,
 	})
@@ -2446,6 +2452,7 @@ output "instance_ami" {
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
+		ModuleLoader:    modules.NewLoader(modules.LiveResolver(t.Context())),
 		WorkDir:         t.TempDir(),
 		RootDir:         t.TempDir(),
 		SchemaLoader:    loader,
@@ -2538,6 +2545,7 @@ resource web "aws:index:Instance" {
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
+		ModuleLoader:    modules.NewLoader(modules.LiveResolver(t.Context())),
 		WorkDir:         outDir,
 		RootDir:         outDir,
 		SchemaLoader:    loader,
@@ -2595,6 +2603,7 @@ func TestReplaceOnChangesPathTranslated(t *testing.T) {
 		ResourceMonitor: mock,
 		WorkDir:         t.TempDir(),
 		RootDir:         t.TempDir(),
+		ModuleLoader:    modules.NewLoader(modules.LiveResolver(t.Context())),
 		SchemaLoader:    loader,
 	})
 	require.NoError(t, engine.Run(t.Context()))
@@ -2648,6 +2657,7 @@ func TestHideDiffsPathTranslated(t *testing.T) {
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
+		ModuleLoader:    modules.NewLoader(modules.LiveResolver(t.Context())),
 		WorkDir:         t.TempDir(),
 		RootDir:         t.TempDir(),
 		SchemaLoader:    loader,

--- a/cmd/pulumi-language-hcl/main.go
+++ b/cmd/pulumi-language-hcl/main.go
@@ -73,16 +73,23 @@ func main() {
 	}
 
 	logging.InitLogging(false, 0, false)
-	if p.tracing != "" {
+
+	otelEndpoint := os.Getenv("PULUMI_OTEL_EXPORTER_OTLP_ENDPOINT")
+	if otelEndpoint == "" {
 		cmdutil.InitTracing("pulumi-language-hcl", "pulumi-language-hcl", p.tracing)
+	} else {
+		if err := cmdutil.InitOtelTracing("pulumi-language-hcl", otelEndpoint); err != nil {
+			logging.V(3).Infof("failed to initialize OTel tracing: %v", err)
+		}
+		defer cmdutil.CloseOtelTracing()
 	}
 
-	if err := run(p); err != nil {
+	if err := run(p, otelEndpoint); err != nil {
 		cmdutil.Exit(err)
 	}
 }
 
-func run(p *runParams) error {
+func run(p *runParams, otelEndpoint string) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
@@ -120,7 +127,7 @@ func run(p *runParams) error {
 			pulumirpc.RegisterLanguageRuntimeServer(srv, host)
 			return nil
 		},
-		Options: rpcutil.OpenTracingServerInterceptorOptions(nil),
+		Options: tracingServerOptions(otelEndpoint),
 	})
 	if err != nil {
 		return fmt.Errorf("could not start language host RPC server: %w", err)
@@ -135,4 +142,11 @@ func run(p *runParams) error {
 	}
 
 	return nil
+}
+
+func tracingServerOptions(otelEndpoint string) []grpc.ServerOption {
+	if otelEndpoint != "" {
+		return rpcutil.OTelServerInterceptorOptions()
+	}
+	return rpcutil.OpenTracingServerInterceptorOptions(nil)
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-bool-ref/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-bool-ref/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-range-bool-ref
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-bool-ref/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-bool-ref/main.pp
@@ -1,0 +1,14 @@
+resource "boolResource" "nestedobject:index:Target" {
+  name = "bool-resource"
+  options {
+    range = createBool
+  }
+}
+
+resource "boolTarget" "nestedobject:index:Target" {
+  name = "${boolResource.name}+"
+}
+
+config "createBool" "bool" {
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-list-ref/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-list-ref/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-range-list-ref
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-list-ref/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-list-ref/main.pp
@@ -1,0 +1,35 @@
+resource "numResource" "nestedobject:index:Target" {
+  name = "num-${range.value}"
+  options {
+    range = numItems
+  }
+}
+
+resource "numTarget" "nestedobject:index:Target" {
+  name = "${numResource[0].name}+"
+}
+
+resource "listResource" "nestedobject:index:Target" {
+  name = "${range.key}:${range.value}"
+  options {
+    range = itemList
+  }
+}
+
+resource "listTarget" "nestedobject:index:Target" {
+  name = "${listResource[1].name}+"
+}
+
+resource "listDynTarget" "nestedobject:index:Target" {
+  name = "${listResource[range.key].name}!"
+  options {
+    range = itemList
+  }
+}
+
+config "numItems" "number" {
+}
+
+config "itemList" "list(string)" {
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-map-ref/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-map-ref/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-range-map-ref
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-map-ref/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-range-map-ref/main.pp
@@ -1,0 +1,14 @@
+resource "mapResource" "nestedobject:index:Target" {
+  name = "${range.key}=${range.value}"
+  options {
+    range = itemMap
+  }
+}
+
+resource "mapTarget" "nestedobject:index:Target" {
+  name = "${mapResource["k1"].name}+"
+}
+
+config "itemMap" "map(string)" {
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-range-bool-ref/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-range-bool-ref/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-range-bool-ref
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-range-bool-ref/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-range-bool-ref/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    nestedobject = {
+      source  = "pulumi/nestedobject"
+      version = "1.42.0"
+    }
+  }
+}
+
+resource "nestedobject_target" "boolResource" {
+  count = var.createBool
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "bool-resource"
+}
+resource "nestedobject_target" "boolTarget" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${nestedobject_target.boolResource.name}+"
+}
+variable "createBool" {
+  type = bool
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-range-list-ref/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-range-list-ref/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-range-list-ref
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-range-list-ref/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-range-list-ref/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_providers {
+    nestedobject = {
+      source  = "pulumi/nestedobject"
+      version = "1.42.0"
+    }
+  }
+}
+
+resource "nestedobject_target" "numResource" {
+  count = var.numItems
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="num-${count.index}"
+}
+resource "nestedobject_target" "numTarget" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${nestedobject_target.numResource[0].name}+"
+}
+resource "nestedobject_target" "listResource" {
+  for_each = {  for  __key,  __value  in  var.itemList  :  tostring(__key)  =>  __value  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${each.key}:${each.value}"
+}
+resource "nestedobject_target" "listTarget" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${nestedobject_target.listResource[1].name}+"
+}
+resource "nestedobject_target" "listDynTarget" {
+  for_each = {  for  __key,  __value  in  var.itemList  :  tostring(__key)  =>  __value  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${nestedobject_target.listResource[each.key].name}!"
+}
+variable "numItems" {
+  type = number
+}
+variable "itemList" {
+  type = list(string)
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-range-map-ref/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-range-map-ref/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-range-map-ref
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-range-map-ref/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-range-map-ref/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    nestedobject = {
+      source  = "pulumi/nestedobject"
+      version = "1.42.0"
+    }
+  }
+}
+
+resource "nestedobject_target" "mapResource" {
+  for_each = var.itemMap
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${each.key}=${each.value}"
+}
+resource "nestedobject_target" "mapTarget" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${nestedobject_target.mapResource["k1"].name}+"
+}
+variable "itemMap" {
+  type = map(string)
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-bool-ref/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-bool-ref/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-range-bool-ref
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-bool-ref/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-bool-ref/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    nestedobject = {
+      source  = "pulumi/nestedobject"
+      version = "1.42.0"
+    }
+  }
+}
+
+resource "nestedobject_target" "boolResource" {
+  count = var.createBool
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "bool-resource"
+}
+resource "nestedobject_target" "boolTarget" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${nestedobject_target.boolResource.name}+"
+}
+variable "createBool" {
+  type = bool
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-list-ref/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-list-ref/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-range-list-ref
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-list-ref/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-list-ref/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_providers {
+    nestedobject = {
+      source  = "pulumi/nestedobject"
+      version = "1.42.0"
+    }
+  }
+}
+
+resource "nestedobject_target" "numResource" {
+  count = var.numItems
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="num-${count.index}"
+}
+resource "nestedobject_target" "numTarget" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${nestedobject_target.numResource[0].name}+"
+}
+resource "nestedobject_target" "listResource" {
+  for_each = {  for  __key,  __value  in  var.itemList  :  tostring(__key)  =>  __value  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${each.key}:${each.value}"
+}
+resource "nestedobject_target" "listTarget" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${nestedobject_target.listResource[1].name}+"
+}
+resource "nestedobject_target" "listDynTarget" {
+  for_each = {  for  __key,  __value  in  var.itemList  :  tostring(__key)  =>  __value  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${nestedobject_target.listResource[each.key].name}!"
+}
+variable "numItems" {
+  type = number
+}
+variable "itemList" {
+  type = list(string)
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-map-ref/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-map-ref/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-range-map-ref
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-map-ref/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-range-map-ref/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    nestedobject = {
+      source  = "pulumi/nestedobject"
+      version = "1.42.0"
+    }
+  }
+}
+
+resource "nestedobject_target" "mapResource" {
+  for_each = var.itemMap
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${each.key}=${each.value}"
+}
+resource "nestedobject_target" "mapTarget" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="${nestedobject_target.mapResource["k1"].name}+"
+}
+variable "itemMap" {
+  type = map(string)
+}

--- a/docs/mlc.md
+++ b/docs/mlc.md
@@ -45,20 +45,18 @@ output "vpc_id" {
 ### `component` block
 
 Declares this module as a component resource. The block is optional; when it is
-omitted, the component name defaults to the package name and the module segment
-to `"index"`. When the block is present, `name` is required.
+omitted, the component name defaults to `"Module"` and the module segment to
+`"index"`. When the block is present, `name` is required.
 
-| Field    | Required | Default   | Description                                  |
-|----------|----------|-----------|----------------------------------------------|
-| `name`   | Yes      | -         | Component name (must be a valid Pulumi name) |
-| `module` | No       | `"index"` | Module segment of the resource token         |
+| Field    | Required | Default    | Description                                  |
+|----------|----------|------------|----------------------------------------------|
+| `name`   | Yes      | `"Module"` | Component name (must be a valid Pulumi name) |
+| `module` | No       | `"index"`  | Module segment of the resource token         |
 
-When the component name equals the package name (the default), the resource
-token collapses to a single segment and is referenced in HCL by the bare
-package name — e.g. a package `randommodule` is consumed as
-`resource "randommodule" "x" { ... }`, the same shape as a single-segment
-Terraform type like `external`. This requires the package name to be a valid
-Pulumi name (no hyphens), since it also becomes the token's member segment.
+With the default component name, the token is `{package}:index:Module` and is
+referenced in HCL as `{package}_module` — e.g. a package `randommodule` is
+consumed as `resource "randommodule_module" "x" { ... }`, mirroring the dynamic
+`hcl:index:Module` resource (referenced as `hcl_module`).
 
 ### `package` block
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/opentofu/svchost v0.0.0-20250610175836-86c9e5e3d8c8
 	github.com/pulumi/providertest v0.7.0
 	github.com/pulumi/pulumi-go-provider v1.3.3-0.20260622142528-c5c3719552bc
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.133.1-0.20260622192304-f792e5a73b3e
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.133.1-0.20260623230107-b8134413f965
 	github.com/pulumi/pulumi/pkg/v3 v3.247.1-0.20260623205855-9fd06c1f63cc
 	github.com/pulumi/pulumi/sdk/v3 v3.247.1-0.20260623205855-9fd06c1f63cc
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	github.com/pulumi/providertest v0.7.0
 	github.com/pulumi/pulumi-go-provider v1.3.3-0.20260622142528-c5c3719552bc
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.133.1-0.20260622192304-f792e5a73b3e
-	github.com/pulumi/pulumi/pkg/v3 v3.247.1-0.20260623065538-6a3cf9e8c4e2
-	github.com/pulumi/pulumi/sdk/v3 v3.247.1-0.20260623065538-6a3cf9e8c4e2
+	github.com/pulumi/pulumi/pkg/v3 v3.247.1-0.20260623205855-9fd06c1f63cc
+	github.com/pulumi/pulumi/sdk/v3 v3.247.1-0.20260623205855-9fd06c1f63cc
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/xanzy/ssh-agent v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -3980,10 +3980,10 @@ github.com/pulumi/pulumi-terraform-bridge/v3 v3.133.1-0.20260622192304-f792e5a73
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.133.1-0.20260622192304-f792e5a73b3e/go.mod h1:daktsVKvKy1JauSrzkvQysnyaj10zGXnyqtbyTWkF/I=
 github.com/pulumi/pulumi-yaml v1.37.1-0.20260622185626-83ac6abce5d9 h1:GPZ02CA1WJmFbPKRyEeYyOGWukUwGppbsgV8RAx6kOc=
 github.com/pulumi/pulumi-yaml v1.37.1-0.20260622185626-83ac6abce5d9/go.mod h1:4R3DhprhbGRDgGoI1m+KcUJSAbgHBe3e9Ij9/daWCbY=
-github.com/pulumi/pulumi/pkg/v3 v3.247.1-0.20260623065538-6a3cf9e8c4e2 h1:PcvkuQIVnqAyZQMhw+lxHcSbfWId/TIdPllLPjwtldo=
-github.com/pulumi/pulumi/pkg/v3 v3.247.1-0.20260623065538-6a3cf9e8c4e2/go.mod h1:3CAS3XJiNMpVd3namRqa3eJSKiGiHvwrwM+r7tN9MMY=
-github.com/pulumi/pulumi/sdk/v3 v3.247.1-0.20260623065538-6a3cf9e8c4e2 h1:n8aAXaehFG8LVJ27ftJzEmvERODSPbHB0Ysj0YVa6JA=
-github.com/pulumi/pulumi/sdk/v3 v3.247.1-0.20260623065538-6a3cf9e8c4e2/go.mod h1:67RnWlA0uRHJKjbOkk1Hqz8BNefYv8csNLgln1EmmII=
+github.com/pulumi/pulumi/pkg/v3 v3.247.1-0.20260623205855-9fd06c1f63cc h1:IaSmjUWsXZfLonQTx02EHmtPEUFCSLmezX/5+WCRQFU=
+github.com/pulumi/pulumi/pkg/v3 v3.247.1-0.20260623205855-9fd06c1f63cc/go.mod h1:3CAS3XJiNMpVd3namRqa3eJSKiGiHvwrwM+r7tN9MMY=
+github.com/pulumi/pulumi/sdk/v3 v3.247.1-0.20260623205855-9fd06c1f63cc h1:knBBlSyYNzylGfoSTDgN/RkopQUDQGpx4Qs3t0Ngb6w=
+github.com/pulumi/pulumi/sdk/v3 v3.247.1-0.20260623205855-9fd06c1f63cc/go.mod h1:67RnWlA0uRHJKjbOkk1Hqz8BNefYv8csNLgln1EmmII=
 github.com/pulumi/terraform-diff-reader v0.0.2 h1:kTE4nEXU3/SYXESvAIem+wyHMI3abqkI3OhJ0G04LLI=
 github.com/pulumi/terraform-diff-reader v0.0.2/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20260318212141-5525259d096b h1:efoz3DmFhw7EPJ3JxVfWYwpg5Dl6QTLvzMV0a7Y7mlo=

--- a/go.sum
+++ b/go.sum
@@ -3976,8 +3976,8 @@ github.com/pulumi/pulumi-go-provider v1.3.3-0.20260622142528-c5c3719552bc h1:fj6
 github.com/pulumi/pulumi-go-provider v1.3.3-0.20260622142528-c5c3719552bc/go.mod h1:LDSFQaNbYbusvOIdsB7WW+mo3WjLlZSfSZJKyCLFhbw=
 github.com/pulumi/pulumi-java v1.31.0 h1:ZRJh/D3J8TmgJoKItgodlv6d2nTtTvpT/jjessWdfvY=
 github.com/pulumi/pulumi-java v1.31.0/go.mod h1:VS1cFlRP3IfrEXtvFg7K3Ro5aQkN47LqNGBCA7TgzPE=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.133.1-0.20260622192304-f792e5a73b3e h1:rboEkYUUjYytgG8RNU2TgBQULqBMVnZ8Q5pc+oTHckw=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.133.1-0.20260622192304-f792e5a73b3e/go.mod h1:daktsVKvKy1JauSrzkvQysnyaj10zGXnyqtbyTWkF/I=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.133.1-0.20260623230107-b8134413f965 h1:HNnKjzMhxhUOaHn9Mgyz7j8T8uW/GFgh6G8xI+Sa9p0=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.133.1-0.20260623230107-b8134413f965/go.mod h1:BHSUTquMGIcJ85Vym0d8yOG6Cyyf23N3hxyyMwBxgFI=
 github.com/pulumi/pulumi-yaml v1.37.1-0.20260622185626-83ac6abce5d9 h1:GPZ02CA1WJmFbPKRyEeYyOGWukUwGppbsgV8RAx6kOc=
 github.com/pulumi/pulumi-yaml v1.37.1-0.20260622185626-83ac6abce5d9/go.mod h1:4R3DhprhbGRDgGoI1m+KcUJSAbgHBe3e9Ij9/daWCbY=
 github.com/pulumi/pulumi/pkg/v3 v3.247.1-0.20260623205855-9fd06c1f63cc h1:IaSmjUWsXZfLonQTx02EHmtPEUFCSLmezX/5+WCRQFU=

--- a/pkg/hcl/modules/loader.go
+++ b/pkg/hcl/modules/loader.go
@@ -59,13 +59,8 @@ type Loader struct {
 	parser    *parser.Parser
 	cache     map[string]*LoadedModule
 	callStack []string
-	cacheDir  string
 
-	fetcher *getmodules.PackageFetcher
-
-	// disco resolves a registry host to its modules.v1 endpoint via service
-	// discovery. Tests pre-seed it with an httptest.Server via ForceHostServices.
-	disco *disco.Disco
+	resolve func(packageSource, versionConstraint, callerDir string) (string, error)
 }
 
 // LoadedModule represents a loaded and parsed module.
@@ -74,14 +69,48 @@ type LoadedModule struct {
 	SourcePath string
 }
 
-// NewLoader creates a new module loader.
-func NewLoader(ctx context.Context) *Loader {
+type ResolverFunc = func(packageSource, versionConstraint, callerDir string) (string, error)
+
+// NewLoader creates a module loader that resolves sources from the filesystem,
+// the registry, and remote getters, downloading and caching as needed.
+func NewLoader(resolver ResolverFunc) *Loader {
 	return &Loader{
-		parser:   parser.NewParser(),
-		cache:    make(map[string]*LoadedModule),
+		parser:  parser.NewParser(),
+		cache:   make(map[string]*LoadedModule),
+		resolve: resolver,
+	}
+}
+
+// LiveResolver returns the default resolution strategy: filesystem sources
+// resolve directly, registry sources via the modules.v1 protocol, and everything
+// else through the remote getter, downloading and caching under PULUMI_HOME.
+func LiveResolver(ctx context.Context) ResolverFunc {
+	n := &networkResolver{
 		cacheDir: defaultCacheDir(),
 		fetcher:  getmodules.NewPackageFetcher(ctx, nil),
 		disco:    disco.New(),
+	}
+	return n.resolve
+}
+
+func (n *networkResolver) resolve(packageSource, versionConstraint, callerDir string) (string, error) {
+	switch {
+	case strings.HasPrefix(packageSource, "./") || strings.HasPrefix(packageSource, "../"):
+		resolved := filepath.Join(callerDir, packageSource)
+		absPath, err := filepath.Abs(resolved)
+		if err != nil {
+			return "", fmt.Errorf("resolving path: %w", err)
+		}
+		return statDir(absPath)
+	case filepath.IsAbs(packageSource):
+		return statDir(packageSource)
+	case isRegistrySource(packageSource):
+		return n.resolveRegistrySource(packageSource, versionConstraint)
+	default:
+		// Anything else (git::, github.com/..., bitbucket.org/..., http(s)://,
+		// s3::, gcs::, hg::, etc.) goes through the package fetcher, which
+		// runs the upstream opentofu detectors to normalize the address.
+		return n.fetchRemote(packageSource, "remote")
 	}
 }
 
@@ -135,47 +164,20 @@ func (l *Loader) LoadModule(source, versionConstraint, callerDir string) (*Loade
 // resolveSource resolves a module source to an absolute path on disk.
 // versionConstraint applies only to registry sources.
 func (l *Loader) resolveSource(source, versionConstraint, callerDir string) (string, error) {
-	source, subdir := getmodules.SplitPackageSubdir(source)
-
-	var resolvedPath string
-	var err error
-	switch {
-	case strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../"):
-		resolvedPath, err = l.resolveLocalSource(source, callerDir)
-	case filepath.IsAbs(source):
-		resolvedPath, err = l.resolveAbsoluteSource(source)
-	case isRegistrySource(source):
-		resolvedPath, err = l.resolveRegistrySource(source, versionConstraint)
-	default:
-		// Anything else (git::, github.com/..., bitbucket.org/..., http(s)://,
-		// s3::, gcs::, hg::, etc.) goes through the package fetcher, which
-		// runs the upstream opentofu detectors to normalize the address.
-		resolvedPath, err = l.fetchRemote(source, "remote")
-	}
+	packageSource, subdir := getmodules.SplitPackageSubdir(source)
+	packageDir, err := l.resolve(packageSource, versionConstraint, callerDir)
 	if err != nil {
 		return "", err
 	}
 
 	if subdir != "" {
-		resolvedPath = filepath.Join(resolvedPath, subdir)
-		if info, statErr := os.Stat(resolvedPath); statErr != nil || !info.IsDir() {
+		resolved := filepath.Join(packageDir, subdir)
+		if info, statErr := os.Stat(resolved); statErr != nil || !info.IsDir() {
 			return "", fmt.Errorf("subdir %q does not exist in module", subdir)
 		}
+		return resolved, nil
 	}
-	return resolvedPath, nil
-}
-
-func (l *Loader) resolveLocalSource(source string, callerDir string) (string, error) {
-	resolved := filepath.Join(callerDir, source)
-	absPath, err := filepath.Abs(resolved)
-	if err != nil {
-		return "", fmt.Errorf("resolving path: %w", err)
-	}
-	return statDir(absPath)
-}
-
-func (l *Loader) resolveAbsoluteSource(source string) (string, error) {
-	return statDir(source)
+	return packageDir, nil
 }
 
 func statDir(p string) (string, error) {
@@ -194,7 +196,7 @@ func statDir(p string) (string, error) {
 
 // fetchRemote normalizes source and downloads it (if not cached) into
 // cacheDir/kind/<hash>. Returns the populated cache directory.
-func (l *Loader) fetchRemote(source, kind string) (string, error) {
+func (l *networkResolver) fetchRemote(source, kind string) (string, error) {
 	pkgAddr, detectedSubdir, err := getmodules.NormalizePackageAddress(source)
 	if err != nil {
 		return "", fmt.Errorf("normalizing module source %q: %w", source, err)
@@ -240,10 +242,16 @@ func dirHasFiles(dir string) bool {
 	return len(entries) > 0
 }
 
+type networkResolver struct {
+	cacheDir string
+	fetcher  *getmodules.PackageFetcher
+	disco    *disco.Disco
+}
+
 // resolveRegistrySource downloads a module via modules.v1. source is
 // `[host/]namespace/name/provider` with an optional ?version=…; versionConstraint
 // takes precedence over the query string.
-func (l *Loader) resolveRegistrySource(source, versionConstraint string) (string, error) {
+func (l *networkResolver) resolveRegistrySource(source, versionConstraint string) (string, error) {
 	baseSource := source
 	if before, query, ok := strings.Cut(source, "?"); ok {
 		baseSource = before
@@ -276,7 +284,7 @@ func (l *Loader) resolveRegistrySource(source, versionConstraint string) (string
 
 // registryBaseURLForHost resolves a registry host to its modules.v1 base URL
 // via service discovery.
-func (l *Loader) registryBaseURLForHost(host svchost.Hostname) (string, error) {
+func (l *networkResolver) registryBaseURLForHost(host svchost.Hostname) (string, error) {
 	u, err := l.disco.DiscoverServiceURL(context.Background(), host, "modules.v1")
 	if err != nil {
 		return "", fmt.Errorf("discovering registry %q: %w", host, err)
@@ -296,7 +304,7 @@ type registryModuleVersions struct {
 
 // getRegistryDownloadURL resolves a concrete download URL via the modules.v1
 // protocol. Empty versionConstraint means "highest published version".
-func (l *Loader) getRegistryDownloadURL(baseURL, namespace, name, provider, versionConstraint string) (string, error) {
+func (l *networkResolver) getRegistryDownloadURL(baseURL, namespace, name, provider, versionConstraint string) (string, error) {
 	chosen, err := l.selectRegistryVersion(baseURL, namespace, name, provider, versionConstraint)
 	if err != nil {
 		return "", err
@@ -350,7 +358,7 @@ func (l *Loader) getRegistryDownloadURL(baseURL, namespace, name, provider, vers
 
 // selectRegistryVersion returns the highest published version satisfying
 // versionConstraint, or the highest overall when it's empty.
-func (l *Loader) selectRegistryVersion(baseURL, namespace, name, provider, versionConstraint string) (string, error) {
+func (l *networkResolver) selectRegistryVersion(baseURL, namespace, name, provider, versionConstraint string) (string, error) {
 	versionsURL := fmt.Sprintf("%s/%s/%s/%s/versions", baseURL, namespace, name, provider)
 	resp, err := http.Get(versionsURL)
 	if err != nil {

--- a/pkg/hcl/modules/loader.go
+++ b/pkg/hcl/modules/loader.go
@@ -38,6 +38,7 @@ import (
 	"github.com/opentofu/svchost/disco"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/potel"
 	"github.com/pulumi-labs/pulumi-hcl/vendored/getmodules"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -128,7 +129,10 @@ func defaultCacheDir() string {
 // LoadModule loads a module from the given source. versionConstraint is a
 // Terraform-style constraint (`~> 4.0`, `>= 1.0.0`, `4.2.1`); ignored for
 // non-registry sources.
-func (l *Loader) LoadModule(source, versionConstraint, callerDir string) (*LoadedModule, error) {
+func (l *Loader) LoadModule(ctx context.Context, source, versionConstraint, callerDir string) (*LoadedModule, error) {
+	_, loadSpan := potel.Start(ctx, "modules.LoadModule")
+	defer loadSpan.End()
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 

--- a/pkg/hcl/modules/loader_test.go
+++ b/pkg/hcl/modules/loader_test.go
@@ -260,7 +260,7 @@ func TestLoadModule_VersionConstraintPlumbedThroughToRegistry(t *testing.T) {
 		map[string]string{"4.0.1": tarURL})
 	l := newTestLoader(t, regSrv.URL)
 
-	loaded, err := l.LoadModule("acme/thing/aws", "~> 4.0", t.TempDir())
+	loaded, err := l.LoadModule(t.Context(), "acme/thing/aws", "~> 4.0", t.TempDir())
 	require.NoError(t, err)
 	require.NotNil(t, loaded.Config)
 	require.Contains(t, loaded.Config.Outputs, "ok",
@@ -285,7 +285,7 @@ func TestLoadModule_VersionQueryStringStillSupported(t *testing.T) {
 		map[string]string{"3.0.0": tarURL})
 	l := newTestLoader(t, regSrv.URL)
 
-	_, err := l.LoadModule("acme/thing/aws?version=3.0.0", "", t.TempDir())
+	_, err := l.LoadModule(t.Context(), "acme/thing/aws?version=3.0.0", "", t.TempDir())
 	require.NoError(t, err)
 	require.Equal(t, 1, reg.downloadHits["3.0.0"])
 }
@@ -334,7 +334,7 @@ func TestLoadModule_HostQualifiedRegistrySource(t *testing.T) {
 	}
 	l := NewLoader(n.resolve)
 
-	loaded, err := l.LoadModule(host+"/myorg/widget/aws", "", t.TempDir())
+	loaded, err := l.LoadModule(t.Context(), host+"/myorg/widget/aws", "", t.TempDir())
 	require.NoError(t, err)
 	require.NotNil(t, loaded.Config)
 	require.Contains(t, loaded.Config.Outputs, "ok")
@@ -353,7 +353,7 @@ func TestLoadModule_GitSubdirWithRef(t *testing.T) {
 	l := newTestLoader(t, "http://invalid.example")
 	source := "git::file://" + repo + "//modules/iam-policy?ref=v1"
 
-	loaded, err := l.LoadModule(source, "", t.TempDir())
+	loaded, err := l.LoadModule(t.Context(), source, "", t.TempDir())
 	require.NoError(t, err)
 	require.NotNil(t, loaded.Config)
 	require.Contains(t, loaded.Config.Outputs, "ok",
@@ -409,17 +409,17 @@ func TestLoaderResolvesViaCustomResolver(t *testing.T) {
 		return pkg, nil
 	})
 
-	root, err := l.LoadModule("acme/widget/aws", "~> 4.0", t.TempDir())
+	root, err := l.LoadModule(t.Context(), "acme/widget/aws", "~> 4.0", t.TempDir())
 	require.NoError(t, err)
 	require.Equal(t, pkg, root.SourcePath)
 
 	// Two subdir references into the one resolved package resolve under it; the
 	// resolver only ever sees the package source.
-	a, err := l.LoadModule("acme/widget/aws//a", "~> 4.0", t.TempDir())
+	a, err := l.LoadModule(t.Context(), "acme/widget/aws//a", "~> 4.0", t.TempDir())
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(pkg, "a"), a.SourcePath)
 
-	b, err := l.LoadModule("acme/widget/aws//b", "~> 4.0", t.TempDir())
+	b, err := l.LoadModule(t.Context(), "acme/widget/aws//b", "~> 4.0", t.TempDir())
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(pkg, "b"), b.SourcePath)
 }

--- a/pkg/hcl/modules/loader_test.go
+++ b/pkg/hcl/modules/loader_test.go
@@ -27,7 +27,6 @@ import (
 	regaddr "github.com/opentofu/registry-address/v2"
 	"github.com/opentofu/svchost"
 	"github.com/opentofu/svchost/disco"
-	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi-labs/pulumi-hcl/vendored/getmodules"
 	"github.com/stretchr/testify/require"
 )
@@ -91,21 +90,24 @@ func versionsPayload(vs []string) []map[string]string {
 	return out
 }
 
-// newTestLoader builds a Loader whose default registry host resolves to
-// modulesV1BaseURL, standing in for the real modules.v1 endpoint.
-func newTestLoader(t *testing.T, modulesV1BaseURL string) *Loader {
+// newTestNetworkResolver builds a networkResolver whose default registry host
+// resolves to modulesV1BaseURL, standing in for the real modules.v1 endpoint.
+func newTestNetworkResolver(t *testing.T, modulesV1BaseURL string) *networkResolver {
 	t.Helper()
 	d := disco.New()
 	d.ForceHostServices(regaddr.DefaultModuleRegistryHost, map[string]any{
 		"modules.v1": modulesV1BaseURL + "/",
 	})
-	return &Loader{
-		parser:   parser.NewParser(),
-		cache:    map[string]*LoadedModule{},
+	return &networkResolver{
 		cacheDir: t.TempDir(),
 		fetcher:  getmodules.NewPackageFetcher(t.Context(), nil),
 		disco:    d,
 	}
+}
+
+func newTestLoader(t *testing.T, modulesV1BaseURL string) *Loader {
+	t.Helper()
+	return NewLoader(newTestNetworkResolver(t, modulesV1BaseURL).resolve)
 }
 
 func TestIsRegistrySource(t *testing.T) {
@@ -142,9 +144,9 @@ func TestGetRegistryDownloadURL_NoConstraintPicksLatest(t *testing.T) {
 	srv, reg := newFakeRegistry(t,
 		[]string{"1.0.0", "3.2.1", "4.0.0", "4.2.0", "2.9.9"},
 		map[string]string{"4.2.0": "https://example.com/v420.tar.gz"})
-	l := newTestLoader(t, srv.URL)
+	n := newTestNetworkResolver(t, srv.URL)
 
-	got, err := l.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "")
+	got, err := n.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "")
 	require.NoError(t, err)
 	require.Equal(t, "https://example.com/v420.tar.gz", got)
 	require.Equal(t, 1, reg.versionsHits)
@@ -156,9 +158,9 @@ func TestGetRegistryDownloadURL_ConstraintPicksHighestMatching(t *testing.T) {
 	srv, reg := newFakeRegistry(t,
 		[]string{"3.0.0", "3.5.0", "4.0.0", "4.0.1", "4.1.0", "5.0.0"},
 		map[string]string{"4.1.0": "https://example.com/v410.tar.gz"})
-	l := newTestLoader(t, srv.URL)
+	n := newTestNetworkResolver(t, srv.URL)
 
-	got, err := l.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "~> 4.0")
+	got, err := n.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "~> 4.0")
 	require.NoError(t, err)
 	require.Equal(t, "https://example.com/v410.tar.gz", got)
 	require.Equal(t, 1, reg.downloadHits["4.1.0"])
@@ -169,9 +171,9 @@ func TestGetRegistryDownloadURL_ExactVersionPin(t *testing.T) {
 	srv, _ := newFakeRegistry(t,
 		[]string{"1.0.0", "2.0.0", "3.0.0"},
 		map[string]string{"2.0.0": "https://example.com/v200.tar.gz"})
-	l := newTestLoader(t, srv.URL)
+	n := newTestNetworkResolver(t, srv.URL)
 
-	got, err := l.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "2.0.0")
+	got, err := n.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "2.0.0")
 	require.NoError(t, err)
 	require.Equal(t, "https://example.com/v200.tar.gz", got)
 }
@@ -181,9 +183,9 @@ func TestGetRegistryDownloadURL_NoMatchingVersionErrors(t *testing.T) {
 	srv, _ := newFakeRegistry(t,
 		[]string{"1.0.0", "2.0.0"},
 		map[string]string{})
-	l := newTestLoader(t, srv.URL)
+	n := newTestNetworkResolver(t, srv.URL)
 
-	_, err := l.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "~> 99.0")
+	_, err := n.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "~> 99.0")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no published version")
 	require.Contains(t, err.Error(), "~> 99.0")
@@ -217,8 +219,8 @@ func TestGetRegistryDownloadURL_OpenTofuStyle_JSONBody(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	l := newTestLoader(t, srv.URL)
-	got, err := l.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "")
+	n := newTestNetworkResolver(t, srv.URL)
+	got, err := n.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "")
 	require.NoError(t, err)
 	require.Equal(t, wantURL, got)
 }
@@ -228,9 +230,9 @@ func TestGetRegistryDownloadURL_InvalidConstraintErrors(t *testing.T) {
 	srv, _ := newFakeRegistry(t,
 		[]string{"1.0.0"},
 		map[string]string{"1.0.0": "https://example.com/x.tar.gz"})
-	l := newTestLoader(t, srv.URL)
+	n := newTestNetworkResolver(t, srv.URL)
 
-	_, err := l.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "not-a-constraint")
+	_, err := n.getRegistryDownloadURL(srv.URL, "acme", "thing", "aws", "not-a-constraint")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "parsing version constraint")
 }
@@ -325,13 +327,12 @@ func TestLoadModule_HostQualifiedRegistrySource(t *testing.T) {
 	d := disco.New()
 	d.ForceHostServices(hostname, map[string]any{"modules.v1": srv.URL + "/v1/modules/"})
 
-	l := &Loader{
-		parser:   parser.NewParser(),
-		cache:    map[string]*LoadedModule{},
+	n := &networkResolver{
 		cacheDir: t.TempDir(),
 		fetcher:  getmodules.NewPackageFetcher(t.Context(), nil),
 		disco:    d,
 	}
+	l := NewLoader(n.resolve)
 
 	loaded, err := l.LoadModule(host+"/myorg/widget/aws", "", t.TempDir())
 	require.NoError(t, err)
@@ -384,6 +385,43 @@ func git(t *testing.T, dir string, args ...string) {
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "git %s: %s", strings.Join(args, " "), out)
+}
+
+// TestLoaderResolvesViaCustomResolver verifies a loader built from a custom
+// resolver (the mechanism a bundle loader uses) resolves a package and joins
+// subdir references under it, with the resolver seeing only the package source.
+func TestLoaderResolvesViaCustomResolver(t *testing.T) {
+	t.Parallel()
+
+	pkg := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(pkg, "main.tf"), []byte(`output "root" { value = 1 }`), 0o600))
+	for _, sub := range []string{"a", "b"} {
+		dir := filepath.Join(pkg, sub)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "main.tf"), []byte(`output "leaf" { value = 1 }`), 0o600))
+	}
+
+	l := NewLoader(func(packageSource, versionConstraint, _ string) (string, error) {
+		require.Equal(t, "acme/widget/aws", packageSource)
+		require.Equal(t, "~> 4.0", versionConstraint)
+		return pkg, nil
+	})
+
+	root, err := l.LoadModule("acme/widget/aws", "~> 4.0", t.TempDir())
+	require.NoError(t, err)
+	require.Equal(t, pkg, root.SourcePath)
+
+	// Two subdir references into the one resolved package resolve under it; the
+	// resolver only ever sees the package source.
+	a, err := l.LoadModule("acme/widget/aws//a", "~> 4.0", t.TempDir())
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(pkg, "a"), a.SourcePath)
+
+	b, err := l.LoadModule("acme/widget/aws//b", "~> 4.0", t.TempDir())
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(pkg, "b"), b.SourcePath)
 }
 
 // buildModuleTarGz packs `files` (name → content) into a gzipped tar archive

--- a/pkg/hcl/resolve/cache.go
+++ b/pkg/hcl/resolve/cache.go
@@ -1,0 +1,74 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolve
+
+import (
+	"context"
+	"hash/maphash"
+	"sync"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc"
+)
+
+type Cache struct {
+	inner pulumirpc.PackageResolverClient
+
+	mu      sync.Mutex
+	entries map[specHash]cacheEntry
+}
+
+type cacheEntry struct {
+	dep *pulumirpc.PackageDependency
+	err error
+}
+
+func NewCache(resolver pulumirpc.PackageResolverClient) *Cache {
+	return &Cache{
+		inner:   resolver,
+		entries: map[specHash]cacheEntry{},
+	}
+}
+
+func (c *Cache) ResolvePackage(
+	ctx context.Context, spec *pulumirpc.PackageSpec, opts ...grpc.CallOption,
+) (*pulumirpc.PackageDependency, error) {
+	key := hashSpec(spec)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, ok := c.entries[key]; ok {
+		return e.dep, e.err
+	}
+	dep, err := c.inner.ResolvePackage(ctx, spec, opts...)
+	c.entries[key] = cacheEntry{dep: dep, err: err}
+	return dep, err
+}
+
+type specHash uint64
+
+var specHashSeed = maphash.MakeSeed()
+
+func hashSpec(spec *pulumirpc.PackageSpec) specHash {
+	var h maphash.Hash
+	h.SetSeed(specHashSeed)
+	maphash.WriteComparable(&h, spec.GetSource())
+	maphash.WriteComparable(&h, spec.GetVersion())
+	maphash.WriteComparable(&h, len(spec.GetParameters()))
+	for _, p := range spec.GetParameters() {
+		maphash.WriteComparable(&h, p)
+	}
+	return specHash(h.Sum64())
+}

--- a/pkg/hcl/resolve/cache_test.go
+++ b/pkg/hcl/resolve/cache_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolve
+
+import (
+	"errors"
+	"testing"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingResolver records how many times ResolvePackage is invoked per source.
+type countingResolver struct {
+	fakeResolver
+	calls map[string]int
+}
+
+func newCountingResolver() *countingResolver {
+	c := &countingResolver{calls: map[string]int{}}
+	c.respond = func(spec *pulumirpc.PackageSpec) (*pulumirpc.PackageDependency, error) {
+		c.calls[spec.Source]++
+		if spec.Source == "boom" {
+			return nil, errors.New("boom")
+		}
+		return &pulumirpc.PackageDependency{Name: spec.Source, Kind: "resource", Version: "1.0.0"}, nil
+	}
+	return c
+}
+
+func TestCacheResolvesEachSpecOnce(t *testing.T) {
+	t.Parallel()
+
+	inner := newCountingResolver()
+	cache := NewCache(inner)
+
+	aws := &pulumirpc.PackageSpec{Source: "terraform-provider", Parameters: []string{"hashicorp/aws", "~> 6.0"}}
+	for range 3 {
+		dep, err := cache.ResolvePackage(t.Context(), aws)
+		require.NoError(t, err)
+		assert.Equal(t, &pulumirpc.PackageDependency{
+			Name: "terraform-provider", Kind: "resource", Version: "1.0.0",
+		}, dep)
+	}
+	assert.Equal(t, 1, inner.calls["terraform-provider"])
+
+	// A spec differing only in its parameters is a distinct cache entry.
+	gcp := &pulumirpc.PackageSpec{Source: "terraform-provider", Parameters: []string{"hashicorp/google", "~> 6.0"}}
+	_, err := cache.ResolvePackage(t.Context(), gcp)
+	require.NoError(t, err)
+	assert.Equal(t, 2, inner.calls["terraform-provider"])
+}
+
+func TestCacheCachesErrors(t *testing.T) {
+	t.Parallel()
+
+	inner := newCountingResolver()
+	cache := NewCache(inner)
+
+	for range 2 {
+		_, err := cache.ResolvePackage(t.Context(), &pulumirpc.PackageSpec{Source: "boom"})
+		assert.EqualError(t, err, "boom")
+	}
+	assert.Equal(t, 1, inner.calls["boom"])
+}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -38,7 +38,6 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modules"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
-	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/util"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -444,6 +443,9 @@ type EngineOptions struct {
 	// The engine calls RegisterPackage on the resource monitor for each entry before running the program.
 	Packages map[string]workspace.PackageDescriptor
 
+	// ModuleLoader loads child module configurations. It must not be nil.
+	ModuleLoader *modules.Loader
+
 	Parallel int
 
 	// AlwaysRegisterProviders forces every `provider` block to be registered
@@ -458,9 +460,10 @@ type EngineOptions struct {
 
 // NewEngine creates a new execution engine.
 func NewEngine(ctx context.Context, config *ast.Config, opts *EngineOptions) *Engine {
-	contract.Assertf(opts.SchemaLoader != nil, "EngineOptions.SchemaLoader cannot be nil")
-	contract.Assertf(opts.WorkDir != "", "EngineOptions.WorkDir cannot be empty")
-	contract.Assertf(opts.RootDir != "", "EngineOptions.RootDir cannot be empty")
+	contract.Requiref(opts.SchemaLoader != nil, "opts.SchemaLoader", "EngineOptions.SchemaLoader cannot be nil")
+	contract.Requiref(opts.WorkDir != "", "opts.WorkDir", "EngineOptions.WorkDir cannot be empty")
+	contract.Requiref(opts.RootDir != "", "opts.RootDir", "EngineOptions.RootDir cannot be empty")
+	contract.Requiref(opts.ModuleLoader != nil, "EngineOptions.ModuleLoader", "cannot be empty")
 
 	evalCtx := eval.NewContext(opts.WorkDir, opts.RootDir, opts.WorkDir,
 		opts.StackName, opts.ProjectName, opts.Organization)
@@ -484,7 +487,7 @@ func NewEngine(ctx context.Context, config *ast.Config, opts *EngineOptions) *En
 		configSecretKeys:        opts.ConfigSecretKeys,
 		packages:                opts.Packages,
 		packageRefs:             make(map[string]PackageRef),
-		moduleLoader:            modules.NewLoader(ctx),
+		moduleLoader:            opts.ModuleLoader,
 		moduleInstances:         util.NewSyncMap[modulepath.Path, []*moduleInstance](),
 		parallel:                opts.Parallel,
 		failedNodes:             util.NewSyncMap[string, error](),
@@ -3577,25 +3580,6 @@ func providerRefFromCty(val cty.Value) (string, error) {
 		return urn + "::" + id, nil
 	}
 	return "", errors.New("provider value is not a resource reference")
-}
-
-// RunFromDirectory parses and executes an HCL program from a directory.
-func RunFromDirectory(ctx context.Context, dir string, opts *EngineOptions) error {
-	// Parse the configuration
-	p := parser.NewParser()
-	config, diags := p.ParseDirectory(dir)
-	if diags.HasErrors() {
-		return fmt.Errorf("parsing configuration: %s", diags.Error())
-	}
-
-	// Set the work dir if not specified
-	if opts.WorkDir == "" {
-		opts.WorkDir = dir
-	}
-
-	// Create and run the engine
-	engine := NewEngine(ctx, config, opts)
-	return engine.Run(ctx)
 }
 
 // Validate validates an HCL configuration without executing it.

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modules"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/potel"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/util"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -499,6 +500,8 @@ func NewEngine(ctx context.Context, config *ast.Config, opts *EngineOptions) *En
 
 // Run executes the HCL program.
 func (e *Engine) Run(ctx context.Context) error {
+	ctx, span := potel.Start(ctx, "Engine.Run")
+	defer span.End()
 	for alias, pkg := range e.packages {
 		ref, err := e.resmon.RegisterPackage(ctx, pkg)
 		if err != nil {
@@ -3011,7 +3014,8 @@ type moduleLoaderAdapter struct {
 }
 
 func (a *moduleLoaderAdapter) LoadModule(source, version, workDir string) (*graph.LoadedModule, error) {
-	loaded, err := a.loader.LoadModule(source, version, workDir)
+	// graph.ModuleLoader carries no context, so there is none to thread here.
+	loaded, err := a.loader.LoadModule(context.TODO(), source, version, workDir)
 	if err != nil {
 		return nil, err
 	}
@@ -3152,7 +3156,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 	if loaderWorkDir == "" {
 		loaderWorkDir = e.workDir
 	}
-	childMod, err := e.moduleLoader.LoadModule(mod.Source, mod.Version, loaderWorkDir)
+	childMod, err := e.moduleLoader.LoadModule(ctx, mod.Source, mod.Version, loaderWorkDir)
 	if err != nil {
 		return fmt.Errorf("loading module %s for input types: %w", mod.Source, err)
 	}

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -167,6 +167,7 @@ resource "pulumi_stack_reference" "ref" {
 		ResourceMonitor: mock,
 		WorkDir:         t.TempDir(),
 		RootDir:         t.TempDir(),
+		ModuleLoader:    modules.NewLoader(modules.LiveResolver(t.Context())),
 		SchemaLoader:    schemaloader.Mock{"pulumi": pulumiPkg},
 	})
 

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modules"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/run"
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil"
@@ -32,6 +33,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testModuleLoader builds a live module loader for the engine. These tests do
+// not exercise child modules, so it is never invoked; the engine just requires a
+// non-nil loader.
+func testModuleLoader(t *testing.T) *modules.Loader {
+	return modules.NewLoader(func(packageSource, versionConstraint, callerDir string) (string, error) {
+		t.Fail()
+		return "", fmt.Errorf("attempted to load (%q, %q, %q)",
+			packageSource, versionConstraint, callerDir)
+	})
+}
+
+// testLiveModuleLoader is for the tests that exercise child modules. Their
+// sources are all local paths, so the live resolver resolves them from the
+// filesystem with no network access.
+func testLiveModuleLoader(t *testing.T) *modules.Loader {
+	return modules.NewLoader(modules.LiveResolver(t.Context()))
+}
 
 func TestEngine_BasicResource(t *testing.T) {
 	t.Parallel()
@@ -56,6 +75,7 @@ resource "aws_instance" "web" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -184,6 +204,7 @@ output "name" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -242,6 +263,7 @@ output "each_name" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -309,6 +331,7 @@ resource "aws_instance" "named" {
 		},
 	}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -370,6 +393,7 @@ resource "aws_s3_bucket" "mybucket" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -430,6 +454,7 @@ resource "aws_subnet" "main" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -557,6 +582,7 @@ resource "aws_instance" "web" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -632,6 +658,7 @@ resource "aws_instance" "web" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -696,6 +723,7 @@ resource "aws_instance" "web" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -762,6 +790,7 @@ resource "aws_instance" "web" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -827,6 +856,7 @@ output "region_value" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -893,6 +923,7 @@ output "region_value" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -961,6 +992,7 @@ output "lst_value" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -1029,6 +1061,7 @@ variable "required_var" {
 
 			mock := &testutil.MockResourceMonitor{}
 			engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+				ModuleLoader:    testModuleLoader(t),
 				ProjectName:     "test-project",
 				StackName:       "dev",
 				ResourceMonitor: mock,
@@ -1096,6 +1129,7 @@ output "item_count" {
 
 		mock := &testutil.MockResourceMonitor{}
 		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ModuleLoader:    testLiveModuleLoader(t),
 			ProjectName:     "test-project",
 			StackName:       "dev",
 			ResourceMonitor: mock,
@@ -1166,6 +1200,7 @@ output "name" {
 
 		mock := &testutil.MockResourceMonitor{}
 		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ModuleLoader:    testLiveModuleLoader(t),
 			ProjectName:     "test-project",
 			StackName:       "dev",
 			ResourceMonitor: mock,
@@ -1203,6 +1238,7 @@ func TestEngine_OutputPrecondition(t *testing.T) {
 	newEngine := func(t *testing.T, config *ast.Config, workDir string) (*testutil.MockResourceMonitor, *run.Engine) {
 		mock := &testutil.MockResourceMonitor{}
 		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ModuleLoader:    testLiveModuleLoader(t),
 			ProjectName:     "test-project",
 			StackName:       "dev",
 			ResourceMonitor: mock,
@@ -1343,6 +1379,7 @@ output "is_sensitive" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testLiveModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -1384,6 +1421,7 @@ output "instance_type" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -1444,6 +1482,7 @@ variable "instance_type" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -1508,6 +1547,7 @@ output "name" {
 		require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
 
 		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ModuleLoader:    testModuleLoader(t),
 			ProjectName:     "test-project",
 			StackName:       "dev",
 			ResourceMonitor: &testutil.MockResourceMonitor{},
@@ -1553,6 +1593,7 @@ variable "password" {
 	}
 
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: &testutil.MockResourceMonitor{},
@@ -1607,6 +1648,7 @@ resource "test_resource" "res" {
 
 		mock := &testutil.MockResourceMonitor{}
 		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ModuleLoader:    testModuleLoader(t),
 			ProjectName:     "test-project",
 			StackName:       "dev",
 			ResourceMonitor: mock,
@@ -1662,6 +1704,7 @@ resource "test_resource" "res" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -1706,6 +1749,7 @@ resource "test_resource" "upstream" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -1766,6 +1810,7 @@ resource "test_resource" "dependent" {
 		},
 	}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -1809,6 +1854,7 @@ resource "test_resource" "res" {
 
 		mock := &testutil.MockResourceMonitor{}
 		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ModuleLoader:    testModuleLoader(t),
 			ProjectName:     "test-project",
 			StackName:       "dev",
 			ResourceMonitor: mock,
@@ -1865,6 +1911,7 @@ resource "aws_instance" "web" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -1920,6 +1967,7 @@ resource "aws_instance" "web" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -1971,6 +2019,7 @@ resource "aws_instance" "web" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -2065,6 +2114,7 @@ output "vpc_id" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testLiveModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -2177,6 +2227,7 @@ module "vpc.primary" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testLiveModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -2245,6 +2296,7 @@ resource "kubernetes_networking.k8s.io_v1_ingress" "ingress" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -2310,6 +2362,7 @@ output "name" { value = "leaf" }
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testLiveModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -2446,6 +2499,7 @@ module "m" {
 		},
 	}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testLiveModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -2507,6 +2561,7 @@ module "multi" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testLiveModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -2546,6 +2601,7 @@ resource "aws_instance" "web" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -2628,6 +2684,7 @@ resource "aws_instance" "web" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -2710,6 +2767,7 @@ resource "aws_instance" "imported" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -2806,6 +2864,7 @@ resource "test_resource" "res" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -2894,6 +2953,7 @@ func TestEngine_HetListOutputRoundTrip(t *testing.T) {
 		},
 	}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: monitor,
@@ -2992,6 +3052,7 @@ func TestEngine_SchemaConstValues(t *testing.T) {
 
 		mock := &testutil.MockResourceMonitor{}
 		engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+			ModuleLoader:    testModuleLoader(t),
 			ProjectName:     "test-project",
 			StackName:       "dev",
 			ResourceMonitor: mock,
@@ -3106,6 +3167,7 @@ resource "aws_ec2_vpd" "example" {}
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -3150,6 +3212,7 @@ data "aws_ec2_vpd" "example" {}
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -3218,6 +3281,7 @@ module "child" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testLiveModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -3314,6 +3378,7 @@ module "child" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testLiveModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,
@@ -3419,6 +3484,7 @@ module "child" {
 
 	mock := &testutil.MockResourceMonitor{}
 	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testLiveModuleLoader(t),
 		ProjectName:     "test-project",
 		StackName:       "dev",
 		ResourceMonitor: mock,

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -50,7 +50,9 @@ type ResourceTypeResolver interface {
 // directory, so module.<name>.<output> references can be typed by recursively
 // typing the child module's outputs.
 type ModuleLoader interface {
-	LoadModule(source, versionConstraint, callerDir string) (config *ast.Config, dir string, err error)
+	LoadModule(
+		ctx context.Context, source, versionConstraint, callerDir string,
+	) (config *ast.Config, dir string, err error)
 }
 
 // Binder supplies the external lookups used to type output expressions that
@@ -315,7 +317,7 @@ func seedModuleTypes(
 	}
 	for _, name := range slices.Sorted(maps.Keys(config.Modules)) {
 		call := config.Modules[name]
-		childConfig, dir, err := binder.Modules.LoadModule(call.Source, call.Version, binder.ModuleDir)
+		childConfig, dir, err := binder.Modules.LoadModule(ctx, call.Source, call.Version, binder.ModuleDir)
 		if err != nil {
 			return fmt.Errorf("loading module %q: %w", name, err)
 		}

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -24,12 +24,14 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/blang/semver"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/bridge"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
 	pulumischema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -123,17 +125,16 @@ type PropertySpec struct {
 }
 
 // GenerateModuleSchema generates a Pulumi schema from an HCL module
-// configuration. binder types output expressions that reference resources, data
-// sources, or child modules; pass nil to leave those references untyped.
+// configuration.
 func GenerateModuleSchema(
 	ctx context.Context, config *ast.Config, binder *Binder,
-	pkgName, pkgVersion, componentName, module string,
+	token tokens.Type, version semver.Version,
 ) (*ModuleSchema, error) {
 	schema := &ModuleSchema{
-		PackageName:      pkgName,
-		Version:          pkgVersion,
-		ComponentName:    componentName,
-		Module:           module,
+		PackageName:      token.Package().Name().String(),
+		Version:          version.String(),
+		ComponentName:    token.Name().String(),
+		Module:           token.Module().Name().String(),
 		InputProperties:  make(map[string]*PropertySpec),
 		OutputProperties: make(map[string]*PropertySpec),
 	}

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -28,11 +28,17 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	pulumiSchema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// componentToken assembles a component type token from its parts.
+func componentToken(pkg, module, component string) tokens.Type {
+	return tokens.Type(pkg + ":" + module + ":" + component)
+}
 
 // TestGenerateModuleSchemaGolden parses the HCL in each testdata case and
 // asserts the Pulumi package schema produced by GenerateModuleSchema followed by
@@ -71,7 +77,7 @@ func TestGenerateModuleSchemaGolden(t *testing.T) {
 			require.False(t, diags.HasErrors(), diags.Error())
 
 			moduleSchema, err := GenerateModuleSchema(
-				t.Context(), config, nil, tc.pkgName, tc.version, tc.componentName, tc.module)
+				t.Context(), config, nil, componentToken(tc.pkgName, tc.module, tc.componentName), semver.MustParse(tc.version))
 			require.NoError(t, err)
 
 			pkgSpec := moduleSchema.ToPulumiPackageSchema()
@@ -153,7 +159,7 @@ output "length" {
 	}}
 
 	moduleSchema, err := GenerateModuleSchema(
-		t.Context(), config, &Binder{Resources: resolver}, "pkg", "0.0.0-dev", "pkg", "index")
+		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]*PropertySpec{
@@ -198,7 +204,7 @@ output "keyed_id" {
 		"random_pet": {Properties: []*pulumiSchema.Property{{Name: "length", Type: pulumiSchema.IntType}}},
 	}}
 	moduleSchema, err := GenerateModuleSchema(
-		t.Context(), config, &Binder{Resources: resolver}, "pkg", "0.0.0-dev", "pkg", "index")
+		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
 	require.NoError(t, err)
 
 	elem := &PropertySpec{Type: "object", Properties: map[string]*PropertySpec{
@@ -267,7 +273,7 @@ output "n" {
 		ModuleDir: ".",
 	}
 	moduleSchema, err := GenerateModuleSchema(
-		t.Context(), config, binder, "pkg", "0.0.0-dev", "pkg", "index")
+		t.Context(), config, binder, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]*PropertySpec{
@@ -293,7 +299,7 @@ output "id" {
 	require.False(t, diags.HasErrors(), diags.Error())
 
 	_, err := GenerateModuleSchema(
-		t.Context(), config, &Binder{Resources: stubResolver{}}, "pkg", "0.0.0-dev", "pkg", "index")
+		t.Context(), config, &Binder{Resources: stubResolver{}}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
 	require.EqualError(t, err, `resolving resource "mystery_thing.x": no schema for type "mystery_thing"`)
 }
 
@@ -336,7 +342,7 @@ output "z" {
 		Modules:   stubModuleLoader{configs: map[string]*ast.Config{"./a": a, "./b": b}},
 		ModuleDir: ".",
 	}
-	_, err := GenerateModuleSchema(t.Context(), root, binder, "pkg", "0.0.0-dev", "pkg", "index")
+	_, err := GenerateModuleSchema(t.Context(), root, binder, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
 	require.Error(t, err)
 }
 

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -223,7 +223,7 @@ type stubModuleLoader struct {
 	configs map[string]*ast.Config
 }
 
-func (s stubModuleLoader) LoadModule(source, _, _ string) (*ast.Config, string, error) {
+func (s stubModuleLoader) LoadModule(_ context.Context, source, _, _ string) (*ast.Config, string, error) {
 	cfg, ok := s.configs[source]
 	if !ok {
 		return nil, "", fmt.Errorf("no module %q", source)

--- a/pkg/potel/potel.go
+++ b/pkg/potel/potel.go
@@ -1,0 +1,28 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package potel
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer = otel.Tracer("github.com/pulumi-labs/pulumi-hcl/pkg/server")
+
+func Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return tracer.Start(ctx, spanName, opts...)
+}

--- a/pkg/server/module_resource.go
+++ b/pkg/server/module_resource.go
@@ -211,10 +211,9 @@ func (m *moduleProvider) construct(ctx context.Context, req p.ConstructRequest) 
 
 	// Resolve every provider the module references to a concrete descriptor, the
 	// dynamic equivalent of the on-disk sdks/ descriptors a source MLC reads.
-	resolved, err := resolve.Packages(ctx, resolver,
-		m.requirementSpecs(ctx, m.moduleLoader, loaded.Config, loaded.SourcePath))
+	resolved, err := m.resolvePackages(ctx, m.moduleLoader, loaded.Config, loaded.SourcePath)
 	if err != nil {
-		return p.ConstructResponse{}, fmt.Errorf("resolving module providers: %w", err)
+		return p.ConstructResponse{}, err
 	}
 
 	// A parameterization-aware loader lets the engine load the schemas of bridged
@@ -283,10 +282,9 @@ func (m *moduleProvider) constructParameterized(ctx context.Context, req p.Const
 		return p.ConstructResponse{}, fmt.Errorf("loading module %q: %w", param.name, err)
 	}
 
-	resolved, err := resolve.Packages(ctx, m.resolver,
-		m.requirementSpecs(ctx, param.loader, loaded.Config, loaded.SourcePath))
+	resolved, err := m.resolvePackages(ctx, param.loader, loaded.Config, loaded.SourcePath)
 	if err != nil {
-		return p.ConstructResponse{}, fmt.Errorf("resolving module providers: %w", err)
+		return p.ConstructResponse{}, err
 	}
 
 	monitorConn, err := grpc.NewClient(req.MonitorEndpoint,

--- a/pkg/server/module_resource.go
+++ b/pkg/server/module_resource.go
@@ -200,7 +200,7 @@ func (m *moduleProvider) construct(ctx context.Context, req p.ConstructRequest) 
 		inputs = v.AsMap()
 	}
 
-	loaded, err := m.moduleLoader.LoadModule(source, version, ".")
+	loaded, err := m.moduleLoader.LoadModule(ctx, source, version, ".")
 	if err != nil {
 		return p.ConstructResponse{}, fmt.Errorf("loading module %q: %w", source, err)
 	}
@@ -277,7 +277,7 @@ func (m *moduleProvider) constructParameterized(ctx context.Context, req p.Const
 	}
 	param := m.param
 
-	loaded, err := param.loader.LoadModule(param.rootSource, param.rootVersion, ".")
+	loaded, err := param.loader.LoadModule(ctx, param.rootSource, param.rootVersion, ".")
 	if err != nil {
 		return p.ConstructResponse{}, fmt.Errorf("loading module %q: %w", param.name, err)
 	}

--- a/pkg/server/module_resource.go
+++ b/pkg/server/module_resource.go
@@ -123,7 +123,7 @@ func (m *moduleProvider) handshake(ctx context.Context, req p.HandshakeRequest) 
 
 	m.schemaLoader = schemaLoader
 	m.providerInfoSource = bridge.NewCache(bridge.NewMapperSource(mapperClient))
-	m.resolver = pulumirpc.NewPackageResolverClient(resolverConn)
+	m.resolver = resolve.NewCache(pulumirpc.NewPackageResolverClient(resolverConn))
 	if req.EngineAddress != "" && m.engine == nil {
 		if engineConn, err := grpc.NewClient(req.EngineAddress,
 			grpc.WithTransportCredentials(insecure.NewCredentials())); err == nil {
@@ -282,11 +282,6 @@ func (m *moduleProvider) constructParameterized(ctx context.Context, req p.Const
 		return p.ConstructResponse{}, fmt.Errorf("loading module %q: %w", param.name, err)
 	}
 
-	resolved, err := m.resolvePackages(ctx, param.loader, loaded.Config, loaded.SourcePath)
-	if err != nil {
-		return p.ConstructResponse{}, err
-	}
-
 	monitorConn, err := grpc.NewClient(req.MonitorEndpoint,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithUnaryInterceptor(rpcutil.OpenTracingClientInterceptor()),
@@ -306,6 +301,9 @@ func (m *moduleProvider) constructParameterized(ctx context.Context, req p.Const
 	resmon := m.newConstructMonitor(ctx, req,
 		pulumirpc.NewResourceMonitorClient(monitorConn), componentInputs, param.schema.OutputsToPulumi)
 
+	loader := pulumiSchema.NewCachedLoader(packages.NewParameterizationAwareLoader(
+		m.schemaLoader, param.packages))
+
 	engineRun := run.NewEngine(ctx, loaded.Config, &run.EngineOptions{
 		ProjectName:        string(req.Urn.Project()),
 		StackName:          string(req.Urn.Stack()),
@@ -314,9 +312,9 @@ func (m *moduleProvider) constructParameterized(ctx context.Context, req p.Const
 		RootDir:            loaded.SourcePath,
 		Config:             moduleConfig(string(req.Urn.Project()), param.schema.InputsToHCL(req.Inputs)),
 		ResourceMonitor:    resmon,
-		SchemaLoader:       pulumiSchema.NewCachedLoader(packages.NewParameterizationAwareLoader(m.schemaLoader, resolved)),
+		SchemaLoader:       loader,
 		ProviderInfoSource: m.providerInfoSource,
-		Packages:           resolved,
+		Packages:           param.packages,
 		ModuleLoader:       param.loader,
 		Parallel:           int(req.Parallel),
 	})

--- a/pkg/server/module_resource.go
+++ b/pkg/server/module_resource.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -35,6 +36,7 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/bridge"
@@ -59,6 +61,11 @@ type moduleProvider struct {
 	schemaLoader       pulumiSchema.ReferenceLoader
 	providerInfoSource bridge.ProviderInfoSource
 	resolver           pulumirpc.PackageResolverClient
+
+	// param is non-nil once the provider has been parameterized by a specific
+	// module source (via Parameterize). It makes the provider serve that module's
+	// typed component schema instead of the generic hcl:index:Module.
+	param *parameterizedModule
 }
 
 // NewModuleProvider builds the fully dynamic HCL provider on top of the raw
@@ -66,12 +73,13 @@ type moduleProvider struct {
 func NewModuleProvider(ctx context.Context, version string) p.Provider {
 	m := &moduleProvider{
 		version:      version,
-		moduleLoader: modules.NewLoader(ctx),
+		moduleLoader: modules.NewLoader(modules.LiveResolver(ctx)),
 	}
 	return p.Provider{
-		Handshake: m.handshake,
-		GetSchema: m.getSchema,
-		Configure: func(context.Context, p.ConfigureRequest) error { return nil },
+		Handshake:    m.handshake,
+		Parameterize: m.parameterize,
+		GetSchema:    m.getSchema,
+		Configure:    func(context.Context, p.ConfigureRequest) error { return nil },
 		CheckConfig: func(_ context.Context, req p.CheckRequest) (p.CheckResponse, error) {
 			return p.CheckResponse{Inputs: req.Inputs}, nil
 		},
@@ -79,6 +87,7 @@ func NewModuleProvider(ctx context.Context, version string) p.Provider {
 			return p.DiffResponse{}, nil
 		},
 		Construct: m.construct,
+		Cancel:    m.cancel,
 	}
 }
 
@@ -125,13 +134,31 @@ func (m *moduleProvider) handshake(ctx context.Context, req p.HandshakeRequest) 
 	return p.HandshakeResponse{}, nil
 }
 
-// getSchema returns the static hcl:index:Module schema.
+// getSchema returns the static hcl:index:Module schema, or — once the provider
+// has been parameterized — the parameterized module's typed component schema with
+// its parameterization Value attached so a generated SDK can re-parameterize.
 func (m *moduleProvider) getSchema(context.Context, p.GetSchemaRequest) (p.GetSchemaResponse, error) {
-	b, err := json.Marshal(moduleResourceSchema(m.version))
+	spec := moduleResourceSchema(m.version)
+	if m.param != nil {
+		spec = m.param.schema.ToPulumiPackageSchema()
+		spec.Parameterization = &pulumiSchema.ParameterizationSpec{
+			BaseProvider: pulumiSchema.BaseProviderSpec{Name: "hcl", Version: m.version},
+			Parameter:    m.param.value,
+		}
+	}
+	b, err := json.Marshal(spec)
 	if err != nil {
 		return p.GetSchemaResponse{}, fmt.Errorf("marshaling schema: %w", err)
 	}
 	return p.GetSchemaResponse{Schema: string(b)}, nil
+}
+
+// cancel removes any unpacked module bundle when the provider shuts down.
+func (m *moduleProvider) cancel(context.Context) error {
+	if m.param != nil && m.param.tempDir != "" {
+		return os.RemoveAll(m.param.tempDir)
+	}
+	return nil
 }
 
 // construct loads the module named by the "source" input, resolves the providers
@@ -139,8 +166,14 @@ func (m *moduleProvider) getSchema(context.Context, p.GetSchemaRequest) (p.GetSc
 // under the component's single "outputs" property.
 func (m *moduleProvider) construct(ctx context.Context, req p.ConstructRequest) (p.ConstructResponse, error) {
 	logging.V(5).Infof("Construct: type=%s name=%s", req.Urn.Type(), req.Urn.Name())
+	if m.param != nil {
+		return m.constructParameterized(ctx, req)
+	}
+	if req.Urn.Type() != ModuleResourceToken {
+		return p.ConstructResponse{}, fmt.Errorf("unknown resource type: %q", req.Urn.Type())
+	}
 
-	schemaLoader, providerInfoSource, resolver, engine := m.schemaLoader, m.providerInfoSource, m.resolver, m.engine
+	schemaLoader, providerInfoSource, resolver := m.schemaLoader, m.providerInfoSource, m.resolver
 	if resolver == nil {
 		return p.ConstructResponse{}, fmt.Errorf("Construct called before a successful Handshake")
 	}
@@ -178,7 +211,8 @@ func (m *moduleProvider) construct(ctx context.Context, req p.ConstructRequest) 
 
 	// Resolve every provider the module references to a concrete descriptor, the
 	// dynamic equivalent of the on-disk sdks/ descriptors a source MLC reads.
-	resolved, err := resolve.Packages(ctx, resolver, m.requirementSpecs(ctx, loaded.Config, loaded.SourcePath))
+	resolved, err := resolve.Packages(ctx, resolver,
+		m.requirementSpecs(ctx, m.moduleLoader, loaded.Config, loaded.SourcePath))
 	if err != nil {
 		return p.ConstructResponse{}, fmt.Errorf("resolving module providers: %w", err)
 	}
@@ -205,9 +239,111 @@ func (m *moduleProvider) construct(ctx context.Context, req p.ConstructRequest) 
 		return p.ConstructResponse{}, fmt.Errorf("marshaling inputs: %w", err)
 	}
 
-	resmon := &constructResourceMonitor{
-		client:                  pulumirpc.NewResourceMonitorClient(monitorConn),
-		engine:                  engine,
+	resmon := m.newConstructMonitor(ctx, req,
+		pulumirpc.NewResourceMonitorClient(monitorConn), componentInputs, wrapModuleOutputs)
+
+	engineRun := run.NewEngine(ctx, loaded.Config, &run.EngineOptions{
+		ProjectName:        string(req.Urn.Project()),
+		StackName:          string(req.Urn.Stack()),
+		DryRun:             req.DryRun,
+		WorkDir:            loaded.SourcePath,
+		RootDir:            loaded.SourcePath,
+		Config:             moduleConfig(string(req.Urn.Project()), inputs),
+		ResourceMonitor:    resmon,
+		SchemaLoader:       pulumiSchema.NewCachedLoader(loader),
+		ProviderInfoSource: providerInfoSource,
+		Packages:           resolved,
+		ModuleLoader:       m.moduleLoader,
+		Parallel:           int(req.Parallel),
+	})
+
+	if err := engineRun.Run(ctx); err != nil {
+		return p.ConstructResponse{}, fmt.Errorf("executing module %q: %w", source, err)
+	}
+
+	return p.ConstructResponse{
+		Urn:   resmon.componentURN,
+		State: resmon.outputs,
+	}, nil
+}
+
+// constructParameterized runs the parameterized module: it maps the typed
+// component inputs to the module's HCL variables, runs the engine against the
+// bundled (offline) module tree, and exposes the module's outputs under their
+// typed schema property names. It mirrors HCLProvider.Construct, the local-path
+// MLC equivalent.
+func (m *moduleProvider) constructParameterized(ctx context.Context, req p.ConstructRequest) (p.ConstructResponse, error) {
+	if m.resolver == nil {
+		return p.ConstructResponse{}, fmt.Errorf("Construct called before a successful Handshake")
+	}
+	param := m.param
+
+	loaded, err := param.loader.LoadModule(param.rootSource, param.rootVersion, ".")
+	if err != nil {
+		return p.ConstructResponse{}, fmt.Errorf("loading module %q: %w", param.name, err)
+	}
+
+	resolved, err := resolve.Packages(ctx, m.resolver,
+		m.requirementSpecs(ctx, param.loader, loaded.Config, loaded.SourcePath))
+	if err != nil {
+		return p.ConstructResponse{}, fmt.Errorf("resolving module providers: %w", err)
+	}
+
+	monitorConn, err := grpc.NewClient(req.MonitorEndpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithUnaryInterceptor(rpcutil.OpenTracingClientInterceptor()),
+		grpc.WithStreamInterceptor(rpcutil.OpenTracingStreamClientInterceptor()),
+	)
+	if err != nil {
+		return p.ConstructResponse{}, fmt.Errorf("connecting to monitor: %w", err)
+	}
+	defer contract.IgnoreClose(monitorConn)
+
+	componentInputs, err := plugin.MarshalProperties(
+		resource.ToResourcePropertyMap(req.Inputs), constructMarshalOptions())
+	if err != nil {
+		return p.ConstructResponse{}, fmt.Errorf("marshaling inputs: %w", err)
+	}
+
+	resmon := m.newConstructMonitor(ctx, req,
+		pulumirpc.NewResourceMonitorClient(monitorConn), componentInputs, param.schema.OutputsToPulumi)
+
+	engineRun := run.NewEngine(ctx, loaded.Config, &run.EngineOptions{
+		ProjectName:        string(req.Urn.Project()),
+		StackName:          string(req.Urn.Stack()),
+		DryRun:             req.DryRun,
+		WorkDir:            loaded.SourcePath,
+		RootDir:            loaded.SourcePath,
+		Config:             moduleConfig(string(req.Urn.Project()), param.schema.InputsToHCL(req.Inputs)),
+		ResourceMonitor:    resmon,
+		SchemaLoader:       pulumiSchema.NewCachedLoader(packages.NewParameterizationAwareLoader(m.schemaLoader, resolved)),
+		ProviderInfoSource: m.providerInfoSource,
+		Packages:           resolved,
+		ModuleLoader:       param.loader,
+		Parallel:           int(req.Parallel),
+	})
+
+	if err := engineRun.Run(ctx); err != nil {
+		return p.ConstructResponse{}, fmt.Errorf("executing module %q: %w", param.name, err)
+	}
+
+	return p.ConstructResponse{
+		Urn:   resmon.componentURN,
+		State: resmon.outputs,
+	}, nil
+}
+
+// newConstructMonitor builds the resource monitor that intercepts the engine's
+// stack registration and re-emits it as the component resource the Construct
+// caller expects. mapOutputs shapes the module's top-level outputs into the
+// component's output property map.
+func (m *moduleProvider) newConstructMonitor(
+	ctx context.Context, req p.ConstructRequest, client pulumirpc.ResourceMonitorClient,
+	componentInputs *structpb.Struct, mapOutputs func(property.Map) property.Map,
+) *constructResourceMonitor {
+	return &constructResourceMonitor{
+		client:                  client,
+		engine:                  m.engine,
 		ctx:                     ctx,
 		parentURN:               string(req.Parent),
 		componentType:           string(req.Urn.Type()),
@@ -224,31 +360,8 @@ func (m *moduleProvider) construct(ctx context.Context, req p.ConstructRequest) 
 		replaceOnChanges:        req.ReplaceOnChanges,
 		retainOnDelete:          req.RetainOnDelete,
 		customTimeouts:          customTimeoutsToProto(req.CustomTimeouts),
-		mapOutputs:              wrapModuleOutputs,
+		mapOutputs:              mapOutputs,
 	}
-
-	engineRun := run.NewEngine(ctx, loaded.Config, &run.EngineOptions{
-		ProjectName:        string(req.Urn.Project()),
-		StackName:          string(req.Urn.Stack()),
-		DryRun:             req.DryRun,
-		WorkDir:            loaded.SourcePath,
-		RootDir:            loaded.SourcePath,
-		Config:             moduleConfig(string(req.Urn.Project()), inputs),
-		ResourceMonitor:    resmon,
-		SchemaLoader:       pulumiSchema.NewCachedLoader(loader),
-		ProviderInfoSource: providerInfoSource,
-		Packages:           resolved,
-		Parallel:           int(req.Parallel),
-	})
-
-	if err := engineRun.Run(ctx); err != nil {
-		return p.ConstructResponse{}, fmt.Errorf("executing module %q: %w", source, err)
-	}
-
-	return p.ConstructResponse{
-		Urn:   resmon.componentURN,
-		State: resmon.outputs,
-	}, nil
 }
 
 // requirementSpecs turns every provider the module tree references into a
@@ -258,9 +371,9 @@ func (m *moduleProvider) construct(ctx context.Context, req p.ConstructRequest) 
 // specs. Built-in providers (pulumi, terraform) are handled by the engine and
 // are not resolved.
 func (m *moduleProvider) requirementSpecs(
-	ctx context.Context, config *ast.Config, workDir string,
+	ctx context.Context, loader *modules.Loader, config *ast.Config, workDir string,
 ) []resolve.Request {
-	tf, pulumi, aliases := collectRequirements(ctx, config, workDir)
+	tf, pulumi, aliases := collectRequirements(ctx, loader, config, workDir)
 	var reqs []resolve.Request
 	for _, alias := range sortedKeys(aliases) {
 		if isBuiltinProvider(alias) {

--- a/pkg/server/module_resource_test.go
+++ b/pkg/server/module_resource_test.go
@@ -126,7 +126,7 @@ func TestModuleConstructRejectsUnknownInput(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m := &moduleProvider{moduleLoader: modules.NewLoader(t.Context()), resolver: stubResolver{}}
+			m := &moduleProvider{moduleLoader: modules.NewLoader(modules.LiveResolver(t.Context())), resolver: stubResolver{}}
 			_, err := m.construct(t.Context(), p.ConstructRequest{
 				Urn: resource.URN("urn:pulumi:test::proj::hcl:index:Module::mod"),
 				Inputs: property.NewMap(map[string]property.Value{
@@ -163,7 +163,7 @@ resource "aws_s3_bucket" "b" {}
 	cfg, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
 	require.False(t, diags.HasErrors(), "diags: %v", diags)
 
-	got := (&moduleProvider{}).requirementSpecs(t.Context(), cfg, "")
+	got := (&moduleProvider{}).requirementSpecs(t.Context(), nil, cfg, "")
 
 	assert.Equal(t, []resolve.Request{
 		{Alias: "aws", Spec: &pulumirpc.PackageSpec{

--- a/pkg/server/parameterize.go
+++ b/pkg/server/parameterize.go
@@ -35,6 +35,7 @@ import (
 	p "github.com/pulumi/pulumi-go-provider"
 	pulumiSchema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
@@ -44,11 +45,6 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/schema"
 	"github.com/pulumi-labs/pulumi-hcl/vendored/getmodules"
 )
-
-// bundleManifestName is the archive path of the manifest that records how every
-// module source resolves. It cannot collide with a package directory, which is
-// named by a numeric index.
-const bundleManifestName = "manifest.json"
 
 // parameterizedModule is the state of a moduleProvider that has been
 // parameterized by a specific module source. While set, the provider serves that
@@ -63,7 +59,10 @@ type parameterizedModule struct {
 	// rootSource and rootVersion address the root module through loader.
 	rootSource  string
 	rootVersion string
-	// value is the parameterization Value (the bundle archive), surfaced in the
+	// packages are the resolved provider descriptors, baked into the bundle at
+	// `package add` time.
+	packages map[string]workspace.PackageDescriptor
+	// value is the parameterization Value (the encoded bundle), surfaced in the
 	// schema so a generated SDK can re-parameterize without re-downloading.
 	value []byte
 	name  string
@@ -72,10 +71,37 @@ type parameterizedModule struct {
 	tempDir string
 }
 
+// bundle is the parameterization Value: a self-contained, offline snapshot of a
+// module tree.
+type bundle struct {
+	// Manifest records how every module reference resolves within Archive, and
+	// how to reach the root module.
+	Manifest bundleManifest `json:"manifest"`
+	// Packages are the resolved provider descriptors, keyed by local provider
+	// name, computed once at `package add` time.
+	Packages map[string]workspace.PackageDescriptor `json:"packages"`
+	// Archive is the deterministic tar.gz of the module package directories.
+	Archive []byte `json:"archive"`
+}
+
+// encodeBundle serialises a bundle to the parameterization Value.
+func (b bundle) encode() []byte {
+	data, err := json.Marshal(b)
+	contract.AssertNoErrorf(err, "bundle is always serializable")
+	return data
+}
+
+// decodeBundle parses a parameterization Value produced by encodeBundle.
+func decodeBundle(value []byte) (bundle, error) {
+	var b bundle
+	if err := json.Unmarshal(value, &b); err != nil {
+		return bundle{}, fmt.Errorf("decoding bundle: %w", err)
+	}
+	return b, nil
+}
+
 // bundleManifest records how to resolve every module reference in a bundled tree
-// with no network access, and how to reach the root module. It is the only thing
-// the parameterization needs beyond the archived files: the schema and provider
-// set are recomputed from the module tree at usage.
+// with no network access, and how to reach the root module.
 type bundleManifest struct {
 	// Root addresses the root module, as passed to `pulumi package add`.
 	Root moduleRef `json:"root"`
@@ -155,10 +181,17 @@ func (m *moduleProvider) parameterizeArgs(ctx context.Context, args []string) (p
 		return p.ParameterizeResponse{}, fmt.Errorf("loading module %q: %w", source, err)
 	}
 
-	// finishParameterize's schema and provider walks drive the recorder; archive
-	// the recorded tree once they have run.
-	return m.finishParameterize(ctx, loader, loaded, source, version, "", func() ([]byte, error) {
-		value, err := rec.archive(moduleRef{Source: source, Version: version})
+	// Resolve every provider now, while the recording loader is active, so the
+	// descriptors can be baked into the bundle and reused offline at usage.
+	resolved, err := m.resolvePackages(ctx, loader, loaded.Config, loaded.SourcePath)
+	if err != nil {
+		return p.ParameterizeResponse{}, err
+	}
+
+	// finishParameterize's schema walk drives the recorder too; bundle the
+	// recorded tree once it has run.
+	return m.finishParameterize(ctx, loader, loaded, source, version, "", resolved, func() ([]byte, error) {
+		value, err := rec.bundle(moduleRef{Source: source, Version: version}, resolved)
 		if err != nil {
 			return nil, fmt.Errorf("bundling module %q: %w", source, err)
 		}
@@ -167,11 +200,17 @@ func (m *moduleProvider) parameterizeArgs(ctx context.Context, args []string) (p
 }
 
 // parameterizeValue handles re-parameterization from a generated SDK. It unpacks
-// the bundled tree, builds a loader that resolves every source from the bundle's
-// manifest with no network access, and recomputes the schema from the module.
+// the bundled module files, builds a loader that resolves every source from the
+// bundle's manifest with no network access, and reuses the bundle's baked
+// provider descriptors rather than re-resolving them through the engine.
 func (m *moduleProvider) parameterizeValue(ctx context.Context, value []byte) (p.ParameterizeResponse, error) {
 	if m.resolver == nil {
 		return p.ParameterizeResponse{}, fmt.Errorf("parameterize called before a successful handshake")
+	}
+
+	b, err := decodeBundle(value)
+	if err != nil {
+		return p.ParameterizeResponse{}, err
 	}
 
 	dir, err := os.MkdirTemp("", "pulumi-hcl-module-")
@@ -187,22 +226,18 @@ func (m *moduleProvider) parameterizeValue(ctx context.Context, value []byte) (p
 		}
 	}()
 
-	if err := unpackArchive(value, dir); err != nil {
+	if err := unpackArchive(b.Archive, dir); err != nil {
 		return p.ParameterizeResponse{}, fmt.Errorf("unpacking module bundle: %w", err)
 	}
-	manifest, err := readManifest(dir)
+
+	loader := modules.NewLoader(bundleResolver(dir, b.Manifest))
+	loaded, err := loader.LoadModule(b.Manifest.Root.Source, b.Manifest.Root.Version, ".")
 	if err != nil {
-		return p.ParameterizeResponse{}, err
+		return p.ParameterizeResponse{}, fmt.Errorf("loading bundled module %q: %w", b.Manifest.Root.Source, err)
 	}
 
-	loader := modules.NewLoader(bundleResolver(dir, manifest))
-	loaded, err := loader.LoadModule(manifest.Root.Source, manifest.Root.Version, ".")
-	if err != nil {
-		return p.ParameterizeResponse{}, fmt.Errorf("loading bundled module %q: %w", manifest.Root.Source, err)
-	}
-
-	resp, err := m.finishParameterize(ctx, loader, loaded, manifest.Root.Source, manifest.Root.Version, dir,
-		func() ([]byte, error) { return value, nil })
+	resp, err := m.finishParameterize(ctx, loader, loaded, b.Manifest.Root.Source, b.Manifest.Root.Version, dir,
+		b.Packages, func() ([]byte, error) { return value, nil })
 	if err != nil {
 		return p.ParameterizeResponse{}, err
 	}
@@ -212,14 +247,10 @@ func (m *moduleProvider) parameterizeValue(ctx context.Context, value []byte) (p
 
 func (m *moduleProvider) finishParameterize(
 	ctx context.Context, loader *modules.Loader, loaded *modules.LoadedModule,
-	rootSource, rootVersion, tempDir string, makeValue func() ([]byte, error),
+	rootSource, rootVersion, tempDir string,
+	resolved map[string]workspace.PackageDescriptor, makeValue func() ([]byte, error),
 ) (p.ParameterizeResponse, error) {
 	token, pkgVer, err := moduleIdentity(loaded, defaultPackageName(rootSource))
-	if err != nil {
-		return p.ParameterizeResponse{}, err
-	}
-
-	resolved, err := m.resolvePackages(ctx, loader, loaded.Config, loaded.SourcePath)
 	if err != nil {
 		return p.ParameterizeResponse{}, err
 	}
@@ -240,6 +271,7 @@ func (m *moduleProvider) finishParameterize(
 		loader:      loader,
 		rootSource:  rootSource,
 		rootVersion: rootVersion,
+		packages:    resolved,
 		value:       value,
 		name:        pkgName,
 		tempDir:     tempDir,
@@ -344,18 +376,20 @@ func (r *resolveRecorder) rel(dir string) string {
 	return rel
 }
 
-// archive packs every recorded package directory and the manifest into a
-// deterministic tar.gz.
-func (r *resolveRecorder) archive(root moduleRef) ([]byte, error) {
+func (r *resolveRecorder) bundle(root moduleRef, packages map[string]workspace.PackageDescriptor) ([]byte, error) {
 	dirs := make(map[string]string, len(r.pkgRel))
 	for absDir, rel := range r.pkgRel {
 		dirs[rel] = absDir
 	}
-	manifestJSON, err := json.Marshal(bundleManifest{Root: root, Edges: dedupeEdges(r.edges)})
+	archive, err := packArchive(dirs)
 	if err != nil {
 		return nil, err
 	}
-	return packArchive(dirs, manifestJSON)
+	return bundle{
+		Manifest: bundleManifest{Root: root, Edges: dedupeEdges(r.edges)},
+		Packages: packages,
+		Archive:  archive,
+	}.encode(), nil
 }
 
 // dedupeEdges drops duplicate edges — each reference is recorded once per walk
@@ -413,19 +447,6 @@ func bundleResolver(unpackDir string, manifest bundleManifest) modules.ResolverF
 	}
 }
 
-// readManifest reads the bundle manifest from an unpacked archive directory.
-func readManifest(dir string) (bundleManifest, error) {
-	data, err := os.ReadFile(filepath.Join(dir, bundleManifestName))
-	if err != nil {
-		return bundleManifest{}, fmt.Errorf("reading bundle manifest: %w", err)
-	}
-	var manifest bundleManifest
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		return bundleManifest{}, fmt.Errorf("decoding bundle manifest: %w", err)
-	}
-	return manifest, nil
-}
-
 // defaultPackageName derives a Pulumi package name from a module source, used
 // when the module declares no terraform `package` block. Registry sources use
 // their module name segment; other sources use the last path component.
@@ -469,17 +490,17 @@ func sanitizePackageName(name string) string {
 // provider identity — are deterministic.
 var bundleEpoch = time.Unix(0, 0).UTC()
 
-// packArchive packs the manifest and each (archive-path → directory) tree into a
-// deterministic tar.gz: entries are sorted, modification times fixed, and only
-// regular files and directories are included.
-func packArchive(dirs map[string]string, manifestJSON []byte) ([]byte, error) {
+// packArchive packs each (archive-path → directory) tree into a deterministic
+// tar.gz: entries are sorted, modification times fixed, and only regular files
+// and directories are included.
+func packArchive(dirs map[string]string) ([]byte, error) {
 	type entry struct {
 		name    string
 		absPath string      // set for files copied from disk
-		data    []byte      // set for in-memory files (the manifest)
+		data    []byte      // set for in-memory files
 		info    os.FileInfo // nil for in-memory files
 	}
-	files := []entry{{name: bundleManifestName, data: manifestJSON}}
+	var files []entry
 	for relPath, absDir := range dirs {
 		err := filepath.Walk(absDir, func(p string, info os.FileInfo, err error) error {
 			if err != nil {

--- a/pkg/server/parameterize.go
+++ b/pkg/server/parameterize.go
@@ -155,36 +155,15 @@ func (m *moduleProvider) parameterizeArgs(ctx context.Context, args []string) (p
 		return p.ParameterizeResponse{}, fmt.Errorf("loading module %q: %w", source, err)
 	}
 
-	token, pkgVer, err := moduleIdentity(loaded, defaultPackageName(source))
-	if err != nil {
-		return p.ParameterizeResponse{}, err
-	}
-
-	resolved, err := resolve.Packages(ctx, m.resolver, m.requirementSpecs(ctx, loader, loaded.Config, loaded.SourcePath))
-	if err != nil {
-		return p.ParameterizeResponse{}, fmt.Errorf("resolving module providers: %w", err)
-	}
-
-	sch, err := m.generateModuleSchema(ctx, loader, loaded, resolved, token, pkgVer)
-	if err != nil {
-		return p.ParameterizeResponse{}, fmt.Errorf("generating schema: %w", err)
-	}
-
-	value, err := rec.archive(moduleRef{Source: source, Version: version})
-	if err != nil {
-		return p.ParameterizeResponse{}, fmt.Errorf("bundling module %q: %w", source, err)
-	}
-
-	pkgName := token.Package().Name().String()
-	m.param = &parameterizedModule{
-		schema:      sch,
-		loader:      loader,
-		rootSource:  source,
-		rootVersion: version,
-		value:       value,
-		name:        pkgName,
-	}
-	return p.ParameterizeResponse{Name: pkgName, Version: pkgVer}, nil
+	// finishParameterize's schema and provider walks drive the recorder; archive
+	// the recorded tree once they have run.
+	return m.finishParameterize(ctx, loader, loaded, source, version, "", func() ([]byte, error) {
+		value, err := rec.archive(moduleRef{Source: source, Version: version})
+		if err != nil {
+			return nil, fmt.Errorf("bundling module %q: %w", source, err)
+		}
+		return value, nil
+	})
 }
 
 // parameterizeValue handles re-parameterization from a generated SDK. It unpacks
@@ -199,6 +178,15 @@ func (m *moduleProvider) parameterizeValue(ctx context.Context, value []byte) (p
 	if err != nil {
 		return p.ParameterizeResponse{}, fmt.Errorf("creating unpack directory: %w", err)
 	}
+	// On success the directory is owned by m.param and removed on Cancel; until
+	// then, clean it up if any step below fails.
+	keep := false
+	defer func() {
+		if !keep {
+			_ = os.RemoveAll(dir)
+		}
+	}()
+
 	if err := unpackArchive(value, dir); err != nil {
 		return p.ParameterizeResponse{}, fmt.Errorf("unpacking module bundle: %w", err)
 	}
@@ -213,14 +201,27 @@ func (m *moduleProvider) parameterizeValue(ctx context.Context, value []byte) (p
 		return p.ParameterizeResponse{}, fmt.Errorf("loading bundled module %q: %w", manifest.Root.Source, err)
 	}
 
-	token, pkgVer, err := moduleIdentity(loaded, defaultPackageName(manifest.Root.Source))
+	resp, err := m.finishParameterize(ctx, loader, loaded, manifest.Root.Source, manifest.Root.Version, dir,
+		func() ([]byte, error) { return value, nil })
+	if err != nil {
+		return p.ParameterizeResponse{}, err
+	}
+	keep = true
+	return resp, nil
+}
+
+func (m *moduleProvider) finishParameterize(
+	ctx context.Context, loader *modules.Loader, loaded *modules.LoadedModule,
+	rootSource, rootVersion, tempDir string, makeValue func() ([]byte, error),
+) (p.ParameterizeResponse, error) {
+	token, pkgVer, err := moduleIdentity(loaded, defaultPackageName(rootSource))
 	if err != nil {
 		return p.ParameterizeResponse{}, err
 	}
 
-	resolved, err := resolve.Packages(ctx, m.resolver, m.requirementSpecs(ctx, loader, loaded.Config, loaded.SourcePath))
+	resolved, err := m.resolvePackages(ctx, loader, loaded.Config, loaded.SourcePath)
 	if err != nil {
-		return p.ParameterizeResponse{}, fmt.Errorf("resolving module providers: %w", err)
+		return p.ParameterizeResponse{}, err
 	}
 
 	sch, err := m.generateModuleSchema(ctx, loader, loaded, resolved, token, pkgVer)
@@ -228,17 +229,34 @@ func (m *moduleProvider) parameterizeValue(ctx context.Context, value []byte) (p
 		return p.ParameterizeResponse{}, fmt.Errorf("generating schema: %w", err)
 	}
 
+	value, err := makeValue()
+	if err != nil {
+		return p.ParameterizeResponse{}, err
+	}
+
 	pkgName := token.Package().Name().String()
 	m.param = &parameterizedModule{
 		schema:      sch,
 		loader:      loader,
-		rootSource:  manifest.Root.Source,
-		rootVersion: manifest.Root.Version,
+		rootSource:  rootSource,
+		rootVersion: rootVersion,
 		value:       value,
 		name:        pkgName,
-		tempDir:     dir,
+		tempDir:     tempDir,
 	}
 	return p.ParameterizeResponse{Name: pkgName, Version: pkgVer}, nil
+}
+
+// resolvePackages resolves every provider the module tree references to a
+// concrete descriptor, walking child modules through loader.
+func (m *moduleProvider) resolvePackages(
+	ctx context.Context, loader *modules.Loader, config *ast.Config, workDir string,
+) (map[string]workspace.PackageDescriptor, error) {
+	resolved, err := resolve.Packages(ctx, m.resolver, m.requirementSpecs(ctx, loader, config, workDir))
+	if err != nil {
+		return nil, fmt.Errorf("resolving module providers: %w", err)
+	}
+	return resolved, nil
 }
 
 // generateModuleSchema builds the typed schema for a loaded module, resolving
@@ -333,11 +351,40 @@ func (r *resolveRecorder) archive(root moduleRef) ([]byte, error) {
 	for absDir, rel := range r.pkgRel {
 		dirs[rel] = absDir
 	}
-	manifestJSON, err := json.Marshal(bundleManifest{Root: root, Edges: r.edges})
+	manifestJSON, err := json.Marshal(bundleManifest{Root: root, Edges: dedupeEdges(r.edges)})
 	if err != nil {
 		return nil, err
 	}
 	return packArchive(dirs, manifestJSON)
+}
+
+// dedupeEdges drops duplicate edges — each reference is recorded once per walk
+// that loads it (provider resolution, schema generation) — and sorts the result,
+// so the manifest is stable regardless of how often a module was loaded.
+func dedupeEdges(edges []resolvedEdge) []resolvedEdge {
+	seen := make(map[resolvedEdge]struct{}, len(edges))
+	out := make([]resolvedEdge, 0, len(edges))
+	for _, e := range edges {
+		if _, ok := seen[e]; ok {
+			continue
+		}
+		seen[e] = struct{}{}
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.Caller != b.Caller {
+			return a.Caller < b.Caller
+		}
+		if a.Source != b.Source {
+			return a.Source < b.Source
+		}
+		if a.Version != b.Version {
+			return a.Version < b.Version
+		}
+		return a.Target < b.Target
+	})
+	return out
 }
 
 // bundleResolver resolves module sources from an unpacked bundle's manifest, with

--- a/pkg/server/parameterize.go
+++ b/pkg/server/parameterize.go
@@ -1,0 +1,544 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/blang/semver"
+	regaddr "github.com/opentofu/registry-address/v2"
+	p "github.com/pulumi/pulumi-go-provider"
+	pulumiSchema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modules"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/resolve"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/schema"
+	"github.com/pulumi-labs/pulumi-hcl/vendored/getmodules"
+)
+
+// bundleManifestName is the archive path of the manifest that records how every
+// module source resolves. It cannot collide with a package directory, which is
+// named by a numeric index.
+const bundleManifestName = "manifest.json"
+
+// parameterizedModule is the state of a moduleProvider that has been
+// parameterized by a specific module source. While set, the provider serves that
+// module's typed component schema rather than the generic hcl:index:Module.
+type parameterizedModule struct {
+	// schema is the typed schema, identical to the one the local-path MLC
+	// (HCLProvider) generates for the same module.
+	schema *schema.ModuleSchema
+	// loader resolves the module and its children. On the usage path it resolves
+	// entirely from the unpacked bundle, with no network access.
+	loader *modules.Loader
+	// rootSource and rootVersion address the root module through loader.
+	rootSource  string
+	rootVersion string
+	// value is the parameterization Value (the bundle archive), surfaced in the
+	// schema so a generated SDK can re-parameterize without re-downloading.
+	value []byte
+	name  string
+	// tempDir is the directory the bundle was unpacked into, removed on Cancel.
+	// Empty on the args (CLI) path, which reads the freshly-downloaded module.
+	tempDir string
+}
+
+// bundleManifest records how to resolve every module reference in a bundled tree
+// with no network access, and how to reach the root module. It is the only thing
+// the parameterization needs beyond the archived files: the schema and provider
+// set are recomputed from the module tree at usage.
+type bundleManifest struct {
+	// Root addresses the root module, as passed to `pulumi package add`.
+	Root moduleRef `json:"root"`
+	// Edges record, for every resolved module reference, the archive directory it
+	// resolves to.
+	Edges []resolvedEdge `json:"edges"`
+}
+
+// moduleRef is a module source and version constraint as written in a
+// configuration (or on the CLI).
+type moduleRef struct {
+	Source  string `json:"source"`
+	Version string `json:"version,omitempty"`
+}
+
+// resolvedEdge records that a module reference — the (Source, Version) requested
+// from the module at archive-relative directory Caller ("" for the root) —
+// resolves to the archive-relative package directory Target.
+type resolvedEdge struct {
+	Caller  string `json:"caller"`
+	Source  string `json:"source"`
+	Version string `json:"version,omitempty"`
+	Target  string `json:"target"`
+}
+
+// parameterize configures the provider for a specific module source. Args is the
+// CLI path (`pulumi package add hcl <source> [version]`): it downloads the module
+// tree and bundles it. Value is the usage path: it unpacks a previously bundled
+// tree and resolves everything from it.
+func (m *moduleProvider) parameterize(ctx context.Context, req p.ParameterizeRequest) (p.ParameterizeResponse, error) {
+	switch {
+	case req.Args != nil:
+		return m.parameterizeArgs(ctx, req.Args.Args)
+	case req.Value != nil:
+		return m.parameterizeValue(ctx, req.Value.Value)
+	default:
+		return p.ParameterizeResponse{}, fmt.Errorf("parameterize requires either arguments or a value")
+	}
+}
+
+// parameterizeArgs handles `pulumi package add hcl <source> [version]`. It
+// downloads the module, generates its schema, and — recording every resolution
+// along the way — bundles the whole module tree into the parameterization Value.
+func (m *moduleProvider) parameterizeArgs(ctx context.Context, args []string) (p.ParameterizeResponse, error) {
+	if m.resolver == nil {
+		return p.ParameterizeResponse{}, fmt.Errorf("parameterize called before a successful handshake")
+	}
+
+	var source, version string
+	switch len(args) {
+	case 1:
+		source = args[0]
+	case 2:
+		source, version = args[0], args[1]
+	default:
+		return p.ParameterizeResponse{}, fmt.Errorf(
+			"the hcl provider is parameterized by a module source and an optional version "+
+				"constraint: expected 1 or 2 arguments, got %d", len(args))
+	}
+
+	// A recording loader resolves sources live while capturing where each one
+	// landed, so the schema-generation and provider walks below populate a
+	// complete manifest as a side effect.
+	rec := newResolveRecorder(modules.LiveResolver(ctx))
+	loader := modules.NewLoader(rec.resolve)
+
+	loaded, err := loader.LoadModule(source, version, ".")
+	if err != nil {
+		return p.ParameterizeResponse{}, fmt.Errorf("loading module %q: %w", source, err)
+	}
+
+	token, pkgVer, err := moduleIdentity(loaded, defaultPackageName(source))
+	if err != nil {
+		return p.ParameterizeResponse{}, err
+	}
+
+	resolved, err := resolve.Packages(ctx, m.resolver, m.requirementSpecs(ctx, loader, loaded.Config, loaded.SourcePath))
+	if err != nil {
+		return p.ParameterizeResponse{}, fmt.Errorf("resolving module providers: %w", err)
+	}
+
+	sch, err := m.generateModuleSchema(ctx, loader, loaded, resolved, token, pkgVer)
+	if err != nil {
+		return p.ParameterizeResponse{}, fmt.Errorf("generating schema: %w", err)
+	}
+
+	value, err := rec.archive(moduleRef{Source: source, Version: version})
+	if err != nil {
+		return p.ParameterizeResponse{}, fmt.Errorf("bundling module %q: %w", source, err)
+	}
+
+	pkgName := token.Package().Name().String()
+	m.param = &parameterizedModule{
+		schema:      sch,
+		loader:      loader,
+		rootSource:  source,
+		rootVersion: version,
+		value:       value,
+		name:        pkgName,
+	}
+	return p.ParameterizeResponse{Name: pkgName, Version: pkgVer}, nil
+}
+
+// parameterizeValue handles re-parameterization from a generated SDK. It unpacks
+// the bundled tree, builds a loader that resolves every source from the bundle's
+// manifest with no network access, and recomputes the schema from the module.
+func (m *moduleProvider) parameterizeValue(ctx context.Context, value []byte) (p.ParameterizeResponse, error) {
+	if m.resolver == nil {
+		return p.ParameterizeResponse{}, fmt.Errorf("parameterize called before a successful handshake")
+	}
+
+	dir, err := os.MkdirTemp("", "pulumi-hcl-module-")
+	if err != nil {
+		return p.ParameterizeResponse{}, fmt.Errorf("creating unpack directory: %w", err)
+	}
+	if err := unpackArchive(value, dir); err != nil {
+		return p.ParameterizeResponse{}, fmt.Errorf("unpacking module bundle: %w", err)
+	}
+	manifest, err := readManifest(dir)
+	if err != nil {
+		return p.ParameterizeResponse{}, err
+	}
+
+	loader := modules.NewLoader(bundleResolver(dir, manifest))
+	loaded, err := loader.LoadModule(manifest.Root.Source, manifest.Root.Version, ".")
+	if err != nil {
+		return p.ParameterizeResponse{}, fmt.Errorf("loading bundled module %q: %w", manifest.Root.Source, err)
+	}
+
+	token, pkgVer, err := moduleIdentity(loaded, defaultPackageName(manifest.Root.Source))
+	if err != nil {
+		return p.ParameterizeResponse{}, err
+	}
+
+	resolved, err := resolve.Packages(ctx, m.resolver, m.requirementSpecs(ctx, loader, loaded.Config, loaded.SourcePath))
+	if err != nil {
+		return p.ParameterizeResponse{}, fmt.Errorf("resolving module providers: %w", err)
+	}
+
+	sch, err := m.generateModuleSchema(ctx, loader, loaded, resolved, token, pkgVer)
+	if err != nil {
+		return p.ParameterizeResponse{}, fmt.Errorf("generating schema: %w", err)
+	}
+
+	pkgName := token.Package().Name().String()
+	m.param = &parameterizedModule{
+		schema:      sch,
+		loader:      loader,
+		rootSource:  manifest.Root.Source,
+		rootVersion: manifest.Root.Version,
+		value:       value,
+		name:        pkgName,
+		tempDir:     dir,
+	}
+	return p.ParameterizeResponse{Name: pkgName, Version: pkgVer}, nil
+}
+
+// generateModuleSchema builds the typed schema for a loaded module, resolving
+// resource/data source references through the handshake schema loader and bridge
+// mapper, and child modules through loader, exactly as the local-path MLC
+// (NewHCLProvider) does.
+func (m *moduleProvider) generateModuleSchema(
+	ctx context.Context, loader *modules.Loader, loaded *modules.LoadedModule,
+	resolved map[string]workspace.PackageDescriptor,
+	token tokens.Type, version semver.Version,
+) (*schema.ModuleSchema, error) {
+	cachedLoader := pulumiSchema.NewCachedLoader(
+		packages.NewParameterizationAwareLoader(m.schemaLoader, resolved))
+	binder := &schema.Binder{
+		Resources: packages.NewResolver(cachedLoader, m.providerInfoSource, resolved, knownProviderNames(loaded.Config)),
+		Modules:   moduleLoaderAdapter{loader},
+		ModuleDir: loaded.SourcePath,
+	}
+	return schema.GenerateModuleSchema(ctx, loaded.Config, binder, token, version)
+}
+
+// knownProviderNames lists the local names the module's terraform block declares,
+// so resource/data type tokens split on the declared provider rather than the
+// first underscore.
+func knownProviderNames(config *ast.Config) []string {
+	if config.Terraform == nil {
+		return nil
+	}
+	names := make([]string, 0, len(config.Terraform.RequiredProviders))
+	for name := range config.Terraform.RequiredProviders {
+		names = append(names, name)
+	}
+	return names
+}
+
+// resolveRecorder wraps a resolver, recording where every module source resolves
+// so the tree can be archived and replayed offline. Each distinct package
+// directory is assigned a numeric archive-relative path; a source resolving
+// inside an already-seen package (a local reference) reuses that package's path.
+type resolveRecorder struct {
+	inner  modules.ResolverFunc
+	pkgRel map[string]string // absolute package directory -> archive-relative path
+	edges  []resolvedEdge
+}
+
+func newResolveRecorder(inner modules.ResolverFunc) *resolveRecorder {
+	return &resolveRecorder{inner: inner, pkgRel: map[string]string{}}
+}
+
+// resolve resolves a source through the wrapped resolver and records the edge.
+// The loader serializes calls under its lock, so the recorder needs none.
+func (r *resolveRecorder) resolve(packageSource, versionConstraint, callerDir string) (string, error) {
+	target, err := r.inner(packageSource, versionConstraint, callerDir)
+	if err != nil {
+		return "", err
+	}
+	r.edges = append(r.edges, resolvedEdge{
+		Caller:  r.rel(callerDir),
+		Source:  packageSource,
+		Version: versionConstraint,
+		Target:  r.rel(target),
+	})
+	return target, nil
+}
+
+// rel returns the archive-relative path for an absolute module directory. The
+// root caller (".") maps to "". A directory inside an already-seen package
+// reuses that package's path with the remaining sub-path appended; any other
+// directory starts a new package.
+func (r *resolveRecorder) rel(dir string) string {
+	if dir == "." || dir == "" {
+		return ""
+	}
+	for pkg, rel := range r.pkgRel {
+		if dir == pkg {
+			return rel
+		}
+		if strings.HasPrefix(dir, pkg+string(os.PathSeparator)) {
+			sub, _ := filepath.Rel(pkg, dir)
+			return path.Join(rel, filepath.ToSlash(sub))
+		}
+	}
+	rel := strconv.Itoa(len(r.pkgRel))
+	r.pkgRel[dir] = rel
+	return rel
+}
+
+// archive packs every recorded package directory and the manifest into a
+// deterministic tar.gz.
+func (r *resolveRecorder) archive(root moduleRef) ([]byte, error) {
+	dirs := make(map[string]string, len(r.pkgRel))
+	for absDir, rel := range r.pkgRel {
+		dirs[rel] = absDir
+	}
+	manifestJSON, err := json.Marshal(bundleManifest{Root: root, Edges: r.edges})
+	if err != nil {
+		return nil, err
+	}
+	return packArchive(dirs, manifestJSON)
+}
+
+// bundleResolver resolves module sources from an unpacked bundle's manifest, with
+// no network access. callerDir is mapped back to its archive-relative form so the
+// recorded edge matches regardless of where the bundle was unpacked.
+func bundleResolver(unpackDir string, manifest bundleManifest) modules.ResolverFunc {
+	type edgeKey struct{ caller, source, version string }
+	index := make(map[edgeKey]string, len(manifest.Edges))
+	for _, e := range manifest.Edges {
+		index[edgeKey{e.Caller, e.Source, e.Version}] = e.Target
+	}
+	return func(packageSource, versionConstraint, callerDir string) (string, error) {
+		caller := ""
+		if callerDir != "." && callerDir != "" {
+			rel, err := filepath.Rel(unpackDir, callerDir)
+			if err != nil {
+				return "", err
+			}
+			caller = filepath.ToSlash(rel)
+		}
+		target, ok := index[edgeKey{caller, packageSource, versionConstraint}]
+		if !ok {
+			return "", fmt.Errorf("module source %q is not present in the parameterization bundle", packageSource)
+		}
+		return filepath.Join(unpackDir, filepath.FromSlash(target)), nil
+	}
+}
+
+// readManifest reads the bundle manifest from an unpacked archive directory.
+func readManifest(dir string) (bundleManifest, error) {
+	data, err := os.ReadFile(filepath.Join(dir, bundleManifestName))
+	if err != nil {
+		return bundleManifest{}, fmt.Errorf("reading bundle manifest: %w", err)
+	}
+	var manifest bundleManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return bundleManifest{}, fmt.Errorf("decoding bundle manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+// defaultPackageName derives a Pulumi package name from a module source, used
+// when the module declares no terraform `package` block. Registry sources use
+// their module name segment; other sources use the last path component.
+func defaultPackageName(source string) string {
+	pkgSource, _ := getmodules.SplitPackageSubdir(source)
+	if mod, err := regaddr.ParseModuleSource(pkgSource); err == nil {
+		return sanitizePackageName(mod.Package.Name)
+	}
+	s := pkgSource
+	if i := strings.IndexByte(s, '?'); i >= 0 {
+		s = s[:i]
+	}
+	s = strings.TrimRight(s, "/")
+	if i := strings.LastIndexByte(s, '/'); i >= 0 {
+		s = s[i+1:]
+	}
+	s = strings.TrimSuffix(s, ".git")
+	return sanitizePackageName(s)
+}
+
+// sanitizePackageName reduces a name to the lowercase alphanumeric-and-hyphen
+// form Pulumi package names use, falling back to "module" when nothing remains.
+func sanitizePackageName(name string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(name) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			b.WriteRune(r)
+		case r == '_' || r == ' ':
+			b.WriteByte('-')
+		}
+	}
+	if out := strings.Trim(b.String(), "-"); out != "" {
+		return out
+	}
+	return "module"
+}
+
+// bundleEpoch is the fixed modification time stamped on every archive entry, so
+// the archive bytes — and thus the parameterization Value the engine hashes for
+// provider identity — are deterministic.
+var bundleEpoch = time.Unix(0, 0).UTC()
+
+// packArchive packs the manifest and each (archive-path → directory) tree into a
+// deterministic tar.gz: entries are sorted, modification times fixed, and only
+// regular files and directories are included.
+func packArchive(dirs map[string]string, manifestJSON []byte) ([]byte, error) {
+	type entry struct {
+		name    string
+		absPath string      // set for files copied from disk
+		data    []byte      // set for in-memory files (the manifest)
+		info    os.FileInfo // nil for in-memory files
+	}
+	files := []entry{{name: bundleManifestName, data: manifestJSON}}
+	for relPath, absDir := range dirs {
+		err := filepath.Walk(absDir, func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			rel, err := filepath.Rel(absDir, p)
+			if err != nil {
+				return err
+			}
+			files = append(files, entry{name: path.Join(relPath, filepath.ToSlash(rel)), absPath: p, info: info})
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].name < files[j].name })
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, f := range files {
+		hdr := &tar.Header{Name: f.name, ModTime: bundleEpoch}
+		var data []byte
+		switch {
+		case f.info != nil && f.info.IsDir():
+			hdr.Typeflag = tar.TypeDir
+			hdr.Mode = 0o755
+			hdr.Name += "/"
+		case f.info != nil && !f.info.Mode().IsRegular():
+			continue // skip symlinks, devices, and other irregular entries
+		default:
+			hdr.Typeflag = tar.TypeReg
+			hdr.Mode = 0o644
+			data = f.data
+			if f.absPath != "" {
+				b, err := os.ReadFile(f.absPath)
+				if err != nil {
+					return nil, err
+				}
+				data = b
+			}
+			hdr.Size = int64(len(data))
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, err
+		}
+		if hdr.Typeflag == tar.TypeReg {
+			if _, err := tw.Write(data); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// unpackArchive extracts a tar.gz produced by packArchive into destDir, rejecting
+// any entry that would escape destDir.
+func unpackArchive(data []byte, destDir string) error {
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		target, err := safeJoin(destDir, hdr.Name)
+		if err != nil {
+			return err
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil { //nolint:gosec // archive is self-produced
+				_ = out.Close()
+				return err
+			}
+			if err := out.Close(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// safeJoin joins name onto base, returning an error if the result escapes base.
+func safeJoin(base, name string) (string, error) {
+	target := filepath.Join(base, filepath.FromSlash(name))
+	if target != base && !strings.HasPrefix(target, base+string(os.PathSeparator)) {
+		return "", fmt.Errorf("archive entry %q escapes the unpack directory", name)
+	}
+	return target, nil
+}

--- a/pkg/server/parameterize.go
+++ b/pkg/server/parameterize.go
@@ -102,9 +102,9 @@ type resolvedEdge struct {
 }
 
 // parameterize configures the provider for a specific module source. Args is the
-// CLI path (`pulumi package add hcl <source> [version]`): it downloads the module
-// tree and bundles it. Value is the usage path: it unpacks a previously bundled
-// tree and resolves everything from it.
+// CLI path (`pulumi package add hcl module <source> [version]`): it downloads the
+// module tree and bundles it. Value is the usage path: it unpacks a previously
+// bundled tree and resolves everything from it.
 func (m *moduleProvider) parameterize(ctx context.Context, req p.ParameterizeRequest) (p.ParameterizeResponse, error) {
 	switch {
 	case req.Args != nil:
@@ -116,24 +116,32 @@ func (m *moduleProvider) parameterize(ctx context.Context, req p.ParameterizeReq
 	}
 }
 
-// parameterizeArgs handles `pulumi package add hcl <source> [version]`. It
-// downloads the module, generates its schema, and — recording every resolution
-// along the way — bundles the whole module tree into the parameterization Value.
+// parameterizeArgs handles `pulumi package add hcl module <source> [version]`.
+// It downloads the module, generates its schema, and — recording every
+// resolution along the way — bundles the whole module tree into the
+// parameterization Value.
 func (m *moduleProvider) parameterizeArgs(ctx context.Context, args []string) (p.ParameterizeResponse, error) {
 	if m.resolver == nil {
 		return p.ParameterizeResponse{}, fmt.Errorf("parameterize called before a successful handshake")
 	}
 
+	// The fixed "module" keyword leaves room for the provider to grow other
+	// parameterization kinds; today a module source is the only one.
+	if len(args) == 0 || args[0] != "module" {
+		return p.ParameterizeResponse{}, fmt.Errorf(
+			`the hcl provider is parameterized by a module: expected "module" as the first argument`)
+	}
+
 	var source, version string
-	switch len(args) {
+	switch rest := args[1:]; len(rest) {
 	case 1:
-		source = args[0]
+		source = rest[0]
 	case 2:
-		source, version = args[0], args[1]
+		source, version = rest[0], rest[1]
 	default:
 		return p.ParameterizeResponse{}, fmt.Errorf(
-			"the hcl provider is parameterized by a module source and an optional version "+
-				"constraint: expected 1 or 2 arguments, got %d", len(args))
+			`the hcl provider is parameterized as "module <source> [version]": `+
+				"expected a source and an optional version constraint, got %d arguments after \"module\"", len(rest))
 	}
 
 	// A recording loader resolves sources live while capturing where each one

--- a/pkg/server/parameterize.go
+++ b/pkg/server/parameterize.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/resolve"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/schema"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/potel"
 	"github.com/pulumi-labs/pulumi-hcl/vendored/getmodules"
 )
 
@@ -176,7 +177,7 @@ func (m *moduleProvider) parameterizeArgs(ctx context.Context, args []string) (p
 	rec := newResolveRecorder(modules.LiveResolver(ctx))
 	loader := modules.NewLoader(rec.resolve)
 
-	loaded, err := loader.LoadModule(source, version, ".")
+	loaded, err := loader.LoadModule(ctx, source, version, ".")
 	if err != nil {
 		return p.ParameterizeResponse{}, fmt.Errorf("loading module %q: %w", source, err)
 	}
@@ -226,12 +227,13 @@ func (m *moduleProvider) parameterizeValue(ctx context.Context, value []byte) (p
 		}
 	}()
 
-	if err := unpackArchive(b.Archive, dir); err != nil {
+	err = unpackArchive(ctx, b.Archive, dir)
+	if err != nil {
 		return p.ParameterizeResponse{}, fmt.Errorf("unpacking module bundle: %w", err)
 	}
 
 	loader := modules.NewLoader(bundleResolver(dir, b.Manifest))
-	loaded, err := loader.LoadModule(b.Manifest.Root.Source, b.Manifest.Root.Version, ".")
+	loaded, err := loader.LoadModule(ctx, b.Manifest.Root.Source, b.Manifest.Root.Version, ".")
 	if err != nil {
 		return p.ParameterizeResponse{}, fmt.Errorf("loading bundled module %q: %w", b.Manifest.Root.Source, err)
 	}
@@ -300,6 +302,8 @@ func (m *moduleProvider) generateModuleSchema(
 	resolved map[string]workspace.PackageDescriptor,
 	token tokens.Type, version semver.Version,
 ) (*schema.ModuleSchema, error) {
+	ctx, span := potel.Start(ctx, "generateModuleSchema")
+	defer span.End()
 	cachedLoader := pulumiSchema.NewCachedLoader(
 		packages.NewParameterizationAwareLoader(m.schemaLoader, resolved))
 	binder := &schema.Binder{
@@ -565,7 +569,9 @@ func packArchive(dirs map[string]string) ([]byte, error) {
 
 // unpackArchive extracts a tar.gz produced by packArchive into destDir, rejecting
 // any entry that would escape destDir.
-func unpackArchive(data []byte, destDir string) error {
+func unpackArchive(ctx context.Context, data []byte, destDir string) error {
+	_, span := potel.Start(ctx, "unpackArchive")
+	defer span.End()
 	gz, err := gzip.NewReader(bytes.NewReader(data))
 	if err != nil {
 		return err

--- a/pkg/server/parameterize_test.go
+++ b/pkg/server/parameterize_test.go
@@ -175,6 +175,84 @@ func TestBundleRoundTripResolvesOffline(t *testing.T) {
 		"submodule must resolve inside the unpacked bundle, got %q", childAgain.SourcePath)
 }
 
+// TestBundleRoundTripEscapingTopology covers a package topology where a local
+// reference escapes the root package: root -> ./A -> ../../B, with B a sibling of
+// the root. B is outside the root package, so it must be bundled as its own
+// package; at usage the escaping "../../B" must resolve to that bundled package
+// from the manifest, not by walking ".." out of the unpacked tree (where nothing
+// exists). A non-escaping local sibling ./C stays inside the root package.
+func TestBundleRoundTripEscapingTopology(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(base, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+	}
+	write("root/main.tf", `module "a" { source = "./A" }`+"\n"+`module "c" { source = "./C" }`)
+	write("root/A/main.tf", `module "b" { source = "../../B" }`)
+	write("root/C/main.tf", `output "from_c" { value = true }`)
+	write("B/main.tf", `output "from_b" { value = true }`)
+
+	rec := newResolveRecorder(modules.LiveResolver(t.Context()))
+	loader := modules.NewLoader(rec.resolve)
+
+	// Load the whole tree (root, its two children, and the escaping grandchild) so
+	// every reference is recorded.
+	rootDir := filepath.Join(base, "root")
+	root, err := loader.LoadModule(rootDir, "", ".")
+	require.NoError(t, err)
+	a, err := loader.LoadModule("./A", "", root.SourcePath)
+	require.NoError(t, err)
+	_, err = loader.LoadModule("./C", "", root.SourcePath)
+	require.NoError(t, err)
+	_, err = loader.LoadModule("../../B", "", a.SourcePath)
+	require.NoError(t, err)
+
+	value, err := rec.archive(moduleRef{Source: rootDir})
+	require.NoError(t, err)
+
+	dest := t.TempDir()
+	require.NoError(t, unpackArchive(value, dest))
+	manifest, err := readManifest(dest)
+	require.NoError(t, err)
+
+	// The escaping reference must be bundled as its own package, not as a path
+	// inside the root package "0".
+	var escaped *resolvedEdge
+	for i := range manifest.Edges {
+		if manifest.Edges[i].Source == "../../B" {
+			escaped = &manifest.Edges[i]
+		}
+	}
+	require.NotNil(t, escaped, "the ../../B reference should be recorded")
+	require.False(t, strings.HasPrefix(escaped.Target, "0/"),
+		"../../B escapes the root package, so it must be its own package, got target %q", escaped.Target)
+
+	offline := modules.NewLoader(bundleResolver(dest, manifest))
+	root2, err := offline.LoadModule(manifest.Root.Source, manifest.Root.Version, ".")
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(root2.SourcePath, dest))
+
+	// The non-escaping local sibling resolves inside the root package.
+	c2, err := offline.LoadModule("./C", "", root2.SourcePath)
+	require.NoError(t, err)
+	require.Contains(t, c2.Config.Outputs, "from_c")
+	require.True(t, strings.HasPrefix(c2.SourcePath, dest))
+
+	// The escaping ../../B resolves to its bundled package, staying inside the
+	// unpack dir rather than walking ".." out of it.
+	a2, err := offline.LoadModule("./A", "", root2.SourcePath)
+	require.NoError(t, err)
+	b2, err := offline.LoadModule("../../B", "", a2.SourcePath)
+	require.NoError(t, err)
+	require.Contains(t, b2.Config.Outputs, "from_b")
+	require.True(t, strings.HasPrefix(b2.SourcePath, dest),
+		"escaping ../../B must resolve inside the bundle, got %q", b2.SourcePath)
+}
+
 func TestPackArchiveDeterministic(t *testing.T) {
 	t.Parallel()
 
@@ -188,4 +266,24 @@ func TestPackArchiveDeterministic(t *testing.T) {
 	second, err := packArchive(map[string]string{"root": dir}, []byte(`{"root":{"source":"x"}}`))
 	require.NoError(t, err)
 	require.Equal(t, first, second)
+}
+
+// TestDedupeEdges verifies edges are deduplicated (each reference is recorded by
+// both the provider and schema walks) and sorted, so the manifest is stable.
+func TestDedupeEdges(t *testing.T) {
+	t.Parallel()
+
+	got := dedupeEdges([]resolvedEdge{
+		{Caller: "0", Source: "b/m/aws", Target: "2"},
+		{Caller: "", Source: "root", Target: "0"},
+		{Caller: "0", Source: "a/m/aws", Target: "1"},
+		{Caller: "", Source: "root", Target: "0"},     // duplicate
+		{Caller: "0", Source: "b/m/aws", Target: "2"}, // duplicate
+	})
+
+	require.Equal(t, []resolvedEdge{
+		{Caller: "", Source: "root", Target: "0"},
+		{Caller: "0", Source: "a/m/aws", Target: "1"},
+		{Caller: "0", Source: "b/m/aws", Target: "2"},
+	}, got)
 }

--- a/pkg/server/parameterize_test.go
+++ b/pkg/server/parameterize_test.go
@@ -55,22 +55,29 @@ func TestParameterizeArgsRejected(t *testing.T) {
 
 	t.Run("before handshake", func(t *testing.T) {
 		t.Parallel()
-		_, err := (&moduleProvider{}).parameterizeArgs(t.Context(), []string{"acme/widget/aws"})
+		_, err := (&moduleProvider{}).parameterizeArgs(t.Context(), []string{"module", "acme/widget/aws"})
 		require.EqualError(t, err, "parameterize called before a successful handshake")
 	})
 
-	t.Run("no args", func(t *testing.T) {
+	t.Run("missing module keyword", func(t *testing.T) {
 		t.Parallel()
-		_, err := (&moduleProvider{resolver: stubResolver{}}).parameterizeArgs(t.Context(), nil)
-		require.EqualError(t, err, "the hcl provider is parameterized by a module source and an "+
-			"optional version constraint: expected 1 or 2 arguments, got 0")
+		_, err := (&moduleProvider{resolver: stubResolver{}}).parameterizeArgs(t.Context(), []string{"acme/widget/aws"})
+		require.EqualError(t, err,
+			`the hcl provider is parameterized by a module: expected "module" as the first argument`)
+	})
+
+	t.Run("no source", func(t *testing.T) {
+		t.Parallel()
+		_, err := (&moduleProvider{resolver: stubResolver{}}).parameterizeArgs(t.Context(), []string{"module"})
+		require.EqualError(t, err, `the hcl provider is parameterized as "module <source> [version]": `+
+			`expected a source and an optional version constraint, got 0 arguments after "module"`)
 	})
 
 	t.Run("too many args", func(t *testing.T) {
 		t.Parallel()
-		_, err := (&moduleProvider{resolver: stubResolver{}}).parameterizeArgs(t.Context(), []string{"a", "b", "c"})
-		require.EqualError(t, err, "the hcl provider is parameterized by a module source and an "+
-			"optional version constraint: expected 1 or 2 arguments, got 3")
+		_, err := (&moduleProvider{resolver: stubResolver{}}).parameterizeArgs(t.Context(), []string{"module", "a", "b", "c"})
+		require.EqualError(t, err, `the hcl provider is parameterized as "module <source> [version]": `+
+			`expected a source and an optional version constraint, got 3 arguments after "module"`)
 	})
 }
 
@@ -85,7 +92,7 @@ func TestParameterizeArgsServesTypedSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	m := &moduleProvider{version: "1.2.3", resolver: stubResolver{}}
-	resp, err := m.parameterizeArgs(t.Context(), []string{dir})
+	resp, err := m.parameterizeArgs(t.Context(), []string{"module", dir})
 	require.NoError(t, err)
 	require.Equal(t, "module-one-var", resp.Name)
 	require.NotNil(t, m.param)

--- a/pkg/server/parameterize_test.go
+++ b/pkg/server/parameterize_test.go
@@ -22,8 +22,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blang/semver"
 	p "github.com/pulumi/pulumi-go-provider"
 	pulumiSchema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modules"
@@ -151,13 +154,14 @@ func TestBundleRoundTripResolvesOffline(t *testing.T) {
 	_, err = loader.LoadModule("acme/widget/aws", "", loaded.SourcePath)
 	require.NoError(t, err)
 
-	value, err := rec.archive(moduleRef{Source: root})
+	value, err := rec.bundle(moduleRef{Source: root}, nil)
 	require.NoError(t, err)
 
-	dest := t.TempDir()
-	require.NoError(t, unpackArchive(value, dest))
-	manifest, err := readManifest(dest)
+	b, err := decodeBundle(value)
 	require.NoError(t, err)
+	dest := t.TempDir()
+	require.NoError(t, unpackArchive(b.Archive, dest))
+	manifest := b.Manifest
 
 	// The bundle resolver has no network and no filesystem fallback: every
 	// source — the absolute-path root included — must come from the manifest.
@@ -211,13 +215,14 @@ func TestBundleRoundTripEscapingTopology(t *testing.T) {
 	_, err = loader.LoadModule("../../B", "", a.SourcePath)
 	require.NoError(t, err)
 
-	value, err := rec.archive(moduleRef{Source: rootDir})
+	value, err := rec.bundle(moduleRef{Source: rootDir}, nil)
 	require.NoError(t, err)
 
-	dest := t.TempDir()
-	require.NoError(t, unpackArchive(value, dest))
-	manifest, err := readManifest(dest)
+	b, err := decodeBundle(value)
 	require.NoError(t, err)
+	dest := t.TempDir()
+	require.NoError(t, unpackArchive(b.Archive, dest))
+	manifest := b.Manifest
 
 	// The escaping reference must be bundled as its own package, not as a path
 	// inside the root package "0".
@@ -261,11 +266,54 @@ func TestPackArchiveDeterministic(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "b.tf"), []byte("b"), 0o600))
 
-	first, err := packArchive(map[string]string{"root": dir}, []byte(`{"root":{"source":"x"}}`))
+	first, err := packArchive(map[string]string{"root": dir})
 	require.NoError(t, err)
-	second, err := packArchive(map[string]string{"root": dir}, []byte(`{"root":{"source":"x"}}`))
+	second, err := packArchive(map[string]string{"root": dir})
 	require.NoError(t, err)
 	require.Equal(t, first, second)
+}
+
+// TestBundleBakesPackages verifies the resolved provider descriptors survive the
+// bundle round-trip — including a bridged provider's parameterization — so the
+// usage path can reuse them instead of re-resolving, and that the encoding is
+// deterministic (the engine hashes the Value for provider identity).
+func TestBundleBakesPackages(t *testing.T) {
+	t.Parallel()
+
+	awsVer := semver.MustParse("6.46.0")
+	tfVer := semver.MustParse("0.9.0")
+	packages := map[string]workspace.PackageDescriptor{
+		"aws": {
+			PluginDescriptor: workspace.PluginDescriptor{
+				Name:    "terraform-provider",
+				Kind:    apitype.ResourcePlugin,
+				Version: &tfVer,
+			},
+			Parameterization: &workspace.Parameterization{
+				Name:    "aws",
+				Version: awsVer,
+				Value:   []byte(`{"remote":{"url":"registry.opentofu.org/hashicorp/aws","version":"6.46.0"}}`),
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`output "x" { value = 1 }`), 0o600))
+	rec := newResolveRecorder(func(string, string, string) (string, error) { return dir, nil })
+	loader := modules.NewLoader(rec.resolve)
+	_, err := loader.LoadModule(dir, "", ".")
+	require.NoError(t, err)
+
+	value, err := rec.bundle(moduleRef{Source: dir}, packages)
+	require.NoError(t, err)
+
+	again, err := rec.bundle(moduleRef{Source: dir}, packages)
+	require.NoError(t, err)
+	require.Equal(t, value, again, "the bundle encoding must be deterministic")
+
+	b, err := decodeBundle(value)
+	require.NoError(t, err)
+	require.Equal(t, packages, b.Packages)
 }
 
 // TestDedupeEdges verifies edges are deduplicated (each reference is recorded by

--- a/pkg/server/parameterize_test.go
+++ b/pkg/server/parameterize_test.go
@@ -149,9 +149,9 @@ func TestBundleRoundTripResolvesOffline(t *testing.T) {
 	loader := modules.NewLoader(rec.resolve)
 
 	// Loading the tree records every resolution into the recorder.
-	loaded, err := loader.LoadModule(root, "", ".")
+	loaded, err := loader.LoadModule(t.Context(), root, "", ".")
 	require.NoError(t, err)
-	_, err = loader.LoadModule("acme/widget/aws", "", loaded.SourcePath)
+	_, err = loader.LoadModule(t.Context(), "acme/widget/aws", "", loaded.SourcePath)
 	require.NoError(t, err)
 
 	value, err := rec.bundle(moduleRef{Source: root}, nil)
@@ -160,19 +160,19 @@ func TestBundleRoundTripResolvesOffline(t *testing.T) {
 	b, err := decodeBundle(value)
 	require.NoError(t, err)
 	dest := t.TempDir()
-	require.NoError(t, unpackArchive(b.Archive, dest))
+	require.NoError(t, unpackArchive(t.Context(), b.Archive, dest))
 	manifest := b.Manifest
 
 	// The bundle resolver has no network and no filesystem fallback: every
 	// source — the absolute-path root included — must come from the manifest.
 	offline := modules.NewLoader(bundleResolver(dest, manifest))
-	rootAgain, err := offline.LoadModule(manifest.Root.Source, manifest.Root.Version, ".")
+	rootAgain, err := offline.LoadModule(t.Context(), manifest.Root.Source, manifest.Root.Version, ".")
 	require.NoError(t, err)
 	require.Contains(t, rootAgain.Config.Modules, "c")
 	require.True(t, strings.HasPrefix(rootAgain.SourcePath, dest),
 		"root must resolve inside the unpacked bundle, got %q", rootAgain.SourcePath)
 
-	childAgain, err := offline.LoadModule("acme/widget/aws", "", rootAgain.SourcePath)
+	childAgain, err := offline.LoadModule(t.Context(), "acme/widget/aws", "", rootAgain.SourcePath)
 	require.NoError(t, err)
 	require.Contains(t, childAgain.Config.Outputs, "id")
 	require.True(t, strings.HasPrefix(childAgain.SourcePath, dest),
@@ -206,13 +206,13 @@ func TestBundleRoundTripEscapingTopology(t *testing.T) {
 	// Load the whole tree (root, its two children, and the escaping grandchild) so
 	// every reference is recorded.
 	rootDir := filepath.Join(base, "root")
-	root, err := loader.LoadModule(rootDir, "", ".")
+	root, err := loader.LoadModule(t.Context(), rootDir, "", ".")
 	require.NoError(t, err)
-	a, err := loader.LoadModule("./A", "", root.SourcePath)
+	a, err := loader.LoadModule(t.Context(), "./A", "", root.SourcePath)
 	require.NoError(t, err)
-	_, err = loader.LoadModule("./C", "", root.SourcePath)
+	_, err = loader.LoadModule(t.Context(), "./C", "", root.SourcePath)
 	require.NoError(t, err)
-	_, err = loader.LoadModule("../../B", "", a.SourcePath)
+	_, err = loader.LoadModule(t.Context(), "../../B", "", a.SourcePath)
 	require.NoError(t, err)
 
 	value, err := rec.bundle(moduleRef{Source: rootDir}, nil)
@@ -221,7 +221,7 @@ func TestBundleRoundTripEscapingTopology(t *testing.T) {
 	b, err := decodeBundle(value)
 	require.NoError(t, err)
 	dest := t.TempDir()
-	require.NoError(t, unpackArchive(b.Archive, dest))
+	require.NoError(t, unpackArchive(t.Context(), b.Archive, dest))
 	manifest := b.Manifest
 
 	// The escaping reference must be bundled as its own package, not as a path
@@ -237,21 +237,21 @@ func TestBundleRoundTripEscapingTopology(t *testing.T) {
 		"../../B escapes the root package, so it must be its own package, got target %q", escaped.Target)
 
 	offline := modules.NewLoader(bundleResolver(dest, manifest))
-	root2, err := offline.LoadModule(manifest.Root.Source, manifest.Root.Version, ".")
+	root2, err := offline.LoadModule(t.Context(), manifest.Root.Source, manifest.Root.Version, ".")
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(root2.SourcePath, dest))
 
 	// The non-escaping local sibling resolves inside the root package.
-	c2, err := offline.LoadModule("./C", "", root2.SourcePath)
+	c2, err := offline.LoadModule(t.Context(), "./C", "", root2.SourcePath)
 	require.NoError(t, err)
 	require.Contains(t, c2.Config.Outputs, "from_c")
 	require.True(t, strings.HasPrefix(c2.SourcePath, dest))
 
 	// The escaping ../../B resolves to its bundled package, staying inside the
 	// unpack dir rather than walking ".." out of it.
-	a2, err := offline.LoadModule("./A", "", root2.SourcePath)
+	a2, err := offline.LoadModule(t.Context(), "./A", "", root2.SourcePath)
 	require.NoError(t, err)
-	b2, err := offline.LoadModule("../../B", "", a2.SourcePath)
+	b2, err := offline.LoadModule(t.Context(), "../../B", "", a2.SourcePath)
 	require.NoError(t, err)
 	require.Contains(t, b2.Config.Outputs, "from_b")
 	require.True(t, strings.HasPrefix(b2.SourcePath, dest),
@@ -301,7 +301,7 @@ func TestBundleBakesPackages(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`output "x" { value = 1 }`), 0o600))
 	rec := newResolveRecorder(func(string, string, string) (string, error) { return dir, nil })
 	loader := modules.NewLoader(rec.resolve)
-	_, err := loader.LoadModule(dir, "", ".")
+	_, err := loader.LoadModule(t.Context(), dir, "", ".")
 	require.NoError(t, err)
 
 	value, err := rec.bundle(moduleRef{Source: dir}, packages)

--- a/pkg/server/parameterize_test.go
+++ b/pkg/server/parameterize_test.go
@@ -106,7 +106,7 @@ func TestParameterizeArgsServesTypedSchema(t *testing.T) {
 	require.NotNil(t, spec.Parameterization)
 	require.Equal(t, "hcl", spec.Parameterization.BaseProvider.Name)
 
-	res, ok := spec.Resources["module-one-var:index:module-one-var"]
+	res, ok := spec.Resources["module-one-var:index:Module"]
 	require.True(t, ok, "schema should declare the typed component")
 	require.True(t, res.IsComponent)
 	require.Equal(t, "string", res.InputProperties["name"].Type)

--- a/pkg/server/parameterize_test.go
+++ b/pkg/server/parameterize_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	pulumiSchema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modules"
+)
+
+func TestDefaultPackageName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		source string
+		want   string
+	}{
+		{"terraform-aws-modules/vpc/aws", "vpc"},
+		{"terraform-aws-modules/vpc/aws//modules/subnets", "vpc"},
+		{"github.com/org/my-repo", "my-repo"},
+		{"git::https://github.com/org/repo.git//subdir", "repo"},
+		{"git::https://example.com/foo/Bar_Baz.git", "bar-baz"},
+		{"./local/path", "path"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.source, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, defaultPackageName(tc.source))
+		})
+	}
+}
+
+func TestParameterizeArgsRejected(t *testing.T) {
+	t.Parallel()
+
+	t.Run("before handshake", func(t *testing.T) {
+		t.Parallel()
+		_, err := (&moduleProvider{}).parameterizeArgs(t.Context(), []string{"acme/widget/aws"})
+		require.EqualError(t, err, "parameterize called before a successful handshake")
+	})
+
+	t.Run("no args", func(t *testing.T) {
+		t.Parallel()
+		_, err := (&moduleProvider{resolver: stubResolver{}}).parameterizeArgs(t.Context(), nil)
+		require.EqualError(t, err, "the hcl provider is parameterized by a module source and an "+
+			"optional version constraint: expected 1 or 2 arguments, got 0")
+	})
+
+	t.Run("too many args", func(t *testing.T) {
+		t.Parallel()
+		_, err := (&moduleProvider{resolver: stubResolver{}}).parameterizeArgs(t.Context(), []string{"a", "b", "c"})
+		require.EqualError(t, err, "the hcl provider is parameterized by a module source and an "+
+			"optional version constraint: expected 1 or 2 arguments, got 3")
+	})
+}
+
+// TestParameterizeArgsServesTypedSchema drives the args path end-to-end for a
+// provider-free local module: it must parameterize without touching the resolver
+// and then serve the module's typed component schema (not the generic
+// hcl:index:Module) with its parameterization Value attached.
+func TestParameterizeArgsServesTypedSchema(t *testing.T) {
+	t.Parallel()
+
+	dir, err := filepath.Abs(filepath.Join("testdata", "module-one-var"))
+	require.NoError(t, err)
+
+	m := &moduleProvider{version: "1.2.3", resolver: stubResolver{}}
+	resp, err := m.parameterizeArgs(t.Context(), []string{dir})
+	require.NoError(t, err)
+	require.Equal(t, "module-one-var", resp.Name)
+	require.NotNil(t, m.param)
+
+	out, err := m.getSchema(t.Context(), p.GetSchemaRequest{})
+	require.NoError(t, err)
+
+	var spec pulumiSchema.PackageSpec
+	require.NoError(t, json.Unmarshal([]byte(out.Schema), &spec))
+
+	require.NotNil(t, spec.Parameterization)
+	require.Equal(t, "hcl", spec.Parameterization.BaseProvider.Name)
+
+	res, ok := spec.Resources["module-one-var:index:module-one-var"]
+	require.True(t, ok, "schema should declare the typed component")
+	require.True(t, res.IsComponent)
+	require.Equal(t, "string", res.InputProperties["name"].Type)
+	require.Equal(t, "string", res.Properties["greeting"].Type)
+	// "name" declares no `nullable = false`, so it is optional, matching the
+	// MLC's handling of a nullable variable.
+	require.Empty(t, res.RequiredInputs)
+}
+
+// TestBundleRoundTripResolvesOffline records a module tree — including a
+// non-local submodule and an absolute-path root — bundles it, then resolves
+// every source from the unpacked bundle with a resolver that has no fallback, so
+// any unrecorded reference would error.
+func TestBundleRoundTripResolvesOffline(t *testing.T) {
+	t.Parallel()
+
+	child := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(child, "main.tf"), []byte(`output "id" { value = "child" }`), 0o600))
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "main.tf"), []byte(`module "c" { source = "acme/widget/aws" }`), 0o600))
+
+	// A custom resolver stands in for the network: the absolute-path root
+	// resolves to itself and the submodule to the child package.
+	rec := newResolveRecorder(func(packageSource, _, _ string) (string, error) {
+		switch packageSource {
+		case root:
+			return root, nil
+		case "acme/widget/aws":
+			return child, nil
+		default:
+			return "", fmt.Errorf("unexpected source %q", packageSource)
+		}
+	})
+	loader := modules.NewLoader(rec.resolve)
+
+	// Loading the tree records every resolution into the recorder.
+	loaded, err := loader.LoadModule(root, "", ".")
+	require.NoError(t, err)
+	_, err = loader.LoadModule("acme/widget/aws", "", loaded.SourcePath)
+	require.NoError(t, err)
+
+	value, err := rec.archive(moduleRef{Source: root})
+	require.NoError(t, err)
+
+	dest := t.TempDir()
+	require.NoError(t, unpackArchive(value, dest))
+	manifest, err := readManifest(dest)
+	require.NoError(t, err)
+
+	// The bundle resolver has no network and no filesystem fallback: every
+	// source — the absolute-path root included — must come from the manifest.
+	offline := modules.NewLoader(bundleResolver(dest, manifest))
+	rootAgain, err := offline.LoadModule(manifest.Root.Source, manifest.Root.Version, ".")
+	require.NoError(t, err)
+	require.Contains(t, rootAgain.Config.Modules, "c")
+	require.True(t, strings.HasPrefix(rootAgain.SourcePath, dest),
+		"root must resolve inside the unpacked bundle, got %q", rootAgain.SourcePath)
+
+	childAgain, err := offline.LoadModule("acme/widget/aws", "", rootAgain.SourcePath)
+	require.NoError(t, err)
+	require.Contains(t, childAgain.Config.Outputs, "id")
+	require.True(t, strings.HasPrefix(childAgain.SourcePath, dest),
+		"submodule must resolve inside the unpacked bundle, got %q", childAgain.SourcePath)
+}
+
+func TestPackArchiveDeterministic(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.tf"), []byte("a"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "b.tf"), []byte("b"), 0o600))
+
+	first, err := packArchive(map[string]string{"root": dir}, []byte(`{"root":{"source":"x"}}`))
+	require.NoError(t, err)
+	second, err := packArchive(map[string]string{"root": dir}, []byte(`{"root":{"source":"x"}}`))
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+}

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -144,12 +144,12 @@ func NewHCLProvider(ctx context.Context, modulePath, addr string) (*HCLProvider,
 
 // moduleIdentity derives a module's component token and version. The terraform
 // `package` and `component` blocks take precedence; absent them defaultName
-// supplies the package name (and, by extension, the component name).
+// supplies the package name.
 //
-// The module segment defaults to "index" and the component name defaults to the
-// package name, so a module with no component block yields the single-segment
-// token "<package>:index:<package>", referenced in HCL by the bare package name
-// (e.g. `resource "foo"`), matching single-segment TF types like `external`.
+// The module segment defaults to "index" and the component name defaults to
+// "Module", so a module with no component block yields the token
+// "<package>:index:Module", referenced in HCL as `<package>_module` (mirroring
+// the dynamic hcl:index:Module resource).
 func moduleIdentity(loaded *modules.LoadedModule, defaultName string) (tokens.Type, semver.Version, error) {
 	module := "index"
 	pkgName := defaultName
@@ -175,7 +175,7 @@ func moduleIdentity(loaded *modules.LoadedModule, defaultName string) (tokens.Ty
 			}
 		}
 	}
-	componentName := pkgName
+	componentName := "Module"
 	if explicitComponentName != "" {
 		componentName = explicitComponentName
 	}

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -105,7 +105,7 @@ func NewHCLProvider(ctx context.Context, modulePath, addr string) (*HCLProvider,
 	}
 
 	// Load the module to generate schema
-	loaded, err := loader.LoadModule(modulePath, "", ".")
+	loaded, err := loader.LoadModule(ctx, modulePath, "", ".")
 	if err != nil {
 		return nil, fmt.Errorf("loading module: %w", err)
 	}
@@ -192,8 +192,11 @@ type moduleLoaderAdapter struct {
 	loader *modules.Loader
 }
 
-func (a moduleLoaderAdapter) LoadModule(source, versionConstraint, callerDir string) (*ast.Config, string, error) {
-	m, err := a.loader.LoadModule(source, versionConstraint, callerDir)
+func (a moduleLoaderAdapter) LoadModule(
+	ctx context.Context, source, versionConstraint, callerDir string,
+) (*ast.Config, string, error) {
+	// schema.ModuleLoader carries no context, so there is none to thread here.
+	m, err := a.loader.LoadModule(ctx, source, versionConstraint, callerDir)
 	if err != nil {
 		return nil, "", err
 	}
@@ -286,7 +289,7 @@ func (p *HCLProvider) Construct(ctx context.Context, req *pulumirpc.ConstructReq
 	monitor := pulumirpc.NewResourceMonitorClient(monitorConn)
 
 	// Load the module
-	loaded, err := p.moduleLoader.LoadModule(p.modulePath, "", ".")
+	loaded, err := p.moduleLoader.LoadModule(ctx, p.modulePath, "", ".")
 	if err != nil {
 		return nil, fmt.Errorf("loading module: %w", err)
 	}

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -157,18 +157,14 @@ func moduleIdentity(loaded *modules.LoadedModule, defaultName string) (tokens.Ty
 	var explicitComponentName string
 	if tf := loaded.Config.Terraform; tf != nil {
 		if comp := tf.Component; comp != nil {
-			// Sanitize names from the package/component blocks so they cannot
-			// produce a malformed token; defaultName is already sanitized.
-			if comp.Name != "" {
-				explicitComponentName = sanitizePackageName(comp.Name)
-			}
+			explicitComponentName = comp.Name
 			if comp.Module != "" {
-				module = sanitizePackageName(comp.Module)
+				module = comp.Module
 			}
 		}
 		if pkg := tf.Package; pkg != nil {
 			if pkg.Name != "" {
-				pkgName = sanitizePackageName(pkg.Name)
+				pkgName = pkg.Name
 			}
 			if pkg.Version != "" {
 				pkgVersion = pkg.Version

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -157,14 +157,18 @@ func moduleIdentity(loaded *modules.LoadedModule, defaultName string) (tokens.Ty
 	var explicitComponentName string
 	if tf := loaded.Config.Terraform; tf != nil {
 		if comp := tf.Component; comp != nil {
-			explicitComponentName = comp.Name
+			// Sanitize names from the package/component blocks so they cannot
+			// produce a malformed token; defaultName is already sanitized.
+			if comp.Name != "" {
+				explicitComponentName = sanitizePackageName(comp.Name)
+			}
 			if comp.Module != "" {
-				module = comp.Module
+				module = sanitizePackageName(comp.Module)
 			}
 		}
 		if pkg := tf.Package; pkg != nil {
 			if pkg.Name != "" {
-				pkgName = pkg.Name
+				pkgName = sanitizePackageName(pkg.Name)
 			}
 			if pkg.Version != "" {
 				pkgVersion = pkg.Version

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/blang/semver"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/bridge"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modules"
@@ -31,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
@@ -68,11 +70,8 @@ type HCLProvider struct {
 	// host is the host callback client.
 	host pulumirpc.EngineClient
 
-	// name is the provider name.
-	name string
-
 	// version is the provider version.
-	version string
+	version semver.Version
 
 	// schema is the generated schema for the module.
 	schema *schema.ModuleSchema
@@ -80,7 +79,7 @@ type HCLProvider struct {
 
 // NewHCLProvider creates a new HCL component provider.
 func NewHCLProvider(ctx context.Context, modulePath, addr string) (*HCLProvider, error) {
-	loader := modules.NewLoader(ctx)
+	loader := modules.NewLoader(modules.LiveResolver(ctx))
 	pkgLoader, err := pulumiSchema.NewLoaderClient(addr)
 	if err != nil {
 		return nil, fmt.Errorf("unable to acquire schema loader: %w", err)
@@ -111,38 +110,9 @@ func NewHCLProvider(ctx context.Context, modulePath, addr string) (*HCLProvider,
 		return nil, fmt.Errorf("loading module: %w", err)
 	}
 
-	// The component block is optional. The module segment defaults to "index"
-	// and the component name defaults to the package name, so a module with no
-	// component block yields the single-segment token "<package>:index:<package>"
-	// and is referenced in HCL by the bare package name (e.g. `resource "foo"`),
-	// matching single-segment TF types like `external`.
-	componentModule := "index"
-	var explicitComponentName string
-	var pkg *ast.PackageBlock
-	if tf := loaded.Config.Terraform; tf != nil {
-		if comp := tf.Component; comp != nil {
-			explicitComponentName = comp.Name
-			if comp.Module != "" {
-				componentModule = comp.Module
-			}
-		}
-		pkg = tf.Package
-	}
-
-	pkgName := filepath.Base(modulePath)
-	pkgVersion := "0.0.0-dev"
-	if pkg != nil {
-		if pkg.Name != "" {
-			pkgName = pkg.Name
-		}
-		if pkg.Version != "" {
-			pkgVersion = pkg.Version
-		}
-	}
-
-	componentName := pkgName
-	if explicitComponentName != "" {
-		componentName = explicitComponentName
+	token, version, err := moduleIdentity(loaded, filepath.Base(modulePath))
+	if err != nil {
+		return nil, err
 	}
 
 	// Resolve resource/data source references in outputs against provider
@@ -150,20 +120,13 @@ func NewHCLProvider(ctx context.Context, modulePath, addr string) (*HCLProvider,
 	// the engine uses, so schema generation types them the way Run resolves them.
 	// The same module loader types references to child modules.
 	cachedLoader := pulumiSchema.NewCachedLoader(schemaLoader)
-	var knownProviders []string
-	if tf := loaded.Config.Terraform; tf != nil {
-		for name := range tf.RequiredProviders {
-			knownProviders = append(knownProviders, name)
-		}
-	}
 	binder := &schema.Binder{
-		Resources: packages.NewResolver(cachedLoader, providerInfoSource, paramDescriptors, knownProviders),
+		Resources: packages.NewResolver(cachedLoader, providerInfoSource, paramDescriptors, knownProviderNames(loaded.Config)),
 		Modules:   moduleLoaderAdapter{loader},
 		ModuleDir: loaded.SourcePath,
 	}
 
-	moduleSchema, err := schema.GenerateModuleSchema(
-		ctx, loaded.Config, binder, pkgName, pkgVersion, componentName, componentModule)
+	moduleSchema, err := schema.GenerateModuleSchema(ctx, loaded.Config, binder, token, version)
 	if err != nil {
 		return nil, fmt.Errorf("generating schema: %w", err)
 	}
@@ -174,10 +137,49 @@ func NewHCLProvider(ctx context.Context, modulePath, addr string) (*HCLProvider,
 		pkgLoader:          cachedLoader,
 		providerInfoSource: providerInfoSource,
 		packages:           paramDescriptors,
-		name:               pkgName,
-		version:            pkgVersion,
+		version:            version,
 		schema:             moduleSchema,
 	}, nil
+}
+
+// moduleIdentity derives a module's component token and version. The terraform
+// `package` and `component` blocks take precedence; absent them defaultName
+// supplies the package name (and, by extension, the component name).
+//
+// The module segment defaults to "index" and the component name defaults to the
+// package name, so a module with no component block yields the single-segment
+// token "<package>:index:<package>", referenced in HCL by the bare package name
+// (e.g. `resource "foo"`), matching single-segment TF types like `external`.
+func moduleIdentity(loaded *modules.LoadedModule, defaultName string) (tokens.Type, semver.Version, error) {
+	module := "index"
+	pkgName := defaultName
+	pkgVersion := "0.0.0-dev"
+	var explicitComponentName string
+	if tf := loaded.Config.Terraform; tf != nil {
+		if comp := tf.Component; comp != nil {
+			explicitComponentName = comp.Name
+			if comp.Module != "" {
+				module = comp.Module
+			}
+		}
+		if pkg := tf.Package; pkg != nil {
+			if pkg.Name != "" {
+				pkgName = pkg.Name
+			}
+			if pkg.Version != "" {
+				pkgVersion = pkg.Version
+			}
+		}
+	}
+	componentName := pkgName
+	if explicitComponentName != "" {
+		componentName = explicitComponentName
+	}
+	version, err := semver.ParseTolerant(pkgVersion)
+	if err != nil {
+		return "", version, fmt.Errorf("parsing module version %q: %w", pkgVersion, err)
+	}
+	return tokens.Type(fmt.Sprintf("%s:%s:%s", pkgName, module, componentName)), version, nil
 }
 
 // moduleLoaderAdapter adapts *modules.Loader to schema.ModuleLoader, so schema
@@ -335,8 +337,8 @@ func (p *HCLProvider) Construct(ctx context.Context, req *pulumirpc.ConstructReq
 		}
 	}
 
-	// Create engine options
-	engineOpts := &run.EngineOptions{
+	// Create and run the engine
+	engine := run.NewEngine(ctx, loaded.Config, &run.EngineOptions{
 		ProjectName:        req.Project,
 		StackName:          req.Stack,
 		Organization:       req.Organization,
@@ -346,12 +348,10 @@ func (p *HCLProvider) Construct(ctx context.Context, req *pulumirpc.ConstructReq
 		Config:             config,
 		ResourceMonitor:    resmon,
 		SchemaLoader:       p.pkgLoader,
+		ModuleLoader:       modules.NewLoader(modules.LiveResolver(ctx)),
 		ProviderInfoSource: p.providerInfoSource,
 		Packages:           p.packages,
-	}
-
-	// Create and run the engine
-	engine := run.NewEngine(ctx, loaded.Config, engineOpts)
+	})
 
 	if err := engine.Run(ctx); err != nil {
 		return nil, fmt.Errorf("executing module: %w", err)
@@ -376,7 +376,7 @@ func (p *HCLProvider) Construct(ctx context.Context, req *pulumirpc.ConstructReq
 // GetPluginInfo returns plugin metadata.
 func (p *HCLProvider) GetPluginInfo(ctx context.Context, req *emptypb.Empty) (*pulumirpc.PluginInfo, error) {
 	return &pulumirpc.PluginInfo{
-		Version: p.version,
+		Version: p.version.String(),
 	}, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -442,7 +442,11 @@ func collectRequirementsRec(
 	if loader == nil {
 		return
 	}
-	for _, mod := range config.Modules {
+	// Iterate in a stable order: this walk drives the archive layout when a module
+	// is bundled for parameterization, so a map's random order would make the
+	// bundle non-deterministic.
+	for _, name := range slices.Sorted(maps.Keys(config.Modules)) {
+		mod := config.Modules[name]
 		if mod.Source == "" {
 			continue
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -364,11 +364,12 @@ func collectRequirements(
 	tf = map[string]*versionSet{}
 	pulumi = map[string]string{}
 	aliases = map[string]*ast.RequiredProvider{}
-	collectRequirementsRec(config, workDir, tf, pulumi, aliases, loader, map[string]struct{}{})
+	collectRequirementsRec(ctx, config, workDir, tf, pulumi, aliases, loader, map[string]struct{}{})
 	return tf, pulumi, aliases
 }
 
 func collectRequirementsRec(
+	ctx context.Context,
 	config *ast.Config, workDir string,
 	tf map[string]*versionSet, pulumi map[string]string, aliases map[string]*ast.RequiredProvider,
 	loader *modules.Loader, visited map[string]struct{},
@@ -450,7 +451,7 @@ func collectRequirementsRec(
 		if mod.Source == "" {
 			continue
 		}
-		loaded, err := loader.LoadModule(mod.Source, mod.Version, workDir)
+		loaded, err := loader.LoadModule(ctx, mod.Source, mod.Version, workDir)
 		if err != nil {
 			// `pulumi install` surfaces a concrete error later; don't block on it here.
 			logging.V(5).Infof("collectRequirements: loading module %q: %v", mod.Source, err)
@@ -460,7 +461,7 @@ func collectRequirementsRec(
 			continue
 		}
 		visited[loaded.SourcePath] = struct{}{}
-		collectRequirementsRec(loaded.Config, loaded.SourcePath, tf, pulumi, aliases, loader, visited)
+		collectRequirementsRec(ctx, loaded.Config, loaded.SourcePath, tf, pulumi, aliases, loader, visited)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -187,7 +187,8 @@ func (host *LanguageHost) GetRequiredPackages(
 	// (the terraform-provider plugin intersects them at resolve time, erroring on
 	// an empty intersection just as tofu does), and distinct sources are distinct
 	// installs.
-	tfSpecs, pulumiPkgs, aliases := collectRequirements(ctx, config, req.Info.ProgramDirectory)
+	tfSpecs, pulumiPkgs, aliases := collectRequirements(ctx, modules.NewLoader(modules.LiveResolver(ctx)),
+		config, req.Info.ProgramDirectory)
 
 	for _, alias := range sortedKeys(aliases) {
 		// A local SDK descriptor (written by `pulumi package add`) is the most
@@ -312,7 +313,7 @@ func readParameterizationInfos(dir string) (map[string]workspace.PackageDescript
 func missingNonPulumiSDKs(
 	ctx context.Context, config *ast.Config, sdks map[string]workspace.PackageDescriptor, workDir string,
 ) []string {
-	_, _, aliases := collectRequirements(ctx, config, workDir)
+	_, _, aliases := collectRequirements(ctx, modules.NewLoader(modules.LiveResolver(ctx)), config, workDir)
 	var missing []string
 	for _, alias := range sortedKeys(aliases) {
 		if isBuiltinProvider(alias) || aliases[alias].IsPulumi() {
@@ -358,15 +359,11 @@ func (v *versionSet) constraint() string { return strings.Join(sortedKeys(v.seen
 // own required_providers, else the "hashicorp/<name>" default), so a provider
 // declared only in a child module still resolves from its declared source.
 func collectRequirements(
-	ctx context.Context, config *ast.Config, workDir string,
+	ctx context.Context, loader *modules.Loader, config *ast.Config, workDir string,
 ) (tf map[string]*versionSet, pulumi map[string]string, aliases map[string]*ast.RequiredProvider) {
 	tf = map[string]*versionSet{}
 	pulumi = map[string]string{}
 	aliases = map[string]*ast.RequiredProvider{}
-	var loader *modules.Loader
-	if workDir != "" && config != nil && len(config.Modules) > 0 {
-		loader = modules.NewLoader(ctx)
-	}
 	collectRequirementsRec(config, workDir, tf, pulumi, aliases, loader, map[string]struct{}{})
 	return tf, pulumi, aliases
 }
@@ -558,6 +555,7 @@ func (host *LanguageHost) Run(
 		ProviderInfoSource:      providerInfoSource,
 		WorkDir:                 req.Info.ProgramDirectory,
 		RootDir:                 req.Info.RootDirectory,
+		ModuleLoader:            modules.NewLoader(modules.LiveResolver(ctx)),
 		Packages:                paramDescriptors,
 		Parallel:                int(req.Parallel),
 		AlwaysRegisterProviders: host.alwaysRegisterProviders,

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -88,13 +88,13 @@ func TestSmokeRandom(t *testing.T) {
 	})
 }
 
-// TestSmokeModule proves a plain HCL module (no component or package block) can
-// be served as a Multi-Language Component: `pulumi package add ../randommodule`
-// generates a local SDK, the consuming HCL program instantiates the component by
-// its bare package name (passing `length` in, reading `pet` out), the component's
-// `random_pet` (a bridged hashicorp/random resource) is created via Construct,
-// and the root output is unknown at preview and a three-word pet name after up.
-func TestSmokeModule(t *testing.T) {
+// TestSmokeInLanguageModule proves a plain HCL module (no component or package block) can
+// be served as a Multi-Language Component: `pulumi package add ../randommodule` generates
+// a local SDK, the consuming HCL program instantiates the component as
+// `randommodule_module` (passing `length` in, reading `pet` out), the component's
+// `random_pet` (a bridged hashicorp/random resource) is created via Construct, and the
+// root output is unknown at preview and a three-word pet name after up.
+func TestSmokeInLanguageModule(t *testing.T) {
 	t.Parallel()
 
 	home := seedPluginCache(t, "terraform-provider")
@@ -178,6 +178,57 @@ func TestSmokeDynamicModule(t *testing.T) {
 				stack.Outputs["name"], stack.Outputs["name"])
 			require.Regexp(t, regexp.MustCompile(`^smoke-[a-z0-9]{8}$`), name,
 				"name should be '<prefix>-<8 lowercase alphanumerics>'")
+		},
+	})
+}
+
+// TestSmokeParameterizedModule exercises the parameterization path through
+// pulumi-resource-hcl: `pulumi package add hcl module <source>` downloads and
+// bundles the same module TestSmokeInLanguageModule serves as a local-path MLC, generates
+// its typed component SDK, and a YAML program instantiates that component by its
+// token (`randommodule:index:Module`), passing `petLength` in and reading
+// `petName` out. The module's `random_pet` (a bridged hashicorp/random resource)
+// is resolved through terraform-provider parameterization, so this drives the
+// whole module-bundle-then-consume flow end-to-end. Hits the public Pulumi + TF
+// registries.
+func TestSmokeParameterizedModule(t *testing.T) {
+	t.Parallel()
+
+	home := seedPluginCache(t, "terraform-provider")
+
+	// The same fixture TestSmokeInLanguageModule serves as a local-path MLC; here it is
+	// loaded by path and bundled into the parameterization, leaving the program
+	// dir untouched, so the fixture can be referenced in place by absolute path.
+	moduleDir, err := filepath.Abs(filepath.Join("testdata", "module", "randommodule"))
+	require.NoError(t, err)
+
+	// `pulumi package add` resolves a bare plugin name (`hcl`) through the
+	// registry, which the locally-built plugin is not in; pointing it at the
+	// built binary on PATH parameterizes the plugin in place.
+	resourceBin, err := filepath.Abs(filepath.Join("..", "..", "bin", "pulumi-resource-hcl"))
+	require.NoError(t, err)
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		NoParallel:    true,
+		Dir:           filepath.Join("testdata", "parameterized", "program"),
+		PulumiHomeDir: home,
+		PrepareProject: func(e *engine.Projinfo) error {
+			cmd := exec.Command("pulumi", "package", "add", resourceBin, "module", moduleDir)
+			cmd.Dir = e.Root
+			cmd.Env = append(os.Environ(), "PULUMI_HOME="+home)
+			cmd.Stdout, cmd.Stderr = os.Stderr, os.Stderr
+			return cmd.Run()
+		},
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			// petLength = 3 flows into the module's random_pet through the
+			// camelCase->snake_case boundary, and the resulting three-word pet name
+			// flows back out, proving the parameterized component round-trips inputs
+			// and outputs.
+			petName, ok := stack.Outputs["petName"].(string)
+			require.True(t, ok, "petName must be a string, got %T (%v)",
+				stack.Outputs["petName"], stack.Outputs["petName"])
+			require.Regexp(t, regexp.MustCompile(`^[a-z]+-[a-z]+-[a-z]+$`), petName,
+				"petLength = 3 should yield a three-word pet name")
 		},
 	})
 }

--- a/tests/smoke/testdata/module/program/main.tf
+++ b/tests/smoke/testdata/module/program/main.tf
@@ -1,4 +1,4 @@
-resource "randommodule" "pet" {
+resource "randommodule_module" "pet" {
   pet_length = 3
   object_value = {
     string_field = "hello"
@@ -9,13 +9,13 @@ resource "randommodule" "pet" {
 }
 
 output "pet_name" {
-  value = randommodule.pet.pet_name
+  value = randommodule_module.pet.pet_name
 }
 
 output "object_field" {
-  value = randommodule.pet.echo_object.string_field
+  value = randommodule_module.pet.echo_object.string_field
 }
 
 output "map_field" {
-  value = randommodule.pet.echo_map.user_key
+  value = randommodule_module.pet.echo_map.user_key
 }

--- a/tests/smoke/testdata/parameterized/program/Pulumi.yaml
+++ b/tests/smoke/testdata/parameterized/program/Pulumi.yaml
@@ -1,0 +1,17 @@
+name: smoke-parameterized
+runtime: yaml
+description: |
+  Consumes the randommodule Terraform module parameterized into
+  pulumi-resource-hcl via `pulumi package add hcl module <source>`, referencing
+  the generated typed component by its token.
+resources:
+  pet:
+    type: randommodule:index:Module
+    properties:
+      petLength: 3
+      objectValue:
+        stringField: hello
+      mapValue:
+        user_key: world
+outputs:
+  petName: ${pet.petName}


### PR DESCRIPTION
This allows users to run `pulumi package add hcl module <source> [version]` and get an SDK that embeds the module. This works on local and remote modules. 

The generated SDKs full embed the module, so HCL module loading is exclusively a parameterization time concern.

Stacked on top of https://github.com/pulumi-labs/pulumi-hcl/pull/282.

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/166