### PR TITLE
Mark module outputs as required or optional

### DIFF
--- a/.changes/unreleased/language-host-Improvements-301.yaml
+++ b/.changes/unreleased/language-host-Improvements-301.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Mark module outputs as required or optional
+time: 2026-06-30T12:09:07+02:00
+custom:
+    Component: language-host
+    PR: "301"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -318,22 +318,39 @@ var typeInferenceTryFunc = function.New(&function.Spec{
 	},
 })
 
-// typeInferenceTry returns the first argument expression that evaluates without
-// error. Unlike tryfunc's try it does not fall back to a dynamic value when the
-// result is not wholly known, so the argument's static type is preserved.
+// typeInferenceTry returns an unknown of the first argument that evaluates
+// without error, preserving its static type rather than falling back to a
+// dynamic value like tryfunc's try. Since try() may fall through to a later
+// argument at runtime (such as the null in try(x, null)), the result is refined
+// not-null only when every candidate is.
 func typeInferenceTry(args []cty.Value) (cty.Value, error) {
 	if len(args) == 0 {
 		return cty.NilVal, errors.New("at least one argument is required")
 	}
+	var result cty.Value
+	found, couldBeNull := false, false
 	for _, arg := range args {
 		closure := customdecode.ExpressionClosureFromVal(arg)
 		v, diags := closure.Value()
 		if diags.HasErrors() {
 			continue
 		}
-		return v, nil
+		v, _ = v.UnmarkDeep()
+		if !found {
+			result = v
+			found = true
+		}
+		if v.Range().CouldBeNull() {
+			couldBeNull = true
+		}
 	}
-	return cty.NilVal, errors.New("no expression succeeded")
+	if !found {
+		return cty.NilVal, errors.New("no expression succeeded")
+	}
+	if couldBeNull {
+		return cty.UnknownVal(result.Type()), nil
+	}
+	return cty.UnknownVal(result.Type()).RefineNotNull(), nil
 }
 
 // String functions

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -97,6 +97,9 @@ type ModuleSchema struct {
 
 	// OutputProperties are the module's outputs.
 	OutputProperties map[string]*PropertySpec `json:"outputProperties,omitempty"`
+
+	// RequiredOutputs lists output property names that are never null.
+	RequiredOutputs []string `json:"requiredOutputs,omitempty"`
 }
 
 // PropertySpec describes a property in the schema.
@@ -121,6 +124,9 @@ type PropertySpec struct {
 
 	// Properties describes object properties.
 	Properties map[string]*PropertySpec `json:"properties,omitempty"`
+
+	// Required lists the names of object properties that are never null.
+	Required []string `json:"required,omitempty"`
 
 	// Ref is a reference to another type definition.
 	Ref string `json:"$ref,omitempty"`
@@ -152,6 +158,11 @@ func GenerateModuleSchema(
 		if v.Default == nil && !v.Nullable {
 			schema.RequiredInputs = append(schema.RequiredInputs, v.Name)
 		}
+
+		// Inputs are echoed as outputs, so a non-null input is a required output.
+		if !v.Nullable {
+			schema.RequiredOutputs = append(schema.RequiredOutputs, v.Name)
+		}
 	}
 
 	scope, err := buildTypeScope(ctx, config, binder, map[string]bool{})
@@ -160,18 +171,22 @@ func GenerateModuleSchema(
 	}
 	evaluator := eval.NewEvaluator(scope)
 	for _, o := range config.Outputs {
-		ty, err := inferOutputType(evaluator, o)
+		val, err := inferOutputType(evaluator, o)
 		if err != nil {
 			return nil, fmt.Errorf("typing output %q: %w", o.Name, err)
 		}
-		prop, err := outputToPropertySpec(o, ty)
+		prop, err := outputToPropertySpec(o, val)
 		if err != nil {
 			return nil, fmt.Errorf("processing output %q: %w", o.Name, err)
 		}
 		schema.OutputProperties[o.Name] = prop
+		if !val.Range().CouldBeNull() {
+			schema.RequiredOutputs = append(schema.RequiredOutputs, o.Name)
+		}
 	}
 
 	sort.Strings(schema.RequiredInputs)
+	sort.Strings(schema.RequiredOutputs)
 
 	return schema, nil
 }
@@ -197,7 +212,7 @@ func buildTypeScope(
 		if t == cty.NilType {
 			t = cty.DynamicPseudoType
 		}
-		scope.SetVariable(name, cty.UnknownVal(t))
+		scope.SetVariable(name, refinedUnknown(t, v.Nullable))
 	}
 
 	if binder != nil {
@@ -283,7 +298,7 @@ func seedResourceTypes(
 		}
 		mapping := resolver.ResourceBodyMapping(ctx, res.Type)
 		ty := rangedType(transform.ResourceReferenceType(schemaRes, mapping), res.Count != nil, res.ForEach != nil)
-		scope.SetResource(key, urn.URN(""), cty.UnknownVal(ty))
+		scope.SetResource(key, urn.URN(""), refinedUnknown(ty, false))
 	}
 
 	for _, key := range slices.Sorted(maps.Keys(config.DataSources)) {
@@ -297,7 +312,7 @@ func seedResourceTypes(
 		}
 		mapping := resolver.DataSourceBodyMapping(ctx, ds.Type)
 		ty := rangedType(transform.DataSourceReferenceType(fn, mapping), ds.Count != nil, ds.ForEach != nil)
-		scope.SetDataSource(key, cty.UnknownVal(ty))
+		scope.SetDataSource(key, refinedUnknown(ty, false))
 	}
 	return nil
 }
@@ -334,32 +349,68 @@ func seedModuleTypes(
 		}
 
 		childEval := eval.NewEvaluator(childScope)
-		attrs := make(map[string]cty.Type, len(childConfig.Outputs))
+		attrs := make(map[string]cty.Value, len(childConfig.Outputs))
 		for _, o := range childConfig.Outputs {
-			ty, err := inferOutputType(childEval, o)
+			val, err := inferOutputType(childEval, o)
 			if err != nil {
 				return fmt.Errorf("typing module %q output %q: %w", name, o.Name, err)
 			}
-			attrs[o.Name] = ty
+			attrs[o.Name] = val
 		}
-		ty := rangedType(cty.Object(attrs), call.Count != nil, call.ForEach != nil)
-		scope.SetModule(name, cty.UnknownVal(ty))
+		// A direct reference resolves attribute by attribute, so the object
+		// value carries each output's nullability. A ranged reference is indexed
+		// first, dropping that refinement, so seed a non-null list/map instead.
+		obj := cty.ObjectVal(attrs)
+		var val cty.Value
+		switch {
+		case call.Count != nil:
+			val = cty.UnknownVal(cty.List(obj.Type())).RefineNotNull()
+		case call.ForEach != nil:
+			val = cty.UnknownVal(cty.Map(obj.Type())).RefineNotNull()
+		default:
+			val = obj
+		}
+		scope.SetModule(name, val)
 	}
 	return nil
 }
 
 // inferOutputType evaluates an output's value expression against the type scope
-// and returns its type. An output with no value, or whose expression cannot be
-// evaluated against the scope, is an error.
-func inferOutputType(evaluator *eval.Evaluator, o *ast.Output) (cty.Type, error) {
+// and returns the resulting unknown value, whose type and nullability describe
+// the output. An output with no value, or one that cannot be evaluated against
+// the scope, is an error. The value is unmarked so its range can be read.
+func inferOutputType(evaluator *eval.Evaluator, o *ast.Output) (cty.Value, error) {
 	if o.Value == nil {
-		return cty.NilType, fmt.Errorf("output has no value expression")
+		return cty.NilVal, fmt.Errorf("output has no value expression")
 	}
 	val, diags := evaluator.Evaluate(o.Value)
 	if diags.HasErrors() {
-		return cty.NilType, fmt.Errorf("%s", diags.Error())
+		return cty.NilVal, fmt.Errorf("%s", diags.Error())
 	}
-	return val.Type(), nil
+	unmarked, _ := val.UnmarkDeep()
+	return unmarked, nil
+}
+
+// refinedUnknown returns an unknown value of type t that refines required
+// (non-optional) object attributes not-null and leaves optional ones nullable.
+// It recurses into nested objects so attribute access preserves the refinement;
+// collections are leaves, since indexing drops refinements and their element
+// types already carry optional-attribute metadata.
+func refinedUnknown(t cty.Type, nullable bool) cty.Value {
+	if t.IsObjectType() && !nullable {
+		optional := t.OptionalAttributes()
+		attrs := make(map[string]cty.Value, len(t.AttributeTypes()))
+		for name, attrType := range t.AttributeTypes() {
+			_, isOptional := optional[name]
+			attrs[name] = refinedUnknown(attrType, isOptional)
+		}
+		return cty.ObjectVal(attrs)
+	}
+	u := cty.UnknownVal(t)
+	if nullable {
+		return u
+	}
+	return u.RefineNotNull()
 }
 
 // variableToPropertySpec converts an HCL variable to a PropertySpec.
@@ -422,17 +473,44 @@ func ctyToConstant(val cty.Value) (any, bool) {
 	}
 }
 
-// outputToPropertySpec converts an HCL output to a PropertySpec. typ is the type
-// inferred from the output's value expression; a DynamicPseudoType maps to the
-// "object" (any) type.
-func outputToPropertySpec(o *ast.Output, typ cty.Type) (*PropertySpec, error) {
-	prop, err := ctyTypeToPropertySpec(typ)
+// outputToPropertySpec converts an HCL output to a PropertySpec. val is the
+// unknown value inferred from the output's value expression; its type gives the
+// property shape and its per-attribute nullability gives nested required fields.
+// A DynamicPseudoType maps to the "object" (any) type.
+func outputToPropertySpec(o *ast.Output, val cty.Value) (*PropertySpec, error) {
+	prop, err := ctyValueToPropertySpec(val)
 	if err != nil {
 		return nil, err
 	}
 	prop.Description = o.Description
 	prop.Secret = o.Sensitive
 	return prop, nil
+}
+
+// ctyValueToPropertySpec converts an inferred unknown value to a PropertySpec.
+// For object types it reads each attribute's nullability from the value's
+// refinements to populate Required; collections fall back to ctyTypeToPropertySpec,
+// where nested object fields' requiredness rides on optional-attribute metadata.
+func ctyValueToPropertySpec(v cty.Value) (*PropertySpec, error) {
+	t := v.Type()
+	if !t.IsObjectType() {
+		return ctyTypeToPropertySpec(t)
+	}
+	props := make(map[string]*PropertySpec, len(t.AttributeTypes()))
+	var required []string
+	for name := range t.AttributeTypes() {
+		attr := v.GetAttr(name)
+		propSpec, err := ctyValueToPropertySpec(attr)
+		if err != nil {
+			return nil, err
+		}
+		props[name] = propSpec
+		if !attr.Range().CouldBeNull() {
+			required = append(required, name)
+		}
+	}
+	sort.Strings(required)
+	return &PropertySpec{Type: "object", Properties: props, Required: required}, nil
 }
 
 // ctyTypeToPropertySpec converts a cty.Type to a PropertySpec.
@@ -500,17 +578,24 @@ func ctyTypeToPropertySpec(t cty.Type) (*PropertySpec, error) {
 		}, nil
 
 	case t.IsObjectType():
+		optional := t.OptionalAttributes()
 		props := make(map[string]*PropertySpec)
+		var required []string
 		for name, attrType := range t.AttributeTypes() {
 			propSpec, err := ctyTypeToPropertySpec(attrType)
 			if err != nil {
 				return nil, err
 			}
 			props[name] = propSpec
+			if _, isOptional := optional[name]; !isOptional {
+				required = append(required, name)
+			}
 		}
+		sort.Strings(required)
 		return &PropertySpec{
 			Type:       "object",
 			Properties: props,
+			Required:   required,
 		}, nil
 
 	default:
@@ -637,6 +722,18 @@ func (s *ModuleSchema) ToPulumiPackageSchema() pulumischema.PackageSpec {
 	}
 	sort.Strings(requiredInputs)
 
+	// Dedup in case an input and an output share a name, collapsing to one
+	// output property.
+	requiredSet := make(map[string]struct{}, len(s.RequiredOutputs))
+	for _, name := range s.RequiredOutputs {
+		requiredSet[pulumiCase(name)] = struct{}{}
+	}
+	requiredOutputs := make([]string, 0, len(requiredSet))
+	for name := range requiredSet {
+		requiredOutputs = append(requiredOutputs, name)
+	}
+	sort.Strings(requiredOutputs)
+
 	return pulumischema.PackageSpec{
 		Name:        s.PackageName,
 		Version:     s.Version,
@@ -648,6 +745,7 @@ func (s *ModuleSchema) ToPulumiPackageSchema() pulumischema.PackageSpec {
 					Type:        "object",
 					Description: s.Description,
 					Properties:  outputProps,
+					Required:    requiredOutputs,
 				},
 				IsComponent:     true,
 				InputProperties: inputProps,
@@ -694,8 +792,13 @@ func (s *ModuleSchema) schemaType(
 			camel := pulumiCase(name)
 			fields[camel] = s.schemaProperty(field, typeName+pascalCase(camel), types)
 		}
+		required := make([]string, 0, len(prop.Required))
+		for _, name := range prop.Required {
+			required = append(required, pulumiCase(name))
+		}
+		sort.Strings(required)
 		types[token] = pulumischema.ComplexTypeSpec{
-			ObjectTypeSpec: pulumischema.ObjectTypeSpec{Type: "object", Properties: fields},
+			ObjectTypeSpec: pulumischema.ObjectTypeSpec{Type: "object", Properties: fields, Required: required},
 		}
 		return pulumischema.TypeSpec{Ref: "#/types/" + token}
 	case prop.AdditionalProperties != nil:

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -210,7 +210,7 @@ output "keyed_id" {
 	elem := &PropertySpec{Type: "object", Properties: map[string]*PropertySpec{
 		"id":     {Type: "string"},
 		"length": {Type: "number"},
-	}}
+	}, Required: []string{"length"}}
 	assert.Equal(t, map[string]*PropertySpec{
 		"counted_id":  {Type: "string"},
 		"keyed_id":    {Type: "string"},
@@ -319,6 +319,66 @@ output "try_id" {
 	}, moduleSchema.OutputProperties)
 }
 
+// TestOutputRequiredness shows that an output is required exactly when its value
+// can never be null: non-null literals, non-null inputs, and required resource
+// attributes are required, while nullable inputs, optional attributes,
+// try(_, null), and a null conditional branch make the output optional. Inputs
+// are echoed as outputs, so a non-null input is also a required output.
+func TestOutputRequiredness(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+variable "req" {
+  type     = string
+  nullable = false
+}
+
+variable "opt" {
+  type = string
+}
+
+resource "random_pet" "this" {
+  length = 2
+}
+
+output "literal"      { value = "x" }
+output "from_req_var" { value = var.req }
+output "from_opt_var" { value = var.opt }
+output "req_attr"     { value = random_pet.this.length }
+output "opt_attr"     { value = random_pet.this.nick }
+output "try_null"     { value = try(random_pet.this.length, null) }
+output "conditional"  { value = var.opt != null ? random_pet.this.length : null }
+output "config"       { value = random_pet.this.config }
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	resolver := stubResolver{resources: map[string]*pulumiSchema.Resource{
+		"random_pet": {Properties: []*pulumiSchema.Property{
+			{Name: "length", Type: pulumiSchema.IntType},
+			{Name: "nick", Type: &pulumiSchema.OptionalType{ElementType: pulumiSchema.StringType}},
+			{Name: "config", Type: &pulumiSchema.ObjectType{Properties: []*pulumiSchema.Property{
+				{Name: "host", Type: pulumiSchema.StringType},
+				{Name: "port", Type: &pulumiSchema.OptionalType{ElementType: pulumiSchema.IntType}},
+			}}},
+		}},
+	}}
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"config", "from_req_var", "literal", "req", "req_attr"}, moduleSchema.RequiredOutputs)
+
+	assert.Equal(t, &PropertySpec{
+		Type:     "object",
+		Required: []string{"host"},
+		Properties: map[string]*PropertySpec{
+			"host": {Type: "string"},
+			"port": {Type: "number"},
+		},
+	}, moduleSchema.OutputProperties["config"])
+}
+
 // stubModuleLoader resolves child modules from parsed configs keyed by source.
 type stubModuleLoader struct {
 	configs map[string]*ast.Config
@@ -381,6 +441,56 @@ output "n" {
 		"greeting": {Type: "string"},
 		"n":        {Type: "number"},
 	}, moduleSchema.OutputProperties)
+}
+
+// TestModuleOutputRequirednessPropagates shows that a child module output's
+// nullability rides through a module.<name>.<output> reference, so the parent
+// output is required exactly when the child output can never be null.
+func TestModuleOutputRequirednessPropagates(t *testing.T) {
+	t.Parallel()
+
+	child, childDiags := parser.NewParser().ParseSource("child.tf", []byte(`
+variable "name" {
+  type     = string
+  nullable = false
+}
+
+output "always" {
+  value = "hello ${var.name}"
+}
+
+output "maybe" {
+  value = try(var.name, null)
+}
+`))
+	require.False(t, childDiags.HasErrors(), childDiags.Error())
+
+	const parent = `
+module "child" {
+  source = "./child"
+  name   = "world"
+}
+
+output "always" {
+  value = module.child.always
+}
+
+output "maybe" {
+  value = module.child.maybe
+}
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(parent))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	binder := &Binder{
+		Modules:   stubModuleLoader{configs: map[string]*ast.Config{"./child": child}},
+		ModuleDir: ".",
+	}
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, binder, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"always"}, moduleSchema.RequiredOutputs)
 }
 
 // TestUnresolvableResourceIsError shows that a resource whose type cannot be

--- a/pkg/hcl/schema/testdata/primitives/schema.json
+++ b/pkg/hcl/schema/testdata/primitives/schema.json
@@ -26,6 +26,11 @@
         }
       },
       "type": "object",
+      "required": [
+        "stringOutput",
+        "stringValue",
+        "templateOutput"
+      ],
       "inputProperties": {
         "boolValue": {
           "type": "boolean",

--- a/pkg/hcl/schema/testdata/required/schema.json
+++ b/pkg/hcl/schema/testdata/required/schema.json
@@ -20,6 +20,11 @@
         }
       },
       "type": "object",
+      "required": [
+        "stringA",
+        "stringB",
+        "stringC"
+      ],
       "inputProperties": {
         "stringA": {
           "type": "string"

--- a/pkg/hcl/schema/testdata/sensitive/schema.json
+++ b/pkg/hcl/schema/testdata/sensitive/schema.json
@@ -19,6 +19,10 @@
         }
       },
       "type": "object",
+      "required": [
+        "sensitiveOutput",
+        "sensitiveString"
+      ],
       "inputProperties": {
         "sensitiveString": {
           "type": "string",


### PR DESCRIPTION
## Problem

Module (MLC) component outputs were all emitted as optional (`Output<T | undefined>`), even when an output can never be null. The schema never set `ObjectTypeSpec.Required` for outputs.

## Change

Infer each output's nullability from its value expression and mark it required when it can never be null.

Nullability rides through the existing type-inference evaluation via cty value refinements:

- **Leaf seeding** — variables, resources, data sources, and child-module references are seeded as known object values whose required (non-optional) attributes are refined not-null (`refinedUnknown`). So attribute access, conditionals (unknown predicate), `coalesce`, and splat all carry the refinement through to the output value.
- **`try`** — the type-inference `try()` now unions nullability across its arguments, so `try(x, null)` is optional (it may fall through to the null at runtime).
- **Requiredness** — an output is required when its inferred value's `Range().CouldBeNull()` is false. For object fields nested inside collections (where the value carries no element refinements), requiredness is read from the cty type's optional-attribute metadata. Non-null inputs are echoed as outputs and so are required outputs too.

`Required` is now emitted on the component output object and on every nested named object type.

## Tests

- `TestOutputRequiredness` — non-null literals/vars/attributes and echoed inputs are required; nullable vars, optional attributes, `try(_, null)`, and a null conditional branch are optional; nested object `Required` fields.
- `TestModuleOutputRequirednessPropagates` — a child output's nullability propagates through a `module.<name>.<output>` reference.
- Updated `TestRangedResourceOutputsAreTyped` and regenerated the `primitives`, `required`, and `sensitive` golden schemas.