### PR TITLE
Unwrap Output/Secret inputs before passing to HCL engine

### DIFF
--- a/pkg/server/module_resource.go
+++ b/pkg/server/module_resource.go
@@ -431,6 +431,7 @@ func validateModuleInputs(inputs property.Map, config *ast.Config) error {
 func moduleConfig(project string, inputs property.Map) map[string]string {
 	config := make(map[string]string, inputs.Len())
 	for k, v := range resource.ToResourcePropertyMap(inputs) {
+		v = unwrapPropertyValue(v)
 		key := project + ":" + string(k)
 		if v.IsString() {
 			config[key] = v.StringValue()
@@ -440,6 +441,41 @@ func moduleConfig(project string, inputs property.Map) map[string]string {
 		config[key] = string(jsonVal)
 	}
 	return config
+}
+
+// unwrapPropertyValue strips Output and Secret wrappers from a PropertyValue,
+// recursing through arrays and objects, to yield the plain underlying value.
+// The HCL engine consumes resolved values; without unwrapping, an Output-typed
+// input (e.g. one wired from another resource's output) serializes as its
+// wrapper struct — {"Element":{"V":"..."}} — instead of the value Terraform
+// expects. Unknown outputs are left intact for the caller to handle.
+func unwrapPropertyValue(v resource.PropertyValue) resource.PropertyValue {
+	switch {
+	case v.IsOutput():
+		o := v.OutputValue()
+		if !o.Known {
+			return v
+		}
+		return unwrapPropertyValue(o.Element)
+	case v.IsSecret():
+		return unwrapPropertyValue(v.SecretValue().Element)
+	case v.IsArray():
+		arr := v.ArrayValue()
+		out := make([]resource.PropertyValue, len(arr))
+		for i, e := range arr {
+			out[i] = unwrapPropertyValue(e)
+		}
+		return resource.NewArrayProperty(out)
+	case v.IsObject():
+		obj := v.ObjectValue()
+		out := make(resource.PropertyMap, len(obj))
+		for key, e := range obj {
+			out[key] = unwrapPropertyValue(e)
+		}
+		return resource.NewObjectProperty(out)
+	default:
+		return v
+	}
 }
 
 // wrapModuleOutputs exposes the module's top-level outputs under the component's

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -331,6 +331,7 @@ func (p *HCLProvider) Construct(ctx context.Context, req *pulumirpc.ConstructReq
 	config := make(map[string]string)
 	hclInputs := resource.ToResourcePropertyMap(p.schema.InputsToHCL(resource.FromResourcePropertyMap(inputs)))
 	for k, v := range hclInputs {
+		v = unwrapPropertyValue(v)
 		configKey := req.Project + ":" + string(k)
 		if v.IsString() {
 			config[configKey] = v.StringValue()


### PR DESCRIPTION
## Problem

Module inputs wired from another resource's output reached the underlying Terraform provider as their **PropertyValue wrapper struct** rather than the resolved value. For example, a `subnet_id=subnet.id` input arrived as:

```
{"Element":{"V":"/subscriptions/.../subnets/aks-prod-subnet"}}
```

instead of the bare ID. This broke validation for any module input fed by a Pulumi `Output` (observed on `resource_group_name` and `subnet_id` for an AKS module), producing errors like:

```
"resource_group_name" may only contain alphanumeric characters, dash, underscores, parentheses and periods
parsing the Subnet ID: the segment at position 0 didn't match
```

## Root cause

Both marshalling sites converted input `PropertyValue`s via `v.Mappable()` + `json.Marshal()` while the values were still wrapped in their Output/Secret envelope. `.Mappable()` serializes the wrapper struct verbatim, so the `{"Element":{"V":...}}` representation leaked through to Terraform.

- `pkg/server/provider.go` — `Construct()`
- `pkg/server/module_resource.go` — `moduleConfig()`

## Fix

Add `unwrapPropertyValue()` which recursively strips Output and Secret wrappers (recursing through arrays and objects, leaving genuinely unknown outputs intact), and apply it at both sites before the existing string/JSON encoding.

## Verification

Manually verified end-to-end against a Python program consuming a `td-aks-cluster` HCL module with `resource_group_name=resource_group.name` and `subnet_id=subnet.id`:

- **Before:** `pulumi up` failed with the wrapper-struct validation errors above.
- **After (rebuilt provider):** `pulumi preview` is clean and resolves the Outputs to the same values as hand-written literals (`6 unchanged`, no diff).

## ⚠️ No automated tests

This change is **not covered by automated tests** — verification was manual only. A regression test for `unwrapPropertyValue` (and ideally an integration test that feeds an Output-typed input through `moduleConfig`/`Construct`) should be added before relying on this long-term. Flagging explicitly so it isn't merged on the assumption of test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)