### PR TITLE
Marshal whole-resource references as actual references, not unknown

### DIFF
--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1365,6 +1365,27 @@ func (e *Engine) registerResourceInstanceInContext(
 	}
 	outputObj["urn"] = cty.StringVal(string(urn)).Mark(eval.SyntheticMark)
 
+	// Expose the resource's self-reference so it can be passed by value as a
+	// resource-reference input — e.g. an aws-apigateway route's
+	// `event_handler = aws_lambda_function.fn`. Without a `__ref`,
+	// ctyToResourceProperty marshals such an input as Computed (unknown), which
+	// makes a remote component's Construct outputs come back unresolved.
+	var selfID property.Value
+	switch {
+	case resSchema.IsComponent:
+		selfID = property.New(property.Null)
+	case id != "":
+		selfID = property.New(id)
+	case e.dryRun:
+		selfID = property.New(property.Computed)
+	default:
+		selfID = property.New(property.Null)
+	}
+	selfRef := property.ResourceReference{URN: urn, ID: selfID}
+	// NB: do not SyntheticMark this — stripSyntheticAttributes would remove it
+	// before ctyToResourceProperty can read it for resource-reference inputs.
+	outputObj["__ref"] = cty.CapsuleVal(eval.ResourceReferenceCapsuleType, &selfRef)
+
 	markedOutputs := cty.ObjectVal(outputObj).Mark(eval.DepMark(urn))
 
 	e.resourceOutputs.Set(instance.Key, markedOutputs)

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -511,6 +511,75 @@ resource "aws_subnet" "main" {
 	}
 }
 
+// TestEngine_WholeResourceReferenceInput is a regression test for
+// https://github.com/pulumi-labs/pulumi-hcl/issues/298. A resource passed by
+// value as a resource-reference input (e.g. an aws-apigateway route's
+// `event_handler = aws_lambda_function.fn`) must marshal as an actual
+// ResourceReference, not as Computed. The Computed (unknown) variant caused a
+// remote component's Construct outputs to come back unresolved.
+func TestEngine_WholeResourceReferenceInput(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "test_fn" "fn" {
+}
+
+resource "test_handler" "h" {
+  target = test_fn.fn
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	if diags.HasErrors() {
+		t.Fatalf("parse error: %s", diags.Error())
+	}
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "test",
+			Resources: map[string]schema.ResourceSpec{
+				"test:index:Fn": {},
+				"test:index:Handler": {
+					InputProperties: map[string]schema.PropertySpec{
+						"target": {TypeSpec: schema.TypeSpec{Ref: "#/resources/test:index:Fn"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"target": {TypeSpec: schema.TypeSpec{Ref: "#/resources/test:index:Fn"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	if err := engine.Run(t.Context()); err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+
+	var handler *run.RegisterResourceRequest
+	for i := range mock.RegisteredResources {
+		if mock.RegisteredResources[i].Type == "test:index:Handler" {
+			handler = &mock.RegisteredResources[i]
+		}
+	}
+	require.NotNil(t, handler, "handler resource was not registered")
+
+	target := handler.Inputs.Get("target")
+	assert.False(t, target.IsComputed(), "target marshaled as Computed (unknown); want a ResourceReference")
+	require.True(t, target.IsResourceReference(), "target = %v; want a ResourceReference", target)
+	assert.Equal(t, "urn:pulumi:test::project::test:index:Fn::fn",
+		string(target.AsResourceReference().URN))
+}
+
 func TestValidate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -1018,7 +1018,10 @@ func ResourceReferenceType(r *schema.Resource, mapping *bridge.BodyMapping) cty.
 			&schema.Property{Name: "pluginDownloadURL", Type: schema.StringType},
 		)
 	}
-	return ctyObjectType(properties, map[string]cty.Type{"id": cty.String}, mapping)
+	return ctyObjectType(properties, map[string]cty.Type{
+		"id":    cty.String,
+		"__ref": eval.ResourceReferenceCapsuleType,
+	}, mapping)
 }
 
 // DataSourceReferenceType returns the cty type of a `data.<type>.<name>`


### PR DESCRIPTION
Fixes #298.

A resource passed by value as a resource-reference input — e.g. an aws-apigateway route's `event_handler = aws_lambda_function.fn` — was marshaled as `property.Computed` (unknown) instead of an actual reference. For a remote (multi-language) component this means `Construct` receives an unknown input and returns unresolved outputs, so every component output (e.g. a `RestAPI`'s `url`) is persisted as the unknown sentinel `04da6b54-...` and `pulumi stack output` returns nothing.

Cause: the cty value stored for a registered resource (in `registerResourceInstanceInContext`) carried the resource's attributes plus `id`/`urn` but no `__ref` capsule. `ctyToResourceProperty`'s `*schema.ResourceType` case requires a known `__ref` and otherwise returns `property.Computed`.

Changes:

- Attach the resource's self-reference as a `__ref` capsule on its stored cty value, mirroring the existing method-call `selfRef` construction.
- Include `__ref` in `ResourceReferenceType` so the value matches its declared type (the nested-property path in `ctyTypeFromType` already seeds `__ref`).
- The `__ref` capsule is intentionally not `SyntheticMark`'d: `stripSyntheticAttributes` removes synthetic-marked attributes before `ctyToResourceProperty` runs, which would drop it and reintroduce the bug.

Adds a regression test in `pkg/hcl/run` asserting a whole-resource reference marshals as a `ResourceReference` rather than `Computed`.

Verified end-to-end against the issue repro: an aws-apigateway `RestAPI` with an `event_handler` route now exports a real invoke URL instead of the sentinel; a RestAPI with only static routes already worked and still does.
