### PR TITLE
Support unknown count/for_each expansion during preview

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-319.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-319.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Support `count` and `for_each` values that are unknown during preview
+time: 2026-07-07T14:20:01Z
+custom:
+    Component: runtime
+    PR: "319"

--- a/pkg/hcl/eval/evaluator.go
+++ b/pkg/hcl/eval/evaluator.go
@@ -121,37 +121,44 @@ func SensitiveArgumentDiagnostic(argName string, expr hcl.Expression) *hcl.Diagn
 	}
 }
 
-// EvaluateCount evaluates a count expression and returns (count, isBool, diags).
-// isBool is true when the expression evaluated to a boolean (true→1, false→0),
-// which suppresses the numeric index suffix on resource names.
-// Returns (1, false, nil) if expr is nil (no count specified).
-func (e *Evaluator) EvaluateCount(expr hcl.Expression) (int, bool, hcl.Diagnostics) {
+// EvaluateCount evaluates a count expression and returns
+// (count, isBool, unknown, diags). isBool is true when the expression
+// evaluated to a boolean (true→1, false→0), which suppresses the numeric
+// index suffix on resource names. unknown is true when the expression reads
+// values the current operation has not yet produced, so the number of
+// instances cannot be determined.
+// Returns (1, false, false, nil) if expr is nil (no count specified).
+func (e *Evaluator) EvaluateCount(expr hcl.Expression) (int, bool, bool, hcl.Diagnostics) {
 	if expr == nil {
-		return 1, false, nil
+		return 1, false, false, nil
 	}
 
 	val, diags := e.Evaluate(expr)
 	if diags.HasErrors() {
-		return 0, false, diags
+		return 0, false, false, diags
 	}
 
 	if val.HasMark(SensitiveMark) {
-		return 0, false, hcl.Diagnostics{SensitiveArgumentDiagnostic("count", expr)}
+		return 0, false, false, hcl.Diagnostics{SensitiveArgumentDiagnostic("count", expr)}
 	}
 
 	// Count never flows into deps, so drop marks; AsBigFloat / True panic on them.
 	val, _ = val.Unmark()
 
+	if !val.IsKnown() {
+		return 0, false, true, nil
+	}
+
 	if val.Type() == cty.Bool {
 		if val.True() {
-			return 1, true, nil
+			return 1, true, false, nil
 		}
-		return 0, true, nil
+		return 0, true, false, nil
 	}
 
 	converted, err := convert.Convert(val, cty.Number)
 	if err != nil {
-		return 0, false, hcl.Diagnostics{{
+		return 0, false, false, hcl.Diagnostics{{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid count value",
 			Detail:   fmt.Sprintf("Count must be a number or boolean, got %s.", val.Type().FriendlyName()),
@@ -163,7 +170,7 @@ func (e *Evaluator) EvaluateCount(expr hcl.Expression) (int, bool, hcl.Diagnosti
 	count := int(i64)
 
 	if count < 0 {
-		return 0, false, hcl.Diagnostics{{
+		return 0, false, false, hcl.Diagnostics{{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid count value",
 			Detail:   "Count must be a non-negative integer.",
@@ -171,28 +178,37 @@ func (e *Evaluator) EvaluateCount(expr hcl.Expression) (int, bool, hcl.Diagnosti
 		}}
 	}
 
-	return count, false, nil
+	return count, false, false, nil
 }
 
-// EvaluateForEach evaluates a for_each expression and returns the map/set of values.
-// Returns nil if expr is nil (no for_each specified).
-func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (map[string]cty.Value, hcl.Diagnostics) {
+// EvaluateForEach evaluates a for_each expression and returns
+// (result, unknown, diags). unknown is true when the collection — or, for a
+// set, any of its elements, since those become instance keys — reads values
+// the current operation has not yet produced, so the instances cannot be
+// enumerated. Map and object values may be unknown as long as their keys are
+// known.
+// Returns a nil map if expr is nil (no for_each specified).
+func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (map[string]cty.Value, bool, hcl.Diagnostics) {
 	if expr == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	val, diags := e.Evaluate(expr)
 	if diags.HasErrors() {
-		return nil, diags
+		return nil, false, diags
 	}
 
 	if val.HasMark(SensitiveMark) {
-		return nil, hcl.Diagnostics{SensitiveArgumentDiagnostic("for_each", expr)}
+		return nil, false, hcl.Diagnostics{SensitiveArgumentDiagnostic("for_each", expr)}
 	}
 
 	// Unmark only the container — per-element DepMarks must survive on the
 	// values stored in result so each.value carries deps into the body.
 	val, _ = val.Unmark()
+
+	if !val.IsKnown() {
+		return nil, true, nil
+	}
 
 	if val.IsNull() {
 		diags = append(diags, &hcl.Diagnostic{
@@ -201,7 +217,7 @@ func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (map[string]cty.Value, 
 			Detail:   "for_each cannot be null.",
 			Subject:  expr.Range().Ptr(),
 		})
-		return nil, diags
+		return nil, false, diags
 	}
 
 	ty := val.Type()
@@ -224,7 +240,10 @@ func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (map[string]cty.Value, 
 				Detail:   "for_each set must contain strings.",
 				Subject:  expr.Range().Ptr(),
 			})
-			return nil, diags
+			return nil, false, diags
+		}
+		if !val.IsWhollyKnown() {
+			return nil, true, nil
 		}
 		for it := val.ElementIterator(); it.Next(); {
 			_, v := it.Element()
@@ -238,10 +257,10 @@ func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (map[string]cty.Value, 
 			Detail:   fmt.Sprintf("for_each must be a map or set, not %s.", ty.FriendlyName()),
 			Subject:  expr.Range().Ptr(),
 		})
-		return nil, diags
+		return nil, false, diags
 	}
 
-	return result, diags
+	return result, false, diags
 }
 
 // GetReferencedVariables returns all variables referenced by an expression.

--- a/pkg/hcl/eval/evaluator_test.go
+++ b/pkg/hcl/eval/evaluator_test.go
@@ -67,6 +67,7 @@ func TestEvaluateCount(t *testing.T) {
 	ctx, err := NewContext("/tmp", "/tmp", "/tmp", "", "", "")
 	require.NoError(t, err)
 	ctx.SetVariable("instance_count", cty.NumberIntVal(3))
+	ctx.SetVariable("unknown_count", cty.UnknownVal(cty.Number))
 
 	eval := NewEvaluator(ctx)
 
@@ -75,21 +76,23 @@ func TestEvaluateCount(t *testing.T) {
 		expr      string
 		expected  int
 		isBool    bool
+		unknown   bool
 		expectErr bool
 	}{
-		{"literal", `3`, 3, false, false},
-		{"variable", `var.instance_count`, 3, false, false},
-		{"zero", `0`, 0, false, false},
-		{"negative", `-1`, 0, false, true},
-		{"bool_true", `true`, 1, true, false},
-		{"bool_false", `false`, 0, true, false},
+		{"literal", `3`, 3, false, false, false},
+		{"variable", `var.instance_count`, 3, false, false, false},
+		{"zero", `0`, 0, false, false, false},
+		{"negative", `-1`, 0, false, false, true},
+		{"bool_true", `true`, 1, true, false, false},
+		{"bool_false", `false`, 0, true, false, false},
+		{"unknown", `var.unknown_count`, 0, false, true, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			expr := parseExpr(t, tt.expr)
-			result, isBool, diags := eval.EvaluateCount(expr)
+			result, isBool, unknown, diags := eval.EvaluateCount(expr)
 			if tt.expectErr {
 				if !diags.HasErrors() {
 					t.Error("Expected error, got none")
@@ -103,6 +106,9 @@ func TestEvaluateCount(t *testing.T) {
 				}
 				if isBool != tt.isBool {
 					t.Errorf("Expected isBool=%v, got %v", tt.isBool, isBool)
+				}
+				if unknown != tt.unknown {
+					t.Errorf("Expected unknown=%v, got %v", tt.unknown, unknown)
 				}
 			}
 		})
@@ -120,10 +126,11 @@ func TestEvaluateCount_MarkedKnownValue(t *testing.T) {
 	))
 	eval := NewEvaluator(ctx)
 
-	result, isBool, diags := eval.EvaluateCount(parseExpr(t, `var.n`))
+	result, isBool, unknown, diags := eval.EvaluateCount(parseExpr(t, `var.n`))
 	require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
 	assert.Equal(t, 3, result)
 	assert.False(t, isBool)
+	assert.False(t, unknown)
 }
 
 // ElementIterator panics on marked containers; a non-sensitive mark must
@@ -137,8 +144,9 @@ func TestEvaluateForEach_MarkedContainer(t *testing.T) {
 	}).WithMarks(cty.NewValueMarks(DepMark("urn:pulumi:dev::p::aws:ec2/vpc:Vpc::test"))))
 	eval := NewEvaluator(ctx)
 
-	result, diags := eval.EvaluateForEach(parseExpr(t, `var.m`))
+	result, unknown, diags := eval.EvaluateForEach(parseExpr(t, `var.m`))
 	require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
+	assert.False(t, unknown)
 	assert.Equal(t, map[string]cty.Value{
 		"primary": cty.StringVal("p"),
 	}, result)
@@ -150,7 +158,7 @@ func TestEvaluateCountNil(t *testing.T) {
 	require.NoError(t, err)
 	eval := NewEvaluator(ctx)
 
-	result, isBool, diags := eval.EvaluateCount(nil)
+	result, isBool, unknown, diags := eval.EvaluateCount(nil)
 	if diags.HasErrors() {
 		t.Errorf("Unexpected error: %s", diags.Error())
 	}
@@ -159,6 +167,9 @@ func TestEvaluateCountNil(t *testing.T) {
 	}
 	if isBool {
 		t.Error("Expected isBool=false for nil count")
+	}
+	if unknown {
+		t.Error("Expected unknown=false for nil count")
 	}
 }
 
@@ -171,10 +182,11 @@ func TestEvaluateForEach(t *testing.T) {
 	t.Run("map", func(t *testing.T) {
 		t.Parallel()
 		expr := parseExpr(t, `{a = "x", b = "y"}`)
-		result, diags := eval.EvaluateForEach(expr)
+		result, unknown, diags := eval.EvaluateForEach(expr)
 		if diags.HasErrors() {
 			t.Errorf("Unexpected error: %s", diags.Error())
 		}
+		assert.False(t, unknown)
 		if len(result) != 2 {
 			t.Errorf("Expected 2 elements, got %d", len(result))
 		}
@@ -186,10 +198,11 @@ func TestEvaluateForEach(t *testing.T) {
 	t.Run("set of strings", func(t *testing.T) {
 		t.Parallel()
 		expr := parseExpr(t, `toset(["a", "b", "c"])`)
-		result, diags := eval.EvaluateForEach(expr)
+		result, unknown, diags := eval.EvaluateForEach(expr)
 		if diags.HasErrors() {
 			t.Errorf("Unexpected error: %s", diags.Error())
 		}
+		assert.False(t, unknown)
 		if len(result) != 3 {
 			t.Errorf("Expected 3 elements, got %d", len(result))
 		}
@@ -197,10 +210,11 @@ func TestEvaluateForEach(t *testing.T) {
 
 	t.Run("nil returns nil", func(t *testing.T) {
 		t.Parallel()
-		result, diags := eval.EvaluateForEach(nil)
+		result, unknown, diags := eval.EvaluateForEach(nil)
 		if diags.HasErrors() {
 			t.Errorf("Unexpected error: %s", diags.Error())
 		}
+		assert.False(t, unknown)
 		if result != nil {
 			t.Errorf("Expected nil, got %v", result)
 		}
@@ -209,10 +223,34 @@ func TestEvaluateForEach(t *testing.T) {
 	t.Run("list rejected", func(t *testing.T) {
 		t.Parallel()
 		expr := parseExpr(t, `["a", "b"]`)
-		_, diags := eval.EvaluateForEach(expr)
+		_, _, diags := eval.EvaluateForEach(expr)
 		if !diags.HasErrors() {
 			t.Error("Expected error for list for_each, got none")
 		}
+	})
+
+	t.Run("unknown container", func(t *testing.T) {
+		t.Parallel()
+		unknownCtx, err := NewContext("/tmp", "/tmp", "/tmp", "", "", "")
+		require.NoError(t, err)
+		unknownCtx.SetVariable("m", cty.UnknownVal(cty.Map(cty.String)))
+
+		result, unknown, diags := NewEvaluator(unknownCtx).EvaluateForEach(parseExpr(t, `var.m`))
+		require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
+		assert.True(t, unknown)
+		assert.Nil(t, result)
+	})
+
+	t.Run("set with unknown element", func(t *testing.T) {
+		t.Parallel()
+		unknownCtx, err := NewContext("/tmp", "/tmp", "/tmp", "", "", "")
+		require.NoError(t, err)
+		unknownCtx.SetVariable("s", cty.UnknownVal(cty.String))
+
+		result, unknown, diags := NewEvaluator(unknownCtx).EvaluateForEach(parseExpr(t, `toset([var.s, "known"])`))
+		require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
+		assert.True(t, unknown)
+		assert.Nil(t, result)
 	})
 }
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1200,24 +1200,48 @@ func (e *Engine) processResourceInContext(
 
 	expander := graph.NewResourceExpander()
 
+	unknownArg := ""
 	if res.Count != nil {
-		count, isBool, diags := tempEvaluator.EvaluateCount(res.Count)
+		count, isBool, unknown, diags := tempEvaluator.EvaluateCount(res.Count)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating count: %s", diags.Error())
 		}
-		if isBool {
+		switch {
+		case unknown:
+			unknownArg = "count"
+		case isBool:
 			expander.SetBoolCount(node.Key, count)
-		} else {
+		default:
 			expander.SetCount(node.Key, count)
 		}
 	}
 
 	if res.ForEach != nil {
-		forEach, diags := tempEvaluator.EvaluateForEach(res.ForEach)
+		forEach, unknown, diags := tempEvaluator.EvaluateForEach(res.ForEach)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating for_each: %s", diags.Error())
 		}
-		expander.SetForEach(node.Key, forEach)
+		if unknown {
+			unknownArg = "for_each"
+		} else {
+			expander.SetForEach(node.Key, forEach)
+		}
+	}
+
+	// A count/for_each that reads values this operation has not yet produced
+	// cannot be expanded. During preview, register no instances and bind the
+	// resource address to unknown so downstream references resolve to unknown
+	// rather than an empty collection.
+	if unknownArg != "" {
+		if !e.dryRun {
+			return fmt.Errorf("%s: the %s value depends on values that are not yet known", node.Key, unknownArg)
+		}
+		baseKey := node.Key
+		if node.ModuleInfo != nil {
+			baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix())
+		}
+		evalCtx.SetResource(baseKey, "", cty.UnknownVal(cty.DynamicPseudoType))
+		return nil
 	}
 
 	result := expander.Expand(node)
@@ -2602,24 +2626,42 @@ func (e *Engine) processRangedDataSource(
 	tempEvaluator := eval.NewEvaluator(evalCtx)
 	expander := graph.NewResourceExpander()
 
+	unknownArg := ""
 	if ds.Count != nil {
-		count, isBool, diags := tempEvaluator.EvaluateCount(ds.Count)
+		count, isBool, unknown, diags := tempEvaluator.EvaluateCount(ds.Count)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating count: %s", diags.Error())
 		}
-		if isBool {
+		switch {
+		case unknown:
+			unknownArg = "count"
+		case isBool:
 			expander.SetBoolCount(node.Key, count)
-		} else {
+		default:
 			expander.SetCount(node.Key, count)
 		}
 	}
 
 	if ds.ForEach != nil {
-		forEach, diags := tempEvaluator.EvaluateForEach(ds.ForEach)
+		forEach, unknown, diags := tempEvaluator.EvaluateForEach(ds.ForEach)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating for_each: %s", diags.Error())
 		}
-		expander.SetForEach(node.Key, forEach)
+		if unknown {
+			unknownArg = "for_each"
+		} else {
+			expander.SetForEach(node.Key, forEach)
+		}
+	}
+
+	// See the matching case in processResourceInContext: unexpandable during
+	// preview means no invokes and an unknown aggregate value.
+	if unknownArg != "" {
+		if !e.dryRun {
+			return fmt.Errorf("%s: the %s value depends on values that are not yet known", node.Key, unknownArg)
+		}
+		evalCtx.SetDataSource(dsKey, cty.UnknownVal(cty.DynamicPseudoType))
+		return nil
 	}
 
 	result := expander.Expand(node)
@@ -3279,9 +3321,14 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 	}
 
 	if mod.Count != nil {
-		count, _, diags := eval.NewEvaluator(parentEvalCtx).EvaluateCount(mod.Count)
+		count, _, unknown, diags := eval.NewEvaluator(parentEvalCtx).EvaluateCount(mod.Count)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating module count: %s", diags.Error())
+		}
+		if unknown {
+			// TODO: support unknown module expansion during preview the way
+			// resources do (register no instances, bind outputs to unknown).
+			return fmt.Errorf("%s: the count value depends on values that are not yet known", node.Key)
 		}
 		var instances []*moduleInstance
 		for idx := range count {
@@ -3312,9 +3359,14 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 		return nil
 	}
 
-	forEach, diags := eval.NewEvaluator(parentEvalCtx).EvaluateForEach(mod.ForEach)
+	forEach, unknown, diags := eval.NewEvaluator(parentEvalCtx).EvaluateForEach(mod.ForEach)
 	if diags.HasErrors() {
 		return fmt.Errorf("evaluating module for_each: %s", diags.Error())
+	}
+	if unknown {
+		// TODO: support unknown module expansion during preview the way
+		// resources do (register no instances, bind outputs to unknown).
+		return fmt.Errorf("%s: the for_each value depends on values that are not yet known", node.Key)
 	}
 
 	var instances []*moduleInstance

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -3994,3 +3994,246 @@ module "child" {
 	assert.Equal(t, rootRef, childResource.Provider,
 		"a child resource with no provider block must inherit the root default provider")
 }
+
+// runExpansion executes src against a monitor whose provider-computed
+// attributes are unknown during preview and concrete during up: a resource's
+// id is unknown / "<name>-id", and its `num` attribute (output-only in the
+// schema) is unknown / 2.
+func runExpansion(t *testing.T, src string, dryRun bool) *testutil.MockResourceMonitor {
+	t.Helper()
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", []byte(src))
+	require.Empty(t, diags)
+
+	num := property.New(property.Computed)
+	if !dryRun {
+		num = property.New(2.0)
+	}
+	mock := &testutil.MockResourceMonitor{
+		DryRun: dryRun,
+		RegisterResourceHandler: func(
+			_ context.Context, req run.RegisterResourceRequest,
+		) (*run.RegisterResourceResponse, error) {
+			id := "" // unknown id during preview
+			if !dryRun {
+				id = req.Name + "-id"
+			}
+			return &run.RegisterResourceResponse{
+				URN:     urn.URN("urn:pulumi:test::project::" + req.Type + "::" + req.Name),
+				ID:      id,
+				Outputs: req.Inputs.Set("num", num),
+			}, nil
+		},
+	}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		DryRun:          dryRun,
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "aws",
+			Resources: map[string]schema.ResourceSpec{
+				"aws:index:Instance": {
+					InputProperties: map[string]schema.PropertySpec{
+						"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"num": {TypeSpec: schema.TypeSpec{Type: "number"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+	require.NoError(t, engine.Run(t.Context()))
+	return mock
+}
+
+// instanceInputs maps every registered aws:index:Instance name to its ami
+// input, giving one comparable view of which instances an operation produced.
+func instanceInputs(mock *testutil.MockResourceMonitor) map[string]string {
+	got := map[string]string{}
+	for _, r := range mock.RegisteredResources {
+		if r.Type == "aws:index:Instance" {
+			got[r.Name] = r.Inputs.Get("ami").AsString()
+		}
+	}
+	return got
+}
+
+// requireComputedOutput asserts that a stack output resolved to unknown
+// during preview — present and computed, rather than an error, an empty
+// collection, or missing.
+func requireComputedOutput(t *testing.T, mock *testutil.MockResourceMonitor, name string) {
+	t.Helper()
+	out, ok := mock.StackOutputs.GetOk(name)
+	require.Truef(t, ok, "expected %q stack output to be registered", name)
+	assert.Truef(t, out.IsComputed(), "expected %q stack output to be unknown, got %v", name, out)
+}
+
+func TestEngine_ForEachFromResourceOutput(t *testing.T) {
+	t.Parallel()
+
+	// The dependent resource's instance keys derive from ids the provider
+	// generates at create time, so the for_each collection is unknown during
+	// preview. Terraform rejects this program at plan time; we instead defer:
+	// preview omits the instances it cannot enumerate yet and up creates them.
+	src := `
+resource "aws_instance" "base" {
+  count = 2
+  ami   = "ami-${count.index}"
+}
+
+resource "aws_instance" "dependent" {
+  for_each = toset(aws_instance.base[*].id)
+  ami      = each.value
+}
+
+output "amis" {
+  value = [for k, r in aws_instance.dependent : r.ami]
+}
+`
+
+	t.Run("preview", func(t *testing.T) {
+		t.Parallel()
+		mock := runExpansion(t, src, true)
+
+		assert.Equal(t, map[string]string{
+			"base-0": "ami-0",
+			"base-1": "ami-1",
+		}, instanceInputs(mock))
+
+		requireComputedOutput(t, mock, "amis")
+	})
+
+	t.Run("up", func(t *testing.T) {
+		t.Parallel()
+		mock := runExpansion(t, src, false)
+
+		assert.Equal(t, map[string]string{
+			"base-0":              "ami-0",
+			"base-1":              "ami-1",
+			"dependent-base-0-id": "base-0-id",
+			"dependent-base-1-id": "base-1-id",
+		}, instanceInputs(mock))
+
+		assert.Equal(t, property.New([]property.Value{
+			property.New("base-0-id"),
+			property.New("base-1-id"),
+		}), mock.StackOutputs.Get("amis"))
+	})
+}
+
+func TestEngine_CountFromResourceOutput(t *testing.T) {
+	t.Parallel()
+
+	// The dependent resource's count reads a provider-computed number, so it
+	// is unknown during preview.
+	src := `
+resource "aws_instance" "base" {
+  ami = "ami-base"
+}
+
+resource "aws_instance" "dependent" {
+  count = aws_instance.base.num
+  ami   = "ami-${count.index}"
+}
+
+output "amis" {
+  value = aws_instance.dependent[*].ami
+}
+`
+
+	t.Run("preview", func(t *testing.T) {
+		t.Parallel()
+		mock := runExpansion(t, src, true)
+
+		assert.Equal(t, map[string]string{
+			"base": "ami-base",
+		}, instanceInputs(mock))
+
+		requireComputedOutput(t, mock, "amis")
+	})
+
+	t.Run("up", func(t *testing.T) {
+		t.Parallel()
+		mock := runExpansion(t, src, false)
+
+		assert.Equal(t, map[string]string{
+			"base":        "ami-base",
+			"dependent-0": "ami-0",
+			"dependent-1": "ami-1",
+		}, instanceInputs(mock))
+
+		assert.Equal(t, property.New([]property.Value{
+			property.New("ami-0"),
+			property.New("ami-1"),
+		}), mock.StackOutputs.Get("amis"))
+	})
+}
+
+func TestEngine_ChainedExpansionFromResourceOutput(t *testing.T) {
+	t.Parallel()
+
+	// Unknowns chain through successive expansions: second's count reads a
+	// computed attribute of a for_each instance of first, and third's for_each
+	// reads the generated ids of the count instances of second. During preview
+	// nothing past first can be enumerated; up must expand the whole chain.
+	src := `
+resource "aws_instance" "first" {
+  for_each = toset(["a", "b"])
+  ami      = "ami-${each.key}"
+}
+
+resource "aws_instance" "second" {
+  count = aws_instance.first["a"].num
+  ami   = aws_instance.first["a"].id
+}
+
+resource "aws_instance" "third" {
+  for_each = toset(aws_instance.second[*].id)
+  ami      = each.value
+}
+
+output "amis" {
+  value = [for k, r in aws_instance.third : r.ami]
+}
+`
+
+	t.Run("preview", func(t *testing.T) {
+		t.Parallel()
+		mock := runExpansion(t, src, true)
+
+		assert.Equal(t, map[string]string{
+			"first-a": "ami-a",
+			"first-b": "ami-b",
+		}, instanceInputs(mock))
+
+		requireComputedOutput(t, mock, "amis")
+	})
+
+	t.Run("up", func(t *testing.T) {
+		t.Parallel()
+		mock := runExpansion(t, src, false)
+
+		assert.Equal(t, map[string]string{
+			"first-a":           "ami-a",
+			"first-b":           "ami-b",
+			"second-0":          "first-a-id",
+			"second-1":          "first-a-id",
+			"third-second-0-id": "second-0-id",
+			"third-second-1-id": "second-1-id",
+		}, instanceInputs(mock))
+
+		assert.Equal(t, property.New([]property.Value{
+			property.New("second-0-id"),
+			property.New("second-1-id"),
+		}), mock.StackOutputs.Get("amis"))
+	})
+}

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -4001,13 +4001,24 @@ module "child" {
 // schema) is unknown / 2.
 func runExpansion(t *testing.T, src string, dryRun bool) *testutil.MockResourceMonitor {
 	t.Helper()
+	mock, err := tryExpansion(t, src, dryRun, dryRun)
+	require.NoError(t, err)
+	return mock
+}
+
+// tryExpansion is runExpansion with the error surfaced and provider-computed
+// attributes controlled independently of dryRun: unknownOutputs=true with
+// dryRun=false models an apply whose dependency outputs never resolved (e.g.
+// a --target update that skipped the dependency).
+func tryExpansion(t *testing.T, src string, dryRun, unknownOutputs bool) (*testutil.MockResourceMonitor, error) {
+	t.Helper()
 
 	p := parser.NewParser()
 	config, diags := p.ParseSource("test.hcl", []byte(src))
 	require.Empty(t, diags)
 
 	num := property.New(property.Computed)
-	if !dryRun {
+	if !unknownOutputs {
 		num = property.New(2.0)
 	}
 	mock := &testutil.MockResourceMonitor{
@@ -4015,8 +4026,8 @@ func runExpansion(t *testing.T, src string, dryRun bool) *testutil.MockResourceM
 		RegisterResourceHandler: func(
 			_ context.Context, req run.RegisterResourceRequest,
 		) (*run.RegisterResourceResponse, error) {
-			id := "" // unknown id during preview
-			if !dryRun {
+			id := "" // unknown id
+			if !unknownOutputs {
 				id = req.Name + "-id"
 			}
 			return &run.RegisterResourceResponse{
@@ -4024,6 +4035,11 @@ func runExpansion(t *testing.T, src string, dryRun bool) *testutil.MockResourceM
 				ID:      id,
 				Outputs: req.Inputs.Set("num", num),
 			}, nil
+		},
+		InvokeHandler: func(_ context.Context, req run.InvokeRequest) (*run.InvokeResponse, error) {
+			return &run.InvokeResponse{Return: property.NewMap(map[string]property.Value{
+				"result": property.New("result-" + req.Args.Get("filter").AsString()),
+			})}, nil
 		},
 	}
 	engine := newTestEngine(t, config, &run.EngineOptions{
@@ -4049,10 +4065,23 @@ func runExpansion(t *testing.T, src string, dryRun bool) *testutil.MockResourceM
 					},
 				},
 			},
+			Functions: map[string]schema.FunctionSpec{
+				"aws:index:getInstance": {
+					Inputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"filter": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+					Outputs: &schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
 		}),
 	})
-	require.NoError(t, engine.Run(t.Context()))
-	return mock
+	return mock, engine.Run(t.Context())
 }
 
 // instanceInputs maps every registered aws:index:Instance name to its ami
@@ -4235,5 +4264,98 @@ output "amis" {
 			property.New("second-0-id"),
 			property.New("second-1-id"),
 		}), mock.StackOutputs.Get("amis"))
+	})
+}
+
+func TestEngine_DataSourceForEachFromResourceOutput(t *testing.T) {
+	t.Parallel()
+
+	// A data source whose for_each reads a generated id must not be invoked
+	// during preview; its aggregate value resolves to unknown instead.
+	src := `
+resource "aws_instance" "base" {
+  ami = "ami-base"
+}
+
+data "aws_instance" "dependent" {
+  for_each = toset([aws_instance.base.id])
+  filter   = each.value
+}
+
+output "results" {
+  value = [for k, d in data.aws_instance.dependent : d.result]
+}
+`
+
+	t.Run("preview", func(t *testing.T) {
+		t.Parallel()
+		mock := runExpansion(t, src, true)
+
+		assert.Empty(t, mock.InvokedFunctions)
+		requireComputedOutput(t, mock, "results")
+	})
+
+	t.Run("up", func(t *testing.T) {
+		t.Parallel()
+		mock := runExpansion(t, src, false)
+
+		require.Len(t, mock.InvokedFunctions, 1)
+		assert.Equal(t, "base-id", mock.InvokedFunctions[0].Args.Get("filter").AsString())
+
+		assert.Equal(t, property.New([]property.Value{
+			property.New("result-base-id"),
+		}), mock.StackOutputs.Get("results"))
+	})
+}
+
+func TestEngine_ExpansionUnknownDuringApply(t *testing.T) {
+	t.Parallel()
+
+	// During apply an unknown count/for_each can only mean a dependency's
+	// outputs never resolved (e.g. a --target update that skipped it); that
+	// must be an error, not a silent expansion to zero instances.
+	t.Run("count", func(t *testing.T) {
+		t.Parallel()
+		_, err := tryExpansion(t, `
+resource "aws_instance" "base" {
+  ami = "ami-base"
+}
+
+resource "aws_instance" "dependent" {
+  count = aws_instance.base.num
+  ami   = "ami-${count.index}"
+}
+`, false, true)
+		require.ErrorContains(t, err, "the count value depends on values that are not yet known")
+	})
+
+	t.Run("for_each", func(t *testing.T) {
+		t.Parallel()
+		_, err := tryExpansion(t, `
+resource "aws_instance" "base" {
+  ami = "ami-base"
+}
+
+resource "aws_instance" "dependent" {
+  for_each = toset([tostring(aws_instance.base.num)])
+  ami      = each.value
+}
+`, false, true)
+		require.ErrorContains(t, err, "the for_each value depends on values that are not yet known")
+	})
+
+	t.Run("data source", func(t *testing.T) {
+		t.Parallel()
+		_, err := tryExpansion(t, `
+resource "aws_instance" "base" {
+  ami = "ami-base"
+}
+
+data "aws_instance" "dependent" {
+  for_each = toset([tostring(aws_instance.base.num)])
+  filter   = each.value
+}
+`, false, true)
+		require.ErrorContains(t, err, "the for_each value depends on values that are not yet known")
 	})
 }


### PR DESCRIPTION
## Problem

A `count` or `for_each` that reads a value the current operation has not yet produced — for example, another resource's generated id:

```hcl
resource "random_pet" "first" {
  count = 2
}

resource "random_pet" "second" {
  for_each = toset(random_pet.first[*].id)
  prefix   = each.value
}
```

panicked during preview (and therefore during a default `pulumi up`):

```
panic: panic in DAG processing: value is unknown
    github.com/zclconf/go-cty/cty.Value.AsString
    .../pkg/hcl/eval.(*Evaluator).EvaluateForEach
```

Terraform rejects such programs outright at plan time ("The \"for_each\" value depends on resource attributes that cannot be determined until apply"). Our runtime model does not need to: the graph walk already defers each node until its dependencies have registered, so at apply time the values are concrete and the expansion works. Only the preview path was broken.

## Fix

- `EvaluateCount` / `EvaluateForEach` report an unknown result instead of panicking. For `for_each`, the collection and set elements must be known (they become instance keys); map/object values may remain unknown, matching the rule Terraform applies when it can plan such values.
- During preview, a resource or data source with an unknown expansion registers no instances and binds its address to unknown, so downstream references — chained expansions, splats, stack outputs — resolve to unknown rather than an empty collection. This mirrors how the SDK languages preview resources created inside an unresolved `apply`.
- During apply, an unknown expansion is a clear error; it can only occur there when a dependency was skipped (e.g. `--target`).
- Module expansion with an unknown `count`/`for_each` now fails with a clear error instead of panicking; full unknown-module support needs the module-output plumbing and is left as a TODO.

## Testing

- New engine tests cover `for_each` from a resource output, `count` from a resource output, and a chained expansion (`for_each` over ids of `count` instances whose count reads a computed attribute of a `for_each` instance), each asserting the preview registers only the enumerable instances with unknown stack outputs and that up expands the full chain.
- Unit coverage for the new unknown results in `EvaluateCount`/`EvaluateForEach`.
- Verified end-to-end: the program above previously panicked at `pulumi preview` and now previews with `names: [unknown]` and applies cleanly with a default `pulumi up`.