### PR TITLE
Match TF_VAR parsing

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-295.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-295.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Match TF_VAR parsing to Terraform
+time: 2026-06-26T14:08:59.093312+02:00
+custom:
+    Component: runtime
+    PR: "295"

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-can/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-can/main.tf
@@ -19,6 +19,7 @@ output "outputTryFailure" {
 # A dynamically typed value, whose field accesses will not be type errors (since the type is not known to the type
 # checker), but may fail dynamically, and can thus be used as test inputs to can.
 variable "anObject" {
+  type = any
 }
 output "dynamicTrySuccess" {
   value = can(var.anObject.a)

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-object/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-object/main.tf
@@ -13,6 +13,7 @@ output "lookupOutputDefault" {
 # An untyped (dynamic) config value. Pins iterating dynamic entries in generated programs
 # (e.g. TypeScript's Object.entries over a value with no static type).
 variable "alternativeNames" {
+  type    = any
   default = {}
 }
 output "names" {

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-try/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-builtin-try/main.tf
@@ -19,6 +19,7 @@ output "outputTryFailure" {
 # A dynamically typed value, whose field accesses will not be type errors (since the type is not known to the type
 # checker), but may fail dynamically, and can thus be used as test inputs to try.
 variable "anObject" {
+  type = any
 }
 output "dynamicTrySuccess" {
   value = try(var.anObject.a, "fallback")

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-config-types-object/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-config-types-object/main.tf
@@ -14,11 +14,13 @@ output "theObject" {
   value = var.anObject.prop[0]
 }
 variable "anyObject" {
+  type = any
 }
 output "theThing" {
   value = var.anyObject.a + var.anyObject.b
 }
 variable "optionalUntypedObject" {
+  type = any
   default = {
     "key" = "value"
   }

--- a/cmd/pulumi-language-hcl/testdata/projects/l1-proxy-index/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l1-proxy-index/main.tf
@@ -3,6 +3,7 @@ variable "anObject" {
   type = object({property=string})
 }
 variable "anyObject" {
+  type = any
 }
 locals {
   l = sensitive([1])

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-can/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-can/main.tf
@@ -19,6 +19,7 @@ output "outputTryFailure" {
 # A dynamically typed value, whose field accesses will not be type errors (since the type is not known to the type
 # checker), but may fail dynamically, and can thus be used as test inputs to can.
 variable "anObject" {
+  type = any
 }
 output "dynamicTrySuccess" {
   value = can(var.anObject.a)

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-object/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-object/main.tf
@@ -13,6 +13,7 @@ output "lookupOutputDefault" {
 # An untyped (dynamic) config value. Pins iterating dynamic entries in generated programs
 # (e.g. TypeScript's Object.entries over a value with no static type).
 variable "alternativeNames" {
+  type    = any
   default = {}
 }
 output "names" {

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-try/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-builtin-try/main.tf
@@ -19,6 +19,7 @@ output "outputTryFailure" {
 # A dynamically typed value, whose field accesses will not be type errors (since the type is not known to the type
 # checker), but may fail dynamically, and can thus be used as test inputs to try.
 variable "anObject" {
+  type = any
 }
 output "dynamicTrySuccess" {
   value = try(var.anObject.a, "fallback")

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-config-types-object/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-config-types-object/main.tf
@@ -14,11 +14,13 @@ output "theObject" {
   value = var.anObject.prop[0]
 }
 variable "anyObject" {
+  type = any
 }
 output "theThing" {
   value = var.anyObject.a + var.anyObject.b
 }
 variable "optionalUntypedObject" {
+  type = any
   default = {
     "key" = "value"
   }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-proxy-index/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l1-proxy-index/main.tf
@@ -3,6 +3,7 @@ variable "anObject" {
   type = object({property=string})
 }
 variable "anyObject" {
+  type = any
 }
 locals {
   l = sensitive([1])

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -1772,13 +1772,17 @@ func (g *generator) genReplaceOnChanges(body *hclwrite.Body, schemaPaths []strin
 func (g *generator) genConfigVariable(body *hclwrite.Body, cv *pcl.ConfigVariable) hcl.Diagnostics {
 	block := body.AppendNewBlock("variable", []string{cv.LogicalName()})
 
-	// Set the type constraint if the config has a type label.
+	// Emit a type constraint. An explicitly typed config keeps its declared type;
+	// an untyped one is `any`, so its structured config value is parsed as HCL
+	// rather than kept as a literal string (HCL treats a typeless `variable {}` as
+	// VariableParseLiteral, which would not decode an object or list value).
+	hclTypeStr := "any"
 	if len(cv.SyntaxNode().(*hclsyntax.Block).Labels) == 2 {
-		hclTypeStr := pclTypeToHCL(cv.Type())
-		block.Body().SetAttributeRaw("type", hclwrite.Tokens{
-			{Type: hclsyntax.TokenIdent, Bytes: []byte(hclTypeStr)},
-		})
+		hclTypeStr = pclTypeToHCL(cv.Type())
 	}
+	block.Body().SetAttributeRaw("type", hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte(hclTypeStr)},
+	})
 
 	// Set the default value if present.
 	if cv.DefaultValue != nil {

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -571,7 +571,11 @@ func (ft *fileTransformer) emitFile(
 			labels := []string{pclName}
 
 			if typeAttr, ok := block.Body.Attributes["type"]; ok {
-				labels = append(labels, convertHCLTypeExpr(src, typeAttr.Expr))
+				// A PCL config with no type label is already `any`, so omit an
+				// explicit `any` rather than emit the redundant label.
+				if pclType := convertHCLTypeExpr(src, typeAttr.Expr); pclType != "any" {
+					labels = append(labels, pclType)
+				}
 			}
 			blk := out.AppendNewBlock("config", labels)
 			if pclName != name {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/bridge"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
@@ -51,8 +52,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/zclconf/go-cty/cty"
 	ctyconvert "github.com/zclconf/go-cty/cty/convert"
-	"github.com/zclconf/go-cty/cty/function/stdlib"
-	"github.com/zclconf/go-cty/cty/json"
 )
 
 // PackageRef is an opaque reference returned by RegisterPackage that routes
@@ -723,20 +722,16 @@ func (e *Engine) processVariable(_ context.Context, node *graph.Node) error {
 		}
 	}
 
-	// Type conversion if value came from string source (env/config)
-	if valueSource == "environment" || valueSource == "config" {
-		if v.TypeConstraint != cty.NilType && v.TypeConstraint != cty.DynamicPseudoType {
-			converted, err := convertStringToType(val.AsString(), v.TypeConstraint)
-			if err != nil {
-				return fmt.Errorf("variable %q: %w", varName, err)
-			}
-			val = converted
-		} else {
-			// No type constraint: try JSON parsing for structured values.
-			if parsed, err := parseJSONAuto(val.AsString()); err == nil {
-				val = parsed
-			}
+	// A value from a string source (env/config) is parsed according to the declared
+	// type. An untyped variable keeps its literal string value, matching OpenTofu's
+	// VariableParseLiteral default for variables declared without a type.
+	if (valueSource == "environment" || valueSource == "config") &&
+		v.TypeConstraint != cty.NilType && v.TypeConstraint != cty.DynamicPseudoType {
+		converted, err := convertStringToType(val.AsString(), v.TypeConstraint)
+		if err != nil {
+			return fmt.Errorf("variable %q: %w", varName, err)
 		}
+		val = converted
 	}
 
 	// Fill in optional()-attribute defaults before sensitive marking.
@@ -798,57 +793,29 @@ func runVariableValidations(ev *eval.Evaluator, varName string, validations []*a
 	return nil
 }
 
-// convertStringToType converts a string value to the specified cty type.
+// convertStringToType converts a string-sourced variable value (Pulumi config
+// or a TF_VAR_ environment variable) to the variable's declared type.
 func convertStringToType(s string, targetType cty.Type) (cty.Value, error) {
-	switch {
-	case targetType == cty.String:
-		return cty.StringVal(s), nil
-	case targetType == cty.Number:
-		// Parse as number
-		var f float64
-		if _, err := fmt.Sscanf(s, "%f", &f); err != nil {
-			return cty.NilVal, fmt.Errorf("cannot convert %q to number: %w", s, err)
+	var val cty.Value
+	if targetType.IsPrimitiveType() {
+		val = cty.StringVal(s)
+	} else {
+		expr, diags := hclsyntax.ParseExpression([]byte(s), "<variable value>", hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			return cty.NilVal, fmt.Errorf("cannot parse %q as an HCL expression: %s", s, diags.Error())
 		}
-		return cty.NumberFloatVal(f), nil
-	case targetType == cty.Bool:
-		switch strings.ToLower(s) {
-		case "true", "1", "yes", "on":
-			return cty.True, nil
-		case "false", "0", "no", "off":
-			return cty.False, nil
-		default:
-			return cty.NilVal, fmt.Errorf("cannot convert %q to bool", s)
+		v, valDiags := expr.Value(nil)
+		if valDiags.HasErrors() {
+			return cty.NilVal, fmt.Errorf("cannot evaluate %q: %s", s, valDiags.Error())
 		}
-	case targetType.IsListType() || targetType.IsTupleType() || targetType.IsSetType():
-		// For complex types, try JSON parsing
-		return parseJSONValue(s, targetType)
-	case targetType.IsMapType() || targetType.IsObjectType():
-		return parseJSONValue(s, targetType)
-	default:
-		// For other types, try to use it as-is
-		return cty.StringVal(s), nil
+		val = v
 	}
-}
 
-// parseJSONValue parses a JSON string into a cty value.
-func parseJSONValue(s string, targetType cty.Type) (cty.Value, error) {
-	// Use cty's built-in JSON unmarshaling
-	val, err := json.Unmarshal([]byte(s), targetType)
+	converted, err := ctyconvert.Convert(val, targetType)
 	if err != nil {
-		return cty.NilVal, fmt.Errorf("cannot parse JSON value: %w", err)
+		return cty.NilVal, fmt.Errorf("cannot convert %q to %s: %w", s, targetType.FriendlyName(), err)
 	}
-	return val, nil
-}
-
-// parseJSONAuto parses a JSON string into a cty value, automatically inferring the type.
-// This uses cty's jsondecode function, which handles plain JSON (objects, arrays, strings, etc.)
-// without requiring a type descriptor.
-func parseJSONAuto(s string) (cty.Value, error) {
-	result, err := stdlib.JSONDecodeFunc.Call([]cty.Value{cty.StringVal(s)})
-	if err != nil {
-		return cty.NilVal, err
-	}
-	return result, nil
+	return converted, nil
 }
 
 // processLocal processes a local value definition.

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -723,10 +723,11 @@ func (e *Engine) processVariable(_ context.Context, node *graph.Node) error {
 	}
 
 	// A value from a string source (env/config) is parsed according to the declared
-	// type. An untyped variable keeps its literal string value, matching OpenTofu's
-	// VariableParseLiteral default for variables declared without a type.
+	// type. A variable declared without a type keeps its literal string value,
+	// matching OpenTofu's VariableParseLiteral default; one declared with any type
+	// — including `any` — parses its value as HCL (VariableParseHCL).
 	if (valueSource == "environment" || valueSource == "config") &&
-		v.TypeConstraint != cty.NilType && v.TypeConstraint != cty.DynamicPseudoType {
+		v.TypeConstraint != cty.NilType {
 		converted, err := convertStringToType(val.AsString(), v.TypeConstraint)
 		if err != nil {
 			return fmt.Errorf("variable %q: %w", varName, err)

--- a/tests/tfcompat/l1_var_tfvar_parsing_test.go
+++ b/tests/tfcompat/l1_var_tfvar_parsing_test.go
@@ -22,20 +22,18 @@ import (
 
 // TestL1VarTFVarParsing pins pulumi-hcl's string-sourced variable parsing
 // (`-var` / TF_VAR_ / Pulumi config) to OpenTofu's: the declared type selects
-// the parsing mode. Primitives are taken literally then converted; complex types
-// are parsed as HCL expressions; an untyped variable keeps its literal string.
-// `str`, `items`, and `untyped` share the identical input `["a", "b"]`, so their
-// differing results prove parsing is type-driven and not a blind JSON/HCL decode.
+// the parsing mode.
 func TestL1VarTFVarParsing(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l1_var_tfvar_parsing", tfcompat.Case{
 		Config: map[string]string{
-			"str":     `["a", "b"]`,
-			"num":     "42",
-			"flag":    "true",
-			"tags":    `{ environment = "prod" }`,
-			"items":   `["a", "b"]`,
-			"untyped": `["a", "b"]`,
+			"str":      `["a", "b"]`,
+			"num":      "42",
+			"flag":     "true",
+			"tags":     `{ environment = "prod" }`,
+			"items":    `["a", "b"]`,
+			"untyped":  `["a", "b"]`,
+			"anyTyped": `["a", "b"]`,
 		},
 	})
 }

--- a/tests/tfcompat/l1_var_tfvar_parsing_test.go
+++ b/tests/tfcompat/l1_var_tfvar_parsing_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1VarTFVarParsing pins pulumi-hcl's string-sourced variable parsing
+// (`-var` / TF_VAR_ / Pulumi config) to OpenTofu's: the declared type selects
+// the parsing mode. Primitives are taken literally then converted; complex types
+// are parsed as HCL expressions; an untyped variable keeps its literal string.
+// `str`, `items`, and `untyped` share the identical input `["a", "b"]`, so their
+// differing results prove parsing is type-driven and not a blind JSON/HCL decode.
+func TestL1VarTFVarParsing(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_var_tfvar_parsing", tfcompat.Case{
+		Config: map[string]string{
+			"str":     `["a", "b"]`,
+			"num":     "42",
+			"flag":    "true",
+			"tags":    `{ environment = "prod" }`,
+			"items":   `["a", "b"]`,
+			"untyped": `["a", "b"]`,
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l1_var_tfvar_parsing/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_var_tfvar_parsing/main.tf
@@ -1,0 +1,62 @@
+# Variable values supplied as strings (`-var` / TF_VAR_ / Pulumi config) must be
+# parsed exactly as OpenTofu parses them: the declared type selects the parsing
+# mode. Primitive types take the value literally (then convert it); complex types
+# parse it as an HCL expression; an untyped variable keeps the literal string.
+#
+# `str`, `items`, and `untyped` are all given the identical value `["a", "b"]`,
+# so the only thing that can produce their differing results is type-driven
+# parsing.
+
+variable "str" {
+  type = string
+}
+
+variable "num" {
+  type = number
+}
+
+variable "flag" {
+  type = bool
+}
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "items" {
+  type = list(string)
+}
+
+variable "untyped" {}
+
+# Primitive: kept literal, so a JSON/HCL-looking string survives verbatim
+# (interior whitespace included) rather than being parsed into a structure.
+output "str" {
+  value = var.str
+}
+
+# Primitive: literal then converted to the declared type.
+output "num" {
+  value = var.num
+}
+
+output "flag" {
+  value = var.flag
+}
+
+# Complex: parsed as an HCL expression, so the idiomatic `{ key = "value" }`
+# form is accepted (it is not valid JSON).
+output "tags" {
+  value = var.tags
+}
+
+# Complex: the same `["a", "b"]` that stays a literal string for `str` parses
+# into a list here.
+output "items" {
+  value = var.items
+}
+
+# Untyped: kept literal, like a primitive — not HCL- or JSON-parsed.
+output "untyped" {
+  value = var.untyped
+}

--- a/tests/tfcompat/testdata/cases/l1_var_tfvar_parsing/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_var_tfvar_parsing/main.tf
@@ -3,9 +3,11 @@
 # mode. Primitive types take the value literally (then convert it); complex types
 # parse it as an HCL expression; an untyped variable keeps the literal string.
 #
-# `str`, `items`, and `untyped` are all given the identical value `["a", "b"]`,
-# so the only thing that can produce their differing results is type-driven
-# parsing.
+# `str`, `items`, `untyped`, and `anyTyped` are all given the identical value
+# `["a", "b"]`, so the only thing that can produce their differing results is
+# type-driven parsing. In particular `untyped` (no type) and `anyTyped`
+# (`type = any`) diverge on that same input: a missing type parses literally,
+# while `any` is a declared type and so parses as HCL.
 
 variable "str" {
   type = string
@@ -28,6 +30,10 @@ variable "items" {
 }
 
 variable "untyped" {}
+
+variable "anyTyped" {
+  type = any
+}
 
 # Primitive: kept literal, so a JSON/HCL-looking string survives verbatim
 # (interior whitespace included) rather than being parsed into a structure.
@@ -59,4 +65,10 @@ output "items" {
 # Untyped: kept literal, like a primitive — not HCL- or JSON-parsed.
 output "untyped" {
   value = var.untyped
+}
+
+# Explicit `any`: a declared type, so the same `["a", "b"]` that stays a literal
+# string for `untyped` parses into a list here.
+output "anyTyped" {
+  value = var.anyTyped
 }


### PR DESCRIPTION
Here we adjust TF_VAR to match `tofu`'s parsing of untyped & complex values.