### PR TITLE
Forward invoke routing fields through the construct-mode monitor

### DIFF
--- a/.changes/unreleased/resource-host-bug-fixes-325.yaml
+++ b/.changes/unreleased/resource-host-bug-fixes-325.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Forward provider routing fields (package ref, provider, version) on data source invokes inside modules run via a direct `hcl.Module`, fixing "Invoke not found" errors
+time: 2026-07-08T10:29:55Z
+custom:
+    Component: resource-host
+    PR: "325"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/apparentlymart/go-shquot v0.0.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bmatcuk/doublestar/v4 v4.6.0
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-getter v1.8.6
@@ -158,7 +159,6 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect

--- a/pkg/server/construct_monitor_test.go
+++ b/pkg/server/construct_monitor_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/run"
+)
+
+// routingCaptureMonitorServer records the raw Invoke/Call requests so tests can
+// assert on exactly what the construct-mode monitor forwards to the engine.
+type routingCaptureMonitorServer struct {
+	pulumirpc.UnimplementedResourceMonitorServer
+	invokeReq *pulumirpc.ResourceInvokeRequest
+	callReq   *pulumirpc.ResourceCallRequest
+}
+
+func (s *routingCaptureMonitorServer) Invoke(
+	_ context.Context, req *pulumirpc.ResourceInvokeRequest,
+) (*pulumirpc.InvokeResponse, error) {
+	s.invokeReq = req
+	return &pulumirpc.InvokeResponse{}, nil
+}
+
+func (s *routingCaptureMonitorServer) Call(
+	_ context.Context, req *pulumirpc.ResourceCallRequest,
+) (*pulumirpc.CallResponse, error) {
+	s.callReq = req
+	return &pulumirpc.CallResponse{}, nil
+}
+
+// TestConstructMonitorForwardsInvokeRouting guards against the construct-mode
+// monitor dropping provider-routing fields from data-source invokes. Without
+// PackageRef the engine resolves dynamically-bridged tokens (e.g.
+// aws:index/getIamPolicyDocument) against the default provider for the package
+// name, which does not serve them, and module execution fails with "Invoke not
+// found".
+func TestConstructMonitorForwardsInvokeRouting(t *testing.T) {
+	t.Parallel()
+
+	capture := &routingCaptureMonitorServer{}
+	m := newTestConstructMonitor(t, capture)
+
+	_, err := m.Invoke(t.Context(), run.InvokeRequest{
+		Token:             "aws:index/getIamPolicyDocument:getIamPolicyDocument",
+		Args:              property.NewMap(map[string]property.Value{"name": property.New("x")}),
+		Provider:          "urn:pulumi:test::proj::pulumi:providers:aws::default::uuid",
+		Version:           "1.2.3",
+		PluginDownloadURL: "https://example.com/download",
+		PackageRef:        "package-ref-uuid",
+	})
+	require.NoError(t, err)
+
+	args, err := structpb.NewStruct(map[string]any{"name": "x"})
+	require.NoError(t, err)
+	assert.Empty(t, cmp.Diff(&pulumirpc.ResourceInvokeRequest{
+		Tok:               "aws:index/getIamPolicyDocument:getIamPolicyDocument",
+		Args:              args,
+		Provider:          "urn:pulumi:test::proj::pulumi:providers:aws::default::uuid",
+		Version:           "1.2.3",
+		PluginDownloadURL: "https://example.com/download",
+		PackageRef:        "package-ref-uuid",
+		AcceptResources:   true,
+	}, capture.invokeReq, protocmp.Transform()))
+}
+
+// TestConstructMonitorForwardsCallRouting is the Call analogue of
+// TestConstructMonitorForwardsInvokeRouting.
+func TestConstructMonitorForwardsCallRouting(t *testing.T) {
+	t.Parallel()
+
+	capture := &routingCaptureMonitorServer{}
+	m := newTestConstructMonitor(t, capture)
+
+	_, err := m.Call(t.Context(), run.CallRequest{
+		Token:      "aws:index:Module/getOutput",
+		Args:       property.NewMap(map[string]property.Value{"name": property.New("x")}),
+		PackageRef: "package-ref-uuid",
+	})
+	require.NoError(t, err)
+
+	args, err := structpb.NewStruct(map[string]any{"name": "x"})
+	require.NoError(t, err)
+	assert.Empty(t, cmp.Diff(&pulumirpc.ResourceCallRequest{
+		Tok:        "aws:index:Module/getOutput",
+		Args:       args,
+		PackageRef: "package-ref-uuid",
+	}, capture.callReq, protocmp.Transform()))
+}
+
+// newTestConstructMonitor serves the given monitor implementation over gRPC and
+// returns a constructResourceMonitor connected to it.
+func newTestConstructMonitor(t *testing.T, srv pulumirpc.ResourceMonitorServer) *constructResourceMonitor {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	grpcServer := grpc.NewServer()
+	pulumirpc.RegisterResourceMonitorServer(grpcServer, srv)
+	go func() { _ = grpcServer.Serve(lis) }()
+	t.Cleanup(grpcServer.Stop)
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return &constructResourceMonitor{client: pulumirpc.NewResourceMonitorClient(conn)}
+}

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -636,9 +636,13 @@ func (m *constructResourceMonitor) Invoke(
 	}
 
 	resp, err := m.client.Invoke(ctx, &pulumirpc.ResourceInvokeRequest{
-		Tok:             req.Token,
-		Args:            argsStruct,
-		AcceptResources: true,
+		Tok:               req.Token,
+		Args:              argsStruct,
+		Provider:          req.Provider,
+		Version:           req.Version,
+		PluginDownloadURL: req.PluginDownloadURL,
+		PackageRef:        string(req.PackageRef),
+		AcceptResources:   true,
 	})
 	if err != nil {
 		return nil, err
@@ -671,8 +675,9 @@ func (m *constructResourceMonitor) Call(
 	}
 
 	resp, err := m.client.Call(ctx, &pulumirpc.ResourceCallRequest{
-		Tok:  req.Token,
-		Args: argsStruct,
+		Tok:        req.Token,
+		Args:       argsStruct,
+		PackageRef: string(req.PackageRef),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("calling method: %w", err)


### PR DESCRIPTION
## Problem

Any data source inside a module run via a direct `hcl.Module` resource failed with:

```
invoking data source: ... invocation of aws:index/getIamPolicyDocument:getIamPolicyDocument returned an error: Invoke 'aws:index/getIamPolicyDocument:getIamPolicyDocument' not found.
```

Reproduced with `terraform-aws-modules/vpc/aws` 5.0.0 and `create_flow_log_cloudwatch_iam_role: true`, whose IAM-role path invokes the `aws_iam_policy_document` data source.

## Root cause

`constructResourceMonitor.Invoke` forwarded only `Tok` and `Args` to the engine, dropping `PackageRef`, `Provider`, `Version`, and `PluginDownloadURL`; `constructResourceMonitor.Call` likewise dropped `PackageRef`. Without a package ref, the engine resolves dynamically-bridged tokens against the default provider for the package name (classic pulumi-aws here), which does not serve them. Program/parameterized mode was unaffected because `resourceMonitorAdapter.Invoke` already forwards all of these fields; resources were unaffected because `RegisterResource` forwards `PackageRef`.

## Fix

Mirror the program-mode adapter in both construct-mode methods.

## Testing

- New regression tests (`TestConstructMonitorForwardsInvokeRouting`, `TestConstructMonitorForwardsCallRouting`) assert the full forwarded request; they fail without the fix.
- Verified end to end with a real `pulumi up` / `pulumi destroy` of the VPC-module repro above (12 resources, including the module-created flow-log IAM role).