### PR TITLE
Fix typo in registry _index.md meta description

### DIFF
--- a/registry/_index.md
+++ b/registry/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Any HCL Module
-meta_desc: Instantiate any Terraform or OpenTofu module as a Pulumi Component Rgesource
+meta_desc: Instantiate any Terraform or OpenTofu module as a Pulumi component resource
 layout: package
 ---
 


### PR DESCRIPTION
Fixes the front-matter meta description typo: "Component Rgesource" → "component resource".

While verifying the v0.9.1 release, every code example in `registry/_index.md` was checked against the published SDKs:

- **TypeScript**: `@pulumi-labs/hcl@0.9.1` from npm; the example typechecks under `tsc --strict`.
- **Python**: `pulumi_labs_hcl==0.9.1` from PyPI; `Module(source=, version=, inputs=)` and the `outputs` property exist as documented.
- **Go**: `github.com/pulumi-labs/pulumi-hcl/sdk/go@v0.9.1`; the example compiles as written.
- **C#**: the example compiles against `Pulumi.Labs.Hcl.0.9.1.nupkg` packed from the `sdk-releases` branch (nuget.org does not serve the package yet — see below).
- **YAML**: `hcl:index:Module` matches the resource token in `registry/schema.json`.

The examples are all accurate; this typo is the only correction.

Note: nuget.org returns 409 Conflict for `Pulumi.Labs.Hcl 0.9.1` pushes but does not serve the package on any feed, and no workflow attempt ever completed an upload (attempts 1–7 failed before the push step). The version slot appears to have been claimed by a manual upload that is still in (or failed) nuget.org validation. That is not addressable in this repository.