### PR TITLE
Allow assigning providers from the default provider block

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-348.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-348.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Resolve `providers = { x = x }` module arguments and bare `provider = x` references when no `provider "x"` block exists, instead of failing with `unknown node "x"`; report `missing provider` for `providers` entries the parent scope does not declare
+time: 2026-07-10T18:30:00Z
+custom:
+    Component: runtime
+    PR: "348"

--- a/pkg/hcl/graph/default_provider_test.go
+++ b/pkg/hcl/graph/default_provider_test.go
@@ -1,0 +1,311 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
+)
+
+// TestPassThroughImplicitDefaultProvider covers a module call passing the
+// implicit default provider — `providers = { simple = simple }` with no
+// `provider "simple"` block anywhere, but with the provider declared in the
+// root's `required_providers`. The reference names the implicit empty default
+// configuration, so the graph must validate without an unresolved `simple`
+// node.
+func TestPassThroughImplicitDefaultProvider(t *testing.T) {
+	t.Parallel()
+
+	childSrc := []byte(`
+resource "simple_resource" "r" {}
+`)
+	child, diags := parser.NewParser().ParseSource("child.hcl", childSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	rootSrc := []byte(`
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+module "child" {
+  source = "./child"
+  providers = {
+    simple = simple
+  }
+}
+`)
+	root, diags := parser.NewParser().ParseSource("root.hcl", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	loader := fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: child, SourcePath: "./child"},
+	}}
+
+	g, err := BuildFromConfig(root, loader, ".")
+	require.NoError(t, err)
+
+	assert.Empty(t, g.Validate())
+}
+
+// TestPassThroughUndeclaredProvider covers a module call passing
+// `providers = { simple = simple }` where the root neither configures the
+// provider nor declares it in `required_providers`: the reference must fail
+// validation as a missing provider.
+func TestPassThroughUndeclaredProvider(t *testing.T) {
+	t.Parallel()
+
+	childSrc := []byte(`
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+resource "simple_resource" "r" {}
+`)
+	child, diags := parser.NewParser().ParseSource("child.hcl", childSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	rootSrc := []byte(`
+module "child" {
+  source = "./child"
+  providers = {
+    simple = simple
+  }
+}
+`)
+	root, diags := parser.NewParser().ParseSource("root.hcl", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	loader := fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: child, SourcePath: "./child"},
+	}}
+
+	g, err := BuildFromConfig(root, loader, ".")
+	require.NoError(t, err)
+
+	errs := g.Validate()
+	require.Len(t, errs, 1)
+	assert.ErrorContains(t, errs[0], `missing provider provider["registry.opentofu.org/hashicorp/simple"]`)
+}
+
+// TestPassThroughParentWithoutProvider covers a mid-level module passing
+// `providers = { simple = simple }` while having no configuration of its own:
+// provider configurations are never inherited into a `providers` argument, so
+// the reference must fail validation even though the root has a
+// `provider "simple"` block.
+func TestPassThroughParentWithoutProvider(t *testing.T) {
+	t.Parallel()
+
+	childSrc := []byte(`
+resource "simple_resource" "r" {}
+`)
+	child, diags := parser.NewParser().ParseSource("child.hcl", childSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	midSrc := []byte(`
+module "child" {
+  source = "./child"
+  providers = {
+    simple = simple
+  }
+}
+`)
+	mid, diags := parser.NewParser().ParseSource("mid.hcl", midSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	rootSrc := []byte(`
+provider "simple" {}
+
+module "mid" {
+  source = "./mid"
+}
+`)
+	root, diags := parser.NewParser().ParseSource("root.hcl", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	loader := fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./mid":   {Config: mid, SourcePath: "./mid"},
+		"./child": {Config: child, SourcePath: "./child"},
+	}}
+
+	g, err := BuildFromConfig(root, loader, ".")
+	require.NoError(t, err)
+
+	errs := g.Validate()
+	require.Len(t, errs, 1)
+	assert.ErrorContains(t, errs[0], `missing provider module.mid.provider["registry.opentofu.org/hashicorp/simple"]`)
+}
+
+// TestPassThroughChainedProviders covers a provider passed down two module
+// levels, each hop naming the configuration it received from its own module
+// call: the chain must validate.
+func TestPassThroughChainedProviders(t *testing.T) {
+	t.Parallel()
+
+	childSrc := []byte(`
+resource "simple_resource" "r" {}
+`)
+	child, diags := parser.NewParser().ParseSource("child.hcl", childSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	midSrc := []byte(`
+module "child" {
+  source = "./child"
+  providers = {
+    simple = simple
+  }
+}
+`)
+	mid, diags := parser.NewParser().ParseSource("mid.hcl", midSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	rootSrc := []byte(`
+provider "simple" {}
+
+module "mid" {
+  source = "./mid"
+  providers = {
+    simple = simple
+  }
+}
+`)
+	root, diags := parser.NewParser().ParseSource("root.hcl", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	loader := fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./mid":   {Config: mid, SourcePath: "./mid"},
+		"./child": {Config: child, SourcePath: "./child"},
+	}}
+
+	g, err := BuildFromConfig(root, loader, ".")
+	require.NoError(t, err)
+
+	assert.Empty(t, g.Validate())
+	assert.True(t, g.HasDependents("simple"))
+}
+
+// TestPassThroughAliasedProviderMissingBlock covers a module call passing an
+// aliased provider that no block defines: aliased configurations are never
+// implicit, so the reference must fail validation as a missing provider.
+func TestPassThroughAliasedProviderMissingBlock(t *testing.T) {
+	t.Parallel()
+
+	childSrc := []byte(`
+resource "simple_resource" "r" {}
+`)
+	child, diags := parser.NewParser().ParseSource("child.hcl", childSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	rootSrc := []byte(`
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+module "child" {
+  source = "./child"
+  providers = {
+    simple = simple.missing
+  }
+}
+`)
+	root, diags := parser.NewParser().ParseSource("root.hcl", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	loader := fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: child, SourcePath: "./child"},
+	}}
+
+	g, err := BuildFromConfig(root, loader, ".")
+	require.NoError(t, err)
+
+	errs := g.Validate()
+	require.Len(t, errs, 1)
+	assert.ErrorContains(t, errs[0], `missing provider provider["registry.opentofu.org/hashicorp/simple"].missing`)
+}
+
+// TestBareProviderReferenceImplicitDefault covers a root resource with
+// `provider = simple` and no `provider "simple"` block anywhere: the
+// reference names the implicit empty default configuration, so the graph
+// must validate without an unresolved `simple` node.
+func TestBareProviderReferenceImplicitDefault(t *testing.T) {
+	t.Parallel()
+
+	rootSrc := []byte(`
+resource "simple_resource" "r" {
+  provider = simple
+}
+`)
+	root, diags := parser.NewParser().ParseSource("root.hcl", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	g, err := BuildFromConfig(root, nil, ".")
+	require.NoError(t, err)
+
+	assert.Empty(t, g.Validate())
+}
+
+// TestBareProviderReferenceInherited covers an in-module resource with
+// `provider = simple` where the default configuration is inherited from the
+// root's `provider "simple"` block: the resource must be ordered after the
+// root block.
+func TestBareProviderReferenceInherited(t *testing.T) {
+	t.Parallel()
+
+	childSrc := []byte(`
+resource "simple_resource" "r" {
+  provider = simple
+}
+`)
+	child, diags := parser.NewParser().ParseSource("child.hcl", childSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	rootSrc := []byte(`
+provider "simple" {}
+
+module "child" {
+  source = "./child"
+}
+`)
+	root, diags := parser.NewParser().ParseSource("root.hcl", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	loader := fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: child, SourcePath: "./child"},
+	}}
+
+	g, err := BuildFromConfig(root, loader, ".")
+	require.NoError(t, err)
+
+	assert.Empty(t, g.Validate())
+	assert.True(t, g.HasDependents("simple"))
+
+	order := walkOrder(t, g)
+	assert.Less(t, indexOf(order, "simple"), indexOf(order, "module.child.simple_resource.r"))
+}

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -203,6 +203,11 @@ type Graph struct {
 	// dependency extraction (which receives only the prefix) can resolve
 	// provider-defined function calls to the provider block they use.
 	scopes map[string]*moduleScope
+
+	// missingProviders collects, keyed by provider address, the diagnostics
+	// for module-call `providers` entries that name a provider configuration
+	// the parent scope does not have. Reported by Validate.
+	missingProviders map[string]*hcl.Diagnostic
 }
 
 type dagNode struct {
@@ -225,6 +230,8 @@ func NewGraph() *Graph {
 		dependents:   make(map[string]int),
 		moved:        make(map[modulepath.Path][]*ast.Moved),
 		scopes:       make(map[string]*moduleScope),
+
+		missingProviders: make(map[string]*hcl.Diagnostic),
 	}
 }
 
@@ -484,11 +491,19 @@ func (g *Graph) inheritedProviderDeps(resource *ast.Resource, parent *moduleScop
 }
 
 // passThroughProviderDeps returns an edge from an in-module resource to the
-// parent-scope provider that the module call's `providers = { ... }` argument
-// passes in for the resource's package. mod is the module call in the parent
-// scope, parentPrefix is the parent scope's prefix. Returns nil when no
-// pass-through entry applies.
-func (g *Graph) passThroughProviderDeps(resource *ast.Resource, mod *ast.Module, parentPrefix string) []pdag.Node {
+// parent-scope provider that its module call's `providers = { ... }` argument
+// passes in for the resource's package. scope is the resource's own module
+// scope. Returns nil when no pass-through entry applies.
+//
+// The reference resolves strictly against the parent scope — provider
+// configurations are never inherited into a `providers` argument: the parent
+// must have a matching `provider` block, have received the configuration
+// through its own module call, or (for an un-aliased reference on the root)
+// declare the provider in `required_providers`, which stands for the implicit
+// empty default configuration. Anything else is a missing provider, reported
+// by Validate.
+func (g *Graph) passThroughProviderDeps(resource *ast.Resource, scope *moduleScope) []pdag.Node {
+	mod := scope.mod
 	if mod == nil || len(mod.Providers) == 0 {
 		return nil
 	}
@@ -508,12 +523,104 @@ func (g *Graph) passThroughProviderDeps(resource *ast.Resource, mod *ast.Module,
 	if !ok {
 		return nil
 	}
+	return g.resolvePassedProvider(scope.config, key, passExpr, scope.parent)
+}
+
+// resolvePassedProvider returns an edge to the parent-scope provider
+// configuration that a module call's `providers = { <childKey> = <passExpr> }`
+// entry names, resolving strictly against parent: its `provider` block, the
+// pass-through entry of its own module call (whose shadow node stands in), or
+// — for an un-aliased reference on the root — its `required_providers`
+// declaration, which stands for the implicit empty default configuration
+// (nothing registers it, so there is no node to order after). Anything else
+// records a missing-provider diagnostic for Validate. childConfig is the
+// called module's config; its `required_providers` names the provider in the
+// diagnostic.
+func (g *Graph) resolvePassedProvider(
+	childConfig *ast.Config, childKey string, passExpr hcl.Expression, parent *moduleScope,
+) []pdag.Node {
 	parentKey := providerExprKey(passExpr)
 	if parentKey == "" {
 		return nil
 	}
-	_, idx := g.newNode(parentPrefix + parentKey)
-	return []pdag.Node{idx}
+	if _, ok := parent.config.Providers[parentKey]; ok {
+		_, idx := g.newNode(parent.prefix + parentKey)
+		return []pdag.Node{idx}
+	}
+	if parent.mod != nil {
+		if _, ok := parent.mod.Providers[parentKey]; ok {
+			_, idx := g.newNode(parent.prefix + parentKey)
+			return []pdag.Node{idx}
+		}
+	}
+	name, alias, aliased := strings.Cut(parentKey, ".")
+	if !aliased && parent.parent == nil && parent.config.Terraform != nil {
+		if _, ok := parent.config.Terraform.RequiredProviders[name]; ok {
+			return nil
+		}
+	}
+	addr := fmt.Sprintf("%sprovider[%q]", parent.prefix, providerFQN(childConfig, strings.SplitN(childKey, ".", 2)[0]))
+	if aliased {
+		addr += "." + alias
+	}
+	g.recordMissingProvider(addr, passExpr.Range())
+	return nil
+}
+
+// recordMissingProvider records a missing-provider diagnostic for Validate,
+// deduplicated by provider address.
+func (g *Graph) recordMissingProvider(addr string, rng hcl.Range) {
+	if _, ok := g.missingProviders[addr]; ok {
+		return
+	}
+	g.missingProviders[addr] = &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  fmt.Sprintf("missing provider %s", addr),
+		Subject:  rng.Ptr(),
+	}
+}
+
+// providerFQN returns the fully-qualified address of the provider behind
+// localName in config: the `required_providers` source when declared, else the
+// default namespace, both anchored at the default registry host.
+func providerFQN(config *ast.Config, localName string) string {
+	source := localName
+	if config.Terraform != nil {
+		if req, ok := config.Terraform.RequiredProviders[localName]; ok && req.Source != "" {
+			source = req.Source
+		}
+	}
+	switch parts := strings.Split(source, "/"); len(parts) {
+	case 1:
+		return "registry.opentofu.org/hashicorp/" + parts[0]
+	case 2:
+		return "registry.opentofu.org/" + source
+	default:
+		return source
+	}
+}
+
+// defaultProviderNode returns an edge to the node that registers the default
+// (un-aliased) provider configuration `name` as seen from scope s: the
+// nearest enclosing scope with a `provider "<name>"` block, or with a
+// `providers = { <name> = ... }` entry on its own module call (whose shadow
+// node stands in). Returns nil when no configuration exists anywhere — the
+// reference then names the implicit empty default configuration, which needs
+// no ordering edge.
+func (g *Graph) defaultProviderNode(name string, s *moduleScope) []pdag.Node {
+	for ; s != nil; s = s.parent {
+		if _, ok := s.config.Providers[name]; ok {
+			_, idx := g.newNode(s.prefix + name)
+			return []pdag.Node{idx}
+		}
+		if s.mod != nil {
+			if _, ok := s.mod.Providers[name]; ok {
+				_, idx := g.newNode(s.prefix + name)
+				return []pdag.Node{idx}
+			}
+		}
+	}
+	return nil
 }
 
 // providerExprKey returns "name" or "name.alias" from a provider-reference
@@ -578,16 +685,16 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node 
 	}
 	// A bare `provider = name` reference (no alias) is a single-segment
 	// traversal, which exprDeps drops because it carries no attribute after the
-	// root. Depend on the named provider node directly so this resource is
-	// ordered after it. Aliased (`name.alias`) and call-based (`call.x.y`)
-	// provider expressions have further segments and are already resolved by
-	// exprDeps above.
+	// root. It names the default configuration, which resolves through
+	// inheritance and may be implicit, so order the resource after whichever
+	// node registers it (if any). Aliased (`name.alias`) and call-based
+	// (`call.x.y`) provider expressions have further segments and are already
+	// resolved by exprDeps above.
 	if resource.Provider != nil {
 		if vars := resource.Provider.Variables(); len(vars) == 1 && len(vars[0]) == 1 {
-			name := vars[0].RootName()
-			g.recordRef(prefix+name, vars[0].SourceRange())
-			_, idx := g.newNode(prefix + name)
-			seen[idx] = true
+			for _, dep := range g.defaultProviderNode(vars[0].RootName(), g.scopes[prefix]) {
+				seen[dep] = true
+			}
 		}
 	}
 	for _, traversal := range resource.Providers {
@@ -930,6 +1037,10 @@ func (g *Graph) Validate() []error {
 		errs = append(errs, diag)
 	}
 
+	for _, addr := range slices.Sorted(maps.Keys(g.missingProviders)) {
+		errs = append(errs, g.missingProviders[addr])
+	}
+
 	return errs
 }
 
@@ -1054,8 +1165,13 @@ func (g *Graph) inlineModule(
 	// `provider` block of its own. In-module resources referencing it would
 	// otherwise leave behind an unresolved node and trip Validate. Register
 	// it as a no-op shadow so the local edge resolves; the real resolution
-	// (to the parent's provider) happens at runtime via mod.Providers.
-	for localKey := range mod.Providers {
+	// (to the parent's provider) happens at runtime via mod.Providers. The
+	// shadow depends on the parent-scope configuration it stands for, so that
+	// a chain of pass-throughs stays ordered after the originating block —
+	// and so every entry is checked against the parent scope, whether or not
+	// anything in the child consumes it.
+	for localKey, passExpr := range mod.Providers {
+		deps := g.resolvePassedProvider(loaded.Config, localKey, passExpr, parent)
 		shadowKey := prefix + localKey
 		if existing, ok := g.seen[shadowKey]; ok && existing.n.Type != NodeTypeUnknown {
 			continue
@@ -1064,7 +1180,7 @@ func (g *Graph) inlineModule(
 			Key:        shadowKey,
 			Type:       NodeTypeBuiltin,
 			ModuleInfo: modInfo,
-		}, nil); err != nil {
+		}, deps); err != nil {
 			return err
 		}
 	}
@@ -1074,7 +1190,7 @@ func (g *Graph) inlineModule(
 		deps := g.resourceDeps(resource, prefix)
 		deps = append(deps, initIdx)
 		ownDeps := g.defaultProviderDeps(resource, loaded.Config, prefix)
-		passDeps := g.passThroughProviderDeps(resource, mod, parentPrefix)
+		passDeps := g.passThroughProviderDeps(resource, scope)
 		deps = append(deps, ownDeps...)
 		deps = append(deps, passDeps...)
 		if len(ownDeps) == 0 && len(passDeps) == 0 {
@@ -1095,7 +1211,7 @@ func (g *Graph) inlineModule(
 		deps := g.resourceDeps(ds, prefix)
 		deps = append(deps, initIdx)
 		ownDeps := g.defaultProviderDeps(ds, loaded.Config, prefix)
-		passDeps := g.passThroughProviderDeps(ds, mod, parentPrefix)
+		passDeps := g.passThroughProviderDeps(ds, scope)
 		deps = append(deps, ownDeps...)
 		deps = append(deps, passDeps...)
 		if len(ownDeps) == 0 && len(passDeps) == 0 {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -994,6 +994,40 @@ func (e *Engine) resolvePassThroughProvider(modInfo *graph.ModuleInfo, localKey 
 	return ref
 }
 
+// resolveExplicitProvider resolves a resource/data source `provider = ...`
+// expression to a "<urn>::<id>" reference. A pass-through entry of the
+// instantiating module call wins over any local definition; otherwise the
+// expression is evaluated in the resource's own scope. A bare `provider =
+// name` reference whose default configuration is registered nowhere in scope
+// resolves to "": the reference names the implicit empty default
+// configuration, i.e. the engine default.
+func (e *Engine) resolveExplicitProvider(
+	expr hcl.Expression, evalCtx *eval.Context, modInfo *graph.ModuleInfo,
+) (string, error) {
+	if ref := e.resolvePassThroughProvider(modInfo, providerExprKey(expr)); ref != "" {
+		return ref, nil
+	}
+	val, valDiags := eval.NewEvaluator(evalCtx).EvaluateExpression(expr)
+	if !valDiags.HasErrors() {
+		return providerRefFromCty(val)
+	}
+	vars := expr.Variables()
+	if len(vars) != 1 || len(vars[0]) != 1 {
+		return "", errors.New(valDiags.Error())
+	}
+	name := vars[0].RootName()
+	if modInfo != nil {
+		if ref := e.inheritedDefaultProvider(modInfo, name); ref != "" {
+			return ref, nil
+		}
+		return "", nil
+	}
+	if ref, ok := e.defaultProviders.Get(name); ok {
+		return ref, nil
+	}
+	return "", nil
+}
+
 // inheritedDefaultProvider walks up the module tree from modInfo, returning the
 // nearest ancestor's registered un-aliased default provider config for pkg
 // (URN::ID), or "" if none. The graph adds a matching edge so that block is
@@ -1601,24 +1635,11 @@ func (e *Engine) buildResourceOptionsInContext(
 	}
 
 	if res.Provider != nil {
-		// `provider = X.alias` (or `provider = X`). For an in-module
-		// resource, the parent module call may have mapped this local
-		// reference to a parent-scope provider via
-		// `providers = { X.alias = ... }` — that wins over any local
-		// definition. Fall back to evaluating the expression in the
-		// resource's own scope, which is what TF does when there is no
-		// pass-through.
-		if ref := e.resolvePassThroughProvider(modInfo, providerExprKey(res.Provider)); ref != "" {
-			opts.Provider = ref
-		} else {
-			val, valDiags := eval.NewEvaluator(evalCtx).EvaluateExpression(res.Provider)
-			if valDiags.HasErrors() {
-				return nil, fmt.Errorf("evaluating provider for %s.%s: %s", res.Type, res.Name, valDiags.Error())
-			}
-			ref, err := providerRefFromCty(val)
-			if err != nil {
-				return nil, fmt.Errorf("resolving provider for %s.%s: %w", res.Type, res.Name, err)
-			}
+		ref, err := e.resolveExplicitProvider(res.Provider, evalCtx, modInfo)
+		if err != nil {
+			return nil, fmt.Errorf("resolving provider for %s.%s: %w", res.Type, res.Name, err)
+		}
+		if ref != "" {
 			opts.Provider = ref
 		}
 	} else if modInfo != nil {
@@ -2856,17 +2877,11 @@ func (e *Engine) invokeDataSourceOnce(
 	}
 
 	if ds.Provider != nil {
-		if ref := e.resolvePassThroughProvider(node.ModuleInfo, providerExprKey(ds.Provider)); ref != "" {
-			invokeReq.Provider = ref
-		} else {
-			val, valDiags := eval.NewEvaluator(evalCtx).EvaluateExpression(ds.Provider)
-			if valDiags.HasErrors() {
-				return cty.NilVal, fmt.Errorf("evaluating provider for data %s.%s: %s", ds.Type, ds.Name, valDiags.Error())
-			}
-			ref, err := providerRefFromCty(val)
-			if err != nil {
-				return cty.NilVal, fmt.Errorf("resolving provider for data %s.%s: %w", ds.Type, ds.Name, err)
-			}
+		ref, err := e.resolveExplicitProvider(ds.Provider, evalCtx, node.ModuleInfo)
+		if err != nil {
+			return cty.NilVal, fmt.Errorf("resolving provider for data %s.%s: %w", ds.Type, ds.Name, err)
+		}
+		if ref != "" {
 			invokeReq.Provider = ref
 		}
 	} else if node.ModuleInfo != nil {

--- a/tests/tfcompat/l2_explicit_provider_implicit_default_test.go
+++ b/tests/tfcompat/l2_explicit_provider_implicit_default_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ExplicitProviderImplicitDefault pins TF's behaviour for a bare
+// `provider = simple` reference with no `provider "simple"` block anywhere:
+// the reference names the implicit (empty) default provider configuration.
+func TestL2ExplicitProviderImplicitDefault(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_explicit_provider_implicit_default", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_module_explicit_provider_inherited_test.go
+++ b/tests/tfcompat/l2_module_explicit_provider_inherited_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ModuleExplicitProviderInherited pins TF's behaviour for a bare
+// `provider = simple` reference inside a module that has no `provider
+// "simple"` block of its own: the reference names the module's default
+// configuration, which is inherited from the root's `provider "simple"`
+// block, so the resource carries the root's `prefix`.
+func TestL2ModuleExplicitProviderInherited(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_explicit_provider_inherited", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_module_implicit_default_provider_passthrough_test.go
+++ b/tests/tfcompat/l2_module_implicit_default_provider_passthrough_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ModuleImplicitDefaultProviderPassthrough pins TF's behaviour for a
+// module block whose `providers` argument passes the *implicit* default
+// provider — `providers = { simple = simple }` with no `provider "simple"`
+// block anywhere in the configuration. TF resolves the reference to the
+// implicit (empty) default provider configuration; pulumi-hcl's graph
+// builder leaves an unresolved `simple` node behind and fails validation
+// with `unknown node "simple"`.
+func TestL2ModuleImplicitDefaultProviderPassthrough(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_implicit_default_provider_passthrough", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_module_providers_passthrough_undeclared_test.go
+++ b/tests/tfcompat/l2_module_providers_passthrough_undeclared_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ModuleProvidersPassthroughUndeclared pins TF's behaviour for a module
+// call passing `providers = { simple = simple }` when the root neither
+// configures the provider nor declares it in `required_providers`: both
+// runtimes must fail with the same missing-provider error.
+func TestL2ModuleProvidersPassthroughUndeclared(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_providers_passthrough_undeclared", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			ExpectErr: `missing provider provider["registry.opentofu.org/hashicorp/simple"]`,
+		}},
+	})
+}

--- a/tests/tfcompat/l2_nested_module_providers_passthrough_undeclared_test.go
+++ b/tests/tfcompat/l2_nested_module_providers_passthrough_undeclared_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2NestedModuleProvidersPassthroughUndeclared pins TF's behaviour for a
+// mid-level module passing `providers = { simple = simple }` while having no
+// provider configuration of its own: provider configurations are never
+// inherited into a `providers` argument, so both runtimes must fail with the
+// same module-qualified missing-provider error even though the root has a
+// `provider "simple"` block.
+func TestL2NestedModuleProvidersPassthroughUndeclared(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_nested_module_providers_passthrough_undeclared", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			ExpectErr: `missing provider module.mid.provider["registry.opentofu.org/hashicorp/simple"]`,
+		}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_explicit_provider_implicit_default/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_explicit_provider_implicit_default/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+resource "simple_resource" "a" {
+  provider  = simple
+  input_one = "world"
+  input_two = true
+}
+
+output "prefix_result" {
+  value = simple_resource.a.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_explicit_provider_inherited/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_explicit_provider_inherited/main.tf
@@ -1,0 +1,11 @@
+provider "simple" {
+  prefix = "from-root"
+}
+
+module "child" {
+  source = "./modules/child"
+}
+
+output "module_prefix_result" {
+  value = module.child.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_explicit_provider_inherited/modules/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_explicit_provider_inherited/modules/child/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+resource "simple_resource" "r" {
+  provider  = simple
+  input_one = "world"
+  input_two = true
+}
+
+output "prefix_result" {
+  value = simple_resource.r.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_implicit_default_provider_passthrough/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_implicit_default_provider_passthrough/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+module "child" {
+  source = "./modules/child"
+  providers = {
+    simple = simple
+  }
+}
+
+output "module_prefix_result" {
+  value = module.child.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_implicit_default_provider_passthrough/modules/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_implicit_default_provider_passthrough/modules/child/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+resource "simple_resource" "r" {
+  input_one = "world"
+  input_two = true
+}
+
+output "prefix_result" {
+  value = simple_resource.r.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_providers_passthrough_undeclared/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_providers_passthrough_undeclared/main.tf
@@ -1,0 +1,10 @@
+module "child" {
+  source = "./modules/child"
+  providers = {
+    simple = simple
+  }
+}
+
+output "module_prefix_result" {
+  value = module.child.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_providers_passthrough_undeclared/modules/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_providers_passthrough_undeclared/modules/child/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+resource "simple_resource" "r" {
+  input_one = "world"
+  input_two = true
+}
+
+output "prefix_result" {
+  value = simple_resource.r.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_nested_module_providers_passthrough_undeclared/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_module_providers_passthrough_undeclared/main.tf
@@ -1,0 +1,11 @@
+provider "simple" {
+  prefix = "from-root"
+}
+
+module "mid" {
+  source = "./modules/mid"
+}
+
+output "module_prefix_result" {
+  value = module.mid.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_nested_module_providers_passthrough_undeclared/modules/mid/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_module_providers_passthrough_undeclared/modules/mid/main.tf
@@ -1,0 +1,10 @@
+module "child" {
+  source = "./modules/child"
+  providers = {
+    simple = simple
+  }
+}
+
+output "prefix_result" {
+  value = module.child.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_nested_module_providers_passthrough_undeclared/modules/mid/modules/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_module_providers_passthrough_undeclared/modules/mid/modules/child/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+resource "simple_resource" "r" {
+  input_one = "world"
+  input_two = true
+}
+
+output "prefix_result" {
+  value = simple_resource.r.prefix_result
+}


### PR DESCRIPTION
Resolve `providers = { x = x }` module arguments and bare `provider = x` references when no `provider "x"` block exists, instead of failing with `unknown node "x"`; report `missing provider` for `providers` entries the parent scope does not declare