### PR TITLE
Release `pulumi-resource-hcl` plugin via goreleaser

### DIFF
--- a/.changes/unreleased/resource-host-Improvements-285.yaml
+++ b/.changes/unreleased/resource-host-Improvements-285.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Release the `pulumi-resource-hcl` plugin as part of the goreleaser build
+time: 2026-06-24T08:14:24+00:00
+custom:
+    Component: resource-host
+    PR: "285"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,25 @@ builds:
     ldflags:
       - -w -s -X github.com/pulumi-labs/pulumi-hcl/pkg/version.version={{.Tag}}
 
+  - id: pulumi-resource-hcl
+    binary: pulumi-resource-hcl
+    main: ./cmd/pulumi-resource-hcl
+    env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
+    goos:
+      - darwin
+      - windows
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - -w -s -X github.com/pulumi-labs/pulumi-hcl/pkg/version.version={{.Tag}}
+
 archives:
   - id: pulumi-language-hcl
     builds:
@@ -48,6 +67,10 @@ archives:
     builds:
       - pulumi-converter-hcl
     name_template: "pulumi-converter-hcl-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
+  - id: pulumi-resource-hcl
+    builds:
+      - pulumi-resource-hcl
+    name_template: "pulumi-resource-hcl-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
 
 snapshot:
   version_template: "{{ .Tag }}-SNAPSHOT"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,15 +60,15 @@ builds:
 
 archives:
   - id: pulumi-language-hcl
-    builds:
+    ids:
       - pulumi-language-hcl
     name_template: "pulumi-language-hcl-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
   - id: pulumi-converter-hcl
-    builds:
+    ids:
       - pulumi-converter-hcl
     name_template: "pulumi-converter-hcl-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
   - id: pulumi-resource-hcl
-    builds:
+    ids:
       - pulumi-resource-hcl
     name_template: "pulumi-resource-hcl-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
 


### PR DESCRIPTION
Extends the goreleaser configuration with a build and archive for the
`pulumi-resource-hcl` plugin, so the resource provider binary is published
in releases alongside `pulumi-language-hcl` and `pulumi-converter-hcl`.

The new build mirrors the existing two: same `goos`/`goarch` matrix, CGO
disabled, `-trimpath`, and the version `ldflags`. A matching archive entry
publishes it as `pulumi-resource-hcl-<tag>-<os>-<arch>`.