### PR TITLE
Enforce precondition and postcondition blocks on data sources

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-342.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-342.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Enforce `precondition` and `postcondition` blocks on data sources
+time: 2026-07-10T13:44:11Z
+custom:
+    Component: runtime
+    PR: "342"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2736,6 +2736,13 @@ func (e *Engine) invokeDataSourceOnce(
 ) (cty.Value, error) {
 	hclCtx := evalCtx.HCLContext()
 
+	// Failed preconditions prevent the read; unknown conditions defer.
+	for i, rule := range ds.Preconditions {
+		if err := evaluatePrecondition(rule, hclCtx, i+1, node.Key); err != nil {
+			return cty.NilVal, err
+		}
+	}
+
 	depMarks := cty.ValueMarks{}
 	addURN := func(urn string) {
 		if urn == "" {
@@ -2844,6 +2851,12 @@ func (e *Engine) invokeDataSourceOnce(
 	ctyOutputs, err := transform.FunctionOutputToCty(outputs, funcSchema, dataSourceMapping, e.dryRun)
 	if err != nil {
 		return cty.NilVal, fmt.Errorf("converting function outputs to HCL types: %w", err)
+	}
+
+	for i, rule := range ds.Postconditions {
+		if err := evaluatePostconditionValue(rule, hclCtx, ctyOutputs, i+1, node.Key); err != nil {
+			return cty.NilVal, err
+		}
 	}
 
 	return ctyOutputs.WithMarks(depMarks), nil
@@ -3825,8 +3838,16 @@ func evaluatePostcondition(
 	if err != nil {
 		return fmt.Errorf("converting outputs for postcondition %d on %s: %w", index, resourceName, err)
 	}
+	return evaluatePostconditionValue(rule, hclCtx, cty.ObjectVal(outputObj), index, resourceName)
+}
+
+// evaluatePostconditionValue evaluates a postcondition with `self` bound to
+// the given value. Unknown conditions defer (return nil).
+func evaluatePostconditionValue(
+	rule *ast.CheckRule, hclCtx *hcl.EvalContext, self cty.Value, index int, resourceName string,
+) error {
 	selfCtx := hclCtx.NewChild()
-	selfCtx.Variables = map[string]cty.Value{"self": cty.ObjectVal(outputObj)}
+	selfCtx.Variables = map[string]cty.Value{"self": self}
 	condVal, diags := rule.Condition.Value(selfCtx)
 	if diags.HasErrors() {
 		return fmt.Errorf("evaluating postcondition %d for %s: %s", index, resourceName, diags.Error())

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -4542,3 +4542,100 @@ data "aws_instance" "dependent" {
 		require.ErrorContains(t, err, "the for_each value depends on values that are not yet known")
 	})
 }
+
+func TestEngine_DataSourceConditions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("precondition fail blocks the read", func(t *testing.T) {
+		t.Parallel()
+		mock, err := tryExpansion(t, `
+variable "enabled" {
+  type    = bool
+  default = false
+}
+
+data "aws_instance" "d" {
+  filter = "x"
+
+  lifecycle {
+    precondition {
+      condition     = var.enabled
+      error_message = "DATA_PRECONDITION_MSG"
+    }
+  }
+}
+`, false, false)
+		require.ErrorContains(t, err, "precondition for data.aws_instance.d: DATA_PRECONDITION_MSG")
+		assert.Empty(t, mock.InvokedFunctions, "a failed precondition must prevent the read")
+	})
+
+	t.Run("postcondition fail after the read", func(t *testing.T) {
+		t.Parallel()
+		mock, err := tryExpansion(t, `
+data "aws_instance" "d" {
+  filter = "x"
+
+  lifecycle {
+    postcondition {
+      condition     = self.result == "nope"
+      error_message = "DATA_POSTCONDITION_MSG"
+    }
+  }
+}
+`, false, false)
+		require.ErrorContains(t, err, "postcondition for data.aws_instance.d: DATA_POSTCONDITION_MSG")
+		require.Len(t, mock.InvokedFunctions, 1, "the postcondition must be evaluated against a completed read")
+	})
+
+	t.Run("passing conditions", func(t *testing.T) {
+		t.Parallel()
+		mock, err := tryExpansion(t, `
+variable "enabled" {
+  type    = bool
+  default = true
+}
+
+data "aws_instance" "d" {
+  filter = "x"
+
+  lifecycle {
+    precondition {
+      condition     = var.enabled
+      error_message = "unreachable"
+    }
+    postcondition {
+      condition     = self.result == "result-x"
+      error_message = "unreachable"
+    }
+  }
+}
+
+output "result" {
+  value = data.aws_instance.d.result
+}
+`, false, false)
+		require.NoError(t, err)
+		assert.Equal(t, property.New("result-x"), mock.StackOutputs.Get("result"))
+	})
+
+	t.Run("unknown postcondition defers during preview", func(t *testing.T) {
+		t.Parallel()
+		_, err := tryExpansion(t, `
+data "aws_instance" "d" {
+  filter = tostring(aws_instance.base.num)
+
+  lifecycle {
+    postcondition {
+      condition     = self.result == "nope"
+      error_message = "unreachable during preview"
+    }
+  }
+}
+
+resource "aws_instance" "base" {
+  ami = "ami-base"
+}
+`, true, true)
+		require.NoError(t, err)
+	})
+}

--- a/tests/tfcompat/l2_data_source_postcondition_fail_test.go
+++ b/tests/tfcompat/l2_data_source_postcondition_fail_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2DataSourcePostconditionFail asserts a failing postcondition with
+// `self` bound to the data source's result state fails the operation on both
+// runtimes with the configured message.
+func TestL2DataSourcePostconditionFail(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_source_postcondition_fail", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			Mode:      tfcompat.StageApply,
+			ExpectErr: "DATA_POSTCONDITION_VIOLATED",
+		}},
+	})
+}

--- a/tests/tfcompat/l2_data_source_precondition_fail_test.go
+++ b/tests/tfcompat/l2_data_source_precondition_fail_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2DataSourcePreconditionFail asserts a failing precondition on a data
+// source blocks the read on both runtimes with the configured message.
+func TestL2DataSourcePreconditionFail(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_source_precondition_fail", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			Mode:      tfcompat.StageApply,
+			ExpectErr: "DATA_PRECONDITION_VIOLATED",
+		}},
+	})
+}
+
+// TestL2DataSourceConditionPass asserts passing precondition and postcondition
+// blocks on a data source do not block the read on either runtime.
+func TestL2DataSourceConditionPass(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_source_condition_pass", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_data_source_condition_pass/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_source_condition_pass/main.tf
@@ -1,0 +1,23 @@
+variable "expected_suffix" {
+  type    = string
+  default = "hello"
+}
+
+data "simple_lookup" "d" {
+  query = "hello"
+
+  lifecycle {
+    precondition {
+      condition     = length(var.expected_suffix) > 0
+      error_message = "unreachable precondition"
+    }
+    postcondition {
+      condition     = endswith(self.prefix_result, var.expected_suffix)
+      error_message = "unreachable postcondition"
+    }
+  }
+}
+
+output "looked_up" {
+  value = data.simple_lookup.d.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_data_source_postcondition_fail/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_source_postcondition_fail/main.tf
@@ -1,0 +1,14 @@
+data "simple_lookup" "d" {
+  query = "hello"
+
+  lifecycle {
+    postcondition {
+      condition     = self.prefix_result == "wrong-expected-value"
+      error_message = "DATA_POSTCONDITION_VIOLATED"
+    }
+  }
+}
+
+output "looked_up" {
+  value = data.simple_lookup.d.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_data_source_precondition_fail/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_source_precondition_fail/main.tf
@@ -1,0 +1,19 @@
+variable "trigger_failure" {
+  type    = bool
+  default = true
+}
+
+data "simple_lookup" "d" {
+  query = "hello"
+
+  lifecycle {
+    precondition {
+      condition     = !var.trigger_failure
+      error_message = "DATA_PRECONDITION_VIOLATED"
+    }
+  }
+}
+
+output "looked_up" {
+  value = data.simple_lookup.d.prefix_result
+}


### PR DESCRIPTION
## Problem

`lifecycle { precondition }` and `postcondition` blocks on `data` blocks were silently dropped. The parser decoded them (the decoding path is shared with `resource` blocks), but the runtime never evaluated them: a data source with a failing condition applied successfully instead of failing with the configured `error_message`. The same blocks on managed resources already worked.

## Fix

Evaluate data-source conditions in `invokeDataSourceOnce`, which covers single, `count`/`for_each`, and module-scoped data sources uniformly:

- **Preconditions** run before the config is evaluated and the read is invoked; a failure prevents the read.
- **Postconditions** run after the read, with `self` bound to the data source's result state.
- Unknown conditions defer (e.g. during preview when the result is not yet known), matching the existing managed-resource behavior.

The resource-side postcondition evaluation is refactored to share a single `evaluatePostconditionValue` helper.

## Tests

- `tests/tfcompat/testdata/cases/l2_data_source_precondition_fail` and `l2_data_source_postcondition_fail`: both runtimes fail apply with the configured message (both failed against pulumi-hcl before this change, which applied successfully).
- `tests/tfcompat/testdata/cases/l2_data_source_condition_pass`: passing conditions do not block the read.
- Unit tests in `pkg/hcl/run` cover precondition failure blocking the invoke, postcondition failure after the invoke, passing conditions, and unknown-condition deferral during preview.

Existing condition suites (`TestL2Precondition*`, `TestL2Postcondition*`, `TestL2Check*`, output preconditions) still pass.