### PR TITLE
Drop the no-monitor fallbacks from the invoke paths

### DIFF
--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -3191,10 +3191,6 @@ func (e *Engine) providerFunctionImpl(
 			req.Provider = ref
 		}
 
-		if e.resmon == nil { // TODO: Remove this check
-			// No resource monitor - return empty outputs for testing
-			return property.Map{}, nil
-		}
 		resp, err := e.resmon.Invoke(ctx, req)
 		if err != nil {
 			return property.Map{}, err
@@ -3213,12 +3209,6 @@ func (e *Engine) invokeFunction(ctx context.Context, tfType string, req InvokeRe
 		return property.Map{}, err
 	}
 
-	if e.resmon == nil { // TODO: Remove this check
-		// No resource monitor - return empty outputs for testing
-		return property.Map{}, nil
-	}
-
-	// Invoke the function
 	resp, err := e.resmon.Invoke(ctx, req)
 	if err != nil {
 		return property.Map{}, err


### PR DESCRIPTION
Stacked on https://github.com/pulumi-labs/pulumi-hcl/pull/315.

Removes the two `if e.resmon == nil { return empty }` fallbacks marked `// TODO: Remove this check` — one in the provider-defined function invoke closure (added by https://github.com/pulumi-labs/pulumi-hcl/pull/315), one in `invokeFunction` (pre-existing). Silently returning empty outputs when the engine has no resource monitor masks wiring mistakes; no test relies on it — every engine test that reaches an invoke installs a `MockResourceMonitor`.

The remaining `e.resmon == nil` guards (stack registration, stack outputs, and the fake-URN resource-registration path) carry no TODO and are intentional test affordances; they are left in place. Say the word if those should go too — that's a larger change, since many engine unit tests run without a monitor and depend on the fake-URN path.

Verified: all 982 `pkg/` tests pass, lint clean.