### PR TITLE
Bump GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v6
         with:
           path: |
             ~/go/pkg/mod
@@ -30,7 +30,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9.0
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v6
         if: always() && github.ref == 'refs/heads/master'
         with:
           path: |
@@ -68,14 +68,14 @@ jobs:
           - shard: smoke
             cache-key: go-test-unit
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: true
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v6
         with:
           path: |
             ~/go/pkg/mod
@@ -102,11 +102,11 @@ jobs:
           # Enable the live terraform_remote_state `remote` backend test.
           TFE_ORGANIZATION: ${{ secrets.TFE_ORGANIZATION }}
           TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@v7
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v6
         if: always() && github.ref == 'refs/heads/master' && matrix.cache-save
         with:
           path: |
@@ -118,34 +118,34 @@ jobs:
     # Generate every SDK and confirm each one builds with its native toolchain.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v6
         with:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
           key: go-sdk-${{ hashFiles('go.sum') }}
           restore-keys: go-sdk-
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
       - uses: pulumi/actions@v7
         with:
           pulumi-version: "latest"
@@ -163,7 +163,7 @@ jobs:
         run: cd sdk/dotnet && dotnet build
       - name: Build Java SDK
         run: cd sdk/java && gradle build
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v6
         if: always() && github.ref == 'refs/heads/master'
         with:
           path: |
@@ -177,7 +177,7 @@ jobs:
     # hand-edits of MPL files and forgotten regens after a SHA bump.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/maintain-release-pr.yml
+++ b/.github/workflows/maintain-release-pr.yml
@@ -28,7 +28,7 @@ jobs:
   maintain-release-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Use the PAT so the `git push` below and the PR-event side-effects
           # come from a user identity, not GITHUB_TOKEN. PRs/pushes authored by

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
   validate-fragments:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - name: Validate unreleased fragments batch cleanly
         # Phony version (rather than `auto`) so this works when there are no

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,7 +303,7 @@ jobs:
       ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=hcl-registry-publish-dispatch
     steps:
       - name: Fetch the dispatch token from ESC
-        uses: pulumi/esc-action@8afe12bb7bb3df0a599e5309ee429ff1079ba85f # v3
+        uses: pulumi/esc-action@v3
       - name: Dispatch a registry docs build
         run: |
           base="https://raw.githubusercontent.com/pulumi-labs/pulumi-hcl/${SHA}/registry"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: jdx/mise-action@v4
       - uses: actions/setup-go@v6
         with:
@@ -66,7 +66,7 @@ jobs:
       VERSION: ${{ needs.release.outputs.version }}
       GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: sdk-releases
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -157,10 +157,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: sdk-releases
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           # Trusted publishing requires Node >= 22.14 and npm >= 11.5.1.
           node-version: '22'
@@ -211,10 +211,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: sdk-releases
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Build distributions
@@ -250,10 +250,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: sdk-releases
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
       - name: Build


### PR DESCRIPTION
Follow-up to https://github.com/pulumi-labs/pulumi-hcl/pull/329 / https://github.com/pulumi-labs/pulumi-hcl/pull/330: bring every action up to its latest major, and standardize on unpinned major-version tags.

| Action | From | To |
|---|---|---|
| `actions/checkout` | v6 | v7 |
| `actions/cache/restore` + `save` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/setup-dotnet` | v4 | v5 |
| `actions/setup-java` | v4 | v5 |
| `gradle/actions/setup-gradle` | v4 | v6 |
| `codecov/codecov-action` | v6 | v7 |
| `pulumi/esc-action` | SHA pin (`8afe12b`) | `v3` (same commit) |

I read each major's release notes: all are Node 24 runtime bumps (runner ≥ 2.327.1, satisfied on GitHub-hosted runners) with no input changes for our usage. `actions/checkout` v7 additionally blocks checking out fork PRs under `pull_request_target`/`workflow_run`, which we don't use. The `pulumi/esc-action` SHA pin was verified identical to the `v3.0.0` tag via the compare API — the swap to `v3` standardizes all workflows on unpinned major-version tags; we can pin by SHA later if we decide we care.

**⚠️ Licensing note on `gradle/actions` v6:** the caching functionality was extracted into a proprietary `gradle-actions-caching` component — upgrading accepts Gradle's [Terms of Use](https://gradle.com/legal/terms-of-use/) for it ([blog post](https://blog.gradle.org/github-actions-for-gradle-v6)). The terms are free-of-charge, carve cached build artifacts out of Gradle's content rights, but let Gradle use caching-service metadata for product improvement and terminate access at their discretion. v5 is the last fully-MIT major if we'd rather not accept that.

Left alone (already current): `actions/setup-go` v6, `dorny/paths-filter` v4, `golangci/golangci-lint-action` v9, `goreleaser/goreleaser-action` v7, `jdx/mise-action` v4, `NuGet/login` v1, `opentofu/setup-opentofu` v2, `pulumi/actions` v7, and `pypa/gh-action-pypi-publish@release/v1` (that project's recommended moving branch).

Verified on this PR's runs: all jobs green, and cache entries saved on master by `actions/cache@v4` restore cleanly under v6 (`Cache restored from key: go-test-conformance-…`), so the warm-cache pipeline is intact. The `release.yml` publish paths (including `esc-action`) only execute at the next release.