### PR TITLE
Type try()-wrapped module outputs by their value type

### DIFF
--- a/.changes/unreleased/language-host-bug-fixes-300.yaml
+++ b/.changes/unreleased/language-host-bug-fixes-300.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Type outputs whose value is `try(...)` by the wrapped expression's type instead of `any`
+time: 2026-06-30T10:53:03.940017+02:00
+custom:
+    Component: language-host
+    PR: "300"

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -88,6 +88,11 @@ type Context struct {
 
 	// self contains the current resource for self references
 	self cty.Value
+
+	// typeInference makes HCLContext serve type-preserving function variants
+	// (see TypeInferenceFunctions). It is set only when the context is used to
+	// infer output/local types from unknown values during schema generation.
+	typeInference bool
 }
 
 // PathContext contains path-related values.
@@ -504,10 +509,23 @@ func (c *Context) HCLContext() *hcl.EvalContext {
 		vars["self"] = c.self
 	}
 
+	functions := Functions(c.rootModuleDir)
+	if c.typeInference {
+		functions = TypeInferenceFunctions(c.rootModuleDir)
+	}
 	return &hcl.EvalContext{
 		Variables: vars,
-		Functions: Functions(c.rootModuleDir),
+		Functions: functions,
 	}
+}
+
+// UseTypeInferenceFunctions switches the context to type-preserving function
+// variants, for inferring types from unknown values during schema generation.
+// See TypeInferenceFunctions.
+func (c *Context) UseTypeInferenceFunctions() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.typeInference = true
 }
 
 // HCLContextWithIteration returns an hcl.EvalContext like HCLContext, but with

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -280,6 +280,62 @@ var canFunc = function.New(&function.Spec{
 	},
 })
 
+// TypeInferenceFunctions returns the Terraform-compatible function set with the
+// functions whose result type collapses to dynamic on not-wholly-known inputs
+// replaced by type-preserving variants. Schema generation evaluates every
+// reference as an unknown of its static type, so the runtime functions would
+// report such an output as the "any" type; these variants recover the type the
+// output takes on the runtime happy path.
+func TypeInferenceFunctions(baseDir string) map[string]function.Function {
+	funcs := Functions(baseDir)
+	funcs["try"] = typeInferenceTryFunc
+	return funcs
+}
+
+// typeInferenceTryFunc is a type-inference-only variant of tryfunc.TryFunc.
+//
+// The upstream try() returns a dynamic value as soon as an argument is not
+// wholly known, because once the unknowns resolve a different argument might win
+// and the result type could change. Schema generation evaluates references as
+// unknowns of their static type, so that conservative rule would type every
+// try()-wrapped output as the "any" type. This variant returns the type of the
+// first argument that evaluates without error — e.g. try(aws_vpc.this[0].id,
+// null) is a string.
+var typeInferenceTryFunc = function.New(&function.Spec{
+	VarParam: &function.Parameter{
+		Name: "expressions",
+		Type: customdecode.ExpressionClosureType,
+	},
+	Type: func(args []cty.Value) (cty.Type, error) {
+		v, err := typeInferenceTry(args)
+		if err != nil {
+			return cty.NilType, err
+		}
+		return v.Type(), nil
+	},
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		return typeInferenceTry(args)
+	},
+})
+
+// typeInferenceTry returns the first argument expression that evaluates without
+// error. Unlike tryfunc's try it does not fall back to a dynamic value when the
+// result is not wholly known, so the argument's static type is preserved.
+func typeInferenceTry(args []cty.Value) (cty.Value, error) {
+	if len(args) == 0 {
+		return cty.NilVal, errors.New("at least one argument is required")
+	}
+	for _, arg := range args {
+		closure := customdecode.ExpressionClosureFromVal(arg)
+		v, diags := closure.Value()
+		if diags.HasErrors() {
+			continue
+		}
+		return v, nil
+	}
+	return cty.NilVal, errors.New("no expression succeeded")
+}
+
 // String functions
 
 // replaceFunc matches OpenTofu's `replace`, which interprets a search string

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -190,6 +190,7 @@ func buildTypeScope(
 	ctx context.Context, config *ast.Config, binder *Binder, path map[string]bool,
 ) (*eval.Context, error) {
 	scope := eval.NewContext(".", ".", ".", "", "", "")
+	scope.UseTypeInferenceFunctions()
 
 	for name, v := range config.Variables {
 		t := v.TypeConstraint

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -287,6 +287,38 @@ output "mode" {
 	assert.Equal(t, map[string]*PropertySpec{"mode": {Type: "string"}}, moduleSchema.OutputProperties)
 }
 
+func TestTryWrappedScalarOutputIsTyped(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+resource "random_pet" "this" {
+  length = 2
+}
+
+output "bare_id" {
+  value = random_pet.this.id
+}
+
+output "try_id" {
+  value = try(random_pet.this.id, null)
+}
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	resolver := stubResolver{resources: map[string]*pulumiSchema.Resource{
+		"random_pet": {Properties: []*pulumiSchema.Property{{Name: "length", Type: pulumiSchema.IntType}}},
+	}}
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]*PropertySpec{
+		"bare_id": {Type: "string"},
+		"try_id":  {Type: "string"},
+	}, moduleSchema.OutputProperties)
+}
+
 // stubModuleLoader resolves child modules from parsed configs keyed by source.
 type stubModuleLoader struct {
 	configs map[string]*ast.Config


### PR DESCRIPTION
## Problem

Consuming an off-the-shelf Terraform module from a Pulumi program — e.g.

```bash
pulumi package add hcl module terraform-aws-modules/vpc/aws 6.6.1
```

generated a typed SDK in which scalar outputs came back as maps:

```ts
declare public /*out*/ readonly vpcId: pulumi.Output<{[key: string]: string} | undefined>;
```

even though `pulumi up` returns `vpcId` as a plain string. `vpcId`, `vpcArn`,
`vpcCidrBlock`, `igwId`, and `defaultVpcId` were all affected.

## Root cause

`inferOutputType` types an output by evaluating its value expression against a
scope where every reference is an *unknown* of its static type. HCL's
`tryfunc.TryFunc` deliberately returns a dynamic value as soon as an argument is
not wholly known — at apply time a later-resolved value could change which `try`
branch wins. During schema generation everything is unknown, so every `try(...)`
collapsed to dynamic, which maps to the schema `any`/object type.

This is the exact shape every `terraform-aws-modules` output uses:

```hcl
output "vpc_id" { value = try(aws_vpc.this[0].id, null) }
```

Splat (`[*]`) and `var.x` outputs were typed correctly, so only `try()`-wrapped
scalars were mistyped.

## Fix

Add a type-inference-only `try()` variant that returns the type of the first
argument that evaluates without error, dropping the unknown-to-dynamic
short-circuit so the argument's static type survives. Schema generation opts into
it via a type-inference mode on the evaluation context (`UseTypeInferenceFunctions`);
runtime evaluation still uses upstream `try`'s conservative behavior.

After the fix the same module regenerates as:

```ts
declare public /*out*/ readonly vpcId: pulumi.Output<string | undefined>;
```

## Test

`TestTryWrappedScalarOutputIsTyped` in `pkg/hcl/schema` asserts that both a bare
reference and a `try()`-wrapped reference type as `string`. All `pkg/hcl/...`
tests pass.