### PR TITLE
Drop spurious context.Canceled from parallel graph walk errors

### DIFF
--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -250,7 +250,7 @@ func (g *Graph) recordRef(key string, rng hcl.Range) {
 }
 
 func (g *Graph) Walk(ctx context.Context, apply func(context.Context, *Node) error, parallel int) error {
-	return g.dag.Walk(ctx, func(ctx context.Context, n dagNode) error {
+	err := g.dag.Walk(ctx, func(ctx context.Context, n dagNode) error {
 		if n.exec != nil {
 			return n.exec(ctx)
 		}
@@ -258,6 +258,33 @@ func (g *Graph) Walk(ctx context.Context, apply func(context.Context, *Node) err
 		contract.Assertf(ok, "invalid graph - key not interned")
 		return apply(ctx, node.n)
 	}, pdag.MaxProcs(parallel))
+	return dropSpuriousCancel(err)
+}
+
+// dropSpuriousCancel removes a top-level context.Canceled that the parallel
+// walker joins onto a genuine failure. When a node fails, pdag.Walk cancels the
+// walk's context and — depending on whether the drain loop is still mid-iteration
+// when cancellation fires — non-deterministically joins the resulting
+// context.Canceled onto the real error. That trailing cancellation is a
+// scheduling artifact, not a distinct failure, so it is dropped whenever a
+// genuine error remains; a walk that fails solely because its context was
+// canceled still surfaces that.
+func dropSpuriousCancel(err error) error {
+	joined, ok := err.(interface{ Unwrap() []error })
+	if !ok {
+		return err
+	}
+	kept := make([]error, 0, len(joined.Unwrap()))
+	for _, e := range joined.Unwrap() {
+		if errors.Is(e, context.Canceled) {
+			continue
+		}
+		kept = append(kept, e)
+	}
+	if len(kept) == 0 {
+		return err
+	}
+	return errors.Join(kept...)
 }
 
 // InjectAfter injects a step to run after all nodes matching the predicate, and before any

--- a/pkg/hcl/graph/walk_test.go
+++ b/pkg/hcl/graph/walk_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDropSpuriousCancel(t *testing.T) {
+	t.Parallel()
+
+	real := errors.New("precondition failed")
+
+	t.Run("drops cancellation joined onto a real error", func(t *testing.T) {
+		t.Parallel()
+		got := dropSpuriousCancel(errors.Join(real, context.Canceled))
+		assert.EqualError(t, got, "precondition failed")
+	})
+
+	t.Run("keeps a cancellation-only failure", func(t *testing.T) {
+		t.Parallel()
+		got := dropSpuriousCancel(errors.Join(context.Canceled))
+		assert.ErrorIs(t, got, context.Canceled)
+	})
+
+	t.Run("passes a lone real error through", func(t *testing.T) {
+		t.Parallel()
+		got := dropSpuriousCancel(real)
+		assert.Same(t, real, got)
+	})
+
+	t.Run("passes nil through", func(t *testing.T) {
+		t.Parallel()
+		assert.NoError(t, dropSpuriousCancel(nil))
+	})
+}

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -1176,7 +1176,7 @@ variable "required_var" {
 			err := engine.Run(t.Context())
 			assert.EqualError(t, err, `variable "required_var" is required but no value was provided. `+
 				`Set it with TF_VAR_required_var environment variable or Pulumi config: `+
-				`pulumi config set required_var <value>`+"\ncontext canceled")
+				`pulumi config set required_var <value>`)
 		})
 	}
 }
@@ -1259,7 +1259,7 @@ output "item_count" {
 
 		_, err := run(t, childNoDefault)
 		assert.EqualError(t, err, `variable "items" must not be set to null: `+
-			`it is declared with nullable = false and has no default`+"\ncontext canceled")
+			`it is declared with nullable = false and has no default`)
 	})
 }
 
@@ -1330,8 +1330,7 @@ output "name" {
 
 		_, err := run(t, "xy")
 		assert.EqualError(t, err,
-			`validation failed for variable "name": name must be longer than three characters`+
-				"\ncontext canceled")
+			`validation failed for variable "name": name must be longer than three characters`)
 	})
 }
 
@@ -1443,7 +1442,7 @@ output "child_result" {
 
 		_, engine := newEngine(t, config, tmpDir)
 		assert.EqualError(t, engine.Run(t.Context()),
-			`precondition for output "result": child output not ok`+"\ncontext canceled")
+			`precondition for output "result": child output not ok`)
 	})
 }
 
@@ -1669,7 +1668,7 @@ output "name" {
 	t.Run("fail", func(t *testing.T) {
 		t.Parallel()
 		assert.EqualError(t, runProgram(t, "xy"),
-			`validation failed for variable "name": name is shorter than min`+"\ncontext canceled")
+			`validation failed for variable "name": name is shorter than min`)
 	})
 }
 


### PR DESCRIPTION
## Problem

`TestEngine_OutputPrecondition/module_fail` flakes in CI ([run 29245517849](https://github.com/pulumi-labs/pulumi-hcl/actions/runs/29245517849/job/86801340738)):

```
expected: "precondition for output \"result\": child output not ok\ncontext canceled"
actual  : "precondition for output \"result\": child output not ok"
```

## Root cause

`graph.Walk` runs the dependency graph through `pdag.Walk`. When a node fails, `pdag.Walk` cancels the walk's context via `errgroup` and returns `errors.Join(processErr, cancelError)`, where `cancelError` is set to `ctx.Err()` **only if the node-drain loop happens to still be mid-iteration when cancellation fires**. Whether it is, is pure scheduling luck — so a real failure non-deterministically gained a trailing `context canceled` line.

The test asserted on the exact error string including that racy suffix, so it flaked whenever the suffix was absent. Four sibling tests hardcoded the same suffix and were latent flakes in the opposite direction.

Reproduced locally at ~2/600 with `go test ./pkg/hcl/run/ -run TestEngine_OutputPrecondition/module_fail -race -cpu=2`.

## Fix

Normalize the walk result in `Graph.Walk` via `dropSpuriousCancel`: strip a top-level `context.Canceled` whenever a genuine error remains, so the walker's own cancellation artifact never reaches the caller — while a walk that fails *solely* because its context was canceled still surfaces that. This deterministically cleans up user-facing errors, not just the tests.

Swept the four sibling tests that hardcoded the same suffix.

## Verification

- New `TestDropSpuriousCancel` unit test (drop / keep-when-only-cancel / passthrough / nil).
- 4500 iterations of all five affected tests under `-race -cpu=2`: 0 failures (was flaking before).
- Full `pkg/hcl/run` + `pkg/hcl/graph` suites and `go vet`: clean.