### PR TITLE
Fix a panic when a timeouts block value is sensitive

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-337.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-337.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Fix a panic when a `timeouts` block value or a `pulumi` block option (`retain_on_delete`, `version`, `plugin_download_url`, `env_var_mappings`) is sensitive
+time: 2026-07-10T12:30:13Z
+custom:
+    Component: runtime
+    PR: "337"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1598,7 +1598,11 @@ func (e *Engine) buildResourceOptionsInContext(
 				return 0, false
 			}
 			val, diags := e.evaluator.EvaluateExpression(expr)
-			if diags.HasErrors() || val.Type() != cty.String {
+			if diags.HasErrors() {
+				return 0, false
+			}
+			val, _ = val.Unmark()
+			if val.Type() != cty.String || val.IsNull() || !val.IsKnown() {
 				return 0, false
 			}
 			d, err := time.ParseDuration(val.AsString())
@@ -1655,7 +1659,8 @@ func (e *Engine) buildResourceOptionsInContext(
 
 	if res.RetainOnDelete != nil {
 		val, diags := res.RetainOnDelete.Value(hclCtx)
-		if !diags.HasErrors() && val.Type() == cty.Bool {
+		val, _ = val.Unmark()
+		if !diags.HasErrors() && val.Type() == cty.Bool && !val.IsNull() && val.IsKnown() {
 			b := val.True()
 			opts.RetainOnDelete = &b
 		}
@@ -1739,10 +1744,12 @@ func (e *Engine) buildResourceOptionsInContext(
 
 	if res.EnvVarMappings != nil {
 		val, diags := res.EnvVarMappings.Value(hclCtx)
-		if !diags.HasErrors() && (val.Type().IsObjectType() || val.Type().IsMapType()) {
+		val, _ = val.UnmarkDeep()
+		if !diags.HasErrors() && (val.Type().IsObjectType() || val.Type().IsMapType()) &&
+			!val.IsNull() && val.IsKnown() {
 			mappings := make(map[string]string)
 			for k, v := range val.AsValueMap() {
-				if v.Type() == cty.String {
+				if v.Type() == cty.String && !v.IsNull() && v.IsKnown() {
 					mappings[k] = v.AsString()
 				}
 			}
@@ -1754,14 +1761,16 @@ func (e *Engine) buildResourceOptionsInContext(
 
 	if res.Version != nil {
 		val, diags := res.Version.Value(hclCtx)
-		if !diags.HasErrors() && val.Type() == cty.String {
+		val, _ = val.Unmark()
+		if !diags.HasErrors() && val.Type() == cty.String && !val.IsNull() && val.IsKnown() {
 			opts.Version = val.AsString()
 		}
 	}
 
 	if res.PluginDownloadURL != nil && !strings.HasPrefix(res.Type, "pulumi_providers_") {
 		val, diags := res.PluginDownloadURL.Value(hclCtx)
-		if !diags.HasErrors() && val.Type() == cty.String {
+		val, _ = val.Unmark()
+		if !diags.HasErrors() && val.Type() == cty.String && !val.IsNull() && val.IsKnown() {
 			opts.PluginDownloadURL = val.AsString()
 		}
 	}

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -2813,6 +2813,95 @@ resource "aws_instance" "web" {
 	}
 }
 
+func TestEngine_SensitiveResourceOptions(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+variable "secret_timeout" {
+  type      = string
+  sensitive = true
+  default   = "10m"
+}
+
+variable "secret_version" {
+  type      = string
+  sensitive = true
+  default   = "1.2.3"
+}
+
+variable "secret_url" {
+  type      = string
+  sensitive = true
+  default   = "https://example.com/plugins"
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-12345"
+  instance_type = "t3.micro"
+
+  timeouts {
+    create = var.secret_timeout
+  }
+
+  pulumi {
+    retain_on_delete    = length(var.secret_timeout) > 0
+    version             = var.secret_version
+    plugin_download_url = var.secret_url
+    env_var_mappings    = { AWS_REGION = var.secret_timeout }
+  }
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "aws",
+			Resources: map[string]schema.ResourceSpec{
+				"aws:index:Instance": {
+					InputProperties: map[string]schema.PropertySpec{
+						"ami":          {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"instanceType": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"ami":          {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"instanceType": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	var instanceReq *run.RegisterResourceRequest
+	for i := range mock.RegisteredResources {
+		if mock.RegisteredResources[i].Type == "aws:index:Instance" {
+			instanceReq = &mock.RegisteredResources[i]
+			break
+		}
+	}
+	require.NotNil(t, instanceReq, "expected aws:index:Instance resource to be registered")
+
+	retain := true
+	assert.Equal(t, &run.CustomTimeouts{Create: 600}, instanceReq.CustomTimeouts)
+	assert.Equal(t, &retain, instanceReq.RetainOnDelete)
+	assert.Equal(t, "1.2.3", instanceReq.Version)
+	assert.Equal(t, "https://example.com/plugins", instanceReq.PluginDownloadURL)
+	assert.Equal(t, map[string]string{"AWS_REGION": "10m"}, instanceReq.EnvVarMappings)
+}
+
 func TestEngine_MovedBlock(t *testing.T) {
 	t.Parallel()
 

--- a/tests/testutil/tfcompat/providers/timeoutable.go
+++ b/tests/testutil/tfcompat/providers/timeoutable.go
@@ -1,0 +1,52 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TimeoutableProvider exposes a resource that declares operation timeouts, so
+// HCL programs can set a `timeouts` block on it.
+func TimeoutableProvider() *schema.Provider {
+	dur := 20 * time.Minute
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"timeoutable_resource": {
+				Timeouts: &schema.ResourceTimeout{
+					Create: &dur,
+					Update: &dur,
+					Delete: &dur,
+				},
+				Schema: map[string]*schema.Schema{
+					"input_one": {Type: schema.TypeString, Optional: true},
+					"result":    {Type: schema.TypeString, Computed: true},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("timeoutable-id")
+					in, _ := d.Get("input_one").(string)
+					return diag.FromErr(d.Set("result", in+"-done"))
+				},
+				ReadContext:   func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				UpdateContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+			},
+		},
+	}
+}

--- a/tests/tfcompat/l2_timeouts_sensitive_test.go
+++ b/tests/tfcompat/l2_timeouts_sensitive_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+func TestL2TimeoutsSensitive(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_timeouts_sensitive", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "timeoutable", Factory: providers.TimeoutableProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_timeouts_sensitive/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_timeouts_sensitive/main.tf
@@ -1,0 +1,17 @@
+variable "secret_timeout" {
+  type      = string
+  sensitive = true
+  default   = "10m"
+}
+
+resource "timeoutable_resource" "test" {
+  input_one = "hello"
+
+  timeouts {
+    create = var.secret_timeout
+  }
+}
+
+output "result" {
+  value = timeoutable_resource.test.result
+}


### PR DESCRIPTION
## The bug

A resource `timeouts` block whose value is sensitive — e.g. `create = var.secret_timeout` where the variable is declared `sensitive = true` — panics the language host, while OpenTofu applies the same program cleanly:

```
panic: value is marked, so must be unmarked first
```

The `evalTimeout` closure in `buildResourceOptionsInContext` evaluated the expression and called `time.ParseDuration(val.AsString())` without unmarking; `cty.Value.AsString()` panics on marked values. The `val.Type() != cty.String` guard does not catch this because a marked string is still `cty.String`.

## The fix

Unmark the value before use (OpenTofu simply uses the timeout value, so silently unmarking preserves its behavior), and additionally skip null/unknown values, which panic the same accessor.

## Sweep

The same root cause existed at the other meta-attribute call sites in `buildResourceOptionsInContext`, all evaluated against the full evaluation context, so a sensitive variable reaches them the same way:

- `retain_on_delete` — `val.True()` on a possibly marked bool
- `env_var_mappings` — `AsValueMap()`/`AsString()` on a possibly marked map or marked elements (fixed with `UnmarkDeep`)
- `version` — raw `AsString()`
- `plugin_download_url` — raw `AsString()`

All four are fixed with the same unmark + null/known guard.

## Tests

- New tfcompat case `l2_timeouts_sensitive` (panicked before the fix, passes after) comparing apply results against OpenTofu.
- New unit test `TestEngine_SensitiveResourceOptions` driving a sensitive value through the timeout and every swept option, asserting the registered resource options (panicked before the fix, passes after).