### PR TITLE
Support terraform.workspace, resolving to the current stack name

### DIFF
--- a/.changes/unreleased/runtime-Improvements-337.yaml
+++ b/.changes/unreleased/runtime-Improvements-337.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Support `terraform.workspace`, resolving to the current stack name
+time: 2026-07-10T12:31:16Z
+custom:
+    Component: runtime
+    PR: "337"

--- a/.changes/unreleased/runtime-Improvements-338.yaml
+++ b/.changes/unreleased/runtime-Improvements-338.yaml
@@ -3,4 +3,4 @@ body: Support `terraform.workspace`, resolving to the current stack name
 time: 2026-07-10T12:31:16Z
 custom:
     Component: runtime
-    PR: "337"
+    PR: "338"

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -541,6 +541,12 @@ func (c *Context) HCLContext() *hcl.EvalContext {
 		"organization": cty.StringVal(c.pulumi.Organization),
 	})
 
+	// terraform.workspace is the stack name: a Pulumi stack, like a Terraform
+	// workspace, selects a named state instance of the same program.
+	vars["terraform"] = cty.ObjectVal(map[string]cty.Value{
+		"workspace": cty.StringVal(c.pulumi.Stack),
+	})
+
 	// Add count.* if in count context
 	if c.count != nil {
 		vars["count"] = cty.ObjectVal(map[string]cty.Value{

--- a/pkg/hcl/eval/evaluator_test.go
+++ b/pkg/hcl/eval/evaluator_test.go
@@ -376,8 +376,13 @@ func TestContextTerraform(t *testing.T) {
 
 	eval := NewEvaluator(ctx)
 
-	expr := parseExpr(t, `pulumi.stack`)
-	assert.Equal(t, "production", evalString(t, eval, expr))
+	assert.Equal(t, "production", evalString(t, eval, parseExpr(t, `pulumi.stack`)))
+	assert.Equal(t, "production", evalString(t, eval, parseExpr(t, `terraform.workspace`)))
+
+	_, diags := eval.Evaluate(parseExpr(t, `terraform.applying`))
+	assert.Equal(t,
+		`test.hcl:1,10-19: Unsupported attribute; This object does not have an attribute named "applying".`,
+		diags.Error())
 }
 
 func TestContextRangedResources(t *testing.T) {

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -971,6 +971,37 @@ output "region_value" {
 		"the secret value should reach the program intact")
 }
 
+func TestEngine_TerraformWorkspace(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+output "ws" {
+  value = terraform.workspace
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader:    schemaloader.New(t, schema.PackageSpec{Name: "aws"}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	ws, ok := mock.StackOutputs.GetOk("ws")
+	require.True(t, ok, "expected ws output")
+	assert.Equal(t, "dev", ws.AsString())
+}
+
 func TestEngine_VariableFromEnv(t *testing.T) {
 	src := []byte(`
 variable "region" {


### PR DESCRIPTION
## Summary

`output "ws" { value = terraform.workspace }` works in OpenTofu (returning the selected workspace name) but pulumi-hcl failed with `Unknown variable; There is no variable named "terraform"` — the `terraform` scope symbol was never wired into the evaluation context.

This adds the `terraform` scope symbol, with `terraform.workspace` resolving to the **current Pulumi stack name**.

## Why the stack name

Pulumi stacks are the direct analogue of Terraform workspaces: both select a named state instance of the same program. Programs that key behavior off `terraform.workspace` (e.g. `terraform.workspace == "prod" ? ... : ...`) therefore get the equivalent behavior when driven by Pulumi, keyed off the stack. Returning a hardcoded `"default"` would silently collapse every stack into one branch.

## Implementation

- The symbol is built in `Context.HCLContext()` (pkg/hcl/eval/context.go) right beside the existing `pulumi` scope, from the same stack name that `pulumi.stack` uses. Child-module contexts are constructed with the same stack name, so the symbol is available in outputs, locals, resource arguments, and modules alike.
- The dependency-analysis layers (pkg/hcl/graph, eval.ExtractDependencies) already treated `terraform` as a non-dependency scope symbol, so no changes were needed there.
- `terraform.<unknown-attr>` produces HCL's standard unsupported-attribute error (`This object does not have an attribute named "..."`), consistent with how `path.*` and `pulumi.*` behave here.

## Tests

- `TestContextTerraform` (pkg/hcl/eval): `terraform.workspace` resolves to the configured stack name; `terraform.applying` yields the unsupported-attribute error.
- `TestEngine_TerraformWorkspace` (pkg/hcl/run): end-to-end engine run exporting `terraform.workspace` as a stack output.
- `go build ./...` and the full eval/run/graph suites pass (493 tests).