### PR TITLE
Standardize tfcompat tests on on-disk case files

### DIFF
--- a/.claude/skills/find-tfcompat-bug/SKILL.md
+++ b/.claude/skills/find-tfcompat-bug/SKILL.md
@@ -130,17 +130,18 @@ including multi-file cases** (e.g. a `templatefile` case ships its `main.tf` *an
 template it reads; `RunCase` loads every file in the directory). The `Case` struct gives
 you more knobs when outputs alone can't show the divergence:
 
-- `Providers` / `Config` — register TF providers / set input variables.
+- `Providers` / `Config` — register TF providers / set input variables. `Config` is the
+  only channel for values not known until runtime (ports, temp paths): declare a variable
+  in the fixture and set it here — never generate program text in Go.
 - `AssertState` — assert on resource fields not reachable via outputs (e.g. `Protect`).
-- `Stages` + `Mode` (`StageApply` / `StagePreview` / `StageDestroy`) — drive preview or
-  destroy, or sequence multiple operations.
-- `Stage.ExpectErr` — require BOTH runtimes to fail with a matching error substring; the
-  way to prove an error-behavior divergence.
-
-Reach for inline `Stages` with a `Files` map **only** when you need something the plain
-disk fixture can't express — an `ExpectErr` assertion, or a multi-stage
-preview/destroy/re-apply sequence. A normal output-comparison case (even one with several
-files) belongs on disk, not inline.
+- `Stages` — per-stage behavior matched positionally against the disk fixture: `Mode`
+  (`StageApply` / `StagePreview` / `StageDestroy`), `ExpectErr` (require BOTH runtimes to
+  fail with a matching error substring — the way to prove an error-behavior divergence),
+  and `AssertOutput`. A `Stage` carries behavior only; program files always come from the
+  case directory. A flat case dir with N `Stages` entries runs the same program N times
+  (e.g. preview then apply); a program that must *change* between stages uses numbered
+  subdirs `testdata/cases/<name>/0/`, `1/`, ... with one `Stages` entry per subdir (or
+  none).
 
 Confirm the bug is real **on master**:
 

--- a/tests/testutil/tfcompat/README.md
+++ b/tests/testutil/tfcompat/README.md
@@ -67,6 +67,12 @@ Requires `tofu` (default) or `terraform` on `PATH`. Override with
 
 ## Writing a new case
 
+Program files always live on disk under the case directory; `Case.Stages`
+carries optional per-stage behavior (mode, expected error, output assertion)
+matched positionally against the disk stages. See
+[`tests/tfcompat/README.md`](../../tfcompat/README.md) for the full case
+layout, staging rules, and how runtime values flow through `Case.Config`.
+
 1. Create `tests/tfcompat/testdata/cases/<case-name>/main.tf` (plus any
    additional `.tf` or auxiliary files).
 2. Add `tests/tfcompat/<case-name>_test.go`:

--- a/tests/testutil/tfcompat/harness.go
+++ b/tests/testutil/tfcompat/harness.go
@@ -24,10 +24,18 @@
 // Recordings are captured by wrapping each *schema.Provider with tfexec.Wrap
 // before either path sees it, so the comparisons are apples-to-apples.
 //
-// A case directory may either be flat (single apply) or contain numbered stage
-// subdirs (0/, 1/, ...) for tests that need to drive multiple applies against
-// the same stack — required when verifying behavior on subsequent changes
-// (e.g. lifecycle.replace_triggered_by).
+// Program files always live on disk under the case directory. A flat
+// directory holds one file set; a directory containing only numbered stage
+// subdirs (0/, 1/, ...) holds one file set per stage, for tests whose program
+// changes between operations. Case.Stages carries optional per-stage behavior
+// (mode, expected error, output assertion) and is matched positionally
+// against the disk stages; a flat directory paired with multiple Stages
+// entries runs the same program once per entry (e.g. preview then apply, or
+// apply then destroy).
+//
+// Values that are only known at runtime (ports, temp paths, credentials) are
+// never spliced into program text; declare a variable in the program and feed
+// it through Case.Config, which reaches both paths identically.
 package tfcompat
 
 import (
@@ -93,14 +101,22 @@ func buildProviders(
 // Case is the test description passed to RunCase.
 type Case struct {
 	Providers []Provider
-	Config    map[string]string
+	// Config is set as stack config on the Pulumi path and passed as -var
+	// flags on the tofu path. It is the only channel for values not known
+	// until runtime: the program declares a variable and the test feeds it
+	// here.
+	Config map[string]string
 
 	// AssertState, if set, runs after `pulumi up`. Use for assertions on
 	// resource fields that aren't reachable via stack outputs (e.g. Protect).
 	AssertState func(t *testing.T, resources []apitype.ResourceV3)
 
-	// Stages, if non-nil, overrides disk-based stage loading. Use this when
-	// you need per-stage expected errors or have inline program content.
+	// Stages attaches per-stage behavior to the stages loaded from disk,
+	// matched positionally. For a case directory with numbered stage subdirs
+	// its length must equal the subdir count. For a flat directory each entry
+	// runs the whole directory's file set, so N entries drive N operations
+	// over the same program. Omitted entries (or a nil Stages) default to a
+	// plain apply.
 	Stages []Stage
 }
 
@@ -112,10 +128,10 @@ const (
 	StageDestroy                  // `tofu destroy` / `pulumi destroy`
 )
 
-// Stage is one operation within a Case.
+// Stage describes how to run one operation of a Case. It carries behavior
+// only; the program files come from the case directory on disk.
 type Stage struct {
-	Files map[string]string
-	Mode  StageMode
+	Mode StageMode
 	// ExpectErr, if non-empty, requires both runtimes to fail with an error
 	// containing this substring.
 	ExpectErr string
@@ -126,26 +142,65 @@ type Stage struct {
 	AssertOutput func(t *testing.T, output string)
 }
 
+// stageRun pairs one stage's program files with its behavior.
+type stageRun struct {
+	files map[string]string
+	Stage
+}
+
 // RunCase resolves testdata/cases/<caseName>/ relative to the calling test
-// file, loads every regular file in that directory, and runs the comparison.
-// If c.Stages is set the disk path is bypassed in favor of inline stages.
+// file, loads its stages, and runs the comparison.
 func RunCase(t *testing.T, caseName string, c Case) {
 	t.Helper()
-
-	if len(c.Stages) > 0 {
-		runCaseStages(t, c)
-		return
-	}
 
 	_, callerFile, _, _ := runtime.Caller(1)
 	caseDir := filepath.Join(filepath.Dir(callerFile), "testdata", "cases", caseName)
 	runCaseFromDir(t, caseDir, c)
 }
 
-// runCaseStages runs inline Case.Stages. Ops/outputs/AssertState are compared
-// against the last successful apply stage; preview stages produce no state.
-func runCaseStages(t *testing.T, c Case) {
+// resolveStages matches Case.Stages positionally against the file sets loaded
+// from disk. A flat case directory (one file set) fans out to max(1, len(meta))
+// stages over the same files; numbered stage dirs require len(meta) to be
+// zero or exactly the dir count.
+func resolveStages(fileSets []map[string]string, numbered bool, meta []Stage) ([]stageRun, error) {
+	if numbered {
+		if len(meta) != 0 && len(meta) != len(fileSets) {
+			return nil, fmt.Errorf(
+				"case has %d numbered stage dirs but Case.Stages has %d entries",
+				len(fileSets), len(meta))
+		}
+		runs := make([]stageRun, len(fileSets))
+		for i, files := range fileSets {
+			runs[i] = stageRun{files: files}
+			if len(meta) != 0 {
+				runs[i].Stage = meta[i]
+			}
+		}
+		return runs, nil
+	}
+
+	runs := make([]stageRun, max(1, len(meta)))
+	for i := range runs {
+		runs[i] = stageRun{files: fileSets[0]}
+		if i < len(meta) {
+			runs[i].Stage = meta[i]
+		}
+	}
+	return runs, nil
+}
+
+// runCaseFromDir runs a case whose program files live in caseDir. Kept
+// separate from RunCase so self-tests can drive the harness with a
+// t.TempDir() rather than an on-disk testdata directory.
+//
+// Ops/outputs/AssertState are compared against the last successful apply
+// stage; preview stages produce no state.
+func runCaseFromDir(t *testing.T, caseDir string, c Case) {
 	t.Helper()
+
+	fileSets, numbered := loadStages(t, caseDir)
+	stages, err := resolveStages(fileSets, numbered, c.Stages)
+	require.NoError(t, err)
 
 	recA, recB := &tfexec.Recorder{}, &tfexec.Recorder{}
 	tfProvs, pulProvs := buildProviders(t, c.Providers, recA, recB)
@@ -155,7 +210,7 @@ func runCaseStages(t *testing.T, c Case) {
 
 	var lastOK pulexec.Result
 	var lastOKTfOutputs map[string]string
-	for i, stage := range c.Stages {
+	for i, stage := range stages {
 		var wg sync.WaitGroup
 		wg.Add(2)
 
@@ -168,22 +223,22 @@ func runCaseStages(t *testing.T, c Case) {
 			defer wg.Done()
 			switch stage.Mode {
 			case StagePreview:
-				tfErr = tfDriver.Plan(t, stage.Files, c.Config)
+				tfErr = tfDriver.Plan(t, stage.files, c.Config)
 			case StageDestroy:
-				tfErr = tfDriver.Destroy(t, stage.Files, c.Config)
+				tfErr = tfDriver.Destroy(t, stage.files, c.Config)
 			default:
-				tfOut, tfText, tfErr = tfDriver.TryApply(t, stage.Files, c.Config)
+				tfOut, tfText, tfErr = tfDriver.TryApply(t, stage.files, c.Config)
 			}
 		}()
 		go func() {
 			defer wg.Done()
 			switch stage.Mode {
 			case StagePreview:
-				pulErr = pulDriver.Preview(t, stage.Files)
+				pulErr = pulDriver.Preview(t, stage.files)
 			case StageDestroy:
-				pulErr = pulDriver.Destroy(t, stage.Files)
+				pulErr = pulDriver.Destroy(t, stage.files)
 			default:
-				pulRes, pulErr = pulDriver.TryApply(t, stage.Files)
+				pulRes, pulErr = pulDriver.TryApply(t, stage.files)
 			}
 		}()
 		wg.Wait()
@@ -234,51 +289,6 @@ func runCaseStages(t *testing.T, c Case) {
 	}
 }
 
-// runCaseFromDir runs a case whose program files live in caseDir. Exposed for
-// self-tests that drive the harness with a t.TempDir() rather than an
-// on-disk testdata directory.
-func runCaseFromDir(t *testing.T, caseDir string, c Case) {
-	t.Helper()
-
-	stages := loadStages(t, caseDir)
-
-	recA, recB := &tfexec.Recorder{}, &tfexec.Recorder{}
-	tfProvs, pulProvs := buildProviders(t, c.Providers, recA, recB)
-
-	tfDriver := tfexec.NewDriver(t, tfProvs)
-	pulDriver := pulexec.NewDriver(t, pulProvs, c.Config)
-
-	var outA map[string]string
-	var pulResult pulexec.Result
-	for i, files := range stages {
-		var wg sync.WaitGroup
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
-			outA = tfDriver.Apply(t, files, c.Config)
-		}()
-		go func() {
-			defer wg.Done()
-			pulResult = pulDriver.Apply(t, files)
-		}()
-		wg.Wait()
-		if t.Failed() {
-			t.Logf("stage %d failed", i)
-			return
-		}
-	}
-
-	require.Equal(t,
-		scrubTmpDir(outA, tfDriver.Dir()),
-		scrubTmpDir(pulResult.Outputs, pulDriver.Dir()),
-		"stack outputs differ between tofu apply and pulumi up")
-	require.Equal(t, recA.Ops(), recB.Ops(), "provider operations differ between tofu apply and pulumi up")
-
-	if c.AssertState != nil {
-		c.AssertState(t, pulResult.Resources)
-	}
-}
-
 // scrubTmpDir replaces driver-specific temp paths in output values with the
 // sentinel "<TMPDIR>" so cross-driver comparison ignores the fact that tofu
 // and pulumi run from different temp directories. Symlink-resolved forms (on
@@ -302,28 +312,29 @@ func scrubTmpDir(outputs map[string]string, dir string) map[string]string {
 	return out
 }
 
-// loadStages returns one entry per apply: a case directory containing only
-// numbered subdirs (0/, 1/, ...) becomes that many stages, in order; any other
-// shape is a single stage built from the whole directory.
-func loadStages(t *testing.T, caseDir string) []map[string]string {
+// loadStages returns one file set per disk stage and whether the case
+// directory used numbered stage subdirs: a directory containing only numbered
+// subdirs (0/, 1/, ...) yields that many file sets, in order; any other shape
+// yields a single file set built from the whole directory.
+func loadStages(t *testing.T, caseDir string) ([]map[string]string, bool) {
 	t.Helper()
-	stages, err := loadStagesFS(caseDir)
+	fileSets, numbered, err := loadStagesFS(caseDir)
 	require.NoError(t, err)
-	return stages
+	return fileSets, numbered
 }
 
-func loadStagesFS(caseDir string) ([]map[string]string, error) {
+func loadStagesFS(caseDir string) ([]map[string]string, bool, error) {
 	info, err := os.Stat(caseDir)
 	if err != nil {
-		return nil, fmt.Errorf("case directory: %w", err)
+		return nil, false, fmt.Errorf("case directory: %w", err)
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("case path %q is not a directory", caseDir)
+		return nil, false, fmt.Errorf("case path %q is not a directory", caseDir)
 	}
 
 	entries, err := os.ReadDir(caseDir)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	stageDirs := make(map[int]string)
@@ -343,9 +354,9 @@ func loadStagesFS(caseDir string) ([]map[string]string, error) {
 	if len(stageDirs) == 0 {
 		files, err := loadCaseFS(caseDir)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
-		return []map[string]string{files}, nil
+		return []map[string]string{files}, false, nil
 	}
 
 	keys := make([]int, 0, len(stageDirs))
@@ -353,15 +364,15 @@ func loadStagesFS(caseDir string) ([]map[string]string, error) {
 		keys = append(keys, k)
 	}
 	sort.Ints(keys)
-	stages := make([]map[string]string, 0, len(keys))
+	fileSets := make([]map[string]string, 0, len(keys))
 	for _, k := range keys {
 		files, err := loadCaseFS(stageDirs[k])
 		if err != nil {
-			return nil, fmt.Errorf("stage %d: %w", k, err)
+			return nil, false, fmt.Errorf("stage %d: %w", k, err)
 		}
-		stages = append(stages, files)
+		fileSets = append(fileSets, files)
 	}
-	return stages, nil
+	return fileSets, true, nil
 }
 
 // loadCaseFS reads every regular file under caseDir and returns a map of

--- a/tests/testutil/tfcompat/loader_test.go
+++ b/tests/testutil/tfcompat/loader_test.go
@@ -23,6 +23,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestResolveStages pins the positional matching between disk-loaded file
+// sets and Case.Stages metadata: a flat directory fans out to one stage per
+// metadata entry (all sharing the same files), numbered stage dirs pair 1:1
+// with metadata, and a count mismatch on numbered dirs is an error.
+func TestResolveStages(t *testing.T) {
+	t.Parallel()
+	a := map[string]string{"main.tf": "a"}
+	b := map[string]string{"main.tf": "b"}
+
+	t.Run("flat default", func(t *testing.T) {
+		t.Parallel()
+		runs, err := resolveStages([]map[string]string{a}, false, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []stageRun{{files: a}}, runs)
+	})
+
+	t.Run("flat fans out over metadata", func(t *testing.T) {
+		t.Parallel()
+		runs, err := resolveStages([]map[string]string{a}, false, []Stage{
+			{Mode: StagePreview},
+			{},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []stageRun{
+			{files: a, Stage: Stage{Mode: StagePreview}},
+			{files: a},
+		}, runs)
+	})
+
+	t.Run("numbered pairs positionally", func(t *testing.T) {
+		t.Parallel()
+		runs, err := resolveStages([]map[string]string{a, b}, true, []Stage{
+			{},
+			{ExpectErr: "boom"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []stageRun{
+			{files: a},
+			{files: b, Stage: Stage{ExpectErr: "boom"}},
+		}, runs)
+	})
+
+	t.Run("numbered without metadata", func(t *testing.T) {
+		t.Parallel()
+		runs, err := resolveStages([]map[string]string{a, b}, true, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []stageRun{{files: a}, {files: b}}, runs)
+	})
+
+	t.Run("numbered count mismatch", func(t *testing.T) {
+		t.Parallel()
+		_, err := resolveStages([]map[string]string{a, b}, true, []Stage{{}})
+		require.EqualError(t, err, "case has 2 numbered stage dirs but Case.Stages has 1 entries")
+	})
+}
+
 // TestLoadCaseFS_MultiFile checks that the directory loader picks up every
 // regular file, keyed by path relative to the case directory.
 func TestLoadCaseFS_MultiFile(t *testing.T) {

--- a/tests/tfcompat/README.md
+++ b/tests/tfcompat/README.md
@@ -10,17 +10,79 @@ to add a new in-memory provider.
 
 ## Layout
 
+Program files always live on disk; the Go test carries only behavior
+(providers, config, per-stage mode/error/output assertions).
+
 ```
 tfcompat/
 ├── *_test.go                       # one test per case
 └── testdata/
     └── cases/
-        └── <case-name>/
-            └── *.tf                # fed verbatim to both paths
+        ├── <case-name>/
+        │   └── *.tf                # flat case: one file set
+        └── <staged-case-name>/
+            ├── 0/
+            │   └── *.tf            # numbered case: one file set per stage
+            └── 1/
+                └── *.tf
 ```
 
 A test's `<case-name>` argument to `tfcompat.RunCase` selects the matching
-directory under `testdata/cases/`.
+directory under `testdata/cases/`. Every regular file in the case directory is
+loaded and fed verbatim to both paths.
+
+## Stages
+
+Each case runs as one or more *stages* — sequential operations against the
+same stack. A stage is an apply by default; `Case.Stages` attaches optional
+per-stage behavior, matched positionally against the stages loaded from disk:
+
+```go
+type Stage struct {
+    Mode         StageMode // StageApply (default), StagePreview, StageDestroy
+    ExpectErr    string    // both runtimes must fail with this substring
+    AssertOutput func(t *testing.T, output string) // runs against each runtime's apply output
+}
+```
+
+The case directory's shape decides where the file sets come from:
+
+- **Flat directory** — one file set. The case runs `max(1, len(Stages))`
+  stages, every stage over the same files. Use multiple `Stages` entries to
+  drive the same program through several operations, e.g. preview then apply:
+
+  ```go
+  tfcompat.RunCase(t, "l2_check_unknown_deferred", tfcompat.Case{
+      Providers: []tfcompat.Provider{{Name: "simple", Factory: providers.SimpleProvider}},
+      Stages: []tfcompat.Stage{
+          {Mode: tfcompat.StagePreview},
+          {},
+      },
+  })
+  ```
+
+- **Numbered stage subdirs** (`0/`, `1/`, ...) — one file set per subdir, for
+  tests whose program *changes* between operations (e.g.
+  `lifecycle.replace_triggered_by`). `Case.Stages`, if set, must have exactly
+  one entry per subdir.
+
+Outputs, provider operations, and `AssertState` are compared after the last
+successful apply stage.
+
+## Runtime values
+
+Program files are committed verbatim — never generate program text in Go. A
+value only known at runtime (a port, a temp path, a credential) enters through
+`Case.Config`: declare a variable in the program and set it in the map. Config
+reaches both paths identically (`-var` flags for tofu, stack config for
+pulumi), and values are converted per the variable's declared type, so
+`variable "port" { type = number }` works from a string config entry.
+
+```go
+tfcompat.RunCase(t, "l1_file_tilde", tfcompat.Case{
+    Config: map[string]string{"name": name},
+})
+```
 
 ## Running
 
@@ -39,7 +101,7 @@ Requires `tofu` on `PATH` (or set `TF_COMMAND_OVERRIDE=terraform`).
 ## Adding a case
 
 1. Create `testdata/cases/<case-name>/main.tf` (plus any other `.tf` files the
-   case needs — every `.tf` in the directory is loaded).
+   case needs — every file in the directory is loaded).
 2. Add `<case-name>_test.go`:
 
    ```go

--- a/tests/tfcompat/l1_cidr_test.go
+++ b/tests/tfcompat/l1_cidr_test.go
@@ -24,47 +24,8 @@ func TestL1Cidr(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l1_cidr", tfcompat.Case{
 		Stages: []tfcompat.Stage{
+			{},
 			{
-				Files: map[string]string{"main.tf": `
-output "host_pos" {
-  value = cidrhost("10.0.0.0/24", 5)
-}
-
-output "host_neg_one" {
-  value = cidrhost("10.0.0.0/24", -1)
-}
-
-output "host_neg_two" {
-  value = cidrhost("10.0.0.0/24", -2)
-}
-
-output "host_leading_zeros" {
-  value = cidrhost("010.001.0.0/24", 5)
-}
-
-output "netmask" {
-  value = cidrnetmask("10.0.0.0/8")
-}
-
-output "netmask_leading_zeros" {
-  value = cidrnetmask("010.001.0.0/24")
-}
-
-output "subnet_leading_zeros" {
-  value = cidrsubnet("010.001.0.0/16", 8, 2)
-}
-
-output "subnets_leading_zeros" {
-  value = cidrsubnets("010.001.0.0/16", 8, 8)
-}
-`},
-			},
-			{
-				Files: map[string]string{"main.tf": `
-output "mask" {
-  value = cidrnetmask("2001:db8::/32")
-}
-`},
 				// OpenTofu line-wraps the diagnostic after "have a", so match
 				// only the portion that stays on a single rendered line in both
 				// runtimes.

--- a/tests/tfcompat/l1_file_tilde_test.go
+++ b/tests/tfcompat/l1_file_tilde_test.go
@@ -28,9 +28,10 @@ import (
 // the user's home directory, matching OpenTofu's openFile. The fixture reads a
 // file via `~/<name>`; OpenTofu reads it and reports it exists, so pulumi-hcl
 // must too. The test writes the referenced file into the shared $HOME both
-// runtimes see and removes it afterwards. The outputs are the file's literal
-// contents and existence booleans, neither of which embeds a machine-specific
-// path, so the comparison is stable across hosts.
+// runtimes see and removes it afterwards; its process-unique name reaches the
+// program as a variable. The outputs are the file's literal contents and
+// existence booleans, neither of which embeds a machine-specific path, so the
+// comparison is stable across hosts.
 func TestL1FileTilde(t *testing.T) {
 	t.Parallel()
 	home, err := os.UserHomeDir()
@@ -41,15 +42,7 @@ func TestL1FileTilde(t *testing.T) {
 	require.NoError(t, os.WriteFile(abs, []byte("from-home"), 0o600))
 	t.Cleanup(func() { _ = os.Remove(abs) })
 
-	program := fmt.Sprintf(`
-output "content" { value = file("~/%[1]s") }
-output "b64"     { value = filebase64("~/%[1]s") }
-output "exists"  { value = fileexists("~/%[1]s") }
-`, name)
-
 	tfcompat.RunCase(t, "l1_file_tilde", tfcompat.Case{
-		Stages: []tfcompat.Stage{
-			{Files: map[string]string{"main.tf": program}},
-		},
+		Config: map[string]string{"name": name},
 	})
 }

--- a/tests/tfcompat/l1_sensitive_error_message_test.go
+++ b/tests/tfcompat/l1_sensitive_error_message_test.go
@@ -29,22 +29,6 @@ func TestL1Validation_SensitiveErrorMessage(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l1_validation_sensitive_error", tfcompat.Case{
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-variable "password" {
-  type      = string
-  sensitive = true
-  default   = "abc"
-
-  validation {
-    condition     = length(var.password) >= 8
-    error_message = "Password is too short: '${var.password}'"
-  }
-}
-
-output "ok" {
-  value = "ok"
-}
-`},
 			ExpectErr: "Error message refers to sensitive values",
 		}},
 	})

--- a/tests/tfcompat/l1_transpose_test.go
+++ b/tests/tfcompat/l1_transpose_test.go
@@ -28,22 +28,8 @@ func TestL1Transpose_NullElement(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l1_transpose", tfcompat.Case{
 		Stages: []tfcompat.Stage{
-			{
-				Files: map[string]string{"main.tf": `
-output "t" {
-  value = transpose({ a = ["x", null] })
-}
-`},
-				ExpectErr: `cannot use null string for ["a"][1]`,
-			},
-			{
-				Files: map[string]string{"main.tf": `
-output "t" {
-  value = transpose({ a = null })
-}
-`},
-				ExpectErr: `cannot use null list for ["a"]`,
-			},
+			{ExpectErr: `cannot use null string for ["a"][1]`},
+			{ExpectErr: `cannot use null list for ["a"]`},
 		},
 	})
 }

--- a/tests/tfcompat/l1_validation_test.go
+++ b/tests/tfcompat/l1_validation_test.go
@@ -35,21 +35,6 @@ func TestL1Validation_Fail(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l1_validation_fail", tfcompat.Case{
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-variable "name" {
-  type    = string
-  default = "x"
-
-  validation {
-    condition     = length(var.name) > 3
-    error_message = "VALIDATION_FAILED_NAME_TOO_SHORT"
-  }
-}
-
-output "name" {
-  value = var.name
-}
-`},
 			ExpectErr: "VALIDATION_FAILED_NAME_TOO_SHORT",
 		}},
 	})

--- a/tests/tfcompat/l2_check_test.go
+++ b/tests/tfcompat/l2_check_test.go
@@ -32,22 +32,6 @@ func TestL2Check_Pass(t *testing.T) {
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "example" {
-  input_one = "hello"
-}
-
-check "result_check" {
-  assert {
-    condition     = simple_resource.example.result == "hello-false"
-    error_message = "result did not match expected value"
-  }
-}
-
-output "result" {
-  value = simple_resource.example.result
-}
-`},
 			AssertOutput: func(t *testing.T, output string) {
 				require.NotContains(t, output, "result did not match expected value")
 			},
@@ -66,22 +50,6 @@ func TestL2Check_FailIsNonBlocking(t *testing.T) {
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "example" {
-  input_one = "hello"
-}
-
-check "result_check" {
-  assert {
-    condition     = simple_resource.example.result == "this-will-never-match"
-    error_message = "result did not match expected value"
-  }
-}
-
-output "result" {
-  value = simple_resource.example.result
-}
-`},
 			AssertOutput: func(t *testing.T, output string) {
 				require.Contains(t, output, "result did not match expected value")
 			},
@@ -95,25 +63,13 @@ output "result" {
 // value is known and the assertion holds.
 func TestL2Check_UnknownDeferred(t *testing.T) {
 	t.Parallel()
-	program := map[string]string{"main.tf": `
-resource "simple_resource" "example" {
-  input_one = "hello"
-}
-
-check "result_check" {
-  assert {
-    condition     = simple_resource.example.result == "hello-false"
-    error_message = "result did not match expected value"
-  }
-}
-`}
 	tfcompat.RunCase(t, "l2_check_unknown_deferred", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 		Stages: []tfcompat.Stage{
-			{Files: program, Mode: tfcompat.StagePreview},
-			{Files: program},
+			{Mode: tfcompat.StagePreview},
+			{},
 		},
 	})
 }
@@ -131,24 +87,6 @@ func TestL2Check_ScopedDataSource(t *testing.T) {
 			{Name: "mark", Factory: providers.MarkProvider},
 		},
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-resource "mark_resource" "example" {}
-
-check "ordering_check" {
-  data "mark_probe" "probe" {
-    token = mark_resource.example.token
-  }
-
-  assert {
-    condition     = data.mark_probe.probe.constructed
-    error_message = "scoped data source ran before mark_resource was constructed"
-  }
-}
-
-output "token" {
-  value = mark_resource.example.token
-}
-`},
 			AssertOutput: func(t *testing.T, output string) {
 				require.NotContains(t, output, "scoped data source ran before")
 				require.NotContains(t, output, "could not evaluate condition")
@@ -166,22 +104,6 @@ func TestL2Check_MultipleDataSourcesRejected(t *testing.T) {
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-check "two_data" {
-  data "simple_lookup" "a" {
-    query = "a"
-  }
-
-  data "simple_lookup" "b" {
-    query = "b"
-  }
-
-  assert {
-    condition     = data.simple_lookup.a.prefix_result == "-a"
-    error_message = "mismatch"
-  }
-}
-`},
 			ExpectErr: "Multiple data resource blocks",
 		}},
 	})

--- a/tests/tfcompat/l2_data_source_unknown_input_preview_test.go
+++ b/tests/tfcompat/l2_data_source_unknown_input_preview_test.go
@@ -34,20 +34,6 @@ func TestL2DataSourceUnknownInputPreview(t *testing.T) {
 		},
 		Stages: []tfcompat.Stage{{
 			Mode: tfcompat.StagePreview,
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "upstream" {
-  input_one = "a"
-  input_two = true
-}
-
-data "simple_lookup" "lookup" {
-  query = simple_resource.upstream.result
-}
-
-output "looked_up" {
-  value = data.simple_lookup.lookup.prefix_result
-}
-`},
 		}},
 	})
 }

--- a/tests/tfcompat/l2_module_variable_validation_test.go
+++ b/tests/tfcompat/l2_module_variable_validation_test.go
@@ -28,32 +28,6 @@ func TestL2ModuleVariableValidation(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_module_variable_validation", tfcompat.Case{
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{
-				"main.tf": `
-module "child" {
-  source = "./child"
-  name   = "x"
-}
-
-output "name" {
-  value = module.child.name
-}
-`,
-				"child/main.tf": `
-variable "name" {
-  type = string
-
-  validation {
-    condition     = length(var.name) > 3
-    error_message = "VALIDATION_FAILED_MODULE_VAR_TOO_SHORT"
-  }
-}
-
-output "name" {
-  value = var.name
-}
-`,
-			},
 			ExpectErr: "VALIDATION_FAILED_MODULE_VAR_TOO_SHORT",
 		}},
 	})

--- a/tests/tfcompat/l2_nested_computed_block_test.go
+++ b/tests/tfcompat/l2_nested_computed_block_test.go
@@ -23,19 +23,12 @@ import (
 
 func TestL2NestedComputedBlock(t *testing.T) {
 	t.Parallel()
-	main := `resource "nested_cluster" "this" {
-}
-
-output "issuer" {
-  value = nested_cluster.this.identity[0].oidc[0].issuer
-}
-`
 	tfcompat.RunCase(t, "l2_nested_computed_block", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "nested", Factory: providers.NestedProvider},
 		},
-		Stages: []tfcompat.Stage{
-			{Files: map[string]string{"main.tf": main}, Mode: tfcompat.StagePreview},
-		},
+		Stages: []tfcompat.Stage{{
+			Mode: tfcompat.StagePreview,
+		}},
 	})
 }

--- a/tests/tfcompat/l2_one_unknown_length_set_test.go
+++ b/tests/tfcompat/l2_one_unknown_length_set_test.go
@@ -37,16 +37,6 @@ func TestL2OneUnknownLengthSet(t *testing.T) {
 		},
 		Stages: []tfcompat.Stage{{
 			Mode: tfcompat.StagePreview,
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "upstream" {
-  input_one = "a"
-  input_two = true
-}
-
-output "the_one" {
-  value = one(toset([simple_resource.upstream.result, "fixed"]))
-}
-`},
 		}},
 	})
 }

--- a/tests/tfcompat/l2_postcondition_test.go
+++ b/tests/tfcompat/l2_postcondition_test.go
@@ -29,21 +29,6 @@ func TestL2Postcondition_Pass(t *testing.T) {
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "guarded" {
-  input_one = "a"
-  input_two = false
-
-  lifecycle {
-    postcondition {
-      condition     = self.result == "a-false"
-      error_message = "result must be a-false"
-    }
-  }
-}
-`},
-		}},
 	})
 }
 
@@ -56,21 +41,6 @@ func TestL2Postcondition_StringBoolCondition(t *testing.T) {
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "guarded" {
-  input_one = "a"
-  input_two = false
-
-  lifecycle {
-    postcondition {
-      condition     = self.result == "a-false" ? "true" : "false"
-      error_message = "result must be a-false"
-    }
-  }
-}
-`},
-		}},
 	})
 }
 
@@ -85,19 +55,6 @@ func TestL2Postcondition_Fail(t *testing.T) {
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "guarded" {
-  input_one = "a"
-  input_two = false
-
-  lifecycle {
-    postcondition {
-      condition     = self.result == "expected-different-value"
-      error_message = "POSTCONDITION_VIOLATED"
-    }
-  }
-}
-`},
 			ExpectErr: "POSTCONDITION_VIOLATED",
 		}},
 	})

--- a/tests/tfcompat/l2_precondition_test.go
+++ b/tests/tfcompat/l2_precondition_test.go
@@ -29,25 +29,6 @@ func TestL2Precondition_Pass(t *testing.T) {
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-variable "expected" {
-  type    = string
-  default = "ok"
-}
-
-resource "simple_resource" "guarded" {
-  input_one = "ok"
-
-  lifecycle {
-    precondition {
-      condition     = var.expected == "ok"
-      error_message = "should never fire"
-    }
-  }
-}
-`},
-		}},
 	})
 }
 
@@ -60,23 +41,6 @@ func TestL2Precondition_Fail(t *testing.T) {
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-variable "trigger_failure" {
-  type    = bool
-  default = true
-}
-
-resource "simple_resource" "guarded" {
-  input_one = "value"
-
-  lifecycle {
-    precondition {
-      condition     = !var.trigger_failure
-      error_message = "PRECONDITION_VIOLATED"
-    }
-  }
-}
-`},
 			ExpectErr: "PRECONDITION_VIOLATED",
 		}},
 	})
@@ -91,25 +55,6 @@ func TestL2Precondition_StringBoolCondition(t *testing.T) {
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-variable "expected" {
-  type    = string
-  default = "ok"
-}
-
-resource "simple_resource" "guarded" {
-  input_one = "ok"
-
-  lifecycle {
-    precondition {
-      condition     = var.expected != "" ? "true" : "false"
-      error_message = "expected must not be empty"
-    }
-  }
-}
-`},
-		}},
 	})
 }
 
@@ -119,29 +64,13 @@ resource "simple_resource" "guarded" {
 // and known at apply (so both runtimes must enforce the condition successfully).
 func TestL2Precondition_UnknownDeferred(t *testing.T) {
 	t.Parallel()
-	program := map[string]string{"main.tf": `
-resource "simple_resource" "upstream" {
-  input_one = "a"
-}
-
-resource "simple_resource" "dependent" {
-  input_one = "b"
-
-  lifecycle {
-    precondition {
-      condition     = simple_resource.upstream.result == "a-false"
-      error_message = "upstream result must match"
-    }
-  }
-}
-`}
 	tfcompat.RunCase(t, "l2_precondition_unknown_deferred", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 		Stages: []tfcompat.Stage{
-			{Files: program, Mode: tfcompat.StagePreview},
-			{Files: program},
+			{Mode: tfcompat.StagePreview},
+			{},
 		},
 	})
 }

--- a/tests/tfcompat/l2_provisioner_ssh_test.go
+++ b/tests/tfcompat/l2_provisioner_ssh_test.go
@@ -15,9 +15,10 @@
 package tfcompat_test
 
 import (
-	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,40 +28,29 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-// Omits host_key so the SSH communicator falls back to
-// InsecureIgnoreHostKey — fine for ephemeral test containers.
-func sshConnectionHCL(c *sshd.Container) string {
-	return fmt.Sprintf(`connection {
-    type     = "ssh"
-    host     = %q
-    port     = %d
-    user     = %q
-    password = %q
-    timeout  = "30s"
-  }`, c.Host, c.Port, c.User, c.Password)
+// The programs omit host_key so the SSH communicator falls back to
+// InsecureIgnoreHostKey — fine for ephemeral test containers. The container's
+// coordinates reach the program as variables.
+func sshConfig(c *sshd.Container, extra map[string]string) map[string]string {
+	cfg := map[string]string{
+		"host":     c.Host,
+		"port":     strconv.Itoa(c.Port),
+		"user":     c.User,
+		"password": c.Password,
+	}
+	maps.Copy(cfg, extra)
+	return cfg
 }
 
 func TestL2Provisioner_RemoteExecInline(t *testing.T) {
 	t.Parallel()
 	c := sshd.Start(t.Context(), t)
 
-	program := map[string]string{"main.tf": fmt.Sprintf(`
-resource "simple_resource" "target" {
-  input_one = "a"
-
-  %s
-
-  provisioner "remote-exec" {
-    inline = ["echo hello-from-remote-exec"]
-  }
-}
-`, sshConnectionHCL(c))}
-
 	tfcompat.RunCase(t, "l2_provisioner_remote_exec_inline", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{Files: program}},
+		Config: sshConfig(c, nil),
 	})
 }
 
@@ -72,23 +62,11 @@ func TestL2Provisioner_RemoteExecScript(t *testing.T) {
 	scriptPath := filepath.Join(scriptDir, "hello.sh")
 	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\necho script-ran\n"), 0o755))
 
-	program := map[string]string{"main.tf": fmt.Sprintf(`
-resource "simple_resource" "target" {
-  input_one = "a"
-
-  %s
-
-  provisioner "remote-exec" {
-    script = %q
-  }
-}
-`, sshConnectionHCL(c), scriptPath)}
-
 	tfcompat.RunCase(t, "l2_provisioner_remote_exec_script", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{Files: program}},
+		Config: sshConfig(c, map[string]string{"script": scriptPath}),
 	})
 }
 
@@ -102,28 +80,19 @@ func TestL2Provisioner_RemoteExecScripts(t *testing.T) {
 	require.NoError(t, os.WriteFile(first, []byte("#!/bin/sh\necho first\n"), 0o755))
 	require.NoError(t, os.WriteFile(second, []byte("#!/bin/sh\necho second\n"), 0o755))
 
-	program := map[string]string{"main.tf": fmt.Sprintf(`
-resource "simple_resource" "target" {
-  input_one = "a"
-
-  %s
-
-  provisioner "remote-exec" {
-    scripts = [%q, %q]
-  }
-}
-`, sshConnectionHCL(c), first, second)}
-
 	tfcompat.RunCase(t, "l2_provisioner_remote_exec_scripts", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{Files: program}},
+		Config: sshConfig(c, map[string]string{
+			"script_first":  first,
+			"script_second": second,
+		}),
 	})
 }
 
 // Default script_path is /tmp/terraform_%RAND%.sh, which isn't writable by
-// the test user. Pointing it at /config (the linuxserver home) means
+// the test user. The program points it at /config (the linuxserver home), so
 // success proves the override took effect.
 func TestL2Provisioner_ScriptPath(t *testing.T) {
 	t.Parallel()
@@ -133,33 +102,11 @@ func TestL2Provisioner_ScriptPath(t *testing.T) {
 	scriptPath := filepath.Join(scriptDir, "hello.sh")
 	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\necho custom-script-path-ok\n"), 0o755))
 
-	conn := fmt.Sprintf(`connection {
-    type        = "ssh"
-    host        = %q
-    port        = %d
-    user        = %q
-    password    = %q
-    timeout     = "30s"
-    script_path = "/config/terraform_%%RAND%%.sh"
-  }`, c.Host, c.Port, c.User, c.Password)
-
-	program := map[string]string{"main.tf": fmt.Sprintf(`
-resource "simple_resource" "target" {
-  input_one = "a"
-
-  %s
-
-  provisioner "remote-exec" {
-    script = %q
-  }
-}
-`, conn, scriptPath)}
-
 	tfcompat.RunCase(t, "l2_provisioner_script_path", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{Files: program}},
+		Config: sshConfig(c, map[string]string{"script": scriptPath}),
 	})
 }
 
@@ -167,24 +114,11 @@ func TestL2Provisioner_FileFromContent(t *testing.T) {
 	t.Parallel()
 	c := sshd.Start(t.Context(), t)
 
-	program := map[string]string{"main.tf": fmt.Sprintf(`
-resource "simple_resource" "target" {
-  input_one = "a"
-
-  %s
-
-  provisioner "file" {
-    content     = "hello-from-file-provisioner\n"
-    destination = "/config/from-content.txt"
-  }
-}
-`, sshConnectionHCL(c))}
-
 	tfcompat.RunCase(t, "l2_provisioner_file_content", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{Files: program}},
+		Config: sshConfig(c, nil),
 	})
 }
 
@@ -196,23 +130,10 @@ func TestL2Provisioner_FileFromSource(t *testing.T) {
 	src := filepath.Join(srcDir, "upload.txt")
 	require.NoError(t, os.WriteFile(src, []byte("hello-from-source\n"), 0o644))
 
-	program := map[string]string{"main.tf": fmt.Sprintf(`
-resource "simple_resource" "target" {
-  input_one = "a"
-
-  %s
-
-  provisioner "file" {
-    source      = %q
-    destination = "/config/from-source.txt"
-  }
-}
-`, sshConnectionHCL(c), src)}
-
 	tfcompat.RunCase(t, "l2_provisioner_file_source", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{Files: program}},
+		Config: sshConfig(c, map[string]string{"src": src}),
 	})
 }

--- a/tests/tfcompat/l2_provisioner_test.go
+++ b/tests/tfcompat/l2_provisioner_test.go
@@ -27,18 +27,6 @@ func TestL2Provisioner_LocalExecPass(t *testing.T) {
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "target" {
-  input_one = "a"
-  input_two = false
-
-  provisioner "local-exec" {
-    command = "true"
-  }
-}
-`},
-		}},
 	})
 }
 
@@ -49,15 +37,6 @@ func TestL2Provisioner_LocalExecFail(t *testing.T) {
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "target" {
-  input_one = "a"
-
-  provisioner "local-exec" {
-    command = "exit 1"
-  }
-}
-`},
 			// "exit status 1" appears in both runtimes' error output.
 			ExpectErr: "exit status 1",
 		}},
@@ -70,18 +49,6 @@ func TestL2Provisioner_OnFailureContinue(t *testing.T) {
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "target" {
-  input_one = "a"
-
-  provisioner "local-exec" {
-    command    = "exit 1"
-    on_failure = "continue"
-  }
-}
-`},
-		}},
 	})
 }
 
@@ -91,64 +58,32 @@ func TestL2Provisioner_SelfReference(t *testing.T) {
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "target" {
-  input_one = "a"
-  input_two = true
-
-  provisioner "local-exec" {
-    command = "test '${self.result}' = 'a-true'"
-  }
-}
-`},
-		}},
 	})
 }
 
 // self.id reference proves prior state is available during destroy.
 func TestL2Provisioner_WhenDestroyPass(t *testing.T) {
 	t.Parallel()
-	program := map[string]string{"main.tf": `
-resource "simple_resource" "target" {
-  input_one = "a"
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "test -n '${self.id}'"
-  }
-}
-`}
 	tfcompat.RunCase(t, "l2_provisioner_when_destroy_pass", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 		Stages: []tfcompat.Stage{
-			{Files: program},
-			{Files: program, Mode: tfcompat.StageDestroy},
+			{},
+			{Mode: tfcompat.StageDestroy},
 		},
 	})
 }
 
 func TestL2Provisioner_WhenDestroyFail(t *testing.T) {
 	t.Parallel()
-	program := map[string]string{"main.tf": `
-resource "simple_resource" "target" {
-  input_one = "a"
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "exit 1"
-  }
-}
-`}
 	tfcompat.RunCase(t, "l2_provisioner_when_destroy_fail", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 		Stages: []tfcompat.Stage{
-			{Files: program},
-			{Files: program, Mode: tfcompat.StageDestroy, ExpectErr: "exit status 1"},
+			{},
+			{Mode: tfcompat.StageDestroy, ExpectErr: "exit status 1"},
 		},
 	})
 }
@@ -161,18 +96,6 @@ func TestL2Provisioner_Quiet(t *testing.T) {
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "target" {
-  input_one = "a"
-
-  provisioner "local-exec" {
-    command = "echo this-should-be-suppressed"
-    quiet   = true
-  }
-}
-`},
-		}},
 	})
 }
 
@@ -185,15 +108,6 @@ func TestL2Provisioner_NotInPreview(t *testing.T) {
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-resource "simple_resource" "target" {
-  input_one = "a"
-
-  provisioner "local-exec" {
-    command = "exit 1"
-  }
-}
-`},
 			Mode: tfcompat.StagePreview,
 		}},
 	})

--- a/tests/tfcompat/l2_terraform_remote_state_remote_test.go
+++ b/tests/tfcompat/l2_terraform_remote_state_remote_test.go
@@ -71,81 +71,39 @@ func TestL2TerraformRemoteStateRemote(t *testing.T) {
 
 	// Every permutation OpenTofu's remote backend accepts (verified live): a
 	// name-bound workspace with no top-level workspace or with the implicit
-	// "default", and a prefix-bound workspace selected by a top-level workspace.
+	// "default", and a prefix-bound workspace selected by a top-level
+	// workspace. Each permutation is its own case directory; the workspace
+	// coordinates reach the program as variables.
 	cases := []struct {
-		name      string
-		dataBody  string // the body of the data block after `backend = "remote"`
-		extraVars []string
-		config    map[string]string
+		name     string
+		caseName string
+		config   map[string]string
 	}{
 		{
-			name: "workspaces.name",
-			dataBody: `  config = {
-    organization = var.org
-    hostname     = var.hostname
-    token        = var.token
-    workspaces   = { name = var.name }
-  }`,
-			extraVars: []string{"name"},
-			config:    withVars(map[string]string{"name": nameWS}),
+			name:     "workspaces.name",
+			caseName: "l2_terraform_remote_state_remote_name",
+			config:   withVars(map[string]string{"name": nameWS}),
 		},
 		{
-			name: "workspaces.name with workspace=default",
-			dataBody: `  workspace = "default"
-  config = {
-    organization = var.org
-    hostname     = var.hostname
-    token        = var.token
-    workspaces   = { name = var.name }
-  }`,
-			extraVars: []string{"name"},
-			config:    withVars(map[string]string{"name": nameWS}),
+			name:     "workspaces.name with workspace=default",
+			caseName: "l2_terraform_remote_state_remote_name_default",
+			config:   withVars(map[string]string{"name": nameWS}),
 		},
 		{
-			name: "workspaces.prefix with workspace selector",
-			dataBody: `  workspace = var.workspace
-  config = {
-    organization = var.org
-    hostname     = var.hostname
-    token        = var.token
-    workspaces   = { prefix = var.prefix }
-  }`,
-			extraVars: []string{"prefix", "workspace"},
-			config:    withVars(map[string]string{"prefix": prefix, "workspace": "prod"}),
+			name:     "workspaces.prefix with workspace selector",
+			caseName: "l2_terraform_remote_state_remote_prefix",
+			config:   withVars(map[string]string{"prefix": prefix, "workspace": "prod"}),
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			tfcompat.RunCase(t, "l2_terraform_remote_state_remote", tfcompat.Case{
-				Stages: []tfcompat.Stage{{Files: map[string]string{
-					"main.tf": remoteStateProgram(append([]string{"org", "hostname", "token"}, c.extraVars...), c.dataBody),
-				}}},
+			tfcompat.RunCase(t, c.caseName, tfcompat.Case{
 				Config: c.config,
 			})
 		})
 	}
-}
-
-// remoteStateProgram builds a terraform_remote_state program that declares the
-// given string variables and uses dataBody as the data block's body (after
-// `backend = "remote"`), exposing the read greeting and number outputs.
-func remoteStateProgram(vars []string, dataBody string) string {
-	var b strings.Builder
-	for _, v := range vars {
-		fmt.Fprintf(&b, "variable %q { type = string }\n", v)
-	}
-	fmt.Fprintf(&b, `
-data "terraform_remote_state" "rs" {
-  backend = "remote"
-%s
-}
-
-output "greeting" { value = data.terraform_remote_state.rs.outputs.greeting }
-output "number"   { value = data.terraform_remote_state.rs.outputs.number }
-`, dataBody)
-	return b.String()
 }
 
 func getEnv(t *testing.T, env string) string {

--- a/tests/tfcompat/output_precondition_test.go
+++ b/tests/tfcompat/output_precondition_test.go
@@ -27,21 +27,6 @@ func TestL1OutputPrecondition(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l1_output_precondition", tfcompat.Case{
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-variable "enabled" {
-  type    = bool
-  default = false
-}
-
-output "result" {
-  value = "ok"
-
-  precondition {
-    condition     = var.enabled
-    error_message = "OUTPUT_PRECONDITION_FAILED"
-  }
-}
-`},
 			ExpectErr: "OUTPUT_PRECONDITION_FAILED",
 		}},
 	})
@@ -54,32 +39,6 @@ func TestL2ModuleOutputPrecondition(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_module_output_precondition", tfcompat.Case{
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{
-				"main.tf": `
-module "child" {
-  source = "./child"
-}
-
-output "child_result" {
-  value = module.child.result
-}
-`,
-				"child/main.tf": `
-variable "ok" {
-  type    = bool
-  default = false
-}
-
-output "result" {
-  value = "ok"
-
-  precondition {
-    condition     = var.ok
-    error_message = "MODULE_OUTPUT_PRECONDITION_FAILED"
-  }
-}
-`,
-			},
 			ExpectErr: "MODULE_OUTPUT_PRECONDITION_FAILED",
 		}},
 	})

--- a/tests/tfcompat/testdata/cases/l1_cidr/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_cidr/0/main.tf
@@ -1,0 +1,31 @@
+output "host_pos" {
+  value = cidrhost("10.0.0.0/24", 5)
+}
+
+output "host_neg_one" {
+  value = cidrhost("10.0.0.0/24", -1)
+}
+
+output "host_neg_two" {
+  value = cidrhost("10.0.0.0/24", -2)
+}
+
+output "host_leading_zeros" {
+  value = cidrhost("010.001.0.0/24", 5)
+}
+
+output "netmask" {
+  value = cidrnetmask("10.0.0.0/8")
+}
+
+output "netmask_leading_zeros" {
+  value = cidrnetmask("010.001.0.0/24")
+}
+
+output "subnet_leading_zeros" {
+  value = cidrsubnet("010.001.0.0/16", 8, 2)
+}
+
+output "subnets_leading_zeros" {
+  value = cidrsubnets("010.001.0.0/16", 8, 8)
+}

--- a/tests/tfcompat/testdata/cases/l1_cidr/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_cidr/1/main.tf
@@ -1,0 +1,3 @@
+output "mask" {
+  value = cidrnetmask("2001:db8::/32")
+}

--- a/tests/tfcompat/testdata/cases/l1_file_tilde/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_file_tilde/main.tf
@@ -1,0 +1,7 @@
+variable "name" {
+  type = string
+}
+
+output "content" { value = file("~/${var.name}") }
+output "b64"     { value = filebase64("~/${var.name}") }
+output "exists"  { value = fileexists("~/${var.name}") }

--- a/tests/tfcompat/testdata/cases/l1_output_precondition/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_output_precondition/main.tf
@@ -1,0 +1,13 @@
+variable "enabled" {
+  type    = bool
+  default = false
+}
+
+output "result" {
+  value = "ok"
+
+  precondition {
+    condition     = var.enabled
+    error_message = "OUTPUT_PRECONDITION_FAILED"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l1_transpose/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_transpose/0/main.tf
@@ -1,0 +1,3 @@
+output "t" {
+  value = transpose({ a = ["x", null] })
+}

--- a/tests/tfcompat/testdata/cases/l1_transpose/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_transpose/1/main.tf
@@ -1,0 +1,3 @@
+output "t" {
+  value = transpose({ a = null })
+}

--- a/tests/tfcompat/testdata/cases/l1_validation_fail/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_validation_fail/main.tf
@@ -1,0 +1,13 @@
+variable "name" {
+  type    = string
+  default = "x"
+
+  validation {
+    condition     = length(var.name) > 3
+    error_message = "VALIDATION_FAILED_NAME_TOO_SHORT"
+  }
+}
+
+output "name" {
+  value = var.name
+}

--- a/tests/tfcompat/testdata/cases/l1_validation_sensitive_error/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_validation_sensitive_error/main.tf
@@ -1,0 +1,14 @@
+variable "password" {
+  type      = string
+  sensitive = true
+  default   = "abc"
+
+  validation {
+    condition     = length(var.password) >= 8
+    error_message = "Password is too short: '${var.password}'"
+  }
+}
+
+output "ok" {
+  value = "ok"
+}

--- a/tests/tfcompat/testdata/cases/l1_variable_validation_xref/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_variable_validation_xref/main.tf
@@ -1,0 +1,18 @@
+variable "min" {
+  type    = number
+  default = 3
+}
+
+variable "name" {
+  type    = string
+  default = "xy"
+
+  validation {
+    condition     = length(var.name) >= var.min
+    error_message = "XREF_VALIDATION_FAILED"
+  }
+}
+
+output "name" {
+  value = var.name
+}

--- a/tests/tfcompat/testdata/cases/l2_check_fail_non_blocking/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_check_fail_non_blocking/main.tf
@@ -1,0 +1,14 @@
+resource "simple_resource" "example" {
+  input_one = "hello"
+}
+
+check "result_check" {
+  assert {
+    condition     = simple_resource.example.result == "this-will-never-match"
+    error_message = "result did not match expected value"
+  }
+}
+
+output "result" {
+  value = simple_resource.example.result
+}

--- a/tests/tfcompat/testdata/cases/l2_check_multiple_data_sources/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_check_multiple_data_sources/main.tf
@@ -1,0 +1,14 @@
+check "two_data" {
+  data "simple_lookup" "a" {
+    query = "a"
+  }
+
+  data "simple_lookup" "b" {
+    query = "b"
+  }
+
+  assert {
+    condition     = data.simple_lookup.a.prefix_result == "-a"
+    error_message = "mismatch"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_check_pass/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_check_pass/main.tf
@@ -1,0 +1,14 @@
+resource "simple_resource" "example" {
+  input_one = "hello"
+}
+
+check "result_check" {
+  assert {
+    condition     = simple_resource.example.result == "hello-false"
+    error_message = "result did not match expected value"
+  }
+}
+
+output "result" {
+  value = simple_resource.example.result
+}

--- a/tests/tfcompat/testdata/cases/l2_check_scoped_data_source/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_check_scoped_data_source/main.tf
@@ -1,0 +1,16 @@
+resource "mark_resource" "example" {}
+
+check "ordering_check" {
+  data "mark_probe" "probe" {
+    token = mark_resource.example.token
+  }
+
+  assert {
+    condition     = data.mark_probe.probe.constructed
+    error_message = "scoped data source ran before mark_resource was constructed"
+  }
+}
+
+output "token" {
+  value = mark_resource.example.token
+}

--- a/tests/tfcompat/testdata/cases/l2_check_unknown_deferred/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_check_unknown_deferred/main.tf
@@ -1,0 +1,10 @@
+resource "simple_resource" "example" {
+  input_one = "hello"
+}
+
+check "result_check" {
+  assert {
+    condition     = simple_resource.example.result == "hello-false"
+    error_message = "result did not match expected value"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_data_source_unknown_input_preview/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_source_unknown_input_preview/main.tf
@@ -1,0 +1,12 @@
+resource "simple_resource" "upstream" {
+  input_one = "a"
+  input_two = true
+}
+
+data "simple_lookup" "lookup" {
+  query = simple_resource.upstream.result
+}
+
+output "looked_up" {
+  value = data.simple_lookup.lookup.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_output_precondition/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_output_precondition/child/main.tf
@@ -1,0 +1,13 @@
+variable "ok" {
+  type    = bool
+  default = false
+}
+
+output "result" {
+  value = "ok"
+
+  precondition {
+    condition     = var.ok
+    error_message = "MODULE_OUTPUT_PRECONDITION_FAILED"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_module_output_precondition/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_output_precondition/main.tf
@@ -1,0 +1,7 @@
+module "child" {
+  source = "./child"
+}
+
+output "child_result" {
+  value = module.child.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_variable_validation/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_variable_validation/child/main.tf
@@ -1,0 +1,12 @@
+variable "name" {
+  type = string
+
+  validation {
+    condition     = length(var.name) > 3
+    error_message = "VALIDATION_FAILED_MODULE_VAR_TOO_SHORT"
+  }
+}
+
+output "name" {
+  value = var.name
+}

--- a/tests/tfcompat/testdata/cases/l2_module_variable_validation/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_variable_validation/main.tf
@@ -1,0 +1,8 @@
+module "child" {
+  source = "./child"
+  name   = "x"
+}
+
+output "name" {
+  value = module.child.name
+}

--- a/tests/tfcompat/testdata/cases/l2_module_variable_validation_xref/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_variable_validation_xref/child/main.tf
@@ -1,0 +1,18 @@
+variable "min" {
+  type    = number
+  default = 3
+}
+
+variable "name" {
+  type    = string
+  default = "xy"
+
+  validation {
+    condition     = length(var.name) >= var.min
+    error_message = "MODULE_XREF_VALIDATION_FAILED"
+  }
+}
+
+output "name" {
+  value = var.name
+}

--- a/tests/tfcompat/testdata/cases/l2_module_variable_validation_xref/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_variable_validation_xref/main.tf
@@ -1,0 +1,7 @@
+module "child" {
+  source = "./child"
+}
+
+output "name" {
+  value = module.child.name
+}

--- a/tests/tfcompat/testdata/cases/l2_nested_computed_block/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_computed_block/main.tf
@@ -1,0 +1,6 @@
+resource "nested_cluster" "this" {
+}
+
+output "issuer" {
+  value = nested_cluster.this.identity[0].oidc[0].issuer
+}

--- a/tests/tfcompat/testdata/cases/l2_one_unknown_length_set/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_one_unknown_length_set/main.tf
@@ -1,0 +1,8 @@
+resource "simple_resource" "upstream" {
+  input_one = "a"
+  input_two = true
+}
+
+output "the_one" {
+  value = one(toset([simple_resource.upstream.result, "fixed"]))
+}

--- a/tests/tfcompat/testdata/cases/l2_postcondition_fail/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_postcondition_fail/main.tf
@@ -1,0 +1,11 @@
+resource "simple_resource" "guarded" {
+  input_one = "a"
+  input_two = false
+
+  lifecycle {
+    postcondition {
+      condition     = self.result == "expected-different-value"
+      error_message = "POSTCONDITION_VIOLATED"
+    }
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_postcondition_pass/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_postcondition_pass/main.tf
@@ -1,0 +1,11 @@
+resource "simple_resource" "guarded" {
+  input_one = "a"
+  input_two = false
+
+  lifecycle {
+    postcondition {
+      condition     = self.result == "a-false"
+      error_message = "result must be a-false"
+    }
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_postcondition_string_bool_condition/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_postcondition_string_bool_condition/main.tf
@@ -1,0 +1,11 @@
+resource "simple_resource" "guarded" {
+  input_one = "a"
+  input_two = false
+
+  lifecycle {
+    postcondition {
+      condition     = self.result == "a-false" ? "true" : "false"
+      error_message = "result must be a-false"
+    }
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_precondition_fail/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_precondition_fail/main.tf
@@ -1,0 +1,15 @@
+variable "trigger_failure" {
+  type    = bool
+  default = true
+}
+
+resource "simple_resource" "guarded" {
+  input_one = "value"
+
+  lifecycle {
+    precondition {
+      condition     = !var.trigger_failure
+      error_message = "PRECONDITION_VIOLATED"
+    }
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_precondition_pass/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_precondition_pass/main.tf
@@ -1,0 +1,15 @@
+variable "expected" {
+  type    = string
+  default = "ok"
+}
+
+resource "simple_resource" "guarded" {
+  input_one = "ok"
+
+  lifecycle {
+    precondition {
+      condition     = var.expected == "ok"
+      error_message = "should never fire"
+    }
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_precondition_string_bool_condition/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_precondition_string_bool_condition/main.tf
@@ -1,0 +1,15 @@
+variable "expected" {
+  type    = string
+  default = "ok"
+}
+
+resource "simple_resource" "guarded" {
+  input_one = "ok"
+
+  lifecycle {
+    precondition {
+      condition     = var.expected != "" ? "true" : "false"
+      error_message = "expected must not be empty"
+    }
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_precondition_unknown_deferred/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_precondition_unknown_deferred/main.tf
@@ -1,0 +1,14 @@
+resource "simple_resource" "upstream" {
+  input_one = "a"
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "b"
+
+  lifecycle {
+    precondition {
+      condition     = simple_resource.upstream.result == "a-false"
+      error_message = "upstream result must match"
+    }
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_file_content/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_file_content/main.tf
@@ -1,0 +1,22 @@
+variable "host" { type = string }
+variable "port" { type = number }
+variable "user" { type = string }
+variable "password" { type = string }
+
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  connection {
+    type     = "ssh"
+    host     = var.host
+    port     = var.port
+    user     = var.user
+    password = var.password
+    timeout  = "30s"
+  }
+
+  provisioner "file" {
+    content     = "hello-from-file-provisioner\n"
+    destination = "/config/from-content.txt"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_file_source/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_file_source/main.tf
@@ -1,0 +1,23 @@
+variable "host" { type = string }
+variable "port" { type = number }
+variable "user" { type = string }
+variable "password" { type = string }
+variable "src" { type = string }
+
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  connection {
+    type     = "ssh"
+    host     = var.host
+    port     = var.port
+    user     = var.user
+    password = var.password
+    timeout  = "30s"
+  }
+
+  provisioner "file" {
+    source      = var.src
+    destination = "/config/from-source.txt"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_local_exec_fail/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_local_exec_fail/main.tf
@@ -1,0 +1,7 @@
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  provisioner "local-exec" {
+    command = "exit 1"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_local_exec_pass/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_local_exec_pass/main.tf
@@ -1,0 +1,8 @@
+resource "simple_resource" "target" {
+  input_one = "a"
+  input_two = false
+
+  provisioner "local-exec" {
+    command = "true"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_not_in_preview/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_not_in_preview/main.tf
@@ -1,0 +1,7 @@
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  provisioner "local-exec" {
+    command = "exit 1"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_on_failure_continue/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_on_failure_continue/main.tf
@@ -1,0 +1,8 @@
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  provisioner "local-exec" {
+    command    = "exit 1"
+    on_failure = "continue"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_quiet/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_quiet/main.tf
@@ -1,0 +1,8 @@
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  provisioner "local-exec" {
+    command = "echo this-should-be-suppressed"
+    quiet   = true
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_remote_exec_inline/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_remote_exec_inline/main.tf
@@ -1,0 +1,21 @@
+variable "host" { type = string }
+variable "port" { type = number }
+variable "user" { type = string }
+variable "password" { type = string }
+
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  connection {
+    type     = "ssh"
+    host     = var.host
+    port     = var.port
+    user     = var.user
+    password = var.password
+    timeout  = "30s"
+  }
+
+  provisioner "remote-exec" {
+    inline = ["echo hello-from-remote-exec"]
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_remote_exec_script/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_remote_exec_script/main.tf
@@ -1,0 +1,22 @@
+variable "host" { type = string }
+variable "port" { type = number }
+variable "user" { type = string }
+variable "password" { type = string }
+variable "script" { type = string }
+
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  connection {
+    type     = "ssh"
+    host     = var.host
+    port     = var.port
+    user     = var.user
+    password = var.password
+    timeout  = "30s"
+  }
+
+  provisioner "remote-exec" {
+    script = var.script
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_remote_exec_scripts/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_remote_exec_scripts/main.tf
@@ -1,0 +1,23 @@
+variable "host" { type = string }
+variable "port" { type = number }
+variable "user" { type = string }
+variable "password" { type = string }
+variable "script_first" { type = string }
+variable "script_second" { type = string }
+
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  connection {
+    type     = "ssh"
+    host     = var.host
+    port     = var.port
+    user     = var.user
+    password = var.password
+    timeout  = "30s"
+  }
+
+  provisioner "remote-exec" {
+    scripts = [var.script_first, var.script_second]
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_script_path/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_script_path/main.tf
@@ -1,0 +1,23 @@
+variable "host" { type = string }
+variable "port" { type = number }
+variable "user" { type = string }
+variable "password" { type = string }
+variable "script" { type = string }
+
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  connection {
+    type        = "ssh"
+    host        = var.host
+    port        = var.port
+    user        = var.user
+    password    = var.password
+    timeout     = "30s"
+    script_path = "/config/terraform_%RAND%.sh"
+  }
+
+  provisioner "remote-exec" {
+    script = var.script
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_self/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_self/main.tf
@@ -1,0 +1,8 @@
+resource "simple_resource" "target" {
+  input_one = "a"
+  input_two = true
+
+  provisioner "local-exec" {
+    command = "test '${self.result}' = 'a-true'"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_when_destroy_fail/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_when_destroy_fail/main.tf
@@ -1,0 +1,8 @@
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "exit 1"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_when_destroy_pass/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_when_destroy_pass/main.tf
@@ -1,0 +1,8 @@
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "test -n '${self.id}'"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_remote_state_remote_name/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_remote_state_remote_name/main.tf
@@ -1,0 +1,17 @@
+variable "org" { type = string }
+variable "hostname" { type = string }
+variable "token" { type = string }
+variable "name" { type = string }
+
+data "terraform_remote_state" "rs" {
+  backend = "remote"
+  config = {
+    organization = var.org
+    hostname     = var.hostname
+    token        = var.token
+    workspaces   = { name = var.name }
+  }
+}
+
+output "greeting" { value = data.terraform_remote_state.rs.outputs.greeting }
+output "number"   { value = data.terraform_remote_state.rs.outputs.number }

--- a/tests/tfcompat/testdata/cases/l2_terraform_remote_state_remote_name_default/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_remote_state_remote_name_default/main.tf
@@ -1,0 +1,18 @@
+variable "org" { type = string }
+variable "hostname" { type = string }
+variable "token" { type = string }
+variable "name" { type = string }
+
+data "terraform_remote_state" "rs" {
+  backend   = "remote"
+  workspace = "default"
+  config = {
+    organization = var.org
+    hostname     = var.hostname
+    token        = var.token
+    workspaces   = { name = var.name }
+  }
+}
+
+output "greeting" { value = data.terraform_remote_state.rs.outputs.greeting }
+output "number"   { value = data.terraform_remote_state.rs.outputs.number }

--- a/tests/tfcompat/testdata/cases/l2_terraform_remote_state_remote_prefix/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_remote_state_remote_prefix/main.tf
@@ -1,0 +1,19 @@
+variable "org" { type = string }
+variable "hostname" { type = string }
+variable "token" { type = string }
+variable "prefix" { type = string }
+variable "workspace" { type = string }
+
+data "terraform_remote_state" "rs" {
+  backend   = "remote"
+  workspace = var.workspace
+  config = {
+    organization = var.org
+    hostname     = var.hostname
+    token        = var.token
+    workspaces   = { prefix = var.prefix }
+  }
+}
+
+output "greeting" { value = data.terraform_remote_state.rs.outputs.greeting }
+output "number"   { value = data.terraform_remote_state.rs.outputs.number }

--- a/tests/tfcompat/variable_validation_xref_test.go
+++ b/tests/tfcompat/variable_validation_xref_test.go
@@ -28,26 +28,6 @@ func TestL1VariableValidationCrossReference(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l1_variable_validation_xref", tfcompat.Case{
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{"main.tf": `
-variable "min" {
-  type    = number
-  default = 3
-}
-
-variable "name" {
-  type    = string
-  default = "xy"
-
-  validation {
-    condition     = length(var.name) >= var.min
-    error_message = "XREF_VALIDATION_FAILED"
-  }
-}
-
-output "name" {
-  value = var.name
-}
-`},
 			ExpectErr: "XREF_VALIDATION_FAILED",
 		}},
 	})
@@ -60,37 +40,6 @@ func TestL2ModuleVariableValidationCrossReference(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_module_variable_validation_xref", tfcompat.Case{
 		Stages: []tfcompat.Stage{{
-			Files: map[string]string{
-				"main.tf": `
-module "child" {
-  source = "./child"
-}
-
-output "name" {
-  value = module.child.name
-}
-`,
-				"child/main.tf": `
-variable "min" {
-  type    = number
-  default = 3
-}
-
-variable "name" {
-  type    = string
-  default = "xy"
-
-  validation {
-    condition     = length(var.name) >= var.min
-    error_message = "MODULE_XREF_VALIDATION_FAILED"
-  }
-}
-
-output "name" {
-  value = var.name
-}
-`,
-			},
 			ExpectErr: "MODULE_XREF_VALIDATION_FAILED",
 		}},
 	})


### PR DESCRIPTION
## Summary

The tfcompat harness had two models that drifted in capability:

| | Disk cases | Inline `Case.Stages` |
|---|---|---|
| Program files | `testdata/cases/<name>/` | `Stage.Files` map in Go source |
| Modes | apply only | apply / preview / destroy |
| `ExpectErr` / `AssertOutput` | no | yes |

Most of the 17 inline tests were inline only because per-stage behavior (`Mode`, `ExpectErr`, `AssertOutput`) was unreachable from the disk path. This PR unifies the two models:

- **Program files always live on disk** under `testdata/cases/<name>/`. `Stage` loses `Files` and carries behavior only, matched positionally against the disk stages.
- A **flat case directory** runs `max(1, len(Stages))` stages over the same file set, covering preview-then-apply and apply-then-destroy sequences without duplicating files. **Numbered stage subdirs** (`0/`, `1/`, ...) pair 1:1 with `Stages` entries for programs that change between operations (count mismatch is a hard error).
- The apply-only runner is deleted; every case goes through one runner, so disk cases gain preview/destroy/`ExpectErr`/`AssertOutput` support, and `RunCase`'s case name is never silently ignored anymore.
- **Runtime values flow exclusively through `Case.Config`** as declared variables (`-var` flags for tofu, stack config for pulumi). The tilde fixture takes its filename as a var, the ssh provisioner cases take host/port/user/password and script paths as vars, and the remote-state permutations become three case directories.

The 17 inline test files move their programs into 30 new case directories. `tests/tfcompat/README.md` documents the model; the `find-tfcompat-bug` skill is updated to stop suggesting inline `Files` maps.

## Testing

- `TestResolveStages` pins the positional-matching semantics.
- Full suite passes locally: `go test ./tests/tfcompat/ ./tests/testutil/tfcompat/` — 135 tests, including the 6 Docker-based ssh provisioner tests (confirming a `number`-typed variable fed from string config works on both paths). The live TFE remote-state test self-skips without credentials.
- `golangci-lint run ./tests/...` is clean.