### PR TITLE
Translate nested object attribute names in bridge mappings

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-349.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-349.yaml
@@ -1,0 +1,7 @@
+kind: bug-fixes
+body: Fix `Unsupported attribute` errors when traversing unknown nested object
+    attributes during preview
+time: 2026-07-11T09:00:00Z
+custom:
+    Component: runtime
+    PR: "349"

--- a/pkg/hcl/bridge/mapping.go
+++ b/pkg/hcl/bridge/mapping.go
@@ -34,7 +34,8 @@ type FieldMapping struct {
 	// MaxItemsOne is true when a TF block is projected to Pulumi as a single
 	// object rather than a list of objects. Only meaningful when TFBlock.
 	MaxItemsOne bool
-	// Nested is the inner-block mapping, populated only for TFBlock fields.
+	// Nested is the inner-body mapping for fields with named nested fields:
+	// blocks (TFBlock) and object-typed attributes (nested attributes).
 	Nested *BodyMapping
 }
 
@@ -136,14 +137,9 @@ func bodyMappingFromSchema(sm shim.SchemaMap, overrides map[string]*tfbridge.Sch
 		if elemRes, isBlock := elemAsResource(sch); isBlock {
 			fm.TFBlock = true
 			fm.MaxItemsOne = computeMaxItemsOne(sch, ov)
-			var nestedOverrides map[string]*tfbridge.SchemaInfo
-			if ov != nil {
-				nestedOverrides = ov.Fields
-				if ov.Elem != nil && len(ov.Elem.Fields) > 0 {
-					nestedOverrides = ov.Elem.Fields
-				}
-			}
-			fm.Nested = bodyMappingFromSchema(elemRes.Schema(), nestedOverrides)
+			fm.Nested = bodyMappingFromSchema(elemRes.Schema(), nestedOverrides(ov))
+		} else if objRes, isObject := elemAsObject(sch); isObject {
+			fm.Nested = bodyMappingFromSchema(objRes.Schema(), nestedOverrides(ov))
 		}
 		m.Fields[tfName] = fm
 		return true
@@ -151,14 +147,55 @@ func bodyMappingFromSchema(sm shim.SchemaMap, overrides map[string]*tfbridge.Sch
 	return m
 }
 
+// nestedOverrides returns the SchemaInfo field overrides that apply to a
+// field's nested body.
+func nestedOverrides(ov *tfbridge.SchemaInfo) map[string]*tfbridge.SchemaInfo {
+	if ov == nil {
+		return nil
+	}
+	if ov.Elem != nil && len(ov.Elem.Fields) > 0 {
+		return ov.Elem.Fields
+	}
+	return ov.Fields
+}
+
 // elemAsResource returns the nested-block element shim if sch is a TF block
-// (TypeList/TypeSet with a Resource Elem). For TypeMap with Resource Elem we
-// also return the resource — SDKv2 reinterprets that case as a string-string
-// map at the schema level, but as a body shape, TF source still uses block
-// syntax.
+// (TypeList/TypeSet with a Resource Elem).
 func elemAsResource(sch shim.Schema) (shim.Resource, bool) {
 	switch sch.Type() {
 	case shim.TypeList, shim.TypeSet:
+		if res, ok := sch.Elem().(shim.Resource); ok {
+			return res, true
+		}
+	}
+	return nil, false
+}
+
+// elemAsObject returns the pseudo-resource carrying an object-typed
+// attribute's named fields. Object types use the tfshim convention
+// Schema{Type: Map, Elem: Resource}: collection-nested attributes carry that
+// schema as their Elem, and a single nested attribute is that schema directly.
+func elemAsObject(sch shim.Schema) (shim.Resource, bool) {
+	switch sch.Type() {
+	case shim.TypeList, shim.TypeSet:
+		if e, ok := sch.Elem().(shim.Schema); ok {
+			return objectSchemaResource(e)
+		}
+	case shim.TypeMap:
+		switch e := sch.Elem().(type) {
+		case shim.Resource:
+			return e, true
+		case shim.Schema:
+			return objectSchemaResource(e)
+		}
+	}
+	return nil, false
+}
+
+// objectSchemaResource unwraps the tfshim object-type convention
+// (Schema{Type: Map, Elem: Resource}) to its pseudo-resource.
+func objectSchemaResource(sch shim.Schema) (shim.Resource, bool) {
+	if sch.Type() == shim.TypeMap {
 		if res, ok := sch.Elem().(shim.Resource); ok {
 			return res, true
 		}

--- a/pkg/hcl/bridge/mapping_test.go
+++ b/pkg/hcl/bridge/mapping_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/bridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	mockschema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"github.com/stretchr/testify/require"
 )
@@ -189,6 +191,62 @@ func TestResourceBodyMapping_NestedBlocks(t *testing.T) {
 	require.NotNil(t, rule.Nested)
 	require.NotNil(t, rule.Nested.Lookup("action"))
 	require.False(t, rule.Nested.Lookup("action").TFBlock)
+}
+
+// Nested attributes are not blocks, but their nested names still need
+// TF→Pulumi translation: pluralized Pulumi names do not snake-case back to
+// their TF names.
+func TestResourceBodyMapping_NestedObjectAttributes(t *testing.T) {
+	t.Parallel()
+	objectOf := func(fields mockschema.SchemaMap) shim.Schema {
+		return (&mockschema.Schema{
+			Type: shim.TypeMap,
+			Elem: (&mockschema.Resource{Schema: fields}).Shim(),
+		}).Shim()
+	}
+	nested := objectOf(mockschema.SchemaMap{
+		"value": (&mockschema.Schema{Type: shim.TypeString, Computed: true}).Shim(),
+	})
+	elem := objectOf(mockschema.SchemaMap{
+		"nested_attr": (&mockschema.Schema{Type: shim.TypeList, Computed: true, Elem: nested}).Shim(),
+	})
+	p := (&mockschema.Provider{ResourcesMap: mockschema.ResourceMap{
+		"test_res": (&mockschema.Resource{Schema: mockschema.SchemaMap{
+			"attr": (&mockschema.Schema{Type: shim.TypeList, Computed: true, Elem: elem}).Shim(),
+			"obj_attr": objectOf(mockschema.SchemaMap{
+				"value": (&mockschema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+			}),
+		}}).Shim(),
+	}}).Shim()
+	info := &tfbridge.ProviderInfo{P: p, Name: "test", Version: "0.0.1"}
+
+	m := bridge.ResourceBodyMapping(info, "test_res")
+	require.NotNil(t, m)
+
+	attrFM := m.Lookup("attr")
+	require.NotNil(t, attrFM)
+	require.Equal(t, &bridge.FieldMapping{
+		TFName:     "attr",
+		PulumiName: "attrs",
+		Nested:     attrFM.Nested, // verified next
+	}, attrFM)
+	require.NotNil(t, attrFM.Nested)
+
+	nestedFM := attrFM.Nested.Lookup("nested_attr")
+	require.NotNil(t, nestedFM)
+	require.Equal(t, &bridge.FieldMapping{
+		TFName:     "nested_attr",
+		PulumiName: "nestedAttrs",
+		Nested:     nestedFM.Nested, // verified next
+	}, nestedFM)
+	require.NotNil(t, nestedFM.Nested)
+	require.NotNil(t, nestedFM.Nested.Lookup("value"))
+
+	objFM := m.Lookup("obj_attr")
+	require.NotNil(t, objFM)
+	require.False(t, objFM.TFBlock)
+	require.NotNil(t, objFM.Nested)
+	require.NotNil(t, objFM.Nested.Lookup("value"))
 }
 
 func TestResourceBodyMapping_MissingResourceReturnsNil(t *testing.T) {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2508,7 +2508,7 @@ type attrPathNameResolver struct {
 // and advances the resolver into the nested schema for the following segment.
 func (r *attrPathNameResolver) next(tfName string) (string, error) {
 	if fm := r.mapping.Lookup(tfName); fm != nil {
-		if fm.TFBlock {
+		if fm.Nested != nil {
 			r.mapping, r.props = fm.Nested, nil
 		} else {
 			r.mapping, r.props = nil, nil

--- a/tests/testutil/tfcompat/providers/pf.go
+++ b/tests/testutil/tfcompat/providers/pf.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	pschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -60,6 +62,7 @@ func (p *pfxProvider) Resources(context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		func() resource.Resource { return &pfxThing{} },
 		func() resource.Resource { return &pfxWidget{} },
+		func() resource.Resource { return &pfxRes{} },
 	}
 }
 
@@ -258,6 +261,95 @@ func (f *pfxJoinStr) Run(ctx context.Context, req function.RunRequest, resp *fun
 		return
 	}
 	resp.Error = function.ConcatFuncErrors(resp.Error, resp.Result.Set(ctx, strings.Join(parts, separator)))
+}
+
+// pfxRes carries a computed list-nested attribute whose element holds
+// another computed list-nested attribute.
+type pfxRes struct{}
+
+var _ resource.Resource = (*pfxRes)(nil)
+
+func (r *pfxRes) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_res"
+}
+
+func (r *pfxRes) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"id": rschema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"attr": rschema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: rschema.NestedAttributeObject{
+					Attributes: map[string]rschema.Attribute{
+						"nested_attr": rschema.ListNestedAttribute{
+							Computed: true,
+							NestedObject: rschema.NestedAttributeObject{
+								Attributes: map[string]rschema.Attribute{
+									"value": rschema.StringAttribute{Computed: true},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type pfxResModel struct {
+	ID   types.String `tfsdk:"id"`
+	Attr types.List   `tfsdk:"attr"`
+}
+
+func pfxResAttrValue(ctx context.Context) (types.List, diag.Diagnostics) {
+	nestedType := types.ObjectType{AttrTypes: map[string]attr.Type{"value": types.StringType}}
+	attrType := types.ObjectType{AttrTypes: map[string]attr.Type{"nested_attr": types.ListType{ElemType: nestedType}}}
+	nested, diags := types.ObjectValue(nestedType.AttrTypes, map[string]attr.Value{
+		"value": types.StringValue("computed-value"),
+	})
+	if diags.HasError() {
+		return types.List{}, diags
+	}
+	nestedList, d := types.ListValue(nestedType, []attr.Value{nested})
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.List{}, diags
+	}
+	attrVal, d := types.ObjectValue(attrType.AttrTypes, map[string]attr.Value{"nested_attr": nestedList})
+	diags.Append(d...)
+	if diags.HasError() {
+		return types.List{}, diags
+	}
+	attrList, d := types.ListValue(attrType, []attr.Value{attrVal})
+	diags.Append(d...)
+	return attrList, diags
+}
+
+func (r *pfxRes) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	attrVal, diags := pfxResAttrValue(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state := pfxResModel{ID: types.StringValue("pfx-res-id"), Attr: attrVal}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *pfxRes) Read(_ context.Context, _ resource.ReadRequest, _ *resource.ReadResponse) {}
+
+func (r *pfxRes) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan pfxResModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *pfxRes) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {
 }
 
 type pfxLookup struct{}

--- a/tests/tfcompat/README.md
+++ b/tests/tfcompat/README.md
@@ -129,6 +129,12 @@ Tests should be named after the noun under test, not the behavior under test. Fo
 to test that variable defaults are applied correctly, we the test might be called
 `l1_var`, not `l1_var_defaults_applied`.
 
+Tests must never mention the real-world providers or fields that motivated
+them (no `aws`, `cluster`, `oidc`, `issuer`, ...). All names are generic and
+describe the *shape* of what they are: prefer field names like `attr`,
+`block`, `nested_block` and resource names like `pfx_res` or
+`simple_resource` over domain nouns like `record`, `cluster`, or `rule`.
+
 ## Scope
 
 Cases here must be valid Terraform programs — both paths run the same `.tf`

--- a/tests/tfcompat/l2_nested_computed_attribute_test.go
+++ b/tests/tfcompat/l2_nested_computed_attribute_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2NestedComputedAttribute traverses a computed nested list attribute
+// (`attr[0].nested_attr[0].value`) while the resource is unknown during
+// preview. Unlike l2_nested_computed_block, the nesting is an object-typed
+// attribute, not an Elem-Resource block.
+func TestL2NestedComputedAttribute(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_nested_computed_attribute", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "pfx", PFFactory: providers.PFXProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StagePreview},
+			{},
+		},
+	})
+}

--- a/tests/tfcompat/l2_nested_computed_block_count_test.go
+++ b/tests/tfcompat/l2_nested_computed_block_count_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2NestedComputedBlockCount traverses a counted resource's computed
+// nested blocks (`r.this[0].identity[0].oidc[0].issuer`) while the resource
+// is unknown during preview.
+func TestL2NestedComputedBlockCount(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_nested_computed_block_count", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "nested", Factory: providers.NestedProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			Mode: tfcompat.StagePreview,
+		}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_nested_computed_attribute/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_computed_attribute/main.tf
@@ -1,0 +1,6 @@
+resource "pfx_res" "this" {
+}
+
+output "value" {
+  value = pfx_res.this.attr[0].nested_attr[0].value
+}

--- a/tests/tfcompat/testdata/cases/l2_nested_computed_block_count/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_computed_block_count/main.tf
@@ -1,0 +1,7 @@
+resource "nested_cluster" "this" {
+  count = 1
+}
+
+output "issuer" {
+  value = nested_cluster.this[0].identity[0].oidc[0].issuer
+}


### PR DESCRIPTION
## Problem

Previewing the Materialize-on-AWS module (the dogfood from https://github.com/pulumi-labs/pulumi-hcl/pull/348) fails inside terraform-aws-eks:

```
aws_eks_cluster.this[0].identity[0].oidc[0].issuer
→ Unsupported attribute; This object does not have an attribute named "oidc".
```

## Root cause

`bodyMappingFromSchema` only descended into `Elem() = shim.Resource` (block) elements. Object-typed attributes — the tfshim `Schema{Type: Map, Elem: Resource}` convention used by plugin-framework providers and by wire-bridged computed SDKv2 fields such as `aws_eks_cluster.identity` — got `Nested: nil`. With no nested mapping, the cty type of an unknown value falls back to snake-casing the Pulumi property names, and pluralization is not reversible that way (`oidc` → `oidcs` → `oidcs`), so the unknown's element type carries `oidcs` and the `.oidc` traversal fails at preview.

## Fix

- `pkg/hcl/bridge/mapping.go`: recognize the object convention (list/set/map of `Schema{Map, Resource}`, and bare `Map`+`Resource` for a single nested attribute) and populate `FieldMapping.Nested`. These stay attributes: `TFBlock` remains false, so there is no block syntax and no MaxItemsOne list rewrap.
- `pkg/hcl/run/run.go`: `attrPathNameResolver` descends into `Nested` whenever it is populated (was gated on `TFBlock`), so attribute paths like `additional_secret_outputs` translate through nested attributes too.

## Testing

- New tfcompat case `l2_nested_computed_attribute` (plugin-framework `pfx_res` with a computed list-nested attribute holding another, traversed while unknown): failed with the exact error above, passes with the fix. Its SDKv2 block twin `l2_nested_computed_block` always passed — the trigger is the attribute-vs-block schema shape, so a `count` variant of the block case is added as coverage too.
- New unit test `TestResourceBodyMapping_NestedObjectAttributes` pins the pluralized nested names (`attr` → `attrs`, `nested_attr` → `nestedAttrs`) with `Nested` populated.
- Full suites pass: tfcompat 148, pkg+cmd 1182.
- The real Materialize preview gets past this error; the next (pre-existing, previously masked) wall is a separate `vpc_config[0]` invalid-index issue.