### PR TITLE
Support `TF_TOKEN_<host>`

### DIFF
--- a/.changes/unreleased/runtime-Improvements-289.yaml
+++ b/.changes/unreleased/runtime-Improvements-289.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Authenticate to module registries with `TF_TOKEN_<host>` and honor `host` service overrides from the Terraform CLI configuration
+time: 2026-06-25T23:29:51.000000+02:00
+custom:
+    Component: runtime
+    PR: "289"

--- a/pkg/hcl/modules/loader.go
+++ b/pkg/hcl/modules/loader.go
@@ -36,6 +36,7 @@ import (
 	regaddr "github.com/opentofu/registry-address/v2"
 	"github.com/opentofu/svchost"
 	"github.com/opentofu/svchost/disco"
+	"github.com/opentofu/svchost/svcauth"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/potel"
@@ -86,11 +87,23 @@ func NewLoader(resolver ResolverFunc) *Loader {
 // resolve directly, registry sources via the modules.v1 protocol, and everything
 // else through the remote getter, downloading and caching under PULUMI_HOME.
 func LiveResolver(ctx context.Context) ResolverFunc {
-	creds := newCloudRegistryCredentials(os.Getenv("PULUMI_API"), os.Getenv("PULUMI_ACCESS_TOKEN"))
+	cloud := newCloudRegistryCredentials(os.Getenv("PULUMI_API"), os.Getenv("PULUMI_ACCESS_TOKEN"))
+	cfg := loadTerraformCLIConfig()
+
+	// Precedence matches OpenTofu: an explicit TF_TOKEN_<host> or a `credentials`
+	// block wins over the auto-injected Pulumi Cloud token, which only ever
+	// matches the discovered cloud host anyway.
+	d := disco.New(disco.WithCredentials(svcauth.Credentials{
+		tfTokenCredentials(),
+		cliConfigCredentials(cfg),
+		cloud,
+	}))
+	applyHostServiceOverrides(d, cfg)
+
 	n := &networkResolver{
 		cacheDir: defaultCacheDir(),
 		fetcher:  getmodules.NewPackageFetcher(ctx, nil),
-		disco:    disco.New(disco.WithCredentials(creds)),
+		disco:    d,
 	}
 	return n.resolve
 }

--- a/pkg/hcl/modules/terraform_cli_config.go
+++ b/pkg/hcl/modules/terraform_cli_config.go
@@ -1,0 +1,187 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/opentofu/svchost"
+	"github.com/opentofu/svchost/disco"
+	"github.com/opentofu/svchost/svcauth"
+)
+
+// tfTokenCredentials reads TF_TOKEN_<host> environment variables into a
+// credentials source, the way Terraform and OpenTofu authenticate to a
+// service-discovery host with no `terraform login`. The host portion of the
+// variable name is decoded the same way they decode it: "__" becomes "-" and
+// "_" becomes ".", so a host with hyphens or dots can be named with a
+// shell-legal variable. An invalid host or empty value is skipped.
+func tfTokenCredentials() svcauth.CredentialsSource {
+	const prefix = "TF_TOKEN_"
+	creds := map[svchost.Hostname]svcauth.HostCredentials{}
+	for _, ev := range os.Environ() {
+		name, value, ok := strings.Cut(ev, "=")
+		if !ok || value == "" || !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		rawHost := name[len(prefix):]
+		rawHost = strings.ReplaceAll(rawHost, "__", "-")
+		rawHost = strings.ReplaceAll(rawHost, "_", ".")
+		host, err := svchost.ForComparison(svchost.ForDisplay(rawHost))
+		if err != nil {
+			continue
+		}
+		creds[host] = svcauth.HostCredentialsToken(value)
+	}
+	return svcauth.StaticCredentialsSource(creds)
+}
+
+// terraformCLIConfig holds the parts of a Terraform/OpenTofu CLI configuration
+// file that affect module registry resolution: `host` blocks that override
+// service discovery and `credentials` blocks that authenticate to a host.
+// Everything else in the file is absorbed by the trailing remain bodies and
+// ignored.
+type terraformCLIConfig struct {
+	Hosts       []cliConfigHost  `hcl:"host,block"`
+	Credentials []cliConfigCreds `hcl:"credentials,block"`
+	Remain      hcl.Body         `hcl:",remain"`
+}
+
+type cliConfigHost struct {
+	Name     string            `hcl:"name,label"`
+	Services map[string]string `hcl:"services,optional"`
+	Remain   hcl.Body          `hcl:",remain"`
+}
+
+type cliConfigCreds struct {
+	Name   string   `hcl:"name,label"`
+	Token  string   `hcl:"token,optional"`
+	Remain hcl.Body `hcl:",remain"`
+}
+
+// terraformCLIConfigPath resolves the CLI configuration file the same way
+// OpenTofu does: an explicit TF_CLI_CONFIG_FILE (or the legacy TERRAFORM_CONFIG)
+// wins, otherwise the per-user default. explicit reports whether the path came
+// from one of those environment variables, so a missing explicit file warns
+// while a missing default file stays silent.
+func terraformCLIConfigPath() (path string, explicit bool) {
+	if p := os.Getenv("TF_CLI_CONFIG_FILE"); p != "" {
+		return p, true
+	}
+	if p := os.Getenv("TERRAFORM_CONFIG"); p != "" {
+		return p, true
+	}
+	if runtime.GOOS == "windows" {
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			return filepath.Join(appData, "terraform.rc"), false
+		}
+		return "", false
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", false
+	}
+	return filepath.Join(home, ".terraformrc"), false
+}
+
+// loadTerraformCLIConfig reads and parses the CLI configuration file. A missing
+// default file is not an error and returns nil. Any other failure — an
+// unreadable explicit file, or a file that does not parse — is reported loudly
+// to stderr and returns nil, so a malformed config degrades to "no overrides,
+// no extra credentials" rather than breaking the run.
+func loadTerraformCLIConfig() *terraformCLIConfig {
+	path, explicit := terraformCLIConfigPath()
+	if path == "" {
+		return nil
+	}
+
+	src, err := os.ReadFile(path)
+	if err != nil {
+		if explicit || !os.IsNotExist(err) {
+			warnTerraformCLIConfig("could not read Terraform CLI configuration file %q: %v", path, err)
+		}
+		return nil
+	}
+
+	file, diags := hclparse.NewParser().ParseHCL(src, path)
+	if diags.HasErrors() {
+		warnTerraformCLIConfig("could not parse Terraform CLI configuration file %q: %s", path, diags)
+		return nil
+	}
+
+	var cfg terraformCLIConfig
+	if diags := gohcl.DecodeBody(file.Body, nil, &cfg); diags.HasErrors() {
+		warnTerraformCLIConfig("could not decode Terraform CLI configuration file %q: %s", path, diags)
+		return nil
+	}
+	return &cfg
+}
+
+// cliConfigCredentials turns the file's `credentials` blocks into a credentials
+// source. A nil config or a config with no credentials yields an empty source
+// that authenticates nothing.
+func cliConfigCredentials(cfg *terraformCLIConfig) svcauth.CredentialsSource {
+	creds := map[svchost.Hostname]svcauth.HostCredentials{}
+	if cfg != nil {
+		for _, c := range cfg.Credentials {
+			if c.Token == "" {
+				continue
+			}
+			host, err := svchost.ForComparison(svchost.ForDisplay(c.Name))
+			if err != nil {
+				warnTerraformCLIConfig("ignoring credentials block for invalid host %q: %v", c.Name, err)
+				continue
+			}
+			creds[host] = svcauth.HostCredentialsToken(c.Token)
+		}
+	}
+	return svcauth.StaticCredentialsSource(creds)
+}
+
+// applyHostServiceOverrides registers each `host` block's service map with the
+// discovery client, so a request for that host uses the configured service URLs
+// instead of network discovery — the standard way to point a registry host at a
+// mirror, proxy, or (in tests) a local server.
+func applyHostServiceOverrides(d *disco.Disco, cfg *terraformCLIConfig) {
+	if cfg == nil {
+		return
+	}
+	for _, h := range cfg.Hosts {
+		host, err := svchost.ForComparison(svchost.ForDisplay(h.Name))
+		if err != nil {
+			warnTerraformCLIConfig("ignoring host block for invalid host %q: %v", h.Name, err)
+			continue
+		}
+		services := make(map[string]any, len(h.Services))
+		for service, url := range h.Services {
+			services[service] = url
+		}
+		d.ForceHostServices(host, services)
+	}
+}
+
+// warnTerraformCLIConfig writes a prominent warning to stderr. The language
+// host's stderr is surfaced to the user by the engine, so a misconfigured CLI
+// file is visible rather than silently dropped.
+func warnTerraformCLIConfig(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "warning: "+format+"\n", args...)
+}

--- a/pkg/hcl/modules/terraform_cli_config_test.go
+++ b/pkg/hcl/modules/terraform_cli_config_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/opentofu/svchost"
+	"github.com/opentofu/svchost/disco"
+	"github.com/opentofu/svchost/svcauth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustHost(t *testing.T, s string) svchost.Hostname {
+	t.Helper()
+	host, err := svchost.ForComparison(s)
+	require.NoError(t, err)
+	return host
+}
+
+func TestTFTokenCredentials(t *testing.T) {
+	// A dotted host names its variable with underscores; a hyphenated host uses
+	// double underscores. An empty value and a non-TF_TOKEN_ name contribute
+	// nothing.
+	t.Setenv("TF_TOKEN_app_terraform_io", "tok-dotted")
+	t.Setenv("TF_TOKEN_my__registry_example_com", "tok-hyphen")
+	t.Setenv("TF_TOKEN_blank_example_com", "")
+	t.Setenv("NOT_A_TF_TOKEN", "ignored")
+
+	src := tfTokenCredentials()
+
+	for _, tt := range []struct {
+		host string
+		want svcauth.HostCredentials
+	}{
+		{"app.terraform.io", svcauth.HostCredentialsToken("tok-dotted")},
+		{"my-registry.example.com", svcauth.HostCredentialsToken("tok-hyphen")},
+		{"blank.example.com", nil},
+		{"unset.example.com", nil},
+	} {
+		got, err := src.ForHost(t.Context(), mustHost(t, tt.host))
+		require.NoError(t, err)
+		assert.Equal(t, tt.want, got, "host %q", tt.host)
+	}
+}
+
+func TestLoadTerraformCLIConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cli.tfrc")
+	require.NoError(t, os.WriteFile(path, []byte(`
+host "registry.example.com" {
+  services = {
+    "modules.v1" = "https://registry.example.com/modules/v1/"
+  }
+}
+
+credentials "app.terraform.io" {
+  token = "from-credentials-block"
+}
+
+# Unrelated blocks are tolerated and ignored.
+plugin_cache_dir = "/tmp/plugins"
+`), 0o600))
+	t.Setenv("TF_CLI_CONFIG_FILE", path)
+
+	cfg := loadTerraformCLIConfig()
+	require.NotNil(t, cfg)
+
+	creds, err := cliConfigCredentials(cfg).ForHost(t.Context(), mustHost(t, "app.terraform.io"))
+	require.NoError(t, err)
+	assert.Equal(t, svcauth.HostCredentialsToken("from-credentials-block"), creds)
+
+	d := disco.New()
+	applyHostServiceOverrides(d, cfg)
+	u, err := d.DiscoverServiceURL(t.Context(), mustHost(t, "registry.example.com"), "modules.v1")
+	require.NoError(t, err)
+	assert.Equal(t, "https://registry.example.com/modules/v1/", u.String())
+}
+
+func TestLoadTerraformCLIConfigParseError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.tfrc")
+	require.NoError(t, os.WriteFile(path, []byte(`host "unterminated" {`), 0o600))
+	t.Setenv("TF_CLI_CONFIG_FILE", path)
+
+	// A malformed file degrades to no config (the warning goes to stderr).
+	assert.Nil(t, loadTerraformCLIConfig())
+}
+
+func TestLoadTerraformCLIConfigMissingExplicitFile(t *testing.T) {
+	t.Setenv("TF_CLI_CONFIG_FILE", filepath.Join(t.TempDir(), "does-not-exist.tfrc"))
+	assert.Nil(t, loadTerraformCLIConfig())
+}

--- a/tests/tfcompat/l2_module_registry_auth_test.go
+++ b/tests/tfcompat/l2_module_registry_auth_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/stretchr/testify/require"
+)
+
+// TestL2ModuleRegistryAuth resolves a registry module from a private modules.v1
+// registry that requires a bearer token, authenticated only via the standard
+// Terraform mechanism: a TF_TOKEN_<host> environment variable plus a CLI-config
+// `host` block redirecting the (non-resolvable) registry host to a local server.
+//
+// OpenTofu honors both, so `tofu init` authenticates and resolves the module.
+// pulumi-hcl must reach parity: respect TF_TOKEN_<host> and the CLI-config host
+// service override so the same private module resolves with no `terraform login`.
+//
+// The test is intentionally provider-free — the served module declares only an
+// output — so it isolates module resolution and registry authentication.
+func TestL2ModuleRegistryAuth(t *testing.T) {
+	const (
+		registryHost = "registry.tfcompat.test"
+		token        = "s3cr3t-registry-token"
+	)
+
+	srv, authedHits := startAuthedModuleRegistry(t, token)
+
+	cliConfig := writeTerraformCLIConfig(t, registryHost, srv.URL+"/v1/modules/")
+
+	t.Setenv("TF_CLI_CONFIG_FILE", cliConfig)
+	t.Setenv("TF_TOKEN_"+strings.ReplaceAll(registryHost, ".", "_"), token)
+
+	tfcompat.RunCase(t, "l2_module_registry_auth", tfcompat.Case{})
+
+	// The registry only answers authenticated callers, so any resolution at all
+	// proves the bearer token was sent — the behavior under test, not bypassed.
+	require.Positive(t, authedHits.Load(),
+		"the registry should have served at least one authenticated modules.v1 request")
+}
+
+// startAuthedModuleRegistry serves the modules.v1 protocol for
+// acme/widget/aws@1.0.0, requiring `Authorization: Bearer <token>` on the
+// versions and download endpoints. The module archive itself is served
+// unauthenticated, the way a registry hands back a pre-signed download URL.
+func startAuthedModuleRegistry(t *testing.T, token string) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+
+	moduleArchive := buildModuleArchive(t, map[string]string{
+		"main.tf": `output "greeting" { value = "from-registry-module" }` + "\n",
+	})
+
+	var authedHits atomic.Int64
+	mux := http.NewServeMux()
+
+	// The module archive: unauthenticated, like a pre-signed object URL. The
+	// ?archive=tar.gz hint tells go-getter which decompressor to use.
+	mux.HandleFunc("/download/module.tar.gz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(moduleArchive)
+	})
+
+	// modules.v1: /v1/modules/<ns>/<name>/<system>/(versions|<version>/download).
+	// Both require the bearer token; an unauthenticated request gets a 401, the
+	// way a private registry refuses an anonymous caller.
+	mux.HandleFunc("/v1/modules/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			http.Error(w, "missing or wrong bearer token", http.StatusUnauthorized)
+			return
+		}
+		authedHits.Add(1)
+		segs := strings.Split(strings.TrimPrefix(r.URL.Path, "/v1/modules/"), "/")
+		switch {
+		case len(segs) == 4 && segs[3] == "versions":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"modules": []map[string]any{
+					{"versions": []map[string]string{{"version": "1.0.0"}}},
+				},
+			})
+		case len(segs) == 5 && segs[4] == "download":
+			w.Header().Set("X-Terraform-Get", "http://"+r.Host+"/download/module.tar.gz?archive=tar.gz")
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &authedHits
+}
+
+// writeTerraformCLIConfig writes a Terraform/OpenTofu CLI config file with a
+// `host` block that overrides service discovery for host, pointing its
+// modules.v1 service at modulesV1URL (a local server). It returns the path, to
+// be exported via TF_CLI_CONFIG_FILE.
+func writeTerraformCLIConfig(t *testing.T, host, modulesV1URL string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "tfcompat.tfrc")
+	body := fmt.Sprintf(`host %q {
+  services = {
+    "modules.v1" = %q
+  }
+}
+`, host, modulesV1URL)
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+// buildModuleArchive returns a gzip-compressed tarball of files, built in
+// memory so it carries none of the macOS AppleDouble (`._*`) sidecars that
+// shelling out to `tar` would add.
+func buildModuleArchive(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name,
+			Mode: 0o600,
+			Size: int64(len(content)),
+		}))
+		_, err := tw.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf.Bytes()
+}

--- a/tests/tfcompat/testdata/cases/l2_module_registry_auth/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_registry_auth/main.tf
@@ -1,0 +1,8 @@
+module "m" {
+  source  = "registry.tfcompat.test/acme/widget/aws"
+  version = "1.0.0"
+}
+
+output "greeting" {
+  value = module.m.greeting
+}


### PR DESCRIPTION
What it says on the tin. We now honor those variables during module resolution & download.