### PR TITLE
Isolate tfcompat provider instances per connection

### DIFF
--- a/tests/testutil/pulexec/bridge.go
+++ b/tests/testutil/pulexec/bridge.go
@@ -19,6 +19,7 @@ package pulexec
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -41,47 +42,61 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// SDKv2Provider builds a Provider from an SDKv2 (helper/schema) provider via
-// the classic bridge.
+// SDKv2Provider builds a Provider from an SDKv2 (helper/schema) provider
+// factory via the classic bridge. Start builds a fresh provider per call so
+// each engine-side provider instance configures its own copy (see
+// connRoutedProvider).
 func SDKv2Provider(
-	t *testing.T, providerName string, tfp *schema.Provider,
+	t *testing.T, providerName string, factory func() *schema.Provider,
 	customize func(*testing.T, *tfbridge.ProviderInfo),
 ) Provider {
 	t.Helper()
-	info := BridgedProvider(t, providerName, tfp, customize)
+	// Surface validation problems at construction time.
+	BridgedProvider(t, providerName, factory(), customize)
 	return Provider{Name: providerName, Start: func(ctx context.Context) (pulumirpc.ResourceProviderServer, error) {
-		return providerServerFromInfo(ctx, info)
+		return providerServerFromInfo(ctx, BridgedProvider(t, providerName, factory(), customize))
 	}}
 }
 
-// PFProvider builds a Provider from a terraform-plugin-framework provider via
-// the plugin-framework bridge, recording provider operations to rec at the
-// tfprotov6 boundary — the same boundary tfexec.PFProvider records at on the
-// OpenTofu path. customize plays the same role as in BridgedProvider.
+// PFProvider builds a Provider from a terraform-plugin-framework provider
+// factory via the plugin-framework bridge, recording provider operations to
+// rec at the tfprotov6 boundary — the same boundary tfexec.PFProvider records
+// at on the OpenTofu path. customize plays the same role as in
+// BridgedProvider. Start builds a fresh provider per call so each engine-side
+// provider instance configures its own copy (see connRoutedProvider).
 func PFProvider(
-	t *testing.T, providerName string, p pfprovider.Provider, rec *tfexec.Recorder,
+	t *testing.T, providerName string, factory func() pfprovider.Provider, rec *tfexec.Recorder,
 	customize func(*testing.T, *tfbridge.ProviderInfo),
 ) Provider {
 	t.Helper()
 
-	requireValidPFSchema(t, p)
+	requireValidPFSchema(t, factory())
 
-	shimProvider, ok := pftfbridge.ShimProvider(p).(pf.ShimProvider)
-	require.True(t, ok, "pftfbridge.ShimProvider did not return a pf.ShimProvider")
-
-	info := tfbridge.ProviderInfo{
-		P:            recordingShim{ShimProvider: shimProvider, rec: rec},
-		Name:         providerName,
-		Version:      "0.0.1",
-		MetadataInfo: tfbridge.NewProviderMetadata(nil),
+	buildInfo := func(p pfprovider.Provider) (tfbridge.ProviderInfo, error) {
+		shimProvider, ok := pftfbridge.ShimProvider(p).(pf.ShimProvider)
+		if !ok {
+			return tfbridge.ProviderInfo{}, errors.New("pftfbridge.ShimProvider did not return a pf.ShimProvider")
+		}
+		info := tfbridge.ProviderInfo{
+			P:            recordingShim{ShimProvider: shimProvider, rec: rec},
+			Name:         providerName,
+			Version:      "0.0.1",
+			MetadataInfo: tfbridge.NewProviderMetadata(nil),
+		}
+		info.MustComputeTokens(tokens.SingleModule(providerName, "index", tokens.MakeStandard(providerName)))
+		if customize != nil {
+			customize(t, &info)
+		}
+		return info, nil
 	}
-	info.MustComputeTokens(tokens.SingleModule(providerName, "index", tokens.MakeStandard(providerName)))
-
-	if customize != nil {
-		customize(t, &info)
-	}
+	_, err := buildInfo(factory())
+	require.NoError(t, err)
 
 	return Provider{Name: providerName, Start: func(ctx context.Context) (pulumirpc.ResourceProviderServer, error) {
+		info, err := buildInfo(factory())
+		if err != nil {
+			return nil, err
+		}
 		res, err := pftfgen.GenerateSchema(ctx, pftfgen.GenerateSchemaOptions{
 			ProviderInfo:    info,
 			DiagnosticsSink: discardSink(),

--- a/tests/testutil/pulexec/conn_router.go
+++ b/tests/testutil/pulexec/conn_router.go
@@ -1,0 +1,273 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulexec
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfexec"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// connRoutedProvider is a pulumirpc.ResourceProviderServer that builds a
+// separate provider instance (via start) for each gRPC client connection,
+// identified by the id a tfexec.ConnTagger on the serving grpc.Server
+// attached. The Pulumi engine dials the attached port once per provider
+// resource instance, so routing by connection gives every instance its own
+// bridged provider — matching production, where each instance is its own
+// plugin process. A single shared instance would share configured state
+// across instances (last Configure wins), coupling every resource to
+// whichever instance configured last.
+type connRoutedProvider struct {
+	pulumirpc.UnimplementedResourceProviderServer
+
+	start func(context.Context) (pulumirpc.ResourceProviderServer, error)
+
+	mu     sync.Mutex
+	byConn map[uint64]pulumirpc.ResourceProviderServer
+}
+
+var _ pulumirpc.ResourceProviderServer = (*connRoutedProvider)(nil)
+
+func newConnRoutedProvider(
+	start func(context.Context) (pulumirpc.ResourceProviderServer, error),
+) *connRoutedProvider {
+	return &connRoutedProvider{start: start, byConn: map[uint64]pulumirpc.ResourceProviderServer{}}
+}
+
+// delegate returns the provider instance owned by the calling connection,
+// creating it on first use.
+func (s *connRoutedProvider) delegate(ctx context.Context) (pulumirpc.ResourceProviderServer, error) {
+	key := tfexec.ConnID(ctx)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	srv, ok := s.byConn[key]
+	if !ok {
+		var err error
+		srv, err = s.start(ctx)
+		if err != nil {
+			return nil, err
+		}
+		s.byConn[key] = srv
+	}
+	return srv, nil
+}
+
+func (s *connRoutedProvider) Handshake(
+	ctx context.Context, req *pulumirpc.ProviderHandshakeRequest,
+) (*pulumirpc.ProviderHandshakeResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Handshake(ctx, req)
+}
+
+func (s *connRoutedProvider) Parameterize(
+	ctx context.Context, req *pulumirpc.ParameterizeRequest,
+) (*pulumirpc.ParameterizeResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Parameterize(ctx, req)
+}
+
+func (s *connRoutedProvider) GetSchema(
+	ctx context.Context, req *pulumirpc.GetSchemaRequest,
+) (*pulumirpc.GetSchemaResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.GetSchema(ctx, req)
+}
+
+func (s *connRoutedProvider) CheckConfig(
+	ctx context.Context, req *pulumirpc.CheckRequest,
+) (*pulumirpc.CheckResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.CheckConfig(ctx, req)
+}
+
+func (s *connRoutedProvider) DiffConfig(
+	ctx context.Context, req *pulumirpc.DiffRequest,
+) (*pulumirpc.DiffResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.DiffConfig(ctx, req)
+}
+
+func (s *connRoutedProvider) Configure(
+	ctx context.Context, req *pulumirpc.ConfigureRequest,
+) (*pulumirpc.ConfigureResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Configure(ctx, req)
+}
+
+func (s *connRoutedProvider) Invoke(
+	ctx context.Context, req *pulumirpc.InvokeRequest,
+) (*pulumirpc.InvokeResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Invoke(ctx, req)
+}
+
+func (s *connRoutedProvider) Call(
+	ctx context.Context, req *pulumirpc.CallRequest,
+) (*pulumirpc.CallResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Call(ctx, req)
+}
+
+func (s *connRoutedProvider) Check(
+	ctx context.Context, req *pulumirpc.CheckRequest,
+) (*pulumirpc.CheckResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Check(ctx, req)
+}
+
+func (s *connRoutedProvider) Diff(
+	ctx context.Context, req *pulumirpc.DiffRequest,
+) (*pulumirpc.DiffResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Diff(ctx, req)
+}
+
+func (s *connRoutedProvider) Create(
+	ctx context.Context, req *pulumirpc.CreateRequest,
+) (*pulumirpc.CreateResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Create(ctx, req)
+}
+
+func (s *connRoutedProvider) Read(
+	ctx context.Context, req *pulumirpc.ReadRequest,
+) (*pulumirpc.ReadResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Read(ctx, req)
+}
+
+func (s *connRoutedProvider) Update(
+	ctx context.Context, req *pulumirpc.UpdateRequest,
+) (*pulumirpc.UpdateResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Update(ctx, req)
+}
+
+func (s *connRoutedProvider) Delete(
+	ctx context.Context, req *pulumirpc.DeleteRequest,
+) (*emptypb.Empty, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Delete(ctx, req)
+}
+
+func (s *connRoutedProvider) Construct(
+	ctx context.Context, req *pulumirpc.ConstructRequest,
+) (*pulumirpc.ConstructResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Construct(ctx, req)
+}
+
+func (s *connRoutedProvider) Cancel(ctx context.Context, req *emptypb.Empty) (*emptypb.Empty, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Cancel(ctx, req)
+}
+
+func (s *connRoutedProvider) GetPluginInfo(ctx context.Context, req *emptypb.Empty) (*pulumirpc.PluginInfo, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.GetPluginInfo(ctx, req)
+}
+
+func (s *connRoutedProvider) Attach(ctx context.Context, req *pulumirpc.PluginAttach) (*emptypb.Empty, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.Attach(ctx, req)
+}
+
+func (s *connRoutedProvider) GetMapping(
+	ctx context.Context, req *pulumirpc.GetMappingRequest,
+) (*pulumirpc.GetMappingResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.GetMapping(ctx, req)
+}
+
+func (s *connRoutedProvider) GetMappings(
+	ctx context.Context, req *pulumirpc.GetMappingsRequest,
+) (*pulumirpc.GetMappingsResponse, error) {
+	d, err := s.delegate(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return d.GetMappings(ctx, req)
+}
+
+func (s *connRoutedProvider) List(
+	req *pulumirpc.ListRequest, stream grpc.ServerStreamingServer[pulumirpc.ListResponse],
+) error {
+	d, err := s.delegate(stream.Context())
+	if err != nil {
+		return err
+	}
+	return d.List(req, stream)
+}

--- a/tests/testutil/pulexec/run.go
+++ b/tests/testutil/pulexec/run.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/server"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfexec"
 	"github.com/pulumi/providertest/providers"
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/optnewstack"
@@ -317,16 +318,18 @@ func (d *Driver) writeStubSDKs(t *testing.T) {
 func startProvider(
 	ctx context.Context, start func(context.Context) (pulumirpc.ResourceProviderServer, error),
 ) (*rpcutil.ServeHandle, error) {
-	prov, err := start(ctx)
-	if err != nil {
+	// Fail fast on providers that cannot start at all; the router then builds
+	// one instance server per engine connection.
+	if _, err := start(ctx); err != nil {
 		return nil, fmt.Errorf("starting provider server: %w", err)
 	}
 
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
 		Init: func(srv *grpc.Server) error {
-			pulumirpc.RegisterResourceProviderServer(srv, prov)
+			pulumirpc.RegisterResourceProviderServer(srv, newConnRoutedProvider(start))
 			return nil
 		},
+		Options: []grpc.ServerOption{grpc.StatsHandler(&tfexec.ConnTagger{})},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("rpcutil.ServeWithOptions failed: %w", err)

--- a/tests/testutil/tfcompat/harness.go
+++ b/tests/testutil/tfcompat/harness.go
@@ -76,7 +76,9 @@ type Provider struct {
 // buildProviders wires each Case provider into both paths, wrapping it with
 // the per-path recorder. SDKv2 providers record at the helper/schema CRUD
 // boundary (tfexec.Wrap); plugin-framework providers record at the tfprotov6
-// boundary (tfexec.WrapServer). Each path gets its own provider instance.
+// boundary (tfexec.WrapServer). Both paths build a fresh provider per
+// configured instance (a provider block with for_each yields several), all
+// recording into the path's shared recorder.
 func buildProviders(
 	t *testing.T, provs []Provider, recA, recB *tfexec.Recorder,
 ) ([]tfexec.Provider, []pulexec.Provider) {
@@ -86,11 +88,12 @@ func buildProviders(
 	for i, p := range provs {
 		switch {
 		case p.Factory != nil && p.PFFactory == nil:
-			tfProvs[i] = tfexec.SDKv2Provider(t, p.Name, tfexec.Wrap(p.Factory(), recA))
-			pulProvs[i] = pulexec.SDKv2Provider(t, p.Name, tfexec.Wrap(p.Factory(), recB), p.Customize)
+			factory := p.Factory
+			tfProvs[i] = tfexec.SDKv2Provider(t, p.Name, func() *schema.Provider { return tfexec.Wrap(factory(), recA) })
+			pulProvs[i] = pulexec.SDKv2Provider(t, p.Name, func() *schema.Provider { return tfexec.Wrap(factory(), recB) }, p.Customize)
 		case p.PFFactory != nil && p.Factory == nil:
-			tfProvs[i] = tfexec.PFProvider(p.Name, p.PFFactory(), recA)
-			pulProvs[i] = pulexec.PFProvider(t, p.Name, p.PFFactory(), recB, p.Customize)
+			tfProvs[i] = tfexec.PFProvider(p.Name, p.PFFactory, recA)
+			pulProvs[i] = pulexec.PFProvider(t, p.Name, p.PFFactory, recB, p.Customize)
 		default:
 			t.Fatalf("provider %q: exactly one of Factory or PFFactory must be set", p.Name)
 		}

--- a/tests/testutil/tfexec/conn_id.go
+++ b/tests/testutil/tfexec/conn_id.go
@@ -1,0 +1,53 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfexec
+
+import (
+	"context"
+	"sync/atomic"
+
+	"google.golang.org/grpc/stats"
+)
+
+type connIDKey struct{}
+
+// ConnTagger is a grpc stats.Handler that tags every server connection with a
+// unique id, inherited by the context of each RPC on that connection. Routers
+// read it back with ConnID to give each client connection its own provider
+// instance. Connection identity cannot come from the gRPC peer address:
+// go-plugin serves reattach providers on a unix socket, where every
+// connection reports the same empty address.
+type ConnTagger struct {
+	nextID atomic.Uint64
+}
+
+var _ stats.Handler = (*ConnTagger)(nil)
+
+func (t *ConnTagger) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return context.WithValue(ctx, connIDKey{}, t.nextID.Add(1))
+}
+
+func (*ConnTagger) HandleConn(context.Context, stats.ConnStats) {}
+
+func (*ConnTagger) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context { return ctx }
+
+func (*ConnTagger) HandleRPC(context.Context, stats.RPCStats) {}
+
+// ConnID returns the connection id attached by ConnTagger, or 0 when the
+// server was built without one.
+func ConnID(ctx context.Context) uint64 {
+	id, _ := ctx.Value(connIDKey{}).(uint64)
+	return id
+}

--- a/tests/testutil/tfexec/conn_router.go
+++ b/tests/testutil/tfexec/conn_router.go
@@ -1,0 +1,195 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfexec
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+// ConnRoutedServer returns a tfprotov6.ProviderServer that builds a separate
+// provider instance (via factory) for each gRPC client connection, identified
+// by the id a ConnTagger on the serving grpc.Server attached. OpenTofu dials
+// the reattach server once per configured provider instance, so routing by
+// connection gives every instance its own provider — matching production,
+// where each instance is its own plugin process. A single shared instance
+// would share configured meta across instances (last Configure wins),
+// coupling every resource to whichever instance configured last.
+func ConnRoutedServer(factory func() tfprotov6.ProviderServer) tfprotov6.ProviderServer {
+	return &connRoutedServer{factory: factory, byConn: map[uint64]tfprotov6.ProviderServer{}}
+}
+
+type connRoutedServer struct {
+	factory func() tfprotov6.ProviderServer
+
+	mu     sync.Mutex
+	byConn map[uint64]tfprotov6.ProviderServer
+}
+
+var _ tfprotov6.ProviderServer = (*connRoutedServer)(nil)
+
+// delegate returns the provider instance owned by the calling connection,
+// creating it on first use.
+func (s *connRoutedServer) delegate(ctx context.Context) tfprotov6.ProviderServer {
+	key := ConnID(ctx)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	srv, ok := s.byConn[key]
+	if !ok {
+		srv = s.factory()
+		s.byConn[key] = srv
+	}
+	return srv
+}
+
+func (s *connRoutedServer) GetMetadata(
+	ctx context.Context, req *tfprotov6.GetMetadataRequest,
+) (*tfprotov6.GetMetadataResponse, error) {
+	return s.delegate(ctx).GetMetadata(ctx, req)
+}
+
+func (s *connRoutedServer) GetProviderSchema(
+	ctx context.Context, req *tfprotov6.GetProviderSchemaRequest,
+) (*tfprotov6.GetProviderSchemaResponse, error) {
+	return s.delegate(ctx).GetProviderSchema(ctx, req)
+}
+
+func (s *connRoutedServer) GetResourceIdentitySchemas(
+	ctx context.Context, req *tfprotov6.GetResourceIdentitySchemasRequest,
+) (*tfprotov6.GetResourceIdentitySchemasResponse, error) {
+	return s.delegate(ctx).GetResourceIdentitySchemas(ctx, req)
+}
+
+func (s *connRoutedServer) ValidateProviderConfig(
+	ctx context.Context, req *tfprotov6.ValidateProviderConfigRequest,
+) (*tfprotov6.ValidateProviderConfigResponse, error) {
+	return s.delegate(ctx).ValidateProviderConfig(ctx, req)
+}
+
+func (s *connRoutedServer) ConfigureProvider(
+	ctx context.Context, req *tfprotov6.ConfigureProviderRequest,
+) (*tfprotov6.ConfigureProviderResponse, error) {
+	return s.delegate(ctx).ConfigureProvider(ctx, req)
+}
+
+func (s *connRoutedServer) StopProvider(
+	ctx context.Context, req *tfprotov6.StopProviderRequest,
+) (*tfprotov6.StopProviderResponse, error) {
+	return s.delegate(ctx).StopProvider(ctx, req)
+}
+
+func (s *connRoutedServer) ValidateResourceConfig(
+	ctx context.Context, req *tfprotov6.ValidateResourceConfigRequest,
+) (*tfprotov6.ValidateResourceConfigResponse, error) {
+	return s.delegate(ctx).ValidateResourceConfig(ctx, req)
+}
+
+func (s *connRoutedServer) UpgradeResourceState(
+	ctx context.Context, req *tfprotov6.UpgradeResourceStateRequest,
+) (*tfprotov6.UpgradeResourceStateResponse, error) {
+	return s.delegate(ctx).UpgradeResourceState(ctx, req)
+}
+
+func (s *connRoutedServer) UpgradeResourceIdentity(
+	ctx context.Context, req *tfprotov6.UpgradeResourceIdentityRequest,
+) (*tfprotov6.UpgradeResourceIdentityResponse, error) {
+	return s.delegate(ctx).UpgradeResourceIdentity(ctx, req)
+}
+
+func (s *connRoutedServer) ReadResource(
+	ctx context.Context, req *tfprotov6.ReadResourceRequest,
+) (*tfprotov6.ReadResourceResponse, error) {
+	return s.delegate(ctx).ReadResource(ctx, req)
+}
+
+func (s *connRoutedServer) PlanResourceChange(
+	ctx context.Context, req *tfprotov6.PlanResourceChangeRequest,
+) (*tfprotov6.PlanResourceChangeResponse, error) {
+	return s.delegate(ctx).PlanResourceChange(ctx, req)
+}
+
+func (s *connRoutedServer) ApplyResourceChange(
+	ctx context.Context, req *tfprotov6.ApplyResourceChangeRequest,
+) (*tfprotov6.ApplyResourceChangeResponse, error) {
+	return s.delegate(ctx).ApplyResourceChange(ctx, req)
+}
+
+func (s *connRoutedServer) ImportResourceState(
+	ctx context.Context, req *tfprotov6.ImportResourceStateRequest,
+) (*tfprotov6.ImportResourceStateResponse, error) {
+	return s.delegate(ctx).ImportResourceState(ctx, req)
+}
+
+func (s *connRoutedServer) MoveResourceState(
+	ctx context.Context, req *tfprotov6.MoveResourceStateRequest,
+) (*tfprotov6.MoveResourceStateResponse, error) {
+	return s.delegate(ctx).MoveResourceState(ctx, req)
+}
+
+func (s *connRoutedServer) GenerateResourceConfig(
+	ctx context.Context, req *tfprotov6.GenerateResourceConfigRequest,
+) (*tfprotov6.GenerateResourceConfigResponse, error) {
+	return s.delegate(ctx).GenerateResourceConfig(ctx, req)
+}
+
+func (s *connRoutedServer) ValidateDataResourceConfig(
+	ctx context.Context, req *tfprotov6.ValidateDataResourceConfigRequest,
+) (*tfprotov6.ValidateDataResourceConfigResponse, error) {
+	return s.delegate(ctx).ValidateDataResourceConfig(ctx, req)
+}
+
+func (s *connRoutedServer) ReadDataSource(
+	ctx context.Context, req *tfprotov6.ReadDataSourceRequest,
+) (*tfprotov6.ReadDataSourceResponse, error) {
+	return s.delegate(ctx).ReadDataSource(ctx, req)
+}
+
+func (s *connRoutedServer) ValidateEphemeralResourceConfig(
+	ctx context.Context, req *tfprotov6.ValidateEphemeralResourceConfigRequest,
+) (*tfprotov6.ValidateEphemeralResourceConfigResponse, error) {
+	return s.delegate(ctx).ValidateEphemeralResourceConfig(ctx, req)
+}
+
+func (s *connRoutedServer) OpenEphemeralResource(
+	ctx context.Context, req *tfprotov6.OpenEphemeralResourceRequest,
+) (*tfprotov6.OpenEphemeralResourceResponse, error) {
+	return s.delegate(ctx).OpenEphemeralResource(ctx, req)
+}
+
+func (s *connRoutedServer) RenewEphemeralResource(
+	ctx context.Context, req *tfprotov6.RenewEphemeralResourceRequest,
+) (*tfprotov6.RenewEphemeralResourceResponse, error) {
+	return s.delegate(ctx).RenewEphemeralResource(ctx, req)
+}
+
+func (s *connRoutedServer) CloseEphemeralResource(
+	ctx context.Context, req *tfprotov6.CloseEphemeralResourceRequest,
+) (*tfprotov6.CloseEphemeralResourceResponse, error) {
+	return s.delegate(ctx).CloseEphemeralResource(ctx, req)
+}
+
+func (s *connRoutedServer) CallFunction(
+	ctx context.Context, req *tfprotov6.CallFunctionRequest,
+) (*tfprotov6.CallFunctionResponse, error) {
+	return s.delegate(ctx).CallFunction(ctx, req)
+}
+
+func (s *connRoutedServer) GetFunctions(
+	ctx context.Context, req *tfprotov6.GetFunctionsRequest,
+) (*tfprotov6.GetFunctionsResponse, error) {
+	return s.delegate(ctx).GetFunctions(ctx, req)
+}

--- a/tests/testutil/tfexec/driver.go
+++ b/tests/testutil/tfexec/driver.go
@@ -36,30 +36,46 @@ import (
 	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 // Provider pairs a terraform provider name with a tfprotov6 server factory.
-// Use SDKv2Provider or PFProvider to build one.
+// The factory is invoked once per provider instance (per gRPC connection, see
+// ConnRoutedServer), so it must return a fresh, independently configurable
+// server on every call. Use SDKv2Provider or PFProvider to build one.
 type Provider struct {
 	Name   string
 	Server func() tfprotov6.ProviderServer
 }
 
-// SDKv2Provider adapts an SDKv2 (helper/schema) provider into a Provider by
-// upgrading it to protocol version 6.
-func SDKv2Provider(t *testing.T, name string, p *schema.Provider) Provider {
+// SDKv2Provider adapts an SDKv2 (helper/schema) provider factory into a
+// Provider by upgrading it to protocol version 6, building a fresh provider
+// per instance.
+func SDKv2Provider(t *testing.T, name string, factory func() *schema.Provider) Provider {
 	t.Helper()
-	v6server, err := tf5to6server.UpgradeServer(t.Context(),
-		func() tfprotov5.ProviderServer { return p.GRPCProvider() })
+	build := func() (tfprotov6.ProviderServer, error) {
+		return tf5to6server.UpgradeServer(t.Context(),
+			func() tfprotov5.ProviderServer { return factory().GRPCProvider() })
+	}
+	// Surface upgrade problems at construction time, where require works.
+	_, err := build()
 	require.NoError(t, err)
-	return Provider{Name: name, Server: func() tfprotov6.ProviderServer { return v6server }}
+	return Provider{Name: name, Server: func() tfprotov6.ProviderServer {
+		server, err := build()
+		if err != nil {
+			panic(fmt.Sprintf("upgrading provider %q to protocol v6: %v", name, err))
+		}
+		return server
+	}}
 }
 
-// PFProvider adapts a terraform-plugin-framework provider into a Provider,
-// recording its operations to rec at the protocol boundary (see WrapServer).
-func PFProvider(name string, p provider.Provider, rec *Recorder) Provider {
-	server := WrapServer(providerserver.NewProtocol6(p)(), rec)
-	return Provider{Name: name, Server: func() tfprotov6.ProviderServer { return server }}
+// PFProvider adapts a terraform-plugin-framework provider factory into a
+// Provider, recording its operations to rec at the protocol boundary (see
+// WrapServer). A fresh provider is built per instance.
+func PFProvider(name string, factory func() provider.Provider, rec *Recorder) Provider {
+	return Provider{Name: name, Server: func() tfprotov6.ProviderServer {
+		return WrapServer(providerserver.NewProtocol6(factory())(), rec)
+	}}
 }
 
 // Driver hosts TF providers in-process and runs the terraform CLI against them.
@@ -91,21 +107,44 @@ func NewDriver(t *testing.T, providers []Provider) *Driver {
 	reattachConfigs := make(map[string]*plugin.ReattachConfig, len(providers))
 	for _, p := range providers {
 		reattachConfigCh := make(chan *plugin.ReattachConfig)
-		closeCh := make(chan struct{})
 
-		serverOpts := []tf6server.ServeOpt{
-			tf6server.WithGoPluginLogger(hclog.FromStandardLogger(log.New(io.Discard, "", 0), hclog.DefaultOptions)),
-			tf6server.WithDebug(t.Context(), reattachConfigCh, closeCh),
-			tf6server.WithoutLogStderrOverride(),
+		// One router per provider name; it builds a fresh provider per client
+		// connection (identified by tagger) so provider instances don't share
+		// state. go-plugin is invoked directly rather than via tf6server.Serve
+		// because the latter offers no way to attach the stats handler the
+		// router's connection identity comes from.
+		name, router, tagger := p.Name, ConnRoutedServer(p.Server), &ConnTagger{}
+		serveConfig := &plugin.ServeConfig{
+			// The handshake tf6server.Serve performs: protocol major version
+			// and the terraform plugin protocol's magic cookie.
+			HandshakeConfig: plugin.HandshakeConfig{
+				ProtocolVersion:  6,
+				MagicCookieKey:   "TF_PLUGIN_MAGIC_COOKIE",
+				MagicCookieValue: "d602bf8f470bc67ca7faa0386276bbdd4330efaf76d1a219cb4d6991ca9872b2",
+			},
+			Logger: hclog.FromStandardLogger(log.New(io.Discard, "", 0), hclog.DefaultOptions),
+			Plugins: plugin.PluginSet{
+				"provider": &tf6server.GRPCProviderPlugin{
+					Name:         name,
+					GRPCProvider: func() tfprotov6.ProviderServer { return router },
+				},
+			},
+			GRPCServer: func(opts []grpc.ServerOption) *grpc.Server {
+				// Message sizes tf6server.Serve would configure.
+				opts = append(opts,
+					grpc.MaxRecvMsgSize(256<<20),
+					grpc.MaxSendMsgSize(256<<20),
+					grpc.StatsHandler(tagger),
+				)
+				return grpc.NewServer(opts...)
+			},
+			Test: &plugin.ServeTestConfig{
+				Context:          t.Context(),
+				ReattachConfigCh: reattachConfigCh,
+				CloseCh:          make(chan struct{}),
+			},
 		}
-
-		name, server := p.Name, p.Server
-		go func() {
-			err := tf6server.Serve(name, server, serverOpts...)
-			if err != nil {
-				t.Logf("tf6server.Serve error: %v", err)
-			}
-		}()
+		go plugin.Serve(serveConfig)
 
 		reattachConfigs[p.Name] = <-reattachConfigCh
 	}


### PR DESCRIPTION
## The flake

`TestL2ProviderForEach` (and siblings from https://github.com/pulumi-labs/pulumi-hcl/pull/343) failed intermittently — locally about 1 in 3 runs, and twice in a row on https://github.com/pulumi-labs/pulumi-hcl/pull/315's CI:

```
expected: map[string]string{"prefix_result":"alpha-world"}
actual  : map[string]string{"prefix_result":"beta-world"}
```

## Root cause (confirmed by instrumenting SimpleProvider)

Both tfcompat paths served every configured instance of a provider from **one shared in-process server**: OpenTofu reattaches to a single `tf6server`, the Pulumi engine attaches to a single debug port. helper/schema stores configured meta on the `*schema.Provider`, so with two `for_each` instances (`prefix = "alpha"` / `"beta"`) the last `Configure` won and every resource operation raced against the other instance's `Configure`:

```
FLAKE-DEBUG configure prefix="alpha"
FLAKE-DEBUG configure prefix="beta"
FLAKE-DEBUG create input_one="world" meta.prefix="beta"   <- selected simple.by_key["a"] (alpha)
```

Worse than a flake: runs where **both** paths landed on the same wrong instance passed. In production each provider instance is its own plugin process, so neither engine behaves this way — the sharing is purely a harness artifact.

## The fix

Both engines dial the shared server once per provider instance, so the harness now gives each gRPC connection its own provider, built fresh by the test's factory:

- `tfexec.ConnTagger` — a `stats.Handler` that tags every server connection with an id (connection identity cannot come from the gRPC peer address: go-plugin serves reattach providers on a unix socket, where every connection reports the same empty address).
- `tfexec.ConnRoutedServer` / `pulexec.connRoutedProvider` — routers that lazily build one provider per connection id.
- `tfexec.NewDriver` calls go-plugin directly instead of `tf6server.Serve`, which offers no hook for gRPC server options; handshake and message-size settings mirror `tf6server.Serve`.
- `SDKv2Provider` / `PFProvider` on both paths now take factories instead of built providers. Recorders are shared across instances; recordings are order-insensitive, so aggregation is unchanged.

As a bonus, the harness can now observe provider-identity disagreements (which instance served which resource) that the shared name-keyed server previously masked.

## Verification

- With isolation on the pulumi path only, tofu (still shared) kept flipping between `alpha-world`/`beta-world` while pulumi answered correctly — demonstrating the fix catches real divergence.
- `TestL2ProviderForEach`, `...DataSource`, `...DynamicKey`, `TestL2ModuleProviderForEachPassthrough`: 40/40 over `-count=10` (previously ~1/3 failure rate).
- Full `tests/tfcompat` + `tests/testutil` suites pass; `golangci-lint` clean.