### PR TITLE
Type `MaxItems: 1` blocks as lists during schema generation

### DIFF
--- a/.changes/unreleased/language-host-bug-fixes-291.yaml
+++ b/.changes/unreleased/language-host-bug-fixes-291.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: "Support `[0]` indexing of `MaxItems: 1` blocks in Multi-Language Component outputs"
+time: 2026-06-26T14:07:30Z
+custom:
+    Component: language-host
+    PR: "291"

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -218,6 +218,75 @@ output "keyed_id" {
 	}, moduleSchema.OutputProperties)
 }
 
+// mappingResolver resolves resources and their bridge body mappings by TF type,
+// so output typing that depends on the mapping (e.g. MaxItemsOne block shape)
+// can be tested without a live provider.
+type mappingResolver struct {
+	resources map[string]*pulumiSchema.Resource
+	mappings  map[string]*bridge.BodyMapping
+}
+
+func (s mappingResolver) ResolveResource(_ context.Context, tfType string) (*pulumiSchema.Resource, error) {
+	return s.resources[tfType], nil
+}
+
+func (mappingResolver) ResolveFunction(_ context.Context, _ string) (*pulumiSchema.Function, error) {
+	return nil, nil
+}
+
+func (s mappingResolver) ResourceBodyMapping(_ context.Context, tfType string) *bridge.BodyMapping {
+	return s.mappings[tfType]
+}
+
+func (mappingResolver) DataSourceBodyMapping(_ context.Context, _ string) *bridge.BodyMapping {
+	return nil
+}
+
+// a MaxItems:1 block is flattened to a single object on the Pulumi side, but TF/OpenTofu
+// models it as a list, so HCL indexes it as `block[0].attr`. Output typing must re-wrap
+// the flattened object as a list — mirroring the runtime — so the numeric index types
+// instead of failing with "Invalid index".
+func TestSingularBlockIndexedOutputIsTyped(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+resource "blocky_thing" "t" {
+}
+
+output "mode" {
+  value = blocky_thing.t.settings[0].mode
+}
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	resolver := mappingResolver{
+		resources: map[string]*pulumiSchema.Resource{
+			"blocky_thing": {Properties: []*pulumiSchema.Property{
+				{Name: "settings", Type: &pulumiSchema.ObjectType{Properties: []*pulumiSchema.Property{
+					{Name: "mode", Type: pulumiSchema.StringType},
+				}}},
+			}},
+		},
+		mappings: map[string]*bridge.BodyMapping{
+			"blocky_thing": {Fields: map[string]*bridge.FieldMapping{
+				"settings": {
+					TFName: "settings", PulumiName: "settings", TFBlock: true, MaxItemsOne: true,
+					Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+						"mode": {TFName: "mode", PulumiName: "mode"},
+					}},
+				},
+			}},
+		},
+	}
+
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]*PropertySpec{"mode": {Type: "string"}}, moduleSchema.OutputProperties)
+}
+
 // stubModuleLoader resolves child modules from parsed configs keyed by source.
 type stubModuleLoader struct {
 	configs map[string]*ast.Config

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -1255,7 +1255,14 @@ func ctyObjectType(
 		if !p.IsRequired() {
 			optional = append(optional, key)
 		}
-		attrs[key] = ctyTypeFromType(p.Type, nestedMappingFor(p.Name, mapping))
+		t := ctyTypeFromType(p.Type, nestedMappingFor(p.Name, mapping))
+		// The bridge flattens a MaxItems=1 block to an object, but TF models it
+		// as a list; re-wrap it as a list so a reference like `r.settings[0].x`
+		// types the same way it resolves at runtime (see propertyObjectToCtyMap).
+		if fieldIsSingularBlock(mapping, p.Name) && !t.IsListType() && !t.IsTupleType() {
+			t = cty.List(t)
+		}
+		attrs[key] = t
 	}
 	return cty.ObjectWithOptionalAttrs(attrs, optional)
 }


### PR DESCRIPTION
## Problem

Adding a Terraform module that indexes a `MaxItems: 1` block with `[0]` — e.g.

```hcl
output "kubelet_identity" {
  value = azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id
}
```

failed during `pulumi package add module …` / `parameterize` (schema generation):

```
typing output "kubelet_identity": …: Invalid index; The given key does not identify an
element in this collection value. An object only supports looking up attributes by name,
not by numeric index.
```

even though the same HCL applies cleanly in OpenTofu. This pattern is extremely common across azurerm/aws/google modules (`kubelet_identity`, `identity`, `network_profile`, …).

## Root cause

The bridge flattens a `MaxItems: 1` block to a single object on the Pulumi side, but TF/OpenTofu model it as a list. The runtime path (`propertyObjectToCtyMap`) already re-wraps the flattened object as a singleton list, so `r.block[0].x` resolves at apply time. The schema-generation type path (`ctyObjectType`), used by `ResourceReferenceType`/`DataSourceReferenceType` when typing module outputs, did not — so it typed the block as an object and `[0]` indexing was invalid.

## Fix

Re-wrap singular blocks as lists in `ctyObjectType`, mirroring the runtime. Because the object and resource cases of `ctyTypeFromType` recurse back through `ctyObjectType` with the nested mapping, nested blocks (block-in-block) and the data-source path are covered by the same change.

A schema-gen unit test (`TestSingularBlockIndexedOutputIsTyped`) reproduces the failure and now passes. This is a schema-gen-time divergence that the runtime `tfcompat` harness cannot exercise; runtime `MaxItems: 1` handling stays covered by `TestL2BlockSingular` and the `l2_renamed_outputs` case.

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/291.