### PR TITLE
Set the schema license to Apache-2.0

### DIFF
--- a/pkg/server/module_resource_schema.go
+++ b/pkg/server/module_resource_schema.go
@@ -68,6 +68,7 @@ func moduleResourceSchema(version string) pulumischema.PackageSpec {
 		Publisher:         "Pulumi",
 		Version:           version,
 		Description:       "Instantiate a Terraform/OpenTofu module as a Pulumi component.",
+		License:           "Apache-2.0",
 		Repository:        "https://github.com/pulumi-labs/pulumi-hcl",
 		PluginDownloadURL: "github://api.github.com/pulumi-labs/pulumi-hcl",
 		Meta:              &pulumischema.MetadataSpec{SupportPack: true},


### PR DESCRIPTION
## What

Set `License: "Apache-2.0"` on the `pulumi-resource-hcl` package schema.

## Why

The schema left the license field unset, so every generated SDK shipped without license metadata:

- **.NET**: empty `<PackageLicenseExpression>` (NuGet warns)
- **npm**: no `license` field in `package.json`
- **Python**: no license classifier
- **Java**: empty `<licenses>` block in the POM — which Maven Central rejects outright

Setting the SPDX identifier `Apache-2.0` makes the codegen populate license metadata consistently across all languages.

## Verification

Rebuilt the provider and regenerated SDKs from it:

- .NET csproj now emits `<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>`
- npm `package.json` now has `"license": "Apache-2.0"`

`go test ./pkg/server/` passes.