### PR TITLE
Correctly pass resource references to and from module components

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-302.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-302.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Correctly pass resource references to and from module components
+time: 2026-06-30T15:06:12+02:00
+custom:
+    Component: runtime
+    PR: "302"

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -224,6 +224,23 @@ func resourceValue(urn urn.URN, value cty.Value) cty.Value {
 	return r.Mark(resourceMark{urn, hashable.Hash()})
 }
 
+// ResourceReferenceURN reports the URN val refers to when val is a
+// whole-resource reference.
+func ResourceReferenceURN(val cty.Value) (urn.URN, bool) {
+	if !val.IsKnown() {
+		return "", false
+	}
+	_, marks := val.Unmark()
+	hashable, _ := val.UnmarkDeep()
+	hash := hashable.Hash()
+	for m := range marks {
+		if rm, ok := m.(resourceMark); ok && rm.resHash == hash {
+			return rm.urn, true
+		}
+	}
+	return "", false
+}
+
 // SetResource sets a resource's output values.
 // The key should be "type.name" (e.g., "aws_instance.web").
 func (c *Context) SetResource(key string, urn urn.URN, value cty.Value) {

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -218,7 +218,12 @@ type resourceMark struct {
 	resHash int
 }
 
-func resourceValue(urn urn.URN, value cty.Value) cty.Value {
+// MarkResourceReference tags value as a reference to the resource identified by
+// urn: it strips synthetic attributes and applies a resourceMark whose hash
+// matches the resulting value. ResourceReferenceURN recovers the URN, and the
+// value's own attributes (its outputs) are read transparently — so a reference
+// to a resource and the resource itself are the same kind of value.
+func MarkResourceReference(value cty.Value, urn urn.URN) cty.Value {
 	r := stripSyntheticAttributes(value)
 	hashable, _ := r.UnmarkDeep()
 	return r.Mark(resourceMark{urn, hashable.Hash()})
@@ -246,7 +251,7 @@ func ResourceReferenceURN(val cty.Value) (urn.URN, bool) {
 func (c *Context) SetResource(key string, urn urn.URN, value cty.Value) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.resources[key] = resourceValue(urn, value)
+	c.resources[key] = MarkResourceReference(value, urn)
 }
 
 // SetCountResource stores a resource instance from count expansion.
@@ -255,7 +260,7 @@ func (c *Context) SetCountResource(baseKey string, index int, urn urn.URN, value
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.rangedResources[baseKey] = append(c.rangedResources[baseKey], rangedInstance{
-		value: resourceValue(urn, value), index: index, isCount: true,
+		value: MarkResourceReference(value, urn), index: index, isCount: true,
 	})
 }
 
@@ -265,7 +270,7 @@ func (c *Context) SetEachResource(baseKey string, eachKey string, urn urn.URN, v
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.rangedResources[baseKey] = append(c.rangedResources[baseKey], rangedInstance{
-		value: resourceValue(urn, value), eachKey: eachKey, isEach: true,
+		value: MarkResourceReference(value, urn), eachKey: eachKey, isEach: true,
 	})
 }
 

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -2228,18 +2228,8 @@ func resourceUrnFuncHelper(fnName string, f func(urn.URN) (cty.Value, error)) fu
 			if !res.IsKnown() {
 				return cty.UnknownVal(cty.String), nil
 			}
-			_, marks := res.Unmark()
-			hashable, _ := res.UnmarkDeep()
-			hash := hashable.Hash()
-			for m := range marks {
-				rP, ok := m.(resourceMark)
-				if !ok {
-					continue
-				}
-
-				if rP.resHash == hash {
-					return f(rP.urn)
-				}
+			if u, ok := ResourceReferenceURN(res); ok {
+				return f(u)
 			}
 			return cty.NilVal, fmt.Errorf("%s: argument must be a resource reference", fnName)
 		},

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -56,7 +56,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	ctyyaml "github.com/zclconf/go-cty-yaml"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
@@ -72,9 +71,6 @@ var (
 
 	// ArchiveCapsuleType is the cty capsule type for Pulumi archives.
 	ArchiveCapsuleType = cty.Capsule("Archive", reflect.TypeFor[archive.Archive]())
-
-	// ResourceReferenceCapsuleType is the cty capsule type for Pulumi resource references.
-	ResourceReferenceCapsuleType = cty.Capsule("ResourceReference", reflect.TypeFor[property.ResourceReference]())
 )
 
 // Functions returns a map of all Terraform-compatible functions.

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/potel"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/util"
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
@@ -2971,7 +2972,7 @@ func (e *Engine) resolveResourceRefsInOutputs(
 ) (property.Map, error) {
 	resolved := outputs
 	for _, p := range resSchema.Properties {
-		resType, ok := p.Type.(*schema.ResourceType)
+		resType, ok := codegen.UnwrapType(p.Type).(*schema.ResourceType)
 		if !ok {
 			continue
 		}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -3535,9 +3535,13 @@ func (e *Engine) processOutput(_ context.Context, name string, output *ast.Outpu
 // The value must be one of:
 //   - a resource-outputs object with direct `urn` and `id` string attributes
 //     (provider blocks like `aws.west` or pulumi_providers_* resources), or
-//   - an object carrying an `__ref` ResourceReference capsule (e.g., the result
-//     of a `call.<resource>.<method>` that returns a provider).
+//   - a resource reference carrying its URN in a resourceMark (e.g., the result
+//     of a `call.<resource>.<method>` that returns a provider), with its id in
+//     the object's id attribute.
 func providerRefFromCty(val cty.Value) (string, error) {
+	// Capture the reference's URN before the unmark below strips its resourceMark.
+	refURN, isRef := eval.ResourceReferenceURN(val)
+
 	if val.IsMarked() {
 		val, _ = val.Unmark()
 	}
@@ -3550,21 +3554,6 @@ func providerRefFromCty(val cty.Value) (string, error) {
 	if !val.Type().IsObjectType() {
 		return "", fmt.Errorf("provider value must be an object, got %s", val.Type().FriendlyName())
 	}
-	if val.Type().HasAttribute("__ref") {
-		refVal, _ := val.GetAttr("__ref").Unmark()
-		if refVal.Type() != eval.ResourceReferenceCapsuleType {
-			return "", fmt.Errorf("provider value has __ref of unexpected type %s", refVal.Type().FriendlyName())
-		}
-		if refVal.IsNull() {
-			return "", errors.New("provider value has null __ref")
-		}
-		ref := refVal.EncapsulatedValue().(*property.ResourceReference)
-		id := ""
-		if ref.ID.IsString() {
-			id = ref.ID.AsString()
-		}
-		return string(ref.URN) + "::" + id, nil
-	}
 	if val.Type().HasAttribute("urn") && val.Type().HasAttribute("id") {
 		urn := ctyAsString(val.GetAttr("urn"))
 		id := ctyAsString(val.GetAttr("id"))
@@ -3572,6 +3561,15 @@ func providerRefFromCty(val cty.Value) (string, error) {
 			return "", fmt.Errorf("provider value urn/id must be non-empty strings, got urn=%q id=%q", urn, id)
 		}
 		return urn + "::" + id, nil
+	}
+	if isRef {
+		id := ""
+		if val.Type().HasAttribute("id") {
+			if idAttr, _ := val.GetAttr("id").Unmark(); idAttr.Type() == cty.String && idAttr.IsKnown() && !idAttr.IsNull() {
+				id = idAttr.AsString()
+			}
+		}
+		return string(refURN) + "::" + id, nil
 	}
 	return "", errors.New("provider value is not a resource reference")
 }

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -654,7 +654,7 @@ func (e *Engine) processGraph(ctx context.Context, g *graph.Graph) error {
 }
 
 // processVariable processes a variable definition.
-func (e *Engine) processVariable(_ context.Context, node *graph.Node) error {
+func (e *Engine) processVariable(ctx context.Context, node *graph.Node) error {
 	v := node.Variable
 	if v == nil {
 		return fmt.Errorf("variable node missing Variable field")
@@ -746,6 +746,19 @@ func (e *Engine) processVariable(_ context.Context, node *graph.Node) error {
 		!val.IsNull() && val.IsKnown() {
 		if converted, err := ctyconvert.Convert(val, v.TypeConstraint); err == nil {
 			val = converted
+		}
+	}
+
+	// A resource reference supplied as a typed config value — e.g. a component
+	// input from a calling program — carries only its identity. Fetch the
+	// referenced resource's state so the program can read its fields.
+	if valueSource == "config-typed" {
+		if u, ok := eval.ResourceReferenceURN(val); ok {
+			resolved, err := e.resolveConfigResourceReference(ctx, val, u)
+			if err != nil {
+				return fmt.Errorf("variable %q: %w", varName, err)
+			}
+			val = resolved
 		}
 	}
 
@@ -2994,6 +3007,49 @@ func (e *Engine) resolveResourceRefsInOutputs(
 		resolved = resolved.Set(p.Name, property.New(refMap))
 	}
 	return resolved, nil
+}
+
+// resolveConfigResourceReference enriches a resource reference supplied as a
+// typed config value with the referenced resource's state, so a program
+// consuming this module as a component can read the resource's fields, not just
+// its id. The referenced resource lives in the calling program, so its state is
+// fetched through the monitor. Best-effort: an unfetchable or preview-unknown
+// reference is returned unchanged.
+func (e *Engine) resolveConfigResourceReference(ctx context.Context, val cty.Value, u urn.URN) (cty.Value, error) {
+	contract.Requiref(e.resmon != nil, "e.resmon", "cannot resolve a resource reference without a resource monitor")
+	unmarked, marks := val.Unmark()
+	contract.Assertf(unmarked.Type().IsObjectType() && unmarked.Type().HasAttribute("id"),
+		"a resource reference must be an object with an id attribute, got %s", unmarked.Type().FriendlyName())
+
+	idAttr, _ := unmarked.GetAttr("id").Unmark()
+	if !idAttr.IsKnown() {
+		// During preview the referenced resource's id is unknown and its state
+		// cannot be fetched; the bare reference flows through unchanged.
+		return val, nil
+	}
+	ref := property.ResourceReference{URN: u, ID: property.New(property.Null)}
+	switch {
+	case idAttr.IsNull():
+		// A component reference has a null id; getResource keys on the URN.
+	case idAttr.Type() == cty.String:
+		ref.ID = property.New(idAttr.AsString())
+	default:
+		return cty.Value{}, fmt.Errorf("resource reference %s has a non-string id of type %s",
+			u, idAttr.Type().FriendlyName())
+	}
+
+	state, err := e.getResourceState(ctx, ref)
+	if err != nil {
+		return cty.Value{}, fmt.Errorf("fetching state of resource reference %s: %w", u, err)
+	}
+	attrs := transform.PropertyMapToCty(state).AsValueMap()
+	if attrs == nil {
+		attrs = map[string]cty.Value{}
+	}
+	attrs["id"] = unmarked.GetAttr("id")
+
+	obj := cty.ObjectVal(attrs).WithMarks(marks)
+	return eval.MarkResourceReference(obj, u), nil
 }
 
 // processModule processes a module call.

--- a/pkg/hcl/run/run_internal_test.go
+++ b/pkg/hcl/run/run_internal_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -36,13 +35,10 @@ func TestProviderRefFromCty(t *testing.T) {
 		"id":  cty.StringVal("provider-id-123"),
 	})
 
-	ref := property.ResourceReference{
-		URN: resource.URN("urn:pulumi:dev::p::pulumi:providers:aws::aws-west"),
-		ID:  property.New("provider-id-123"),
-	}
-	callResult := cty.ObjectVal(map[string]cty.Value{
-		"__ref": cty.CapsuleVal(eval.ResourceReferenceCapsuleType, &ref),
-	})
+	callResult := eval.MarkResourceReference(
+		cty.ObjectVal(map[string]cty.Value{"id": cty.StringVal("provider-id-123")}),
+		resource.URN("urn:pulumi:dev::p::pulumi:providers:aws::aws-west"),
+	)
 
 	nonProviderResource := cty.ObjectVal(map[string]cty.Value{
 		"name": cty.StringVal("my-bucket"),

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modules"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/run"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil"
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/schemaloader"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -2965,6 +2966,7 @@ resource "test_component" "comp" {
 		ID:  property.New("fn-id"),
 	}, handler.AsResourceReference())
 }
+
 func TestEngine_FieldAccessOnComponentReferenceOutput(t *testing.T) {
 	t.Parallel()
 
@@ -3057,6 +3059,146 @@ resource "test_resource" "consumer" {
 	require.True(t, ok, "consumer should receive the value input")
 	require.Equal(t, "hello-from-ref", value.AsString(),
 		"a field read off a component's reference output should resolve to the referenced resource's state")
+}
+
+// TestEngine_SecretResourceReferenceConfig locks in that a secret resource
+// reference keeps its mark across the component boundary: when a secret
+// reference is supplied as config and its state is fetched, the resolved outputs
+// are secret too, so a value derived from one of its fields stays secret.
+func TestEngine_SecretResourceReferenceConfig(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+variable "handler" {
+}
+
+resource "test_resource" "consumer" {
+  value = var.handler.value
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	ref := property.New(property.ResourceReference{
+		URN: "urn:pulumi:test::project::test:index:Resource::inner",
+		ID:  property.New("inner-id"),
+	}).WithSecret(true)
+
+	mock := &testutil.MockResourceMonitor{
+		InvokeHandler: func(_ context.Context, req run.InvokeRequest) (*run.InvokeResponse, error) {
+			if req.Token == "pulumi:pulumi:getResource" {
+				return &run.InvokeResponse{Return: property.NewMap(map[string]property.Value{
+					"state": property.New(property.NewMap(map[string]property.Value{
+						"value": property.New("secret-val"),
+					})),
+				})}, nil
+			}
+			return &run.InvokeResponse{Return: property.NewMap(nil)}, nil
+		},
+	}
+	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "test",
+			Resources: map[string]schema.ResourceSpec{
+				"test:index:Resource": {
+					InputProperties: map[string]schema.PropertySpec{
+						"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+		Config: map[string]run.ConfigValue{
+			"test-project:handler": run.TypedConfigValue(transform.PropertyValueToCty(ref)),
+		},
+	})
+	require.NoError(t, engine.Run(t.Context()))
+
+	var consumer *run.RegisterResourceRequest
+	for i := range mock.RegisteredResources {
+		if mock.RegisteredResources[i].Name == "consumer" {
+			consumer = &mock.RegisteredResources[i]
+		}
+	}
+	require.NotNil(t, consumer, "consumer resource should be registered")
+
+	value, ok := consumer.Inputs.GetOk("value")
+	require.True(t, ok, "consumer should receive the value input")
+	require.Equal(t, "secret-val", value.AsString(),
+		"the field should resolve to the referenced resource's fetched state")
+	require.True(t, value.Secret(),
+		"a value derived from a secret resource reference must stay secret")
+}
+
+// TestEngine_WholeResourceModuleOutput covers returning a resource the program
+// created as a whole: a module/component output `value = test_resource.r`
+// exposes the resource's fields to the caller. (This is the run-engine view of
+// what a component returns; the construct boundary only wraps these outputs.)
+func TestEngine_WholeResourceModuleOutput(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "test_resource" "r" {
+  value = "exported"
+}
+
+output "exported" {
+  value = test_resource.r
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "test",
+			Resources: map[string]schema.ResourceSpec{
+				"test:index:Resource": {
+					InputProperties: map[string]schema.PropertySpec{
+						"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+	require.NoError(t, engine.Run(t.Context()))
+
+	exported, ok := mock.StackOutputs.GetOk("exported")
+	require.True(t, ok, "expected the exported output")
+	out := exported.AsMap()
+
+	value, ok := out.GetOk("value")
+	require.True(t, ok, "the whole-resource output should expose the resource's value field")
+	require.Equal(t, "exported", value.AsString())
+
+	_, hasURN := out.GetOk("urn")
+	require.False(t, hasURN, "the synthetic urn attribute must not leak into the output")
 }
 
 func TestEngine_ReplaceTriggeredBy(t *testing.T) {

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -2889,6 +2889,83 @@ func hasRegisteredResource(mock *testutil.MockResourceMonitor, typ string) bool 
 	return false
 }
 
+// TestEngine_WholeResourceReferenceAsComponentInput covers passing a whole
+// resource by value into a component (MLC) input typed as a resource reference,
+func TestEngine_WholeResourceReferenceAsComponentInput(t *testing.T) {
+	t.Parallel()
+
+	componentSchema := schema.PackageSpec{
+		Name: "test",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Resource": {
+				InputProperties: map[string]schema.PropertySpec{
+					"field": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"field": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+			"test:index:Component": {
+				IsComponent: true,
+				InputProperties: map[string]schema.PropertySpec{
+					"handler": {TypeSpec: schema.TypeSpec{Ref: "#/resources/test:index:Resource"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"url": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	src := []byte(`
+resource "test_resource" "fn" {
+  field = "value"
+}
+
+resource "test_component" "comp" {
+  handler = test_resource.fn
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader:    schemaloader.New(t, componentSchema),
+	})
+	require.NoError(t, engine.Run(t.Context()))
+
+	var component *run.RegisterResourceRequest
+	for i := range mock.RegisteredResources {
+		if mock.RegisteredResources[i].Type == "test:index:Component" {
+			component = &mock.RegisteredResources[i]
+		}
+	}
+	require.NotNil(t, component, "component resource should be registered")
+
+	handler, ok := component.Inputs.GetOk("handler")
+	require.True(t, ok, "component should receive the handler input")
+	require.True(t, handler.IsResourceReference(),
+		"the whole-resource input should reach the component as a resource reference, not %s",
+		handler.GoString())
+	require.Equal(t, property.ResourceReference{
+		URN: "urn:pulumi:test::project::test:index:Resource::fn",
+		ID:  property.New("fn-id"),
+	}, handler.AsResourceReference())
+}
+
 func TestEngine_ReplaceTriggeredBy(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -2965,6 +2965,99 @@ resource "test_component" "comp" {
 		ID:  property.New("fn-id"),
 	}, handler.AsResourceReference())
 }
+func TestEngine_FieldAccessOnComponentReferenceOutput(t *testing.T) {
+	t.Parallel()
+
+	componentSchema := schema.PackageSpec{
+		Name: "test",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Resource": {
+				InputProperties: map[string]schema.PropertySpec{
+					"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+			"test:index:Component": {
+				IsComponent: true,
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"ref": {TypeSpec: schema.TypeSpec{Ref: "#/resources/test:index:Resource"}},
+					},
+				},
+			},
+		},
+	}
+
+	const innerURN = "urn:pulumi:test::project::test:index:Resource::inner"
+
+	src := []byte(`
+resource "test_component" "comp" {
+}
+
+resource "test_resource" "consumer" {
+  value = test_component.comp.ref.value
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	mock := &testutil.MockResourceMonitor{
+		// The component returns a reference to a resource it created.
+		RegisterResourceHandler: func(_ context.Context, req run.RegisterResourceRequest) (*run.RegisterResourceResponse, error) {
+			resURN := urn.URN("urn:pulumi:test::project::" + req.Type + "::" + req.Name)
+			outputs := req.Inputs
+			if req.Type == "test:index:Component" {
+				outputs = property.NewMap(map[string]property.Value{
+					"ref": property.New(property.ResourceReference{
+						URN: innerURN,
+						ID:  property.New("inner-id"),
+					}),
+				})
+			}
+			return &run.RegisterResourceResponse{URN: resURN, ID: req.Name + "-id", Outputs: outputs}, nil
+		},
+		// getResource on the referenced resource returns its state.
+		InvokeHandler: func(_ context.Context, req run.InvokeRequest) (*run.InvokeResponse, error) {
+			if req.Token == "pulumi:pulumi:getResource" {
+				return &run.InvokeResponse{Return: property.NewMap(map[string]property.Value{
+					"state": property.New(property.NewMap(map[string]property.Value{
+						"value": property.New("hello-from-ref"),
+					})),
+				})}, nil
+			}
+			return &run.InvokeResponse{Return: property.NewMap(nil)}, nil
+		},
+	}
+	engine := run.NewEngine(t.Context(), config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader:    schemaloader.New(t, componentSchema),
+	})
+	require.NoError(t, engine.Run(t.Context()))
+
+	var consumer *run.RegisterResourceRequest
+	for i := range mock.RegisteredResources {
+		if mock.RegisteredResources[i].Name == "consumer" {
+			consumer = &mock.RegisteredResources[i]
+		}
+	}
+	require.NotNil(t, consumer, "consumer resource should be registered")
+
+	value, ok := consumer.Inputs.GetOk("value")
+	require.True(t, ok, "consumer should receive the value input")
+	require.Equal(t, "hello-from-ref", value.AsString(),
+		"a field read off a component's reference output should resolve to the referenced resource's state")
+}
 
 func TestEngine_ReplaceTriggeredBy(t *testing.T) {
 	t.Parallel()

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -685,6 +685,11 @@ func getDefault(path string, d *schema.DefaultValue, typ schema.Type) (property.
 // ctyToResourceProperty's expr, when non-nil, lets union-discrimination
 // failures attach an HCL source range to the returned error.
 func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, expr hcl.Expression, alreadyInSecret bool) (property.Value, error) {
+	// A whole-resource reference (e.g. `handler = aws_lambda_function.fn`) is
+	// identified by its resourceMark; capture the URN before the unmark below
+	// strips it, so the *schema.ResourceType case can build a reference from it.
+	resRefURN, isResRef := eval.ResourceReferenceURN(val)
+
 	if val.IsMarked() {
 		var marks cty.ValueMarks
 		val, marks = val.Unmark()
@@ -751,18 +756,26 @@ func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, expr hc
 		if !val.Type().IsObjectType() {
 			return property.Value{}, fmt.Errorf("expected object at %q for resource reference, found %#v", path, val.Type())
 		}
-		refAttr, hasRef := val.AsValueMap()["__ref"]
-		if hasRef {
+		attrs := val.AsValueMap()
+		// A call/method/provider result carries an explicit __ref capsule.
+		if refAttr, hasRef := attrs["__ref"]; hasRef {
 			refAttr, _ = refAttr.Unmark()
+			if !refAttr.IsKnown() {
+				return property.New(property.Computed), nil
+			}
+			ref, ok := refAttr.EncapsulatedValue().(*property.ResourceReference)
+			if !ok {
+				return property.Value{}, fmt.Errorf("expected resource reference capsule at %q", path)
+			}
+			return property.New(*ref), nil
 		}
-		if !hasRef || !refAttr.IsKnown() {
-			return property.New(property.Computed), nil
+		// A whole-resource reference arrives as the referenced resource's outputs
+		// object: its identity comes from the resourceMark (captured above), its
+		// ID from the resource's id attribute.
+		if isResRef {
+			return property.New(resourceReferenceFromOutputs(resRefURN, attrs)), nil
 		}
-		ref, ok := refAttr.EncapsulatedValue().(*property.ResourceReference)
-		if !ok {
-			return property.Value{}, fmt.Errorf("expected resource reference capsule at %q", path)
-		}
-		return property.New(*ref), nil
+		return property.New(property.Computed), nil
 	case *schema.ObjectType:
 		if !val.Type().IsObjectType() {
 			return property.Value{}, fmt.Errorf("expected object at %q, found %#v", path, val.Type())
@@ -823,6 +836,29 @@ func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, expr hc
 	default:
 		return property.Value{}, fmt.Errorf("%q: unknown schema type %s when converting %#v", path, prop, val.Type())
 	}
+}
+
+// resourceReferenceFromOutputs builds a reference to a whole resource. The URN
+// comes from the resourceMark; the ID from the resource's id output attribute,
+// which is unknown during preview (mapped to a computed ID) and null for a
+// component, mirroring the cases a Pulumi resource reference distinguishes.
+func resourceReferenceFromOutputs(u resource.URN, attrs map[string]cty.Value) property.ResourceReference {
+	ref := property.ResourceReference{URN: u}
+	idAttr, ok := attrs["id"]
+	if !ok {
+		ref.ID = property.New(property.Null)
+		return ref
+	}
+	idAttr, _ = idAttr.Unmark()
+	switch {
+	case !idAttr.IsKnown():
+		ref.ID = property.New(property.Computed)
+	case idAttr.Type() == cty.String && !idAttr.IsNull():
+		ref.ID = property.New(idAttr.AsString())
+	default:
+		ref.ID = property.New(property.Null)
+	}
+	return ref
 }
 
 func camelCaseFromSnakeCase(s string, props []*schema.Property) (string, *schema.Property) {
@@ -1612,6 +1648,15 @@ func PropertyValueToCty(pv property.Value) cty.Value {
 
 	case pv.IsArchive():
 		return cty.CapsuleVal(eval.ArchiveCapsuleType, pv.AsArchive())
+
+	case pv.IsResourceReference():
+		// No schema here to type the referenced resource's attributes, so the
+		// value is the bare __ref capsule. ctyToResourceProperty reads the
+		// capsule back when this flows into a resource-typed input.
+		ref := pv.AsResourceReference()
+		return cty.ObjectVal(map[string]cty.Value{
+			"__ref": cty.CapsuleVal(eval.ResourceReferenceCapsuleType, &ref),
+		})
 
 	default:
 		return cty.NullVal(cty.DynamicPseudoType)

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -756,24 +756,11 @@ func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, expr hc
 		if !val.Type().IsObjectType() {
 			return property.Value{}, fmt.Errorf("expected object at %q for resource reference, found %#v", path, val.Type())
 		}
-		attrs := val.AsValueMap()
-		// A call/method/provider result carries an explicit __ref capsule.
-		if refAttr, hasRef := attrs["__ref"]; hasRef {
-			refAttr, _ = refAttr.Unmark()
-			if !refAttr.IsKnown() {
-				return property.New(property.Computed), nil
-			}
-			ref, ok := refAttr.EncapsulatedValue().(*property.ResourceReference)
-			if !ok {
-				return property.Value{}, fmt.Errorf("expected resource reference capsule at %q", path)
-			}
-			return property.New(*ref), nil
-		}
-		// A whole-resource reference arrives as the referenced resource's outputs
+		// A resource reference arrives as the referenced resource's outputs
 		// object: its identity comes from the resourceMark (captured above), its
 		// ID from the resource's id attribute.
 		if isResRef {
-			return property.New(resourceReferenceFromOutputs(resRefURN, attrs)), nil
+			return property.New(resourceReferenceFromOutputs(resRefURN, val.AsValueMap())), nil
 		}
 		return property.New(property.Computed), nil
 	case *schema.ObjectType:
@@ -859,6 +846,24 @@ func resourceReferenceFromOutputs(u resource.URN, attrs map[string]cty.Value) pr
 		ref.ID = property.New(property.Null)
 	}
 	return ref
+}
+
+func resourceReferenceCty(outputs map[string]cty.Value, id property.Value, u resource.URN) cty.Value {
+	attrs := make(map[string]cty.Value, len(outputs)+1)
+	maps.Copy(attrs, outputs)
+	attrs["id"] = resourceRefIDCty(id)
+	return eval.MarkResourceReference(cty.ObjectVal(attrs), u)
+}
+
+func resourceRefIDCty(id property.Value) cty.Value {
+	switch {
+	case id.IsComputed():
+		return cty.UnknownVal(cty.String)
+	case id.IsString():
+		return cty.StringVal(id.AsString())
+	default:
+		return cty.NullVal(cty.String)
+	}
 }
 
 func camelCaseFromSnakeCase(s string, props []*schema.Property) (string, *schema.Property) {
@@ -1248,7 +1253,7 @@ func ctyTypeFromTypeRec(typ schema.Type, mapping *bridge.BodyMapping, seen map[a
 		seen[typ.Resource] = true
 		defer delete(seen, typ.Resource)
 		return ctyObjectTypeRec(typ.Resource.Properties,
-			map[string]cty.Type{"__ref": eval.ResourceReferenceCapsuleType}, mapping, seen)
+			map[string]cty.Type{"id": cty.String}, mapping, seen)
 	case *schema.InvalidType:
 		return cty.DynamicPseudoType
 	case *schema.TokenType:
@@ -1293,8 +1298,8 @@ func ctyTypeFromTypeRec(typ schema.Type, mapping *bridge.BodyMapping, seen map[a
 
 // ctyObjectType builds an object type whose attributes are named by the
 // mapping's TF names (snake_case-of-Pulumi-name when mapping is nil). seed
-// pre-populates always-optional synthetic attributes (e.g. the
-// resource-reference `__ref`).
+// pre-populates always-optional synthetic attributes (e.g. a resource
+// reference's `id`).
 func ctyObjectType(
 	properties []*schema.Property, seed map[string]cty.Type, mapping *bridge.BodyMapping,
 ) cty.Type {
@@ -1497,16 +1502,27 @@ func propertyValueToCtyWithMapping(path string, v property.Value, typ schema.Typ
 			if err != nil {
 				return cty.Value{}, err
 			}
+			// resolveResourceRefsInOutputs carries a resource reference and any
+			// fetched state through the map's __ref key; the rest of the map is
+			// the referenced resource's outputs.
+			var ref *property.ResourceReference
 			if refVal, ok := v.AsMap().GetOk("__ref"); ok && refVal.IsResourceReference() {
-				ref := refVal.AsResourceReference()
-				result["__ref"] = cty.CapsuleVal(eval.ResourceReferenceCapsuleType, &ref)
+				r := refVal.AsResourceReference()
+				ref = &r
+				result["id"] = resourceRefIDCty(r.ID)
 			}
-			if mapping != nil {
-				// Mapping-aware: keys are TF names which the schema-derived
-				// type won't accept; emit the literal object value instead.
-				return cty.ObjectVal(result), nil
+			obj := cty.ObjectVal(result)
+			if mapping == nil {
+				// Mapping-aware values keep TF names the schema type rejects, so
+				// only convert when there is no mapping.
+				if obj, err = convertToSchemaCtyType(path, obj, typ); err != nil {
+					return cty.Value{}, err
+				}
 			}
-			return convertToSchemaCtyType(path, cty.ObjectVal(result), typ)
+			if ref != nil {
+				obj = eval.MarkResourceReference(obj, ref.URN)
+			}
+			return obj, nil
 		case *schema.ObjectType:
 			m, err := propertyObjectToCtyMap(path, v.AsMap(), typ.Properties, mapping, dryRun)
 			if err != nil {
@@ -1582,8 +1598,7 @@ func propertyValueToCtyWithMapping(path string, v property.Value, typ schema.Typ
 		if err != nil {
 			return cty.Value{}, err
 		}
-		result["__ref"] = cty.CapsuleVal(eval.ResourceReferenceCapsuleType, &ref)
-		return cty.ObjectVal(result), nil
+		return resourceReferenceCty(result, ref.ID, ref.URN), nil
 
 	case v.IsAsset():
 		return cty.CapsuleVal(eval.AssetCapsuleType, v.AsAsset()), nil
@@ -1650,13 +1665,10 @@ func PropertyValueToCty(pv property.Value) cty.Value {
 		return cty.CapsuleVal(eval.ArchiveCapsuleType, pv.AsArchive())
 
 	case pv.IsResourceReference():
-		// No schema here to type the referenced resource's attributes, so the
-		// value is the bare __ref capsule. ctyToResourceProperty reads the
-		// capsule back when this flows into a resource-typed input.
+		// No schema here to type the referenced resource's outputs, so the value
+		// carries only the id attribute and the identifying resourceMark.
 		ref := pv.AsResourceReference()
-		return cty.ObjectVal(map[string]cty.Value{
-			"__ref": cty.CapsuleVal(eval.ResourceReferenceCapsuleType, &ref),
-		})
+		return resourceReferenceCty(nil, ref.ID, ref.URN)
 
 	default:
 		return cty.NullVal(cty.DynamicPseudoType)

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -857,8 +857,8 @@ func TestPropertyValueToCty_Secret(t *testing.T) {
 
 // TestPropertyValueToCty_ResourceReference covers the schemaless path a
 // resource reference takes into a dynamic module input: without a schema to
-// type the referenced resource, the value is the bare __ref capsule rather than
-// a dropped null.
+// type the referenced resource, the value is its outputs object (here just id)
+// marked as a reference, rather than a dropped null.
 func TestPropertyValueToCty_ResourceReference(t *testing.T) {
 	t.Parallel()
 
@@ -869,10 +869,12 @@ func TestPropertyValueToCty_ResourceReference(t *testing.T) {
 
 	result := PropertyValueToCty(property.New(ref))
 
-	require.True(t, result.Type().IsObjectType(), "expected an object carrying __ref")
-	refAttr := result.GetAttr("__ref")
-	require.Equal(t, eval.ResourceReferenceCapsuleType, refAttr.Type())
-	require.Equal(t, &ref, refAttr.EncapsulatedValue().(*property.ResourceReference))
+	gotURN, ok := eval.ResourceReferenceURN(result)
+	require.True(t, ok, "the value should be identifiable as a resource reference")
+	require.Equal(t, ref.URN, gotURN)
+
+	unmarked, _ := result.Unmark()
+	require.Equal(t, ref, resourceReferenceFromOutputs(gotURN, unmarked.AsValueMap()))
 }
 
 func TestCtyToPropertyMap(t *testing.T) {

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -855,6 +855,26 @@ func TestPropertyValueToCty_Secret(t *testing.T) {
 	}
 }
 
+// TestPropertyValueToCty_ResourceReference covers the schemaless path a
+// resource reference takes into a dynamic module input: without a schema to
+// type the referenced resource, the value is the bare __ref capsule rather than
+// a dropped null.
+func TestPropertyValueToCty_ResourceReference(t *testing.T) {
+	t.Parallel()
+
+	ref := property.ResourceReference{
+		URN: resource.URN("urn:pulumi:dev::p::test:index:Resource::fn"),
+		ID:  property.New("fn-id"),
+	}
+
+	result := PropertyValueToCty(property.New(ref))
+
+	require.True(t, result.Type().IsObjectType(), "expected an object carrying __ref")
+	refAttr := result.GetAttr("__ref")
+	require.Equal(t, eval.ResourceReferenceCapsuleType, refAttr.Type())
+	require.Equal(t, &ref, refAttr.EncapsulatedValue().(*property.ResourceReference))
+}
+
 func TestCtyToPropertyMap(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/server/module_resource_test.go
+++ b/pkg/server/module_resource_test.go
@@ -15,6 +15,8 @@
 package server
 
 import (
+	"context"
+	"net"
 	"path/filepath"
 	"testing"
 
@@ -24,6 +26,8 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modules"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
@@ -176,4 +180,78 @@ resource "aws_s3_bucket" "b" {}
 		}},
 		{Alias: "random", Spec: &pulumirpc.PackageSpec{Source: "random"}},
 	}, got)
+}
+
+// refMonitorServer adds getResource support to captureMonitorServer so a
+// construct test can resolve a resource passed in by reference.
+type refMonitorServer struct {
+	captureMonitorServer
+}
+
+func (s *refMonitorServer) Invoke(
+	_ context.Context, req *pulumirpc.ResourceInvokeRequest,
+) (*pulumirpc.InvokeResponse, error) {
+	if req.Tok != "pulumi:pulumi:getResource" {
+		return &pulumirpc.InvokeResponse{}, nil
+	}
+	ret, err := structpb.NewStruct(map[string]any{
+		"state": map[string]any{"value": "from-handler"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &pulumirpc.InvokeResponse{Return: ret}, nil
+}
+
+// TestModuleConstructResourceReferenceInput drives construct with a whole
+// resource passed by reference as a module input and asserts the module can read
+// the referenced resource's fields: the runtime fetches its state (via
+// getResource) so `var.handler.value` resolves to the resource's value, not just
+// its id.
+func TestModuleConstructResourceReferenceInput(t *testing.T) {
+	t.Parallel()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer()
+	pulumirpc.RegisterResourceMonitorServer(srv, &refMonitorServer{})
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	dir, err := filepath.Abs(filepath.Join("testdata", "module-resource-ref"))
+	require.NoError(t, err)
+
+	m := &moduleProvider{
+		moduleLoader: modules.NewLoader(modules.LiveResolver(t.Context())),
+		resolver:     stubResolver{},
+	}
+
+	resp, err := m.construct(t.Context(), p.ConstructRequest{
+		Urn:             resource.URN("urn:pulumi:test::proj::hcl:index:Module::mod"),
+		MonitorEndpoint: lis.Addr().String(),
+		Inputs: property.NewMap(map[string]property.Value{
+			"source": property.New(dir),
+			"inputs": property.New(property.NewMap(map[string]property.Value{
+				"handler": property.New(property.ResourceReference{
+					URN: "urn:pulumi:test::proj::aws:lambda/function:Function::fn",
+					ID:  property.New("fn-id"),
+				}),
+			})),
+		}),
+	})
+	require.NoError(t, err)
+
+	outputs, ok := resp.State.GetOk("outputs")
+	require.True(t, ok, "construct response should expose an outputs map")
+	out := outputs.AsMap()
+
+	value, ok := out.GetOk("handler_value")
+	require.True(t, ok, "module should expose a handler_value output")
+	require.Equal(t, "from-handler", value.AsString(),
+		"reading a field off the passed-in reference should resolve the referenced resource's state")
+
+	id, ok := out.GetOk("handler_id")
+	require.True(t, ok, "module should expose a handler_id output")
+	require.Equal(t, "fn-id", id.AsString(),
+		"the reference's own id should remain readable")
 }

--- a/pkg/server/testdata/module-resource-ref/main.tf
+++ b/pkg/server/testdata/module-resource-ref/main.tf
@@ -1,0 +1,13 @@
+variable "handler" {
+}
+
+# var.handler is a whole resource the calling program passed by reference. Its
+# fields are read here, inside the module, which requires the runtime to have
+# fetched the referenced resource's state.
+output "handler_value" {
+  value = var.handler.value
+}
+
+output "handler_id" {
+  value = var.handler.id
+}


### PR DESCRIPTION
Resource references — a whole resource passed by value — did not survive the component (MLC) boundary, and references returned by components could not have their fields read.

## Fixes

- **Whole-resource references passed as component inputs marshaled as unknown** (https://github.com/pulumi-labs/pulumi-hcl/issues/298). A reference like `event_handler = aws_lambda_function.fn` reached the component as the unknown-value sentinel, leaving every component output unknown. It now arrives as a resource reference. The inverse — a reference passed to a dynamic module input through the schemaless conversion — previously became null and is fixed too.
- **Optional resource-reference outputs of a component did not resolve their fields.** `resolveResourceRefsInOutputs` matched `*schema.ResourceType` without unwrapping `OptionalType`, so an optional `ref` output was skipped and `comp.ref.value` read back null. It now unwraps the type before matching, so the referenced resource's state is fetched and its fields are readable.

## Representation change

A resource reference and a materialized resource are now the same kind of cty value: the resource's outputs object (carrying an `id` attribute) tagged with the identifying `resourceMark`. The separate `__ref` cty capsule (`ResourceReferenceCapsuleType`) is removed — identity comes from the mark (the same mechanism `pulumiResourceName`/`pulumiResourceType` already use), and a reference's outputs are read transparently as attributes. So passing a resource to a component, reading a reference back out, and accessing its fields all go through one uniform representation.

## Tests

- `TestEngine_WholeResourceReferenceAsComponentInput` — a whole resource passed into a component arrives as a reference, not unknown.
- `TestEngine_FieldAccessOnComponentReferenceOutput` — a field read off a component's reference output resolves to the referenced resource's state (exercises the optional-output fix).
- `TestPropertyValueToCty_ResourceReference`, updated `TestProviderRefFromCty` — the schemaless and provider-reference paths under the new representation.
- Conformance `l2-ref-ref`, `l2-primitive-ref`, `l3-range-*-ref`, `l2-component-program-resource-ref`, `l2-component-component-resource-ref` and the full `tfcompat` suite pass.


Closes https://github.com/pulumi-labs/pulumi-hcl/pull/299
Fixes #298