### PR TITLE
Publish provider docs to the Pulumi registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      # The sdk-releases commit that carries this version's registry payload
+      # (registry/schema.json and registry/_index.md). Empty when the version was
+      # already published, which skips the downstream registry dispatch.
+      registry-sha: ${{ steps.commit.outputs.registry-sha }}
     env:
       VERSION: ${{ needs.release.outputs.version }}
       GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -104,7 +109,14 @@ jobs:
           git fetch --depth 1 origin "refs/tags/${VERSION}"
           git show "FETCH_HEAD:README.md" > sdk/go/README.md
           git show "FETCH_HEAD:LICENSE" > sdk/go/LICENSE
+      - name: Assemble the registry payload
+        if: steps.already-tagged.outputs.exists == 'false'
+        run: |
+          mkdir -p registry
+          pulumi package get-schema "${RUNNER_TEMP}/pulumi-resource-hcl" > registry/schema.json
+          git show "FETCH_HEAD:registry/_index.md" > registry/_index.md
       - name: Commit, tag, and push
+        id: commit
         if: steps.already-tagged.outputs.exists == 'false'
         run: |
           git config user.name "github-actions[bot]"
@@ -118,6 +130,7 @@ jobs:
           fi
           git tag "sdk/go/${VERSION}"
           git push origin "sdk/go/${VERSION}"
+          echo "registry-sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Warm the Go module proxy
         if: steps.already-tagged.outputs.exists == 'false'
         continue-on-error: true
@@ -260,3 +273,49 @@ jobs:
             --source https://api.nuget.org/v3/index.json \
             --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --skip-duplicate
+
+  # Ask the Pulumi registry to publish docs for this version.
+  #
+  # publish-go-sdk committed registry/schema.json (version baked in by the
+  # released provider binary) and registry/_index.md to the sdk-releases branch;
+  # we pin the dispatch to that exact commit so the URLs are immutable. The
+  # registry's `push-provider-update` handler reads the package version out of
+  # the schema itself, so we send neither a ref nor a schema path.
+  #
+  # The dispatch is a cross-repo GitHub API call, which GitHub OIDC can't
+  # authenticate on its own. Instead this job trades its GitHub OIDC token for a
+  # Pulumi ESC session (no secret stored in this repo) and pulls the
+  # dispatch-capable GitHub token out of the github-secrets/pulumi-hcl
+  # environment, mirroring how pulumi/registry authenticates.
+  publish-registry:
+    needs: publish-go-sdk
+    if: needs.publish-go-sdk.outputs.registry-sha != ''
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      SHA: ${{ needs.publish-go-sdk.outputs.registry-sha }}
+      ESC_ACTION_OIDC_AUTH: true
+      ESC_ACTION_OIDC_ORGANIZATION: pulumi
+      ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+      ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-hcl
+      ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=hcl-registry-publish-dispatch
+    steps:
+      - name: Fetch the dispatch token from ESC
+        uses: pulumi/esc-action@8afe12bb7bb3df0a599e5309ee429ff1079ba85f # v3
+      - name: Dispatch a registry docs build
+        run: |
+          base="https://raw.githubusercontent.com/pulumi-labs/pulumi-hcl/${SHA}/registry"
+          jq -n \
+            --arg schema "${base}/schema.json" \
+            --arg index "${base}/_index.md" \
+            '{
+              event_type: "push-provider-update",
+              client_payload: {
+                "project-shortname": "hcl",
+                "schema-url": $schema,
+                "index-url": $index
+              }
+            }' \
+          | gh api --method POST repos/pulumi/registry/dispatches --input -

--- a/registry/_index.md
+++ b/registry/_index.md
@@ -1,0 +1,156 @@
+---
+title: Any HCL Module
+meta_desc: Instantiate any Terraform or OpenTofu module as a Pulumi Component Rgesource
+layout: package
+---
+
+The `hcl` package lets you instantiate any Terraform or OpenTofu module as a
+Pulumi [component resource](https://www.pulumi.com/docs/concepts/resources/components/).
+Point the `Module` resource at a module source — a Terraform registry reference,
+a Git URL, or a local path — pass its input variables, and consume its outputs
+like any other Pulumi resource, from any supported language.
+
+The module runs under Pulumi's engine: its resources are tracked in your Pulumi
+state, its provider credentials come from your Pulumi configuration, and its
+sensitive outputs are handled as Pulumi secrets.
+
+## Example
+
+The following program instantiates the community
+[`terraform-aws-modules/vpc/aws`](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws)
+module and exports the resulting VPC id.
+
+{{< chooser language "typescript,python,go,csharp,yaml" / >}}
+
+{{% choosable language typescript %}}
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as hcl from "@pulumi-labs/hcl";
+
+const vpc = new hcl.Module("vpc", {
+    source: "terraform-aws-modules/vpc/aws",
+    version: "5.0.0",
+    inputs: {
+        name: "example-vpc",
+        cidr: "10.0.0.0/16",
+    },
+});
+
+export const vpcId = vpc.outputs.apply(o => o["vpc_id"]);
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+import pulumi
+import pulumi_labs_hcl as hcl
+
+vpc = hcl.Module("vpc",
+    source="terraform-aws-modules/vpc/aws",
+    version="5.0.0",
+    inputs={
+        "name": "example-vpc",
+        "cidr": "10.0.0.0/16",
+    })
+
+pulumi.export("vpc_id", vpc.outputs["vpc_id"])
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+package main
+
+import (
+	"github.com/pulumi-labs/pulumi-hcl/sdk/go/hcl"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		vpc, err := hcl.NewModule(ctx, "vpc", &hcl.ModuleArgs{
+			Source:  "terraform-aws-modules/vpc/aws",
+			Version: pulumi.StringRef("5.0.0"),
+			Inputs: pulumi.Map{
+				"name": pulumi.String("example-vpc"),
+				"cidr": pulumi.String("10.0.0.0/16"),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("vpcId", vpc.Outputs.MapIndex(pulumi.String("vpc_id")))
+		return nil
+	})
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+using System.Collections.Generic;
+using Pulumi;
+using Pulumi.Labs.Hcl;
+
+return await Deployment.RunAsync(() =>
+{
+    var vpc = new Module("vpc", new ModuleArgs
+    {
+        Source = "terraform-aws-modules/vpc/aws",
+        Version = "5.0.0",
+        Inputs =
+        {
+            { "name", "example-vpc" },
+            { "cidr", "10.0.0.0/16" },
+        },
+    });
+
+    return new Dictionary<string, object?>
+    {
+        ["vpcId"] = vpc.Outputs.Apply(o => o["vpc_id"]),
+    };
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+```yaml
+name: example
+runtime: yaml
+resources:
+  vpc:
+    type: hcl:index:Module
+    properties:
+      source: terraform-aws-modules/vpc/aws
+      version: "5.0.0"
+      inputs:
+        name: example-vpc
+        cidr: 10.0.0.0/16
+outputs:
+  vpcId: ${vpc.outputs["vpc_id"]}
+```
+
+{{% /choosable %}}
+
+## Strongly typed SDKs
+
+The `Module` resource above takes its `source` at runtime, so its inputs and
+outputs are untyped maps. To get a strongly typed SDK for a specific module,
+generate a parameterized provider for it:
+
+```bash
+pulumi package add hcl module <source> [version]
+```
+
+For example, `pulumi package add hcl module terraform-aws-modules/vpc/aws 5.0.0`
+generates a local SDK whose resource exposes that module's variables and outputs
+as first-class, typed properties in your language of choice.


### PR DESCRIPTION
## What

Wires the release workflow to onboard the `hcl` provider into the [Pulumi registry](https://www.pulumi.com/registry/) automatically on each release, and adds the registry landing page (`registry/_index.md`).

## How it publishes

Rather than a `community-packages/package-list.json` entry — which requires the schema to live at a tagged path in the source tree — this uses the registry's `push-provider-update` `repository_dispatch` (the `resourcedocsgen metadata from-urls` path), which accepts arbitrary durable URLs for the schema and index and reads the package version out of the schema itself.

On release, `publish-go-sdk`:
- generates `registry/schema.json` from the released, version-baked provider binary (`pulumi package get-schema`),
- copies `registry/_index.md` alongside it,
- commits both to the `sdk-releases` branch, and
- exposes that commit SHA as a job output.

A new `publish-registry` job then pins the dispatch to that exact commit, so the schema/index URLs are **immutable** (a moving branch ref would let the fetched content drift from the version being published). It sends neither a ref nor a schema path.

## Auth

The dispatch is a cross-repo GitHub API call. The built-in Actions `GITHUB_TOKEN` can't make it, and GitHub OIDC can't authenticate the GitHub API directly. The job trades its GitHub OIDC token for a Pulumi ESC session (**no secret stored in this repo**) and pulls a dispatch-scoped token out of the `github-secrets/pulumi-hcl` environment, mirroring how `pulumi/registry` authenticates.

Depends on two out-of-band setup steps (tracked separately):
- ESC env `github-secrets/pulumi-hcl` exposing `hcl-registry-publish-dispatch` (a fine-grained PAT scoped to `pulumi/registry` with `Contents: write`).
- A Pulumi-org OIDC auth policy trusting `repo:pulumi-labs/pulumi-hcl:*`.

## Docs

`registry/_index.md` is the hand-maintained landing page: a summary, a `Module` example in TypeScript/Python/Go/C#/YAML, and a note on generating strongly typed SDKs with `pulumi package add hcl module <source> [version]`.

## Notes

- Validated end-to-end by running `resourcedocsgen metadata from-urls` against the generated `schema.json` + `_index.md`; it produces a valid `hcl.yaml` (name `hcl`, version `0.9.0`, publisher Pulumi).
- `installation-configuration.md` is intentionally not published — the `push-provider-update` path only forwards the schema and index URLs.
- The first dispatch fires on the next release that lands a new `sdk-releases` commit carrying `registry/_index.md`.