### PR TITLE
Fix anytrue returning unknown when a known true element is present

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-335.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-335.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Fix `anytrue` returning unknown during preview when a known `true` element is present
+time: 2026-07-10T13:05:00Z
+custom:
+    Component: runtime
+    PR: "335"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -446,14 +446,19 @@ var anyTrueFunc = function.New(&function.Spec{
 	},
 	Type: function.StaticReturnType(cty.Bool),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		var hasUnknown bool
 		for it := args[0].ElementIterator(); it.Next(); {
 			_, v := it.Element()
 			if !v.IsKnown() {
-				return cty.UnknownVal(cty.Bool), nil
+				hasUnknown = true
+				continue
 			}
 			if v.True() {
 				return cty.True, nil
 			}
+		}
+		if hasUnknown {
+			return cty.UnknownVal(cty.Bool), nil
 		}
 		return cty.False, nil
 	},

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -1472,6 +1472,148 @@ func TestUnknownPropagation(t *testing.T) {
 	}
 }
 
+func TestAnyTrueAllTrue(t *testing.T) {
+	t.Parallel()
+	funcs := Functions("/tmp")
+
+	unknownBool := cty.UnknownVal(cty.Bool)
+	nullBool := cty.NullVal(cty.Bool)
+
+	tests := []struct {
+		name string
+		fn   string
+		args []cty.Value
+		want cty.Value
+	}{
+		{
+			name: "anytrue known true after unknown",
+			fn:   "anytrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{unknownBool, cty.True})},
+			want: cty.True,
+		},
+		{
+			name: "anytrue known true before unknown",
+			fn:   "anytrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{cty.True, unknownBool})},
+			want: cty.True,
+		},
+		{
+			name: "anytrue unknown and false",
+			fn:   "anytrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{unknownBool, cty.False})},
+			want: unknownBool,
+		},
+		{
+			name: "anytrue only unknown",
+			fn:   "anytrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{unknownBool})},
+			want: unknownBool,
+		},
+		{
+			name: "anytrue unknown list",
+			fn:   "anytrue",
+			args: []cty.Value{cty.UnknownVal(cty.List(cty.Bool))},
+			want: unknownBool,
+		},
+		{
+			name: "anytrue all false",
+			fn:   "anytrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{cty.False, cty.False})},
+			want: cty.False,
+		},
+		{
+			name: "anytrue empty list",
+			fn:   "anytrue",
+			args: []cty.Value{cty.ListValEmpty(cty.Bool)},
+			want: cty.False,
+		},
+		{
+			name: "anytrue only null",
+			fn:   "anytrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{nullBool})},
+			want: cty.False,
+		},
+		{
+			name: "anytrue null then true",
+			fn:   "anytrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{nullBool, cty.True})},
+			want: cty.True,
+		},
+		{
+			name: "anytrue null and unknown",
+			fn:   "anytrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{nullBool, unknownBool})},
+			want: unknownBool,
+		},
+		{
+			name: "alltrue unknown before false",
+			fn:   "alltrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{unknownBool, cty.False})},
+			want: unknownBool,
+		},
+		{
+			name: "alltrue known false before unknown",
+			fn:   "alltrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{cty.False, unknownBool})},
+			want: cty.False,
+		},
+		{
+			name: "alltrue unknown and true",
+			fn:   "alltrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{unknownBool, cty.True})},
+			want: unknownBool,
+		},
+		{
+			name: "alltrue only unknown",
+			fn:   "alltrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{unknownBool})},
+			want: unknownBool,
+		},
+		{
+			name: "alltrue unknown list",
+			fn:   "alltrue",
+			args: []cty.Value{cty.UnknownVal(cty.List(cty.Bool))},
+			want: unknownBool,
+		},
+		{
+			name: "alltrue all true",
+			fn:   "alltrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{cty.True, cty.True})},
+			want: cty.True,
+		},
+		{
+			name: "alltrue empty list",
+			fn:   "alltrue",
+			args: []cty.Value{cty.ListValEmpty(cty.Bool)},
+			want: cty.True,
+		},
+		{
+			name: "alltrue only null",
+			fn:   "alltrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{nullBool})},
+			want: cty.False,
+		},
+		{
+			name: "alltrue true then null",
+			fn:   "alltrue",
+			args: []cty.Value{cty.ListVal([]cty.Value{cty.True, nullBool})},
+			want: cty.False,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fn, ok := funcs[tt.fn]
+			require.True(t, ok, "function %q not registered", tt.fn)
+
+			got, err := fn.Call(tt.args)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // TestLengthMarkPropagation mirrors OpenTofu's LengthFunc, which carries the
 // argument's marks onto the returned count for every supported type. The tuple
 // and object branches build the count themselves, so they must reapply the


### PR DESCRIPTION
## Divergence

`anytrue` returned an unknown result as soon as it hit an unknown element, so `anytrue([<unknown bool>, true])` evaluated to unknown even though the result is decidable: one known `true` element makes the answer `true` no matter what the unknown resolves to.

The divergence only manifests during **preview**, where resource outputs are unknown. At apply time every element is known and the old and new implementations agree, which is why the tfcompat harness (which compares applied output values) could not observe it — unit tests are the coverage here.

## Fix

`anyTrueFunc` (`pkg/hcl/eval/functions.go`) now records that an unknown element was seen and keeps scanning. A known `true` anywhere returns known `cty.True`; unknown is returned only when no known `true` exists and at least one element (or the whole list) is unknown; `false` requires a fully known list with no `true`. Null elements are still skipped, and an empty list still returns `false`.

## Sweep: alltrue

`allTrueFunc` was checked for the sibling bug and **needs no change**. The reference semantics short-circuit to unknown on the first unknown element (a later known `false` does not win), return `false` on a null or `false` element, and `true` for an empty list — which is exactly what the existing implementation does. The new tests pin this, including the ordering cases (`[unknown, false]` → unknown, `[false, unknown]` → `false`).

## Verification

- New `TestAnyTrueAllTrue` table in `pkg/hcl/eval/functions_test.go` covers unknown/known ordering, whole-list unknown, null elements, and empty lists for both functions.
- The `anytrue known true after unknown` case fails on `master` (`expected cty.True, actual cty.UnknownVal(cty.Bool)`) and passes with this change.
- `go build ./...` and the full `pkg/hcl/eval` suite (356 tests) pass.