### PR TITLE
Exclude .git and .terraform artifacts when bundling a module

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-353.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-353.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Exclude `.git` and `.terraform` artifacts when bundling a module into a parameterized package
+time: 2026-07-13T08:20:15Z
+custom:
+    Component: runtime
+    PR: "353"

--- a/pkg/server/parameterize.go
+++ b/pkg/server/parameterize.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -496,6 +497,36 @@ func sanitizePackageName(name string) string {
 // provider identity — are deterministic.
 var bundleEpoch = time.Unix(0, 0).UTC()
 
+// excludedFromBundle reports whether an archive-relative path should be left out
+// of the bundle (skip), and whether its whole subtree can be pruned (skipDeep).
+func excludedFromBundle(rel string) (skip, skipDeep bool) {
+	// It mirrors go-slug's default `.terraformignore` ruleset that Terraform applies
+	// when it packages a configuration for transmission.
+
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	// A `.git` anywhere wins, even under `.terraform/modules` (go-slug applies
+	// the `.git` rule last, so it overrides the modules exception).
+	if slices.Contains(parts, ".git") {
+		return true, true
+	}
+	for i, part := range parts {
+		if part != ".terraform" {
+			continue
+		}
+		switch {
+		case i+1 >= len(parts):
+			// The `.terraform` directory itself: exclude it, but descend so a
+			// `.terraform/modules` child below can still be kept.
+			return true, false
+		case parts[i+1] == "modules":
+			return false, false
+		default:
+			return true, true
+		}
+	}
+	return false, false
+}
+
 // packArchive packs each (archive-path → directory) tree into a deterministic
 // tar.gz: entries are sorted, modification times fixed, and only regular files
 // and directories are included.
@@ -515,6 +546,12 @@ func packArchive(dirs map[string]string) ([]byte, error) {
 			rel, err := filepath.Rel(absDir, p)
 			if err != nil {
 				return err
+			}
+			if skip, skipDeep := excludedFromBundle(rel); skip {
+				if info.IsDir() && skipDeep {
+					return filepath.SkipDir
+				}
+				return nil
 			}
 			files = append(files, entry{name: path.Join(relPath, filepath.ToSlash(rel)), absPath: p, info: info})
 			return nil

--- a/pkg/server/parameterize_test.go
+++ b/pkg/server/parameterize_test.go
@@ -273,6 +273,85 @@ func TestPackArchiveDeterministic(t *testing.T) {
 	require.Equal(t, first, second)
 }
 
+func TestExcludedFromBundle(t *testing.T) {
+	t.Parallel()
+
+	type result struct{ skip, skipDeep bool }
+	cases := []struct {
+		path string
+		want result
+	}{
+		{"main.tf", result{false, false}},
+		{"sub/main.tf", result{false, false}},
+		{".gitignore", result{false, false}},      // a file, not the .git dir
+		{".gitattributes", result{false, false}},  // likewise
+		{"modules/main.tf", result{false, false}}, // "modules" only matters under .terraform
+		{".git", result{true, true}},
+		{".git/config", result{true, true}},
+		{"sub/.git/HEAD", result{true, true}},
+		{".terraform", result{true, false}},            // exclude, but descend for modules
+		{".terraform/environment", result{true, true}}, // any non-modules .terraform subtree
+		{".terraform/providers/x/y", result{true, true}},
+		{".terraform/modules", result{false, false}},
+		{".terraform/modules/child/main.tf", result{false, false}},
+		{".terraform/modules/.git/config", result{true, true}}, // .git wins over the modules exception
+	}
+	for _, tt := range cases {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			skip, skipDeep := excludedFromBundle(tt.path)
+			require.Equal(t, tt.want, result{skip, skipDeep})
+		})
+	}
+}
+
+// TestPackArchiveExcludesVCSArtifacts proves the bundle drops `.git` trees and
+// `.terraform` (except `.terraform/modules`) — the go-slug default ruleset — so a
+// git-fetched module's VCS/cache artifacts do not bloat the parameterization
+// Value, while real module content is preserved end to end through pack+unpack.
+func TestPackArchiveExcludesVCSArtifacts(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+	}
+	write("main.tf", "root")
+	write(".gitignore", "*.tfstate")
+	write(".git/config", "[core]")
+	write("sub/.git/HEAD", "ref: refs/heads/main")
+	write(".terraform/environment", "default")
+	write(".terraform/modules/child/main.tf", "child")
+
+	archive, err := packArchive(map[string]string{"": dir})
+	require.NoError(t, err)
+
+	dest := t.TempDir()
+	require.NoError(t, unpackArchive(t.Context(), archive, dest))
+
+	var got []string
+	require.NoError(t, filepath.Walk(dest, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			rel, err := filepath.Rel(dest, p)
+			require.NoError(t, err)
+			got = append(got, filepath.ToSlash(rel))
+		}
+		return nil
+	}))
+
+	require.ElementsMatch(t, []string{
+		"main.tf",
+		".gitignore",
+		".terraform/modules/child/main.tf",
+	}, got)
+}
+
 // TestBundleBakesPackages verifies the resolved provider descriptors survive the
 // bundle round-trip — including a bridged provider's parameterization — so the
 // usage path can reuse them instead of re-resolving, and that the encoding is


### PR DESCRIPTION
## What

`pulumi package add hcl module <source>` bundles the whole fetched module tree into the package's parameterization value (so module content ships with the schema). But go-getter leaves each fetched module's `.git` clone on disk, and the bundler embedded it verbatim — tens of MB of git history for a large module.

The parameterization value is part of the provider's registration. The Pulumi Cloud service rejects a registration payload over **10 MB** with `[413] Content Too Large`, so for a large module `pulumi up` failed:

```
pulumi:providers:<pkg>: error: pre-step event returned an error: [413] Content Too Large: greater than 10485760 bytes
```

`pulumi preview` succeeded because it doesn't journal provider state to the service — only `up` did, which made this look mysterious.

## Fix

When packing the archive, skip `.git` trees and everything under `.terraform` except `.terraform/modules` — mirroring the default ruleset (`**/.git/**`, `**/.terraform/**`, keep `**/.terraform/modules/**`) that `go-slug` applies when Terraform packages a configuration for transmission. Bundling a module for the parameterization value is the same "package and send" operation, so the same exclusions apply.

`excludedFromBundle` returns `(skip, skipDeep)`: `.git` prunes its whole subtree; the bare `.terraform` directory is skipped but still descended so a `.terraform/modules` child survives.

We can't reuse `go-slug` directly: its default ruleset lives in an `internal/` package (not importable) and its public `Pack` writes real mtimes in filesystem order (non-deterministic), which would break the deterministic archive the engine hashes for provider identity.

## Impact

For the Materialize AWS module (`registry.terraform.io/MaterializeInc/materialize/aws 0.8.38`) the archive drops from **~15.7 MB → ~4.2 MB** (the removed ~12 MB was `.git`), well under the 10 MB limit, with the full module content preserved.

## Tests

- `TestExcludedFromBundle` — table-driven over the ruleset, including the `.git`-wins-over-`.terraform/modules` and `.gitignore`-is-not-`.git` edge cases.
- `TestPackArchiveExcludesVCSArtifacts` — end-to-end pack → unpack, asserting `.git`/`.terraform` are dropped while `main.tf`, `.gitignore`, and `.terraform/modules/child/main.tf` survive.
- Existing `TestPackArchiveDeterministic` / bundle round-trip tests still pass (determinism preserved).