### PR TITLE
Fetch full history in build-sdk so the SDK version is always valid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod


### PR DESCRIPTION
The first master CI run after https://github.com/pulumi-labs/pulumi-hcl/pull/329 failed in `build-sdk`: https://github.com/pulumi-labs/pulumi-hcl/actions/runs/29054134103/job/86241591038

## Root cause (pre-existing, not introduced by #329)

The Makefile computes `VERSION` with `git describe --tags --always --dirty`. `build-sdk` checks out a shallow, tagless clone, so `describe` degrades to the bare short commit hash. A hex-looking hash (e.g. `d3fae98`) is not a parseable version and gets dropped, which is why this always "worked" — the generated SDKs silently carried no version. But an all-digit short hash parses as a version, and the merge commit of #329 abbreviated to `1113888`, producing .NET assembly version `1113888.0.0.0`, which exceeds .NET's 65534-per-part limit (CS7034). Roughly 4% of commits have an all-digit short hash, so this was a latent coin-flip on every `build-sdk` run.

## Fix

`fetch-depth: 0` on the `build-sdk` checkout, so `describe` always yields a real `v<tag>-<n>-g<sha>` version. Side benefit: the generated SDKs now always carry a version, so `build-sdk` exercises the versioned path every run instead of only when the hash happens to be numeric.

Verified locally: `pulumi package gen-sdk` with version `0.9.0-18-gd3fae98` bakes `<Version>0.9.0-18-gd3fae98</Version>` into the csproj and `dotnet build` succeeds (0 errors).