### PR TITLE
Support resource hooks in modules consumed as components

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-352.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-352.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Run `precondition`, `postcondition`, and provisioner blocks in modules consumed as components
+time: 2026-07-11T13:47:38Z
+custom:
+    Component: runtime
+    PR: "352"

--- a/pkg/server/construct_hooks_test.go
+++ b/pkg/server/construct_hooks_test.go
@@ -110,7 +110,6 @@ func (s *hookInvokingMonitor) RegisterResource(
 		OldOutputs: req.Object,
 	}
 	for _, name := range req.GetHooks().GetBeforeDelete() {
-		name := name
 		s.mu.Lock()
 		s.deferredDeletes = append(s.deferredDeletes, func(ctx context.Context) error {
 			return s.invokeHook(ctx, name, deleteReq)

--- a/pkg/server/construct_hooks_test.go
+++ b/pkg/server/construct_hooks_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modules"
+)
+
+// hookInvokingMonitor is a ResourceMonitor test double that invokes a resource's
+// bound hooks over the provider's callback server as the engine does around a
+// step — a hook error fails the registration — so tests observe a condition
+// actually firing, not merely being registered.
+type hookInvokingMonitor struct {
+	pulumirpc.UnimplementedResourceMonitorServer
+
+	mu    sync.Mutex
+	hooks map[string]*pulumirpc.Callback
+	// deferredDeletes holds before_delete invocations recorded during
+	// RegisterResource; runDeletes fires them later, as the engine deletes the
+	// component's children during `destroy --run-program`.
+	deferredDeletes []func(context.Context) error
+}
+
+func newHookInvokingMonitor() *hookInvokingMonitor {
+	return &hookInvokingMonitor{hooks: map[string]*pulumirpc.Callback{}}
+}
+
+func (s *hookInvokingMonitor) runDeletes(ctx context.Context) error {
+	for _, d := range s.deferredDeletes {
+		if err := d(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *hookInvokingMonitor) RegisterResourceHook(
+	_ context.Context, req *pulumirpc.RegisterResourceHookRequest,
+) (*emptypb.Empty, error) {
+	s.mu.Lock()
+	s.hooks[req.Name] = req.Callback
+	s.mu.Unlock()
+	return &emptypb.Empty{}, nil
+}
+
+func (s *hookInvokingMonitor) RegisterResource(
+	ctx context.Context, req *pulumirpc.RegisterResourceRequest,
+) (*pulumirpc.RegisterResourceResponse, error) {
+	urn := "urn:pulumi:test::proj::" + req.Type + "::" + req.Name
+
+	// The engine echoes checked inputs back as outputs for a resource with no
+	// provider diff; enough for a postcondition's `self` to resolve.
+	hookReq := &pulumirpc.ResourceHookRequest{
+		Urn:        urn,
+		Id:         req.Name,
+		Name:       req.Name,
+		Type:       req.Type,
+		NewInputs:  req.Object,
+		NewOutputs: req.Object,
+	}
+
+	for _, name := range req.GetHooks().GetBeforeCreate() {
+		if err := s.invokeHook(ctx, name, hookReq); err != nil {
+			return nil, err
+		}
+	}
+	for _, name := range req.GetHooks().GetAfterCreate() {
+		if err := s.invokeHook(ctx, name, hookReq); err != nil {
+			return nil, err
+		}
+	}
+
+	// before_delete fires when the engine later deletes this resource, not now;
+	// record it against the prior state (`self` reads old outputs).
+	deleteReq := &pulumirpc.ResourceHookRequest{
+		Urn:        urn,
+		Id:         req.Name,
+		Name:       req.Name,
+		Type:       req.Type,
+		OldInputs:  req.Object,
+		OldOutputs: req.Object,
+	}
+	for _, name := range req.GetHooks().GetBeforeDelete() {
+		name := name
+		s.mu.Lock()
+		s.deferredDeletes = append(s.deferredDeletes, func(ctx context.Context) error {
+			return s.invokeHook(ctx, name, deleteReq)
+		})
+		s.mu.Unlock()
+	}
+
+	return &pulumirpc.RegisterResourceResponse{Urn: urn, Object: req.Object}, nil
+}
+
+func (s *hookInvokingMonitor) RegisterResourceOutputs(
+	_ context.Context, _ *pulumirpc.RegisterResourceOutputsRequest,
+) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+// invokeHook dials the provider-hosted callback server and runs the named hook,
+// surfacing a hook-reported error as a registration failure.
+func (s *hookInvokingMonitor) invokeHook(
+	ctx context.Context, name string, req *pulumirpc.ResourceHookRequest,
+) error {
+	s.mu.Lock()
+	cb, ok := s.hooks[name]
+	s.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("hook %q was bound but never registered", name)
+	}
+
+	conn, err := grpc.NewClient(cb.Target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("dialing callback server: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	reqBytes, err := proto.Marshal(req)
+	if err != nil {
+		return err
+	}
+	resp, err := pulumirpc.NewCallbacksClient(conn).Invoke(ctx, &pulumirpc.CallbackInvokeRequest{
+		Token:   cb.Token,
+		Request: reqBytes,
+	})
+	if err != nil {
+		return err
+	}
+	var hookResp pulumirpc.ResourceHookResponse
+	if err := proto.Unmarshal(resp.Response, &hookResp); err != nil {
+		return err
+	}
+	if hookResp.Error != "" {
+		return fmt.Errorf("%s", hookResp.Error)
+	}
+	return nil
+}
+
+// serveMonitor starts the hook-invoking monitor and returns a module provider
+// wired to it. One provider spans a test's construct and delete phases so its
+// callback server outlives any single Construct call.
+func serveMonitor(t *testing.T) (*hookInvokingMonitor, *moduleProvider, string) {
+	t.Helper()
+	mon := newHookInvokingMonitor()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer()
+	pulumirpc.RegisterResourceMonitorServer(srv, mon)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	m := &moduleProvider{
+		moduleLoader: modules.NewLoader(modules.LiveResolver(t.Context())),
+		resolver:     stubResolver{},
+	}
+	return mon, m, lis.Addr().String()
+}
+
+func construct(
+	t *testing.T, m *moduleProvider, endpoint, testdataDir string, inputs map[string]property.Value,
+) error {
+	t.Helper()
+	dir, err := filepath.Abs(filepath.Join("testdata", testdataDir))
+	require.NoError(t, err)
+	_, err = m.construct(t.Context(), p.ConstructRequest{
+		Urn:             resource.URN("urn:pulumi:test::proj::hcl:index:Module::mod"),
+		MonitorEndpoint: endpoint,
+		Inputs: property.NewMap(map[string]property.Value{
+			"source": property.New(dir),
+			"inputs": property.New(property.NewMap(inputs)),
+		}),
+	})
+	return err
+}
+
+func constructModule(t *testing.T, testdataDir string, expected string) error {
+	t.Helper()
+	_, m, endpoint := serveMonitor(t)
+	return construct(t, m, endpoint, testdataDir, map[string]property.Value{
+		"expected": property.New(expected),
+	})
+}
+
+// TestModuleConstructResourcePrecondition asserts a resource `precondition`
+// inside a constructed module is registered and fired: satisfied passes, a
+// violated one blocks construct with the configured message.
+func TestModuleConstructResourcePrecondition(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pass", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, constructModule(t, "module-precondition", "ok"))
+	})
+
+	t.Run("fail", func(t *testing.T) {
+		t.Parallel()
+		err := constructModule(t, "module-precondition", "not-ok")
+		require.ErrorContains(t, err, "PRECONDITION_IN_MODULE")
+	})
+}
+
+// TestModuleConstructResourcePostcondition asserts a resource `postcondition`
+// inside a constructed module fires against the resource's outputs (`self`):
+// satisfied passes, a violated one blocks construct with the configured message.
+func TestModuleConstructResourcePostcondition(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pass", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, constructModule(t, "module-postcondition", "ok"))
+	})
+
+	t.Run("fail", func(t *testing.T) {
+		t.Parallel()
+		err := constructModule(t, "module-postcondition", "not-ok")
+		require.ErrorContains(t, err, "POSTCONDITION_IN_MODULE")
+	})
+}
+
+// TestModuleConstructDestroyProvisioner models the two phases of `destroy
+// --run-program`: Construct runs the create provisioner, then the child is
+// deleted later, firing the destroy provisioner after Construct returned. The
+// delete hook only reaches a live callback server because the provider hosts it.
+func TestModuleConstructDestroyProvisioner(t *testing.T) {
+	t.Parallel()
+
+	markerDir := t.TempDir()
+	mon, m, endpoint := serveMonitor(t)
+
+	require.NoError(t, construct(t, m, endpoint, "module-destroy-provisioner",
+		map[string]property.Value{"marker_dir": property.New(markerDir)}))
+	require.FileExists(t, filepath.Join(markerDir, "created"),
+		"create-time provisioner should run during Construct")
+
+	// Model the engine deleting the component's child after Construct returned.
+	require.NoError(t, mon.runDeletes(t.Context()))
+	require.FileExists(t, filepath.Join(markerDir, "destroyed"),
+		"destroy-time provisioner should run when the child is deleted post-Construct")
+}

--- a/pkg/server/construct_hooks_test.go
+++ b/pkg/server/construct_hooks_test.go
@@ -266,3 +266,17 @@ func TestModuleConstructDestroyProvisioner(t *testing.T) {
 	require.FileExists(t, filepath.Join(markerDir, "destroyed"),
 		"destroy-time provisioner should run when the child is deleted post-Construct")
 }
+
+// TestModuleProviderReleasesHooks asserts the provider-owned callback server is
+// created lazily by a construct that registers hooks and released on cancel.
+func TestModuleProviderReleasesHooks(t *testing.T) {
+	t.Parallel()
+
+	_, m, endpoint := serveMonitor(t)
+	require.NoError(t, construct(t, m, endpoint, "module-precondition",
+		map[string]property.Value{"expected": property.New("ok")}))
+	require.NotNil(t, m.hooks.cbs, "registering a hook should start the callback server")
+
+	require.NoError(t, m.cancel(t.Context()))
+	require.Nil(t, m.hooks.cbs, "cancel should release the callback server")
+}

--- a/pkg/server/hooks.go
+++ b/pkg/server/hooks.go
@@ -118,6 +118,54 @@ var hookMarshalOptions = plugin.MarshalOptions{
 	KeepOutputValues: true,
 }
 
+// lazyCallbackServer is a callback server created on first use and shared for
+// the lifetime of the owning provider, so a `before_delete` hook — which fires
+// during a later `destroy --run-program`, after Construct returns — still has a
+// live callback server to reach.
+type lazyCallbackServer struct {
+	mu  sync.Mutex
+	cbs *callbackServer
+}
+
+func (l *lazyCallbackServer) get() (*callbackServer, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.cbs == nil {
+		cbs, err := newCallbackServer()
+		if err != nil {
+			return nil, err
+		}
+		l.cbs = cbs
+	}
+	return l.cbs, nil
+}
+
+func (l *lazyCallbackServer) close() {
+	l.mu.Lock()
+	cbs := l.cbs
+	l.cbs = nil
+	l.mu.Unlock()
+	if cbs != nil {
+		_ = cbs.Close()
+	}
+}
+
+// hooksToProto returns nil for a nil binding so the field is omitted.
+func hooksToProto(hooks *run.ResourceHookBinding) *pulumirpc.RegisterResourceRequest_ResourceHooksBinding {
+	if hooks == nil {
+		return nil
+	}
+	return &pulumirpc.RegisterResourceRequest_ResourceHooksBinding{
+		BeforeCreate: hooks.BeforeCreate,
+		BeforeUpdate: hooks.BeforeUpdate,
+		AfterCreate:  hooks.AfterCreate,
+		AfterUpdate:  hooks.AfterUpdate,
+		BeforeDelete: hooks.BeforeDelete,
+		AfterDelete:  hooks.AfterDelete,
+		OnError:      hooks.OnError,
+	}
+}
+
 // resourceHookCallback adapts a run.ResourceHookFunction to the proto-level
 // hook callback contract.
 func resourceHookCallback(fn run.ResourceHookFunction) callbackFunction {

--- a/pkg/server/module_resource.go
+++ b/pkg/server/module_resource.go
@@ -68,6 +68,10 @@ type moduleProvider struct {
 	// module source (via Parameterize). It makes the provider serve that module's
 	// typed component schema instead of the generic hcl:index:Module.
 	param *parameterizedModule
+
+	// hooks is provider-scoped so a `before_delete` hook survives past the
+	// Construct call that registered it, to fire during `destroy --run-program`.
+	hooks lazyCallbackServer
 }
 
 // NewModuleProvider builds the fully dynamic HCL provider on top of the raw
@@ -156,6 +160,7 @@ func (m *moduleProvider) getSchema(context.Context, p.GetSchemaRequest) (p.GetSc
 
 // cancel removes any unpacked module bundle when the provider shuts down.
 func (m *moduleProvider) cancel(context.Context) error {
+	m.hooks.close()
 	if m.param != nil && m.param.tempDir != "" {
 		return os.RemoveAll(m.param.tempDir)
 	}
@@ -239,8 +244,12 @@ func (m *moduleProvider) construct(ctx context.Context, req p.ConstructRequest) 
 		return p.ConstructResponse{}, fmt.Errorf("marshaling inputs: %w", err)
 	}
 
+	hooks, err := m.hooks.get()
+	if err != nil {
+		return p.ConstructResponse{}, fmt.Errorf("starting hook callback server: %w", err)
+	}
 	resmon := m.newConstructMonitor(ctx, req,
-		pulumirpc.NewResourceMonitorClient(monitorConn), componentInputs, wrapModuleOutputs)
+		pulumirpc.NewResourceMonitorClient(monitorConn), componentInputs, wrapModuleOutputs, hooks)
 
 	engineRun, err := run.NewEngine(ctx, loaded.Config, &run.EngineOptions{
 		ProjectName:        string(req.Urn.Project()),
@@ -303,8 +312,12 @@ func (m *moduleProvider) constructParameterized(ctx context.Context, req p.Const
 		return p.ConstructResponse{}, fmt.Errorf("marshaling inputs: %w", err)
 	}
 
+	hooks, err := m.hooks.get()
+	if err != nil {
+		return p.ConstructResponse{}, fmt.Errorf("starting hook callback server: %w", err)
+	}
 	resmon := m.newConstructMonitor(ctx, req,
-		pulumirpc.NewResourceMonitorClient(monitorConn), componentInputs, param.schema.OutputsToPulumi)
+		pulumirpc.NewResourceMonitorClient(monitorConn), componentInputs, param.schema.OutputsToPulumi, hooks)
 
 	loader := pulumiSchema.NewCachedLoader(packages.NewParameterizationAwareLoader(
 		m.schemaLoader, param.packages))
@@ -344,11 +357,12 @@ func (m *moduleProvider) constructParameterized(ctx context.Context, req p.Const
 // component's output property map.
 func (m *moduleProvider) newConstructMonitor(
 	ctx context.Context, req p.ConstructRequest, client pulumirpc.ResourceMonitorClient,
-	componentInputs *structpb.Struct, mapOutputs func(property.Map) property.Map,
+	componentInputs *structpb.Struct, mapOutputs func(property.Map) property.Map, hooks *callbackServer,
 ) *constructResourceMonitor {
 	return &constructResourceMonitor{
 		client:                  client,
 		engine:                  m.engine,
+		hooks:                   hooks,
 		ctx:                     ctx,
 		parentURN:               string(req.Parent),
 		componentType:           string(req.Urn.Type()),

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -76,6 +76,8 @@ type HCLProvider struct {
 
 	// schema is the generated schema for the module.
 	schema *schema.ModuleSchema
+
+	hooks lazyCallbackServer
 }
 
 // NewHCLProvider creates a new HCL component provider.
@@ -324,6 +326,9 @@ func (p *HCLProvider) Construct(ctx context.Context, req *pulumirpc.ConstructReq
 		replacementTrigger:      req.ReplacementTrigger,
 		mapOutputs:              p.schema.OutputsToPulumi,
 	}
+	if resmon.hooks, err = p.hooks.get(); err != nil {
+		return nil, fmt.Errorf("starting hook callback server: %w", err)
+	}
 
 	// Set up config from inputs, prefixing with project name as the engine
 	// expects. Inputs arrive under their camelCase schema property names (with
@@ -384,6 +389,7 @@ func (p *HCLProvider) GetPluginInfo(ctx context.Context, req *emptypb.Empty) (*p
 
 // Cancel cancels any in-flight operations.
 func (p *HCLProvider) Cancel(ctx context.Context, req *emptypb.Empty) (*emptypb.Empty, error) {
+	p.hooks.close()
 	return &emptypb.Empty{}, nil
 }
 
@@ -425,6 +431,11 @@ type constructResourceMonitor struct {
 	// mapOutputs transforms the HCL module's top-level outputs into the
 	// component's output property map before they are registered.
 	mapOutputs func(property.Map) property.Map
+
+	// hooks is the provider-owned callback server (not this monitor's): a
+	// `before_delete` hook fires after this Construct call has returned, so the
+	// callback server must outlive any single construct.
+	hooks *callbackServer
 }
 
 // constructMarshalOptions are the property (un)marshal options used on every
@@ -526,6 +537,7 @@ func (m *constructResourceMonitor) RegisterResource(
 		PackageRef:          string(req.PackageRef),
 		Version:             req.Version,
 		PluginDownloadURL:   req.PluginDownloadURL,
+		Hooks:               hooksToProto(req.Hooks),
 		AcceptSecrets:       true,
 		AcceptResources:     true,
 	})
@@ -711,13 +723,27 @@ func (m *constructResourceMonitor) RegisterPackage(
 	return registerPackage(ctx, m.client, pkg)
 }
 
-// RegisterResourceHook is not yet supported in Construct modules: the callback
-// server would need to be hosted on the provider (outliving any single
-// Construct call) rather than per-monitor.
+// RegisterResourceHook hosts the callback on the provider-owned callback server
+// and registers it with the engine's monitor.
 func (m *constructResourceMonitor) RegisterResourceHook(
 	ctx context.Context, name string, callback run.ResourceHookFunction, opts run.ResourceHookOptions,
 ) error {
-	return fmt.Errorf("resource hooks are not supported within component constructions")
+	if m.hooks == nil {
+		return fmt.Errorf("resource hooks are not supported: no callback server is available")
+	}
+	cb, err := m.hooks.register(resourceHookCallback(callback))
+	if err != nil {
+		return fmt.Errorf("registering hook callback: %w", err)
+	}
+	_, err = m.client.RegisterResourceHook(ctx, &pulumirpc.RegisterResourceHookRequest{
+		Name:     name,
+		Callback: cb,
+		OnDryRun: opts.OnDryRun,
+	})
+	if err != nil {
+		return fmt.Errorf("registering hook %q: %w", name, err)
+	}
+	return nil
 }
 
 // LogWarning emits a non-fatal warning diagnostic to the engine.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1222,17 +1222,7 @@ func (r *resourceMonitorAdapter) RegisterResource(
 		}
 	}
 
-	if req.Hooks != nil {
-		registerReq.Hooks = &pulumirpc.RegisterResourceRequest_ResourceHooksBinding{
-			BeforeCreate: req.Hooks.BeforeCreate,
-			BeforeUpdate: req.Hooks.BeforeUpdate,
-			AfterCreate:  req.Hooks.AfterCreate,
-			AfterUpdate:  req.Hooks.AfterUpdate,
-			BeforeDelete: req.Hooks.BeforeDelete,
-			AfterDelete:  req.Hooks.AfterDelete,
-			OnError:      req.Hooks.OnError,
-		}
-	}
+	registerReq.Hooks = hooksToProto(req.Hooks)
 
 	// Add replacement trigger if specified
 	if !req.ReplacementTrigger.IsNull() {

--- a/pkg/server/testdata/module-destroy-provisioner/main.tf
+++ b/pkg/server/testdata/module-destroy-provisioner/main.tf
@@ -1,0 +1,16 @@
+variable "marker_dir" {
+  type = string
+}
+
+resource "terraform_data" "guarded" {
+  input = var.marker_dir
+
+  provisioner "local-exec" {
+    command = "touch '${var.marker_dir}/created'"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "touch '${self.input}/destroyed'"
+  }
+}

--- a/pkg/server/testdata/module-postcondition/main.tf
+++ b/pkg/server/testdata/module-postcondition/main.tf
@@ -1,0 +1,15 @@
+variable "expected" {
+  type    = string
+  default = "ok"
+}
+
+resource "terraform_data" "guarded" {
+  input = var.expected
+
+  lifecycle {
+    postcondition {
+      condition     = self.input == "ok"
+      error_message = "POSTCONDITION_IN_MODULE"
+    }
+  }
+}

--- a/pkg/server/testdata/module-precondition/main.tf
+++ b/pkg/server/testdata/module-precondition/main.tf
@@ -1,0 +1,15 @@
+variable "expected" {
+  type    = string
+  default = "ok"
+}
+
+resource "terraform_data" "guarded" {
+  input = var.expected
+
+  lifecycle {
+    precondition {
+      condition     = var.expected == "ok"
+      error_message = "PRECONDITION_IN_MODULE"
+    }
+  }
+}

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -242,6 +242,41 @@ func TestSmokeParameterizedModule(t *testing.T) {
 	})
 }
 
+// TestSmokeDestroyHooks proves resource-hook-backed constructs (precondition,
+// postcondition, create and destroy provisioners) work end-to-end through the
+// dynamic MLC. `up` runs the create provisioner and `destroy --run-program`
+// fires the destroy provisioner; each drops a marker file the test asserts on.
+func TestSmokeDestroyHooks(t *testing.T) {
+	t.Parallel()
+
+	moduleDir, err := filepath.Abs(filepath.Join("testdata", "destroy-hooks", "module"))
+	require.NoError(t, err)
+	markerDir := t.TempDir()
+
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		NoParallel: true,
+		Dir:        filepath.Join("testdata", "destroy-hooks", "program"),
+		Config: map[string]string{
+			"moduleSource": moduleDir,
+			"markerDir":    markerDir,
+		},
+		Quick:       true,
+		SkipRefresh: true,
+		// The destroy-time provisioner is a before_delete hook; the engine only
+		// runs it when destroy re-runs the program to re-register it.
+		DestroyCommandlineFlags: []string{"--run-program"},
+		ExtraRuntimeValidation: func(t *testing.T, _ integration.RuntimeValidationStackInfo) {
+			require.FileExists(t, filepath.Join(markerDir, "created"),
+				"create-time provisioner should have run during up")
+		},
+	})
+
+	// ProgramTest runs up (validated above) then destroy --run-program; once it
+	// returns, the destroy-time provisioner must have left its marker.
+	require.FileExists(t, filepath.Join(markerDir, "destroyed"),
+		"destroy-time provisioner should have run during destroy --run-program")
+}
+
 func copyDir(t *testing.T, src, dst string) {
 	t.Helper()
 	require.NoError(t, filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {

--- a/tests/smoke/testdata/destroy-hooks/module/main.tf
+++ b/tests/smoke/testdata/destroy-hooks/module/main.tf
@@ -1,0 +1,34 @@
+# A precondition, postcondition, and create/destroy provisioners on a builtin
+# terraform_data resource (no external providers). Each provisioner drops a
+# marker file so the test can observe that it ran.
+variable "marker" {
+  type = string
+}
+
+resource "terraform_data" "guarded" {
+  input = var.marker
+
+  lifecycle {
+    precondition {
+      condition     = var.marker != ""
+      error_message = "PRECONDITION_FAILED"
+    }
+    postcondition {
+      condition     = self.input != ""
+      error_message = "POSTCONDITION_FAILED"
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "touch '${var.marker}/created'"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "touch '${self.input}/destroyed'"
+  }
+}
+
+output "marker" {
+  value = terraform_data.guarded.input
+}

--- a/tests/smoke/testdata/destroy-hooks/program/Pulumi.yaml
+++ b/tests/smoke/testdata/destroy-hooks/program/Pulumi.yaml
@@ -1,0 +1,19 @@
+name: smoke-destroy-hooks
+runtime: yaml
+description: Instantiates an HCL module with pre/post conditions and create/destroy provisioners.
+config:
+  # Set by the test to the absolute path of ../module.
+  moduleSource:
+    type: string
+  # Set by the test to a scratch directory the provisioners write markers into.
+  markerDir:
+    type: string
+resources:
+  mod:
+    type: hcl:index:Module
+    properties:
+      source: ${moduleSource}
+      inputs:
+        marker: ${markerDir}
+outputs:
+  marker: ${mod.outputs["marker"]}

--- a/tests/tfcompat/l2_module_precondition_test.go
+++ b/tests/tfcompat/l2_module_precondition_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ModulePrecondition_Pass asserts a passing resource `precondition`
+// inside a child module does not block the resource on either runtime.
+func TestL2ModulePrecondition_Pass(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_precondition_pass", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}
+
+// TestL2ModulePrecondition_Fail asserts a failing resource `precondition`
+// inside a child module blocks the update on both runtimes with the configured
+// error message.
+func TestL2ModulePrecondition_Fail(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_precondition_fail", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			ExpectErr: "MODULE_RESOURCE_PRECONDITION_FAILED",
+		}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_module_precondition_fail/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_precondition_fail/child/main.tf
@@ -1,0 +1,18 @@
+variable "expected" {
+  type = string
+}
+
+resource "simple_resource" "guarded" {
+  input_one = "ok"
+
+  lifecycle {
+    precondition {
+      condition     = var.expected == "ok"
+      error_message = "MODULE_RESOURCE_PRECONDITION_FAILED"
+    }
+  }
+}
+
+output "id" {
+  value = simple_resource.guarded.id
+}

--- a/tests/tfcompat/testdata/cases/l2_module_precondition_fail/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_precondition_fail/main.tf
@@ -1,0 +1,8 @@
+module "child" {
+  source   = "./child"
+  expected = "not-ok"
+}
+
+output "child_id" {
+  value = module.child.id
+}

--- a/tests/tfcompat/testdata/cases/l2_module_precondition_pass/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_precondition_pass/child/main.tf
@@ -1,0 +1,18 @@
+variable "expected" {
+  type = string
+}
+
+resource "simple_resource" "guarded" {
+  input_one = "ok"
+
+  lifecycle {
+    precondition {
+      condition     = var.expected == "ok"
+      error_message = "should never fire"
+    }
+  }
+}
+
+output "id" {
+  value = simple_resource.guarded.id
+}

--- a/tests/tfcompat/testdata/cases/l2_module_precondition_pass/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_precondition_pass/main.tf
@@ -1,0 +1,8 @@
+module "child" {
+  source   = "./child"
+  expected = "ok"
+}
+
+output "child_id" {
+  value = module.child.id
+}


### PR DESCRIPTION
## What

Resource-hook-backed constructs inside an HCL module — `precondition`, `postcondition`, and `provisioner` blocks — now work when the module is consumed as a multi-language component (the `Construct` path), including the destroy path.

Previously any of these blocks in a component module failed at registration with:

```
registering precondition hook: resource hooks are not supported within component constructions
```

because `constructResourceMonitor.RegisterResourceHook` was a stub that errored unconditionally.


## Tests

- **Unit** (`pkg/server/construct_hooks_test.go`): a resource-monitor double that actually invokes bound hooks, so a violated condition surfaces. Covers precondition and postcondition (pass + fail) and a create/destroy provisioner — the destroy case fires the `before_delete` hook *after* Construct returns, guarding the callback-server lifetime.
- **End-to-end** (`tests/smoke`, `TestSmokeDestroyHooks`): real `pulumi up` then `pulumi destroy --run-program` on a `terraform_data` module (no external providers) carrying all four constructs; asserts the `created` and `destroyed` marker files each provisioner drops.
- Also adds program-path `tfcompat` coverage for a `precondition` in a local (`./child`) module.