### PR TITLE
Exclude tfcompat test providers from Codecov coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "tests/testutil/tfcompat/providers"


### PR DESCRIPTION
Adds a `codecov.yml` that ignores `tests/testutil/tfcompat/providers`. These packages are test-only provider implementations, so counting them in coverage metrics is noise.

The config validates against `https://codecov.io/validate`. No changelog fragment since this is CI-only and not user-visible.