### PR TITLE
Fix `sum` panicking on a `null` element

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-336.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-336.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Fix `sum` panicking on a `null` element
+time: 2026-07-10T12:29:53Z
+custom:
+    Component: runtime
+    PR: "336"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -32,6 +32,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"net/url"
 	"os"
@@ -811,20 +812,65 @@ var coalesceFunc = function.New(&function.Spec{
 
 var sumFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
-		{Name: "list", Type: cty.List(cty.Number)},
+		{Name: "list", Type: cty.DynamicPseudoType},
 	},
-	Type: function.StaticReturnType(cty.Number),
-	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+	Type:         function.StaticReturnType(cty.Number),
+	RefineResult: func(b *cty.RefinementBuilder) *cty.RefinementBuilder { return b.NotNull() },
+	Impl: func(args []cty.Value, retType cty.Type) (ret cty.Value, err error) {
+		if !args[0].CanIterateElements() {
+			return cty.NilVal, function.NewArgErrorf(0, "cannot sum noniterable")
+		}
+
 		if args[0].LengthInt() == 0 {
-			// Matching OpenTofu's behavior, we error on an empty list
-			return cty.NilVal, fmt.Errorf("cannot sum an empty list")
+			return cty.NilVal, function.NewArgErrorf(0, "cannot sum an empty list")
 		}
-		elements := args[0].AsValueSlice()
-		sum := elements[0]
-		for _, v := range elements[1:] {
-			sum = sum.Add(v)
+
+		arg := args[0].AsValueSlice()
+		ty := args[0].Type()
+
+		if !ty.IsListType() && !ty.IsSetType() && !ty.IsTupleType() {
+			return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple. Received %s", ty.FriendlyName())
 		}
-		return sum, nil
+
+		if !args[0].IsWhollyKnown() {
+			return cty.UnknownVal(cty.Number), nil
+		}
+
+		// big.Float.Add can panic if the input values are opposing infinities,
+		// so we must catch that here in order to remain within
+		// the cty Function abstraction.
+		defer func() {
+			if r := recover(); r != nil {
+				if _, ok := r.(big.ErrNaN); ok {
+					ret = cty.NilVal
+					err = fmt.Errorf("can't compute sum of opposing infinities")
+				} else {
+					// not a panic we recognize
+					panic(r)
+				}
+			}
+		}()
+
+		s := arg[0]
+		if s.IsNull() {
+			return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple of number values")
+		}
+		s, err = convert.Convert(s, cty.Number)
+		if err != nil {
+			return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple of number values")
+		}
+		for _, v := range arg[1:] {
+			if v.IsNull() {
+				return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple of number values")
+			}
+			v, err = convert.Convert(v, cty.Number)
+			if err != nil {
+				return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple of number values")
+			}
+			s = s.Add(v)
+		}
+
+		return s, nil
 	},
 })
 

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -815,6 +815,17 @@ func TestSumEmptyList(t *testing.T) {
 	assert.EqualError(t, err, "cannot sum an empty list")
 }
 
+// TestSumNullElement pins that `sum` of a list containing a null element
+// returns a graceful argument error rather than panicking inside the function
+// implementation.
+func TestSumNullElement(t *testing.T) {
+	t.Parallel()
+	_, err := sumFunc.Call([]cty.Value{cty.TupleVal([]cty.Value{
+		cty.NumberIntVal(1), cty.NullVal(cty.Number), cty.NumberIntVal(3),
+	})})
+	assert.EqualError(t, err, "argument must be list, set, or tuple of number values")
+}
+
 // TestTransposeNull pins that `transpose` returns a graceful argument error,
 // rather than panicking inside the function implementation, when a list value
 // is null or a list contains a null string.

--- a/tests/tfcompat/l1_sum_null_test.go
+++ b/tests/tfcompat/l1_sum_null_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1SumNull asserts that both runtimes reject a null element passed to
+// `sum` with the same graceful argument error, rather than panicking inside
+// the function implementation as pulumi-hcl previously did.
+func TestL1SumNull(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_sum_null", tfcompat.Case{
+		Stages: []tfcompat.Stage{
+			{ExpectErr: "argument must be list, set, or tuple"},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l1_sum_null/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_sum_null/main.tf
@@ -1,0 +1,3 @@
+output "sum_null" {
+  value = sum([1, null, 3])
+}


### PR DESCRIPTION
## Problem

`sum([1, null, 3])` surfaced a recovered panic instead of a clean error:

```
Call to function "sum" failed: panic in function implementation: interface conversion: interface {} is nil, not *big.Float
```

The implementation added elements without any per-element null guard, so a null element reached `cty.Value.Add`, which panicked.

## Fix

`sum` now validates its argument and each element before accumulating:

- null or non-numeric elements fail with `Invalid value for "list" parameter: argument must be list, set, or tuple of number values.`
- non-iterable and non-list/set/tuple arguments fail with clean argument errors
- a not-wholly-known argument returns an unknown number instead of accumulating unknowns element by element
- summing opposing infinities is caught and reported as an error rather than a `big.ErrNaN` panic
- the result is refined not-null

## Tests

- Unit: `TestSumNullElement` pins the clean error for a null element.
- tfcompat: `TestL1SumNull` proves both runtimes fail an apply of `output "sum_null" { value = sum([1, null, 3]) }` with the same argument error.