### PR TITLE
Upgrade go-cty-yaml to v1.2.0 for full YAML merge-key support

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-345.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-345.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Support merging a sequence of mappings and multiple `<<` keys in `yamldecode`
+time: 2026-07-10T15:05:00Z
+custom:
+    Component: runtime
+    PR: "345"

--- a/.changes/unreleased/runtime-bug-fixes-347.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-347.yaml
@@ -3,4 +3,4 @@ body: Support merging a sequence of mappings and multiple `<<` keys in `yamldeco
 time: 2026-07-10T15:05:00Z
 custom:
     Component: runtime
-    PR: "345"
+    PR: "347"

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/xanzy/ssh-agent v0.3.3
 	github.com/zclconf/go-cty v1.18.1
-	github.com/zclconf/go-cty-yaml v1.1.0
+	github.com/zclconf/go-cty-yaml v1.2.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.53.0

--- a/go.sum
+++ b/go.sum
@@ -4176,8 +4176,8 @@ github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRK
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 github.com/zclconf/go-cty-yaml v1.0.1/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
-github.com/zclconf/go-cty-yaml v1.1.0 h1:nP+jp0qPHv2IhUVqmQSzjvqAWcObN0KBkUl2rWBdig0=
-github.com/zclconf/go-cty-yaml v1.1.0/go.mod h1:9YLUH4g7lOhVWqUbctnVlZ5KLpg7JAprQNgxSZ1Gyxs=
+github.com/zclconf/go-cty-yaml v1.2.0 h1:GDyL4+e/Qe/S0B7YaecMLbVvAR/Mp21CXMOSiCTOi1M=
+github.com/zclconf/go-cty-yaml v1.2.0/go.mod h1:9YLUH4g7lOhVWqUbctnVlZ5KLpg7JAprQNgxSZ1Gyxs=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=

--- a/tests/tfcompat/l1_yaml_merge_test.go
+++ b/tests/tfcompat/l1_yaml_merge_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1YamlMerge exercises the YAML merge key `<<` referencing a sequence of
+// mappings in `yamldecode`.
+func TestL1YamlMerge(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_yaml_merge", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_yaml_merge/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_yaml_merge/main.tf
@@ -1,0 +1,36 @@
+# The YAML merge key `<<` may reference a sequence of mappings, each of which
+# is merged into the enclosing mapping. `result` below merges both `base1` and
+# `base2` (with `p` pinning cross-merge precedence), then overrides with its
+# own keys. `multi` uses two separate `<<` keys in one mapping, and `scalar.v`
+# uses `<<` outside key position, where it is a plain string.
+locals {
+  doc = <<-YAML
+    base1: &b1
+      a: 1
+      p: from1
+    base2: &b2
+      c: 3
+      p: from2
+    result:
+      <<: [*b1, *b2]
+      b: 20
+      d: 4
+    multi:
+      <<: *b1
+      <<: *b2
+    scalar:
+      v: <<
+  YAML
+}
+
+output "merged" {
+  value = jsonencode(yamldecode(local.doc)["result"])
+}
+
+output "multi" {
+  value = jsonencode(yamldecode(local.doc)["multi"])
+}
+
+output "scalar_v" {
+  value = yamldecode(local.doc)["scalar"]["v"]
+}


### PR DESCRIPTION
`yamldecode` errored with `cannot merge tuple into mapping` on YAML documents whose merge key `<<` references a sequence of mappings (`<<: [*a, *b]`), a form OpenTofu decodes. OpenTofu ships go-cty-yaml v1.2.0, which added complete `tag:yaml.org,2002:merge` support; we were on v1.1.0.

This bumps go-cty-yaml to v1.2.0 and adds a tfcompat case pinning the merge-key behaviors that changed:

- `<<` referencing a sequence of mappings, merged with later mentions of a key taking precedence over earlier ones;
- multiple `<<` keys in one mapping;
- `<<` outside key position resolving as the plain string `"<<"`.

The tfcompat case failed against both runtimes before the bump and passes after; the `pkg/hcl/eval` unit suite and the existing `l1_yaml` case are unaffected.