### PR TITLE
Support for_each on aliased provider blocks

### DIFF
--- a/.changes/unreleased/runtime-Improvements-343.yaml
+++ b/.changes/unreleased/runtime-Improvements-343.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Support `for_each` on aliased `provider` blocks and indexed provider instance references
+time: 2026-07-10T13:51:34Z
+custom:
+    Component: runtime
+    PR: "343"

--- a/pkg/hcl/ast/provider.go
+++ b/pkg/hcl/ast/provider.go
@@ -34,6 +34,12 @@ type Provider struct {
 	// This allows multiple configurations of the same provider.
 	Alias string
 
+	// ForEach is the raw expression from the `for_each` attribute, if
+	// specified. It expands the block into one provider instance per key,
+	// selected on resources as `<name>.<alias>[<key>]`. Only valid together
+	// with Alias.
+	ForEach hcl.Expression
+
 	// Config is the body containing provider configuration attributes
 	// (with the Pulumi-specific resource-option attributes already extracted).
 	Config hcl.Body

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -620,10 +620,16 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node 
 
 // providerDeps extracts all dependencies from a provider block, applying prefix to resolved keys.
 func (g *Graph) providerDeps(provider *ast.Provider, prefix string) []pdag.Node {
-	if provider.Config == nil {
-		return nil
+	seen := make(map[pdag.Node]bool)
+	for _, dep := range g.exprDeps(provider.ForEach, prefix) {
+		seen[dep] = true
 	}
-	return g.bodyDeps(provider.Config, prefix, nil)
+	if provider.Config != nil {
+		for _, dep := range g.bodyDeps(provider.Config, prefix, nil) {
+			seen[dep] = true
+		}
+	}
+	return slices.Collect(maps.Keys(seen))
 }
 
 // bodyDeps extracts dependencies from an HCL body, applying prefix to resolved keys.

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -433,6 +433,17 @@ func (p *Parser) parseProviderBlock(config *ast.Config, block *hcl.Block) hcl.Di
 			provider.Alias = val.AsString()
 		}
 	}
+	if attr, ok := content.Attributes["for_each"]; ok {
+		provider.ForEach = attr.Expr
+	}
+	if provider.ForEach != nil && provider.Alias == "" {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  `Alias required when using "for_each"`,
+			Detail:   "The for_each argument is allowed only for provider configurations with an alias.",
+			Subject:  provider.ForEach.Range().Ptr(),
+		})
+	}
 	for _, subBlock := range content.Blocks {
 		if subBlock.Type == "pulumi" {
 			diags = append(diags, p.parsePulumiProviderOptions(subBlock, provider)...)

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -772,6 +772,41 @@ variable "subnets" {
 	}
 }
 
+func TestParseProviderForEach(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+provider "simple" {
+  alias    = "by_key"
+  for_each = { a = "alpha" }
+  prefix   = each.value
+}
+`)
+	config, diags := NewParser().ParseSource("test.tf", src)
+	require.False(t, diags.HasErrors(), "unexpected errors: %v", diags.Errs())
+
+	provider, ok := config.Providers["simple.by_key"]
+	require.True(t, ok)
+	assert.Equal(t, "simple", provider.Name)
+	assert.Equal(t, "by_key", provider.Alias)
+	assert.NotNil(t, provider.ForEach)
+}
+
+func TestParseProviderForEachRequiresAlias(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+provider "simple" {
+  for_each = { a = "alpha" }
+  prefix   = each.value
+}
+`)
+	_, diags := NewParser().ParseSource("test.tf", src)
+	require.True(t, diags.HasErrors())
+	assert.Equal(t,
+		`test.tf:3,14-29: Alias required when using "for_each"; `+
+			"The for_each argument is allowed only for provider configurations with an alias.",
+		diags.Error())
+}
+
 func contains(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {
 		if s[i:i+len(sub)] == sub {

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -80,13 +80,14 @@ var terraformPackageSchema = &hcl.BodySchema{
 	},
 }
 
-// providerSchema defines the structure of a provider block. Only `alias` (a
-// Terraform-standard meta-argument) lives at the top level; Pulumi-specific
-// options go in the nested `pulumi` block so they cannot collide with a
-// provider's own configuration attributes.
+// providerSchema defines the structure of a provider block. Only `alias` and
+// `for_each` (Terraform-standard meta-arguments) live at the top level;
+// Pulumi-specific options go in the nested `pulumi` block so they cannot
+// collide with a provider's own configuration attributes.
 var providerSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{Name: "alias"},
+		{Name: "for_each"},
 	},
 	Blocks: []hcl.BlockHeaderSchema{
 		{Type: "pulumi"},

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -906,11 +906,60 @@ func (e *Engine) processProvider(ctx context.Context, node *graph.Node) error {
 
 	if node.ModuleInfo != nil {
 		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-			return e.registerProviderInContext(ctx, node, provider, inst.EvalCtx, inst.URN, inst)
+			return e.registerProvider(ctx, node, provider, inst.EvalCtx, inst.URN, inst)
 		})
 	}
 
-	return e.registerProviderInContext(ctx, node, provider, e.evaluator.Context(), e.stackURN, nil)
+	return e.registerProvider(ctx, node, provider, e.evaluator.Context(), e.stackURN, nil)
+}
+
+// providerInstance carries one `for_each` instance of a provider block: the
+// instance key and the element value bound to each.key/each.value while the
+// block's config is evaluated.
+type providerInstance struct {
+	key   string
+	value cty.Value
+}
+
+// registerProvider registers a provider block in evalCtx: one instance per
+// for_each key when the block has `for_each`, otherwise a single
+// configuration.
+func (e *Engine) registerProvider(
+	ctx context.Context, node *graph.Node, provider *ast.Provider,
+	evalCtx *eval.Context, parentURN urn.URN, modInst *moduleInstance,
+) error {
+	if provider.ForEach == nil {
+		return e.registerProviderInContext(ctx, node, provider, evalCtx, parentURN, modInst, nil)
+	}
+
+	forEach, unknown, diags := eval.NewEvaluator(evalCtx).EvaluateForEach(provider.ForEach)
+	if diags.HasErrors() {
+		return fmt.Errorf("evaluating for_each for provider %s: %s", node.Key, diags.Error())
+	}
+	// Provider instances must be configurable up front, so unlike a
+	// resource's for_each an unknown value is an error even during preview.
+	if unknown {
+		return fmt.Errorf("%s: the for_each value depends on values that are not yet known", node.Key)
+	}
+
+	for _, key := range slices.Sorted(maps.Keys(forEach)) {
+		inst := &providerInstance{key: key, value: forEach[key]}
+		if err := e.registerProviderInContext(ctx, node, provider, evalCtx, parentURN, modInst, inst); err != nil {
+			return err
+		}
+	}
+
+	// An empty for_each still binds the provider address so a reference
+	// evaluates to an empty collection rather than "no such attribute".
+	if len(forEach) == 0 {
+		baseKey := node.Key
+		if node.ModuleInfo != nil {
+			baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix())
+		}
+		evalCtx.SetResource(baseKey, "", cty.EmptyObjectVal)
+	}
+
+	return nil
 }
 
 // resolvePassThroughProvider looks up a provider passed into a module via
@@ -1001,8 +1050,14 @@ func providerExprKey(expr hcl.Expression) string {
 func (e *Engine) registerProviderInContext(
 	ctx context.Context, node *graph.Node, provider *ast.Provider,
 	evalCtx *eval.Context, parentURN urn.URN, modInst *moduleInstance,
+	inst *providerInstance,
 ) error {
 	typeToken := "pulumi:providers:" + provider.Name
+
+	if inst != nil {
+		evalCtx.SetEach(cty.StringVal(inst.key), inst.value)
+		defer evalCtx.ClearEach()
+	}
 
 	hclCtx := evalCtx.HCLContext()
 
@@ -1039,6 +1094,9 @@ func (e *Engine) registerProviderInContext(
 	logicalName := provider.Alias
 	if logicalName == "" {
 		logicalName = provider.Name
+	}
+	if inst != nil {
+		logicalName = logicalName + "-" + inst.key
 	}
 	if modInst != nil {
 		modInstanceName := modInst.Path.LogicalName()
@@ -1148,7 +1206,11 @@ func (e *Engine) registerProviderInContext(
 	// into.
 	outputObj["urn"] = cty.StringVal(string(resp.URN))
 
-	e.resourceOutputs.Set(node.Key, cty.ObjectVal(outputObj).Mark(eval.DepMark(resp.URN)))
+	outputsKey := node.Key
+	if inst != nil {
+		outputsKey = fmt.Sprintf("%s[%q]", node.Key, inst.key)
+	}
+	e.resourceOutputs.Set(outputsKey, cty.ObjectVal(outputObj).Mark(eval.DepMark(resp.URN)))
 
 	// Top-level un-aliased provider blocks become the default provider for
 	// resources of the same package that don't set `provider` explicitly.
@@ -1157,12 +1219,17 @@ func (e *Engine) registerProviderInContext(
 	}
 
 	markedProviderOutputs := cty.ObjectVal(outputObj).Mark(eval.DepMark(resp.URN))
+	bareKey := node.Key
 	if node.ModuleInfo != nil {
 		// Strip prefix for module-internal references
-		bareKey := strings.TrimPrefix(node.Key, node.ModuleInfo.Prefix())
-		evalCtx.SetResource(bareKey, resp.URN, markedProviderOutputs)
+		bareKey = strings.TrimPrefix(node.Key, node.ModuleInfo.Prefix())
+	}
+	if inst != nil {
+		// Instances assemble into an object keyed by each.key, so
+		// `<name>.<alias>["key"]` selects one through ordinary indexing.
+		evalCtx.SetEachResource(bareKey, inst.key, resp.URN, markedProviderOutputs)
 	} else {
-		evalCtx.SetResource(node.Key, resp.URN, markedProviderOutputs)
+		evalCtx.SetResource(bareKey, resp.URN, markedProviderOutputs)
 	}
 
 	return nil

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -3991,6 +3992,108 @@ module "child" {
 // When both the root and a child module declare a default `provider "simple"`
 // config, a resource in the child binds to the child's own block, not the
 // inherited root default.
+// A provider block with for_each registers one provider per key, each
+// configured with its own each.value, and a resource's
+// `provider = simple.by_key["a"]` binds to the matching instance.
+func TestEngine_ProviderForEach(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+variable "prefixes" {
+  type = map(string)
+  default = {
+    a = "alpha"
+    b = "beta"
+  }
+}
+
+provider "simple" {
+  alias    = "by_key"
+  for_each = var.prefixes
+  prefix   = each.value
+}
+
+resource "simple_resource" "r" {
+  provider = simple.by_key["a"]
+  input    = "world"
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "simple",
+			Provider: &schema.ResourceSpec{
+				InputProperties: map[string]schema.PropertySpec{
+					"prefix": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+			Resources: map[string]schema.ResourceSpec{
+				"simple:index:Resource": {
+					InputProperties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	var stackURN urn.URN
+	var providerRegs []run.RegisterResourceRequest
+	var resourceReg *run.RegisterResourceRequest
+	for i, r := range mock.RegisteredResources {
+		switch r.Type {
+		case "pulumi:pulumi:Stack":
+			stackURN = urn.URN("urn:pulumi:test::project::" + r.Type + "::" + r.Name)
+		case "pulumi:providers:simple":
+			providerRegs = append(providerRegs, r)
+		case "simple:index:Resource":
+			resourceReg = &mock.RegisteredResources[i]
+		}
+	}
+	sort.Slice(providerRegs, func(i, j int) bool { return providerRegs[i].Name < providerRegs[j].Name })
+
+	assert.Equal(t, []run.RegisterResourceRequest{
+		{
+			Type:   "pulumi:providers:simple",
+			Name:   "by_key-a",
+			Inputs: property.NewMap(map[string]property.Value{"prefix": property.New("alpha")}),
+			Custom: true,
+			Parent: stackURN,
+		},
+		{
+			Type:   "pulumi:providers:simple",
+			Name:   "by_key-b",
+			Inputs: property.NewMap(map[string]property.Value{"prefix": property.New("beta")}),
+			Custom: true,
+			Parent: stackURN,
+		},
+	}, providerRegs)
+
+	require.NotNil(t, resourceReg, "resource should register")
+	assert.Equal(t,
+		"urn:pulumi:test::project::pulumi:providers:simple::by_key-a::by_key-a-id",
+		resourceReg.Provider,
+		"the resource must bind to the provider instance selected by its key")
+}
+
 func TestEngine_ProviderResolution_ChildModuleBlockWins(t *testing.T) {
 	t.Parallel()
 

--- a/tests/tfcompat/l2_module_provider_for_each_passthrough_test.go
+++ b/tests/tfcompat/l2_module_provider_for_each_passthrough_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ModuleProviderForEachPassthrough passes one instance of a `for_each`
+// provider into a child module via `providers = { simple = simple.by_key["b"] }`.
+// The child's resource has no provider argument, so it should be configured by
+// the "beta" instance: `prefix_result` is "beta-world".
+func TestL2ModuleProviderForEachPassthrough(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_provider_for_each_passthrough", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_provider_for_each_data_source_test.go
+++ b/tests/tfcompat/l2_provider_for_each_data_source_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ProviderForEachDataSource reads a data source through a dynamic
+// provider instance (`simple.by_key["b"]`), so `prefix_result` should carry
+// the "beta" instance's config: "beta-hello".
+func TestL2ProviderForEachDataSource(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_provider_for_each_data_source", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_provider_for_each_dynamic_key_test.go
+++ b/tests/tfcompat/l2_provider_for_each_dynamic_key_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ProviderForEachDynamicKey selects a provider instance with a
+// per-instance key expression: a resource that itself uses `for_each` picks
+// `simple.by_key[each.key]`, so each resource instance is configured by the
+// provider instance sharing its key ("a" → "alpha-a", "b" → "beta-b").
+func TestL2ProviderForEachDynamicKey(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_provider_for_each_dynamic_key", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_provider_for_each_test.go
+++ b/tests/tfcompat/l2_provider_for_each_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ProviderForEach exercises OpenTofu 1.9's `for_each` on an aliased
+// provider block, selecting a single dynamic provider instance with
+// `simple.by_key["a"]`. The resource is configured by the "alpha" instance,
+// so `prefix_result` should be "alpha-world".
+func TestL2ProviderForEach(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_provider_for_each", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_module_provider_for_each_passthrough/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_provider_for_each_passthrough/main.tf
@@ -1,0 +1,24 @@
+variable "prefixes" {
+  type = map(string)
+  default = {
+    a = "alpha"
+    b = "beta"
+  }
+}
+
+provider "simple" {
+  alias    = "by_key"
+  for_each = var.prefixes
+  prefix   = each.value
+}
+
+module "child" {
+  source = "./modules/child"
+  providers = {
+    simple = simple.by_key["b"]
+  }
+}
+
+output "module_prefix_result" {
+  value = module.child.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_provider_for_each_passthrough/modules/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_provider_for_each_passthrough/modules/child/main.tf
@@ -1,0 +1,8 @@
+resource "simple_resource" "r" {
+  input_one = "world"
+  input_two = true
+}
+
+output "prefix_result" {
+  value = simple_resource.r.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_provider_for_each/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provider_for_each/main.tf
@@ -1,0 +1,23 @@
+variable "prefixes" {
+  type = map(string)
+  default = {
+    a = "alpha"
+    b = "beta"
+  }
+}
+
+provider "simple" {
+  alias    = "by_key"
+  for_each = var.prefixes
+  prefix   = each.value
+}
+
+resource "simple_resource" "a" {
+  provider  = simple.by_key["a"]
+  input_one = "world"
+  input_two = true
+}
+
+output "prefix_result" {
+  value = simple_resource.a.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_provider_for_each_data_source/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provider_for_each_data_source/main.tf
@@ -1,0 +1,22 @@
+variable "prefixes" {
+  type = map(string)
+  default = {
+    a = "alpha"
+    b = "beta"
+  }
+}
+
+provider "simple" {
+  alias    = "by_key"
+  for_each = var.prefixes
+  prefix   = each.value
+}
+
+data "simple_lookup" "d" {
+  provider = simple.by_key["b"]
+  query    = "hello"
+}
+
+output "prefix_result" {
+  value = data.simple_lookup.d.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_provider_for_each_dynamic_key/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provider_for_each_dynamic_key/main.tf
@@ -1,0 +1,24 @@
+variable "prefixes" {
+  type = map(string)
+  default = {
+    a = "alpha"
+    b = "beta"
+  }
+}
+
+provider "simple" {
+  alias    = "by_key"
+  for_each = var.prefixes
+  prefix   = each.value
+}
+
+resource "simple_resource" "r" {
+  for_each  = var.prefixes
+  provider  = simple.by_key[each.key]
+  input_one = each.key
+  input_two = true
+}
+
+output "prefix_results" {
+  value = { for k, r in simple_resource.r : k => r.prefix_result }
+}


### PR DESCRIPTION
## The gap

OpenTofu 1.9+ supports `for_each` on aliased provider configuration blocks (provider iteration), with resources selecting an instance via `provider = simple.by_key["a"]`. `tofu apply` handles such programs cleanly, while pulumi-hcl rejected them at parse time with `An argument named "for_each" is not expected here`.

## What now works

- `provider` blocks with an alias may declare `for_each`, expanding into one provider instance per key. `each.key` and `each.value` are in scope inside the block's configuration.
- Resources and data sources select an instance with an indexed reference: `provider = simple.by_key["a"]`, including dynamic keys such as `simple.by_key[each.key]` on a resource that itself uses `for_each`.
- A module call's `providers = { simple = simple.by_key["b"] }` passes a single indexed instance through to a child module.
- `for_each` on a provider block without an alias is an error, and an unknown `for_each` value is an error even during preview, since provider instances must be configurable up front.

## Design notes

- The parser extracts `for_each` as a provider meta-argument alongside `alias`, keeping it out of the provider's config body.
- The graph adds the `for_each` expression's references as dependencies of the provider node, so e.g. a `var` it reads is resolved first. Indexed references like `simple.by_key["a"]` already resolved to the `simple.by_key` node, so ordering and lazy configure (unused blocks are never configured) carry over unchanged.
- The engine registers one `pulumi:providers:*` resource per key (named `<alias>-<key>`) and binds the instances into the evaluation context through the same ranged-instance machinery resources use, assembling an object keyed by `each.key`. Instance selection is then ordinary HCL indexing feeding the existing provider-reference resolution, which is what makes dynamic keys and module passthrough work without dedicated code paths.

## Testing

Four new tfcompat cases (each verified against real `tofu` by the harness): `l2_provider_for_each`, `l2_provider_for_each_dynamic_key`, `l2_provider_for_each_data_source`, and `l2_module_provider_for_each_passthrough`; plus parser unit tests for the meta-argument and its alias requirement, and an engine test asserting per-key provider registrations and instance binding.