### PR TITLE
Shard the test suite and prime Go caches from master

### DIFF
--- a/.github/scripts/test-shard.sh
+++ b/.github/scripts/test-shard.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Runs one shard of the test suite. The shards partition `go test ./...` by
+# construction:
+#
+#   - unit runs every package except tests/tfcompat and tests/smoke, and
+#     skips TestLanguage (which only exists in cmd/pulumi-language-hcl).
+#   - conformance-0 runs the TestLanguage subtests whose name ends in
+#     s, t, or l -- measured to be ~half the suite's runtime -- and
+#     conformance-1 runs the exact complement, so any new subtest lands in
+#     exactly one of the two.
+#   - conformance-large runs only l2-large-string (excluded from both
+#     conformance shards: it ends in "g" so conformance-0 never matches it,
+#     and conformance-1 skips it explicitly).
+#   - tfcompat-N partitions the package's tests by their position in
+#     `go test -list` order, so every test runs in exactly one shard.
+#   - smoke runs tests/smoke.
+set -euo pipefail
+
+shard="${1:?usage: test-shard.sh <shard>}"
+
+GOTEST=(go test -race -coverpkg=./... -coverprofile=coverage.out)
+
+case "$shard" in
+  unit)
+    # shellcheck disable=SC2046
+    "${GOTEST[@]}" -skip '^TestLanguage$' \
+      $(go list ./... | grep -v -e '/tests/tfcompat$' -e '/tests/smoke$')
+    ;;
+  conformance-0)
+    "${GOTEST[@]}" -run '^TestLanguage$/[stl]$' ./cmd/pulumi-language-hcl
+    ;;
+  conformance-1)
+    "${GOTEST[@]}" -run '^TestLanguage$' \
+      -skip '^TestLanguage$/([stl]$|^l2-large-string$)' ./cmd/pulumi-language-hcl
+    ;;
+  conformance-large)
+    # l2-large-string pushes a ~100MB value through the language host and
+    # takes minutes under the race detector. Every code path it exercises
+    # also runs race-instrumented on small values in the other conformance
+    # shards, so this one value-size stress test runs without -race.
+    go test -coverpkg=./... -coverprofile=coverage.out \
+      -run '^TestLanguage$/^l2-large-string$' ./cmd/pulumi-language-hcl
+    ;;
+  tfcompat-[0-9])
+    index="${shard#tfcompat-}"
+    total=3
+    if ((index >= total)); then
+      echo "unknown shard: $shard (only tfcompat-0..$((total - 1)) exist)" >&2
+      exit 1
+    fi
+    tests="$(go test -list '.*' ./tests/tfcompat |
+      grep '^Test' |
+      awk -v i="$index" -v n="$total" 'NR % n == i' |
+      paste -sd'|' -)"
+    "${GOTEST[@]}" -run "^($tests)$" ./tests/tfcompat
+    ;;
+  smoke)
+    "${GOTEST[@]}" ./tests/smoke
+    ;;
+  *)
+    echo "unknown shard: $shard" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/test-shard.sh
+++ b/.github/scripts/test-shard.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 shard="${1:?usage: test-shard.sh <shard>}"
 
-GOTEST=(go test -race -coverpkg=./... -coverprofile=coverage.out)
+GOTEST=(go test -v -race -coverpkg=./... -coverprofile=coverage.out)
 
 case "$shard" in
   unit)
@@ -39,7 +39,7 @@ case "$shard" in
     # takes minutes under the race detector. Every code path it exercises
     # also runs race-instrumented on small values in the other conformance
     # shards, so this one value-size stress test runs without -race.
-    go test -coverpkg=./... -coverprofile=coverage.out \
+    go test -v -coverpkg=./... -coverprofile=coverage.out \
       -run '^TestLanguage$/^l2-large-string$' ./cmd/pulumi-language-hcl
     ;;
   tfcompat-[0-9])

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@ name: CI
 on:
   workflow_call:
 
+# Caching strategy: jobs restore the Go module and build caches but only
+# master runs (see master.yml) save them. Pull requests restore master's
+# cache and skip the save entirely, which keeps the multi-minute cache
+# upload off the PR critical path. setup-go's built-in cache is disabled
+# everywhere because its cache key is shared across jobs, so only one job's
+# build cache would ever be saved.
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -12,12 +19,54 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
+      - uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-lint-${{ hashFiles('go.sum') }}
+          restore-keys: go-lint-
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9.0
+      - uses: actions/cache/save@v4
+        if: always() && github.ref == 'refs/heads/master'
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-lint-${{ hashFiles('go.sum') }}
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Shard definitions live in .github/scripts/test-shard.sh. Each
+        # shard is its own runner, so wall time is bounded by the slowest
+        # shard rather than the whole suite. cache-key groups shards with
+        # similar build graphs; only the shard with cache-save set uploads
+        # its cache (on master), the rest just restore it.
+        include:
+          - shard: unit
+            cache-key: go-test-unit
+            cache-save: true
+          - shard: conformance-0
+            cache-key: go-test-conformance
+            cache-save: true
+          - shard: conformance-1
+            cache-key: go-test-conformance
+          - shard: conformance-large
+            cache-key: go-test-conformance
+          - shard: tfcompat-0
+            cache-key: go-test-unit
+          - shard: tfcompat-1
+            cache-key: go-test-unit
+          - shard: tfcompat-2
+            cache-key: go-test-unit
+          - shard: smoke
+            cache-key: go-test-unit
     steps:
       - uses: actions/checkout@v6
         with:
@@ -25,6 +74,16 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
+      - uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ matrix.cache-key }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ matrix.cache-key }}-
+            go-test-
       - uses: pulumi/actions@v7
         with:
           pulumi-version: "latest"
@@ -37,8 +96,8 @@ jobs:
       - run: pulumi plugin install resource terraform-provider 1.1.3
       - run: pulumi plugin install resource local 0.1.6
       - run: make bin/pulumi-language-hcl bin/pulumi-converter-hcl bin/pulumi-resource-hcl
-      - run: echo "$PWD/bin" >> $GITHUB_PATH
-      - run: make test_cover
+      - run: echo "$PWD/bin" >> "$GITHUB_PATH"
+      - run: .github/scripts/test-shard.sh ${{ matrix.shard }}
         env:
           # Enable the live terraform_remote_state `remote` backend test.
           TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
@@ -47,6 +106,13 @@ jobs:
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: actions/cache/save@v4
+        if: always() && github.ref == 'refs/heads/master' && matrix.cache-save
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ matrix.cache-key }}-${{ hashFiles('go.sum') }}
 
   build-sdk:
     # Generate every SDK and confirm each one builds with its native toolchain.
@@ -56,6 +122,14 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
+      - uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-sdk-${{ hashFiles('go.sum') }}
+          restore-keys: go-sdk-
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -87,6 +161,13 @@ jobs:
         run: cd sdk/dotnet && dotnet build
       - name: Build Java SDK
         run: cd sdk/java && gradle build
+      - uses: actions/cache/save@v4
+        if: always() && github.ref == 'refs/heads/master'
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-sdk-${{ hashFiles('go.sum') }}
 
   vendored-drift:
     # Ensures the vendored/ tree matches what `go generate ./vendored`
@@ -98,6 +179,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
       - run: go generate ./vendored
       - name: Fail on drift
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,23 @@
+name: Master
+
+# Runs full CI on every merge to master. Besides validating master itself,
+# this is what keeps the Go caches warm: cache saves in ci.yml only happen on
+# master runs, and pull requests can only restore caches saved on their base
+# branch. Changelog-only pushes are skipped because release.yml already runs
+# ci.yml for those.
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - CHANGELOG.md
+      - '.changes/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,12 @@ name: PR
 on:
   pull_request:
 
+# A new push to the PR obsoletes any in-flight run; cancel it so the fresh
+# run isn't queued behind jobs whose result no longer matters.
+concurrency:
+  group: pr-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read


### PR DESCRIPTION
## Problem

PR CI wall time is 11–13 minutes, dominated by a single `test` job (~11.5 min). Two independent causes:

1. **Every PR starts with a cold Go cache.** CI only runs on `pull_request`, so no cache is ever saved to `master`, and PR branches can only restore caches from their base branch. Every run rebuilt the binaries from scratch (~2m22s in `test`, ~3m48s in `build-sdk`) and then spent ~56s uploading a cache at the end of the job.
2. **The whole suite runs serially on one runner.** `tests/tfcompat` has 807s of serial test time, `TestLanguage` 697s, `tests/smoke` 169s. Within `TestLanguage`, the `l2-large-string` conformance test alone takes **285s** on CI: it pushes a ~100MB value through the language host, and the engine-side property/snapshot handling plus race-instrumented gRPC marshaling of that payload is inherently slow.

## Change

Since hosted runners are free for public repos, trade runner count for wall time:

- **Shard the test job into an 8-way matrix** (`unit`, `conformance-0/1`, `conformance-large`, `tfcompat-0/1/2`, `smoke`). Partition logic lives in `.github/scripts/test-shard.sh`; every test runs in exactly one shard *by construction*:
  - tfcompat splits by position in `go test -list` order (38+39+39 = 116 tests, disjoint).
  - `TestLanguage` splits by a measured half-by-runtime regex (`[stl]$` = 192s vs complement = 195s serial; 72 + 98 + 1 = all 171 subtests).
  - `l2-large-string` runs alone **without `-race`**: it is a value-size stress test whose code paths all run race-instrumented on small values in the other conformance shards, and the race detector multiplies its 100MB payload handling into minutes.
- **Run CI on master merges** (new `master.yml`) and make jobs restore caches explicitly, with saves happening **only on master runs**. PRs restore master's cache and skip the upload entirely. `setup-go`'s built-in cache is disabled: its key is shared across jobs, so only one job's build cache would ever be saved.
- **Cancel superseded PR runs** (`concurrency` on `pr.yml`) so a new push isn't queued behind stale jobs.

Coverage is unchanged: every shard uploads its `coverage.out` and Codecov merges reports for the commit.

## Measured on this PR

Both runs on this PR are still **cache-cold** (no master cache can exist until this merges), so they show the sharding win only:

- Before (run 29050302523, PR #328): **11m50s**
- This PR, sharded, cache-cold: **7m25s** ([run 29053181486](https://github.com/pulumi-labs/pulumi-hcl/actions/runs/29053181486), all green)
- The union of tests executed across the 8 shards is **byte-identical** to the old single job's set: 1244 unique test names, zero diff in either direction.

After merge, master runs prime the caches, which removes the ~2m22s binary build and module downloads from every shard plus golangci-lint's cold start; expected steady state is **~5 min**.

`l2-large-string` remains the single-test floor (~2–4 min in its shard). Making it cheaper needs runtime perf work (e.g. `eval.MarkResourceReference` deep-hashes the full 100MB value via `cty.Value.Hash`) or an upstream look at the engine-side cost of the test — out of scope here.

Note: `TestSmokeParameterizedModule` flaked once during validation on a `registry.opentofu.org` 502 — pre-existing network dependence, unrelated to this change.

## Verification

- `actionlint` and `shellcheck` clean.
- Ran locally: `conformance-large` (50s, exactly 1 subtest), `conformance-0` (72 subtests), `conformance-1` (98 subtests), `unit` (19 packages ok), `tfcompat-0` (150s, ok).
- Invalid shard names (`bogus`, `tfcompat-7`) are rejected with exit 1.