### PR TITLE
Isolate PULUMI_HOME in the pulexec harness

### DIFF
--- a/tests/testutil/pulexec/pluginhome.go
+++ b/tests/testutil/pulexec/pluginhome.go
@@ -1,0 +1,99 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulexec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// runtimePlugins are the resource plugins tfcompat programs resolve through
+// the engine at runtime (terraform_remote_state → terraform, dynamic provider
+// sources → terraform-provider, its local backend → local). Mirrors the set
+// ci.yml pre-installs.
+var runtimePlugins = []string{"terraform", "terraform-provider", "local"}
+
+// isolatedPulumiHome returns a fresh PULUMI_HOME whose plugin cache contains
+// only runtimePlugins, borrowed from the host cache. Resolving a dynamic TF
+// package makes the engine interrogate every installed plugin for a Terraform
+// mapping, so pointing the CLI at the real host cache costs one
+// spawn-every-plugin sweep per `pulumi up` (~10s on a dev machine with many
+// plugins installed) and makes test runtime depend on what happens to be
+// installed there.
+//
+// Each seeded plugin is a real directory of symlinks rather than a symlinked
+// directory: the engine's plugin scan reads directory entries without
+// following links (workspace.tryPlugin requires DirEntry.IsDir), so a
+// symlinked plugin directory is invisible to it, while a symlinked file
+// inside is resolved normally when the binary is stat'ed and spawned.
+//
+// When the host cache is missing the home is left empty: a test that resolves
+// one of these plugins fails the same way it would have without isolation,
+// since the harness disables plugin acquisition.
+func isolatedPulumiHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	pluginsDir := filepath.Join(home, "plugins")
+	require.NoError(t, os.MkdirAll(pluginsDir, 0o755))
+
+	hostDir := hostPluginsDir()
+	entries, err := os.ReadDir(hostDir)
+	if err != nil {
+		return home
+	}
+	for _, e := range entries {
+		for _, name := range runtimePlugins {
+			// Matches every installed version of the plugin, and its
+			// adjacent .lock file.
+			if strings.HasPrefix(e.Name(), "resource-"+name+"-v") {
+				seedEntry(t, filepath.Join(hostDir, e.Name()), filepath.Join(pluginsDir, e.Name()), e)
+				break
+			}
+		}
+	}
+	return home
+}
+
+// seedEntry materializes one host plugin-cache entry at dst: a directory
+// becomes a real directory whose contents are symlinks into the host cache;
+// anything else is symlinked directly.
+func seedEntry(t *testing.T, src, dst string, e os.DirEntry) {
+	t.Helper()
+	if !e.IsDir() {
+		require.NoError(t, os.Symlink(src, dst))
+		return
+	}
+	require.NoError(t, os.MkdirAll(dst, 0o755))
+	inner, err := os.ReadDir(src)
+	require.NoError(t, err)
+	for _, f := range inner {
+		require.NoError(t, os.Symlink(filepath.Join(src, f.Name()), filepath.Join(dst, f.Name())))
+	}
+}
+
+func hostPluginsDir() string {
+	if h := os.Getenv("PULUMI_HOME"); h != "" {
+		return filepath.Join(h, "plugins")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".pulumi", "plugins")
+}

--- a/tests/testutil/pulexec/run.go
+++ b/tests/testutil/pulexec/run.go
@@ -127,8 +127,9 @@ backend:
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte(pulumiYAML), 0o600))
 
 	opts := append(
-		make([]opttest.Option, 0, 5+len(provs)),
+		make([]opttest.Option, 0, 6+len(provs)),
 		opttest.Env("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true"),
+		opttest.Env("PULUMI_HOME", isolatedPulumiHome(t)),
 		opttest.Env("PULUMI_DEBUG_LANGUAGES", fmt.Sprintf("hcl:%d", hostPort)),
 		// The runtime under test is served in-process via PULUMI_DEBUG_LANGUAGES, so
 		// the engine must never spawn (or download) the pulumi-language-hcl binary.


### PR DESCRIPTION
## What

`pulexec.NewDriver` now points the pulumi CLI at a per-test `PULUMI_HOME` whose plugin cache is seeded with only the plugins tfcompat programs resolve at runtime (`terraform`, `terraform-provider`, `local` — the same set `ci.yml` pre-installs), borrowed from the host cache.

## Why

Resolving a dynamic TF package (`terraform_data`, `terraform_remote_state`) makes the engine interrogate every plugin installed in the host's plugin cache for a Terraform mapping, spawning each one. Observed by sampling processes during `TestL2TerraformDataLifecycle`: each `pulumi up` spawned aws, azure, gcp, kubernetes, auth0, equinix, … alphabetically — ~10s per up on a dev machine with 137 cached plugins, repeated every stage because each up is a fresh engine. Test runtime therefore depended on whatever happened to be installed in `~/.pulumi/plugins`, and the suite was not hermetic against it.

Measured locally (12 cores, 137 host plugins):

| | before | after |
|---|---|---|
| `go test ./tests/tfcompat` | 73s | 36s |
| `TestL2TerraformDataLifecycle` | 33s | 5s |
| `TestL2TerraformRemoteState` | 22s | <4s |

CI runners install only the three plugins, so the CI effect is small; this mainly speeds up local runs and removes the environment dependence.

## Notes

Seeding materializes each plugin as a real directory of symlinks rather than symlinking the plugin directory itself: the engine's plugin scan reads directory entries without following links (`workspace.tryPlugin` requires `DirEntry.IsDir`), so a symlinked plugin directory is invisible to the exact-version scan, while symlinked files inside are resolved normally when the binary is spawned. When the host cache is absent the home is left empty, which fails the same way it does today since the harness disables plugin acquisition.

Test-harness-only change, so no changelog fragment.