### PR TITLE
Type unknown MaxItemsOne block placeholders as lists

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-351.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-351.yaml
@@ -1,0 +1,7 @@
+kind: bug-fixes
+body: Fix `Invalid index` errors when indexing into a MaxItems=1 block that is
+    unknown during preview
+time: 2026-07-11T12:00:00Z
+custom:
+    Component: runtime
+    PR: "351"

--- a/pkg/hcl/run/singular_block_test.go
+++ b/pkg/hcl/run/singular_block_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/run"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/schemaloader"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	schemashim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// singularBlockPackage describes a resource whose TF schema carries a
+// MaxItems=1 block: the bridge flattens it to a single object property.
+func singularBlockPackage() schema.PackageSpec {
+	return schema.PackageSpec{
+		Name: "simple",
+		Meta: &schema.MetadataSpec{ModuleFormat: `(.*)(?:/[^/]*)`},
+		Resources: map[string]schema.ResourceSpec{
+			"simple:index:Resource": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"block": {TypeSpec: schema.TypeSpec{
+							Ref: "#/types/simple:index:Block",
+						}},
+					},
+					Required: []string{"block"},
+				},
+			},
+		},
+		Types: map[string]schema.ComplexTypeSpec{
+			"simple:index:Block": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]schema.PropertySpec{
+						"field": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+}
+
+// singularBlockInfoSource serves the bridge mapping for the "simple" provider:
+// `block` is a TypeList MaxItems=1 block, so the mapping marks it MaxItemsOne.
+type singularBlockInfoSource struct{}
+
+func (singularBlockInfoSource) GetProviderInfo(
+	_ context.Context, tfProvider string, _ *workspace.PackageDescriptor,
+) (*tfbridge.ProviderInfo, error) {
+	if tfProvider != "simple" {
+		return nil, fmt.Errorf("unknown provider %q", tfProvider)
+	}
+	return &tfbridge.ProviderInfo{
+		Name: "simple",
+		P: (&schemashim.Provider{
+			ResourcesMap: schemashim.ResourceMap{
+				"simple_resource": (&schemashim.Resource{Schema: schemashim.SchemaMap{
+					"block": (&schemashim.Schema{
+						Type:     shim.TypeList,
+						Required: true,
+						MaxItems: 1,
+						Elem: (&schemashim.Resource{Schema: schemashim.SchemaMap{
+							"field": (&schemashim.Schema{Type: shim.TypeString, Computed: true}).Shim(),
+						}}).Shim(),
+					}).Shim(),
+				}}).Shim(),
+			},
+		}).Shim(),
+		Resources: map[string]*info.Resource{
+			"simple_resource": {Tok: "simple:index:Resource"},
+		},
+	}, nil
+}
+
+// TestEngine_SingularBlockUnknownDuringPreview indexes into a MaxItems=1 block
+// (`block[0].field`) whose value the monitor omits from the preview outputs,
+// the way the engine drops unknown properties. The unknown placeholder is
+// typed from the flattened Pulumi object, so it must be re-wrapped as a list
+// for the index to resolve.
+func TestEngine_SingularBlockUnknownDuringPreview(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "simple_resource" "r" {
+}
+
+output "field" {
+  value = simple_resource.r.block[0].field
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.Empty(t, diags)
+
+	mock := &testutil.MockResourceMonitor{
+		DryRun: true,
+		RegisterResourceHandler: func(_ context.Context, req run.RegisterResourceRequest) (*run.RegisterResourceResponse, error) {
+			return &run.RegisterResourceResponse{
+				URN: urn.URN("urn:pulumi:test::project::" + req.Type + "::" + req.Name),
+				// No outputs: unknown properties are dropped during preview.
+				Outputs: property.Map{},
+			}, nil
+		},
+	}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:       testModuleLoader(t),
+		ProjectName:        "test-project",
+		StackName:          "dev",
+		ResourceMonitor:    mock,
+		WorkDir:            t.TempDir(),
+		RootDir:            t.TempDir(),
+		DryRun:             true,
+		SchemaLoader:       schemaloader.New(t, singularBlockPackage()),
+		ProviderInfoSource: singularBlockInfoSource{},
+	})
+	require.NoError(t, engine.Run(t.Context()))
+
+	assert.True(t, mock.StackOutputs.Get("field").IsComputed(),
+		"the traversal through the unknown block should stay unknown during preview")
+}

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -1172,21 +1172,21 @@ func propertyObjectToCtyMap(path string, m property.Map, properties []*schema.Pr
 		// `r.settings[0].x` resolves the same way as in TF.
 		singularBlock := mapping != nil && fieldIsSingularBlock(mapping, p.Name)
 		v, ok := m.GetOk(p.Name)
-		if !ok {
-			if dryRun {
-				result[hclName] = cty.UnknownVal(ctyTypeFromType(p.Type, nested))
-			} else {
-				result[hclName] = cty.NullVal(ctyTypeFromType(p.Type, nested))
-			}
-			continue
-		}
 		// During preview, required properties that are null are treated as unknown.
 		// This is because resource.Computed{} (the SDK's representation of an unknown value)
 		// has a null inner element, which gets serialized to a null proto value by gRPC
 		// marshaling, losing the "unknown" signal. Since a required property should never
 		// legitimately be null, we safely treat null-during-preview as unknown.
-		if dryRun && v.IsNull() && p.IsRequired() {
-			result[hclName] = cty.UnknownVal(ctyTypeFromType(p.Type, nested))
+		if !ok || (dryRun && v.IsNull() && p.IsRequired()) {
+			t := ctyTypeFromType(p.Type, nested)
+			if singularBlock && !t.IsListType() && !t.IsTupleType() {
+				t = cty.List(t)
+			}
+			if dryRun {
+				result[hclName] = cty.UnknownVal(t)
+			} else {
+				result[hclName] = cty.NullVal(t)
+			}
 			continue
 		}
 		var vPath string

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/bridge"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/testing/utils/rapidresource"
@@ -969,6 +970,61 @@ func TestResourceOutputToCtyDoesNotErrorOnValidValues(t *testing.T) {
 			_, err := ResourceOutputToCty(outputs, res, nil, false)
 			require.NoError(t, err)
 		}
+	})
+}
+
+// TestResourceOutputToCtySingularBlockPlaceholder pins the shape of the
+// placeholder emitted when a MaxItemsOne block property is missing or null:
+// TF models the block as a list, so the unknown/null value must be list-typed
+// for a traversal like `r.block[0].field` to resolve.
+func TestResourceOutputToCtySingularBlockPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	res := &schema.Resource{
+		Token: "test:index:R",
+		Properties: []*schema.Property{
+			{Name: "block", Type: &schema.ObjectType{
+				Properties: []*schema.Property{
+					{Name: "field", Type: schema.StringType},
+				},
+			}},
+		},
+	}
+	mapping := &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+		"block": {
+			TFName:      "block",
+			PulumiName:  "block",
+			TFBlock:     true,
+			MaxItemsOne: true,
+			Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+				"field": {TFName: "field", PulumiName: "field"},
+			}},
+		},
+	}}
+	blockList := cty.List(cty.Object(map[string]cty.Type{"field": cty.String}))
+
+	t.Run("missing during preview", func(t *testing.T) {
+		t.Parallel()
+		r, err := ResourceOutputToCty(property.Map{}, res, mapping, true)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]cty.Value{"block": cty.UnknownVal(blockList)}, r)
+	})
+
+	t.Run("null during preview", func(t *testing.T) {
+		t.Parallel()
+		outputs := property.NewMap(map[string]property.Value{
+			"block": property.New(property.Null),
+		})
+		r, err := ResourceOutputToCty(outputs, res, mapping, true)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]cty.Value{"block": cty.UnknownVal(blockList)}, r)
+	})
+
+	t.Run("missing during apply", func(t *testing.T) {
+		t.Parallel()
+		r, err := ResourceOutputToCty(property.Map{}, res, mapping, false)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]cty.Value{"block": cty.NullVal(blockList)}, r)
 	})
 }
 

--- a/tests/tfcompat/l2_unknown_single_block_test.go
+++ b/tests/tfcompat/l2_unknown_single_block_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2UnknownSingleBlock indexes into a MaxItems=1 block
+// (`settings[0].mode`) while the block's contents are unknown during preview.
+// The block projects to a single Pulumi object, so the value must be
+// re-wrapped as a singleton list for the index to resolve.
+func TestL2UnknownSingleBlock(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_unknown_single_block", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+			{Name: "blocky", Factory: providers.BlockyProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StagePreview},
+			{},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_unknown_single_block/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_unknown_single_block/main.tf
@@ -1,0 +1,14 @@
+resource "simple_resource" "dep" {
+  input_one = "a"
+}
+
+resource "blocky_thing" "this" {
+  name = "x"
+  settings {
+    mode = simple_resource.dep.result
+  }
+}
+
+output "mode" {
+  value = blocky_thing.this.settings[0].mode
+}


### PR DESCRIPTION
## Problem

Previewing the Materialize-on-AWS module (`MaterializeInc/materialize/aws 0.8.38`, which consumes `terraform-aws-modules/eks`) failed at eks `main.tf:198`:

```
aws_eks_cluster.this[0].vpc_config[0].cluster_security_group_id
                                  ^^^
Invalid index; The given key does not identify an element in this collection
value. An object only supports looking up attributes by name, not by numeric
index.
```

`vpc_config` is a required MaxItems=1 block. During preview the engine returned the eks cluster's outputs with the `vpcConfig` property missing entirely, so `propertyObjectToCtyMap` emitted an unknown placeholder typed straight from the Pulumi schema — the flattened *object* type. TF models a MaxItems=1 block as a list, so the `[0]` index on that object failed.

The present-value path already handles this: it re-wraps a converted object value as a singleton tuple. Only the missing/null placeholder branches lacked the re-wrap (confirmed by instrumenting the failing preview: `ok=false singularBlock=true dryRun=true`).

## Fix

Merge the three placeholder branches and wrap the placeholder type in `cty.List` when the bridge mapping marks the field as a MaxItemsOne block, mirroring the type-level re-wrap `ctyObjectTypeRec` already performs.

## Testing

- Unit test `TestResourceOutputToCtySingularBlockPlaceholder` covering missing-at-preview, null-at-preview, and missing-at-apply; it fails without the fix.
- Engine-level test `TestEngine_SingularBlockUnknownDuringPreview` locks the behavior end-to-end: the mock monitor omits the block property from the preview outputs (the way the engine drops unknown properties) and the `block[0].field` traversal must resolve. It fails with the exact production error without the fix.
- tfcompat case `l2_unknown_single_block` covers the adjacent present-value path (block contents unknown during preview, singleton re-wrap). tfcompat's in-process providers keep the unknown signal, so the placeholder branches are unreachable from that suite — verified empirically; the engine-level test covers them instead.
- `go test ./pkg/...` and the full tfcompat suite (now 149 cases) pass.
- The real Materialize preview advances past this error (87 → 94 resources planned); the next blocker is unrelated (`precondition` hooks inside component constructions).