### PR TITLE
Defer dynamic blocks with an unknown for_each during preview

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-339.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-339.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Fix panics when a `dynamic` block's `for_each` is unknown during preview, null, or not iterable
+time: 2026-07-10T12:36:48Z
+custom:
+    Component: runtime
+    PR: "339"

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -334,6 +334,26 @@ func evalDynamicBlocks(
 		var forEachMarks cty.ValueMarks
 		forEachVal, forEachMarks = forEachVal.Unmark()
 
+		if !forEachVal.CanIterateElements() && forEachVal.Type() != cty.DynamicPseudoType {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid dynamic for_each value",
+				Detail: fmt.Sprintf("Cannot use a %s value in for_each. An iterable collection is required.",
+					forEachVal.Type().FriendlyName()),
+				Subject: content.Attributes["for_each"].Expr.Range().Ptr(),
+			})
+			return diags
+		}
+		if forEachVal.IsNull() {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid dynamic for_each value",
+				Detail:   "Cannot use a null value in for_each.",
+				Subject:  content.Attributes["for_each"].Expr.Range().Ptr(),
+			})
+			return diags
+		}
+
 		// Determine the iterator variable name (defaults to block label).
 		// `iterator = <ident>` takes a bare identifier as the new iterator
 		// name, not an expression to evaluate — extract it directly from
@@ -372,6 +392,32 @@ func evalDynamicBlocks(
 			return diags
 		}
 
+		var nestedMapping *bridge.BodyMapping
+		if mapping != nil {
+			if fm := mapping.Lookup(propName); fm != nil {
+				nestedMapping = fm.Nested
+			}
+		}
+
+		key := snakeCaseFromCamelCase(prop.Name)
+
+		// An unknown for_each means the set of expanded blocks cannot be
+		// enumerated yet, so the whole property becomes unknown. Content
+		// expressions are not evaluated; the content body is still checked
+		// against the schema, with every attribute standing in as unknown.
+		if !forEachVal.IsKnown() {
+			unknownEval := func(resource.PropertyKey, hcl.Expression, map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
+				return cty.DynamicVal.WithMarks(forEachMarks), nil
+			}
+			_, _, d := evalBlockWithSchema(contentBody, blockProps, nestedMapping, unknownEval)
+			diags = diags.Extend(d)
+			if d.HasErrors() {
+				return diags
+			}
+			resourceInputs[key] = cty.DynamicVal.WithMarks(forEachMarks)
+			continue
+		}
+
 		// Evaluate the content block for each element.
 		var values []cty.Value
 		it := forEachVal.ElementIterator()
@@ -396,12 +442,6 @@ func evalDynamicBlocks(
 				return eval(propKey, expr, merged)
 			}
 
-			var nestedMapping *bridge.BodyMapping
-			if mapping != nil {
-				if fm := mapping.Lookup(propName); fm != nil {
-					nestedMapping = fm.Nested
-				}
-			}
 			evaluated, _, d := evalBlockWithSchema(contentBody, blockProps, nestedMapping, dynamicEval)
 			diags = diags.Extend(d)
 			if d.HasErrors() {
@@ -410,11 +450,16 @@ func evalDynamicBlocks(
 			values = append(values, evaluated)
 		}
 
-		key := snakeCaseFromCamelCase(prop.Name)
 		if len(values) > 0 {
 			switch {
 			case isList:
 				if existing, ok := resourceInputs[key]; ok {
+					// A previous dynamic block with an unknown for_each already
+					// made the whole property unknown; the expanded set of
+					// blocks cannot be enumerated, so keep it unknown.
+					if unmarked, _ := existing.Unmark(); !unmarked.IsKnown() {
+						continue
+					}
 					// Merge with existing static blocks.
 					for it := existing.ElementIterator(); it.Next(); {
 						_, v := it.Element()
@@ -463,7 +508,7 @@ func conformCtyToType(val cty.Value, typ cty.Type) cty.Value {
 }
 
 func conformUnmarkedCtyToType(val cty.Value, typ cty.Type) cty.Value {
-	if val.Type().Equals(typ) {
+	if val.Type().Equals(typ) || !val.IsKnown() || val.IsNull() {
 		return val
 	}
 

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -1642,3 +1642,186 @@ func TestResourceOutputToCtyRecursiveArrayMixedDepth(t *testing.T) {
 	assert.Equal(t, cty.String, deep.Type())
 	assert.Equal(t, "d2c", deep.AsString())
 }
+
+// parseDynamicBlockResource parses src and returns the body of its single
+// `resource` block together with a schema whose `settings` property is a
+// list-shaped block with a string `name` field.
+func parseDynamicBlockResource(t *testing.T, src string) (hcl.Body, *schema.Resource) {
+	t.Helper()
+
+	file, diags := hclsyntax.ParseConfig([]byte(src), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	body := file.Body.(*hclsyntax.Body)
+	var resourceBody hcl.Body
+	for _, b := range body.Blocks {
+		if b.Type == "resource" {
+			resourceBody = b.Body
+			break
+		}
+	}
+	require.NotNil(t, resourceBody)
+
+	return resourceBody, &schema.Resource{
+		Token: "fake:index:F",
+		InputProperties: []*schema.Property{{
+			Name: "settings",
+			Type: &schema.ArrayType{ElementType: &schema.ObjectType{
+				Properties: []*schema.Property{{Name: "name", Type: schema.StringType}},
+			}},
+		}},
+	}
+}
+
+func TestEvalDynamicBlocks_UnknownForEach(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		forEach  cty.Value
+		expected property.Value
+	}{
+		{
+			name:     "unknown collection",
+			forEach:  cty.UnknownVal(cty.List(cty.Object(map[string]cty.Type{"name": cty.String}))),
+			expected: property.New(property.Computed),
+		},
+		{
+			name:     "unknown of dynamic type",
+			forEach:  cty.DynamicVal,
+			expected: property.New(property.Computed),
+		},
+		{
+			name: "sensitive unknown collection",
+			forEach: cty.UnknownVal(cty.List(cty.String)).
+				WithMarks(cty.NewValueMarks(eval.SensitiveMark)),
+			expected: property.New(property.Computed).WithSecret(true),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resourceBody, r := parseDynamicBlockResource(t, `
+resource "fake" "f" {
+  dynamic "settings" {
+    for_each = local.vpcs
+    content {
+      name = settings.value.name
+    }
+  }
+}`)
+
+			evalFn := func(_ resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
+				if extraVars == nil {
+					return tt.forEach, nil
+				}
+				return expr.Value(&hcl.EvalContext{Variables: extraVars})
+			}
+
+			out, diags := EvalResourceWithSchema(resourceBody, r, nil, evalFn)
+			require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
+			assert.Equal(t, property.NewMap(map[string]property.Value{
+				"settings": tt.expected,
+			}), out)
+		})
+	}
+}
+
+// A known dynamic block cannot restore an enumerable value once a sibling
+// dynamic block with an unknown for_each made the whole property unknown.
+func TestEvalDynamicBlocks_UnknownForEachThenKnown(t *testing.T) {
+	t.Parallel()
+
+	resourceBody, r := parseDynamicBlockResource(t, `
+resource "fake" "f" {
+  dynamic "settings" {
+    for_each = local.unknown
+    content {
+      name = settings.value
+    }
+  }
+  dynamic "settings" {
+    for_each = local.known
+    content {
+      name = settings.value
+    }
+  }
+}`)
+
+	evalFn := func(_ resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
+		if extraVars == nil {
+			traversal := expr.Variables()[0]
+			if traversal[len(traversal)-1].(hcl.TraverseAttr).Name == "unknown" {
+				return cty.UnknownVal(cty.List(cty.String)), nil
+			}
+			return cty.ListVal([]cty.Value{cty.StringVal("p")}), nil
+		}
+		return expr.Value(&hcl.EvalContext{Variables: extraVars})
+	}
+
+	out, diags := EvalResourceWithSchema(resourceBody, r, nil, evalFn)
+	require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"settings": property.New(property.Computed),
+	}), out)
+}
+
+func TestEvalDynamicBlocks_InvalidForEach(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		forEach cty.Value
+		detail  string
+	}{
+		{
+			name:    "null",
+			forEach: cty.NullVal(cty.List(cty.String)),
+			detail:  "Cannot use a null value in for_each.",
+		},
+		{
+			name:    "not iterable",
+			forEach: cty.StringVal("nope"),
+			detail:  "Cannot use a string value in for_each. An iterable collection is required.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resourceBody, r := parseDynamicBlockResource(t, `
+resource "fake" "f" {
+  dynamic "settings" {
+    for_each = local.vpcs
+    content {
+      name = settings.value
+    }
+  }
+}`)
+
+			evalFn := func(_ resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
+				if extraVars == nil {
+					return tt.forEach, nil
+				}
+				return expr.Value(&hcl.EvalContext{Variables: extraVars})
+			}
+
+			_, diags := EvalResourceWithSchema(resourceBody, r, nil, evalFn)
+			require.True(t, diags.HasErrors())
+			assert.Equal(t, "Invalid dynamic for_each value", diags[0].Summary)
+			assert.Equal(t, tt.detail, diags[0].Detail)
+		})
+	}
+}
+
+func TestConformCtyToType_UnknownAndNull(t *testing.T) {
+	t.Parallel()
+
+	objType := cty.Object(map[string]cty.Type{"a": cty.String})
+	for _, val := range []cty.Value{cty.UnknownVal(objType), cty.NullVal(objType)} {
+		assert.Equal(t, val, conformCtyToType(val, cty.Map(cty.String)))
+	}
+}

--- a/tests/tfcompat/l2_dynamic_unknown_for_each_test.go
+++ b/tests/tfcompat/l2_dynamic_unknown_for_each_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A `dynamic` block whose `for_each` reads a computed attribute of a
+// not-yet-created resource is unknown at preview time. Preview must
+// treat the whole block property as unknown instead of panicking with
+// "can't use ElementIterator on unknown value"; apply then expands the
+// block with the known value.
+func TestL2DynamicUnknownForEach(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_dynamic_unknown_for_each", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+			{Name: "blocky", Factory: providers.BlockyProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StagePreview},
+			{Mode: tfcompat.StageApply},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_dynamic_unknown_for_each/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_dynamic_unknown_for_each/main.tf
@@ -1,0 +1,22 @@
+# A `dynamic` block whose `for_each` is unknown at preview time
+# (it reads a computed attribute of a not-yet-created resource).
+# The whole `tag` property must render as unknown during preview
+# and expand normally at apply.
+resource "simple_resource" "upstream" {
+  input_one = "a"
+  input_two = true
+}
+
+resource "blocky_thing" "x" {
+  name = "y"
+
+  dynamic "tag" {
+    for_each = simple_resource.upstream.result == "never" ? ["a"] : ["b"]
+    content {
+      key   = "k"
+      value = tag.value
+    }
+  }
+}
+
+output "summary" { value = blocky_thing.x.summary }


### PR DESCRIPTION
## Problem

A `dynamic` block whose `for_each` is unknown at preview time — for example, one that reads a computed attribute of a not-yet-created resource:

```hcl
resource "blocky_thing" "x" {
  name = "y"

  dynamic "tag" {
    for_each = simple_resource.upstream.result == "never" ? ["a"] : ["b"]
    content {
      key   = "k"
      value = tag.value
    }
  }
}
```

plans cleanly under `tofu plan`, rendering the whole `tag` block as "(known after apply)", but `pulumi preview` panicked:

```
panic: panic in DAG processing: can't use ElementIterator on unknown value
    github.com/zclconf/go-cty/cty.Value.ElementIterator
    .../pkg/hcl/transform.evalDynamicBlocks
```

`evalDynamicBlocks` called `ElementIterator()` on the `for_each` value without checking `IsKnown()`. The resource-level `count`/`for_each` analogue was already fixed in https://github.com/pulumi-labs/pulumi-hcl/pull/319; this is the dynamic-block-expansion sibling.

## Fix

When `for_each` is unknown, the whole block property becomes unknown, matching how HCL's dynblock extension substitutes an unknown body for the expanded block. The content body is still validated against the schema — every attribute stands in as an unknown value carrying the `for_each` marks — but its expressions are not evaluated. Sensitivity and dependency marks on the `for_each` value propagate to the unknown property. A sibling dynamic block with a known `for_each` cannot restore an enumerable value once the property is unknown.

## Sweep for the same root cause

All `ElementIterator()`/`LengthInt()`/`AsBigFloat()` call sites in `pkg/hcl/transform/` were audited for possibly-unknown operands:

- A null or non-iterable (e.g. string) dynamic `for_each` panicked the same way; both now report a proper diagnostic ("Cannot use a null value in for_each." / "Cannot use a string value in for_each. An iterable collection is required.").
- `conformUnmarkedCtyToType` iterated an object-typed value to conform it to a map-typed attribute without checking known/null; an unknown or null object now passes through and converts to a computed/null property downstream.
- Resource-level unknown `count`/`for_each` was verified as already guarded (`EvaluateCount`/`EvaluateForEach` return an unknown result before any iteration) and covered by the tests from https://github.com/pulumi-labs/pulumi-hcl/pull/319 (`TestEngine_CountFromResourceOutput` and friends); no further changes needed there.
- The remaining call sites only run after an `IsKnown()` guard or on freshly constructed known values.

## Testing

- New tfcompat case `l2_dynamic_unknown_for_each` runs the fixture above through a preview stage (panicked before the fix, now matches `tofu plan`) and an apply stage (end-state parity).
- Unit tests in `pkg/hcl/transform` cover the unknown `for_each` result (plain, dynamic-typed, and sensitive), the unknown-then-known sibling block, the null / non-iterable diagnostics, and the unknown/null object pass-through in `conformCtyToType`.
