### PR TITLE
Fix Go SDK publish: name the toolchain go.mod correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - CHANGELOG.md
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,10 +67,11 @@ jobs:
       - name: Read the Go toolchain from the released source
         run: |
           git fetch --depth 1 origin "refs/tags/${VERSION}"
-          git show "FETCH_HEAD:go.mod" > "${RUNNER_TEMP}/source-go.mod"
+          mkdir -p "${RUNNER_TEMP}/go-toolchain"
+          git show "FETCH_HEAD:go.mod" > "${RUNNER_TEMP}/go-toolchain/go.mod"
       - uses: actions/setup-go@v6
         with:
-          go-version-file: ${{ runner.temp }}/source-go.mod
+          go-version-file: ${{ runner.temp }}/go-toolchain/go.mod
       - uses: pulumi/actions@v7
         with:
           pulumi-version: "latest"


### PR DESCRIPTION
## Problem

The `publish-go-sdk` job in the Release workflow fails at `actions/setup-go@v6`:

```
Setup go version spec module github.com/pulumi-labs/pulumi-hcl
##[error]Unable to find Go version 'module github.com/pulumi-labs/pulumi-hcl...
```

The job copies the released source's `go.mod` to `${RUNNER_TEMP}/source-go.mod` and passes it to `setup-go` via `go-version-file`. `setup-go` only parses the `go`/`toolchain` directive when the file's basename is exactly `go.mod` or `go.work`; for any other name it treats the entire file contents as a literal version string. So it read the first line (`module github.com/pulumi-labs/pulumi-hcl`) and failed.

Failing run: https://github.com/pulumi-labs/pulumi-hcl/actions/runs/28506988083/job/84503180069

## Fix

- Write the toolchain file into its own temp subdirectory as `go.mod` so `setup-go` parses the version out of it.
- Add a `workflow_dispatch` trigger to the Release workflow. It otherwise only fires on pushes touching `CHANGELOG.md`, so once the changelog commit for a version has landed there is no way to re-run the release. The `release` job skips GoReleaser when the tag already exists and `publish-go-sdk` is guarded on the SDK tag, so a manual dispatch is idempotent — it re-runs the SDK publish without re-releasing the binary.

After merge, publish the pending v0.9.0 Go SDK with `gh workflow run Release --ref master`.