### PR TITLE
Reject base64decode results that are not valid UTF-8

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-341.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-341.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Reject `base64decode` results that are not valid UTF-8
+time: 2026-07-10T13:39:01Z
+custom:
+    Component: runtime
+    PR: "341"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -43,6 +43,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/bmatcuk/doublestar/v4"
@@ -1028,6 +1029,9 @@ var base64DecodeFunc = function.New(&function.Spec{
 		decoded, err := base64.StdEncoding.DecodeString(args[0].AsString())
 		if err != nil {
 			return cty.NilVal, err
+		}
+		if !utf8.Valid(decoded) {
+			return cty.NilVal, fmt.Errorf("the result of decoding the provided string is not valid UTF-8")
 		}
 		return cty.StringVal(string(decoded)), nil
 	},

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -445,6 +445,35 @@ func TestEncodingFunctions(t *testing.T) {
 	}
 }
 
+func TestBase64DecodeUTF8Validation(t *testing.T) {
+	t.Parallel()
+	fn := Functions("/tmp")["base64decode"]
+
+	t.Run("valid utf-8", func(t *testing.T) {
+		t.Parallel()
+		result, err := fn.Call([]cty.Value{cty.StringVal("SGVsbG8=")})
+		require.NoError(t, err)
+		assert.Equal(t, cty.StringVal("Hello"), result)
+	})
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"single 0xff byte", "/w=="},
+		{"single 0x80 byte", "gA=="},
+		{"multiple invalid bytes", "//79"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := fn.Call([]cty.Value{cty.StringVal(tt.input)})
+			require.Error(t, err)
+			assert.Equal(t, "the result of decoding the provided string is not valid UTF-8", err.Error())
+		})
+	}
+}
+
 func TestHashFunctions(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/tests/tfcompat/l1_base64decode_utf8_test.go
+++ b/tests/tfcompat/l1_base64decode_utf8_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+func TestL1Base64DecodeUTF8(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_base64decode_utf8", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_base64decode_utf8/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_base64decode_utf8/main.tf
@@ -1,0 +1,11 @@
+# base64decode of a valid base64 string whose decoded bytes are NOT valid
+# UTF-8. can() isolates the difference into a comparable boolean output that
+# both runtimes can produce.
+output "can_ff" { value = can(base64decode("/w==")) }
+
+output "can_80" { value = can(base64decode("gA==")) }
+
+output "can_multi" { value = can(base64decode("//79")) }
+
+# A control: valid UTF-8 decodes cleanly on both.
+output "can_hello" { value = can(base64decode("SGVsbG8=")) }


### PR DESCRIPTION
## Summary

`base64decode` returned `cty.StringVal(string(decoded))` for any successfully decoded base64 payload, even when the decoded bytes were not valid UTF-8. OpenTofu's `Base64DecodeFunc` guards this case and fails with "the result of decoding the provided string is not valid UTF-8", so expressions like `can(base64decode("/w=="))` evaluated to `true` under pulumi-hcl but `false` under tofu.

This adds the same `utf8.Valid` guard with the same error message. The base64 alphabet handling already matched (both use `base64.StdEncoding`), so no other changes were needed.

## Testing

- Unit test `TestBase64DecodeUTF8Validation` in `pkg/hcl/eval/functions_test.go` covers a valid UTF-8 decode plus `/w==`, `gA==`, and `//79` returning the exact error.
- New tfcompat case `l1_base64decode_utf8` compares `can(base64decode(...))` outputs across both runtimes; it fails on master (all `true` vs tofu's `false`) and passes with this change.