### PR TITLE
Bind count.index and each per-instance during registration

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-356.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-356.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Fix concurrent `count`/`for_each` registration binding the wrong `count.index`
+time: 2026-07-13T14:05:51Z
+custom:
+    Component: runtime
+    PR: "356"

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -42,8 +42,9 @@ func splitResourceKey(key string) []string {
 // Context manages the evaluation context for HCL expressions.
 // It tracks variables, locals, resources, and other values that can be referenced.
 type Context struct {
-	// mu protects concurrent access to maps
-	mu sync.RWMutex
+	// mu protects concurrent access to maps. A pointer so a WithIteration view
+	// shares the lock with the context it derives from.
+	mu *sync.RWMutex
 
 	// rootModuleDir is the directory of the root module (the program files).
 	rootModuleDir string
@@ -216,6 +217,7 @@ func NewAbsolutePathContext(moduleDir, rootDir, rootModuleDir, stack, project, o
 
 func newContext(path PathContext, rootModuleDir, stack, project, organization string) *Context {
 	return &Context{
+		mu:              new(sync.RWMutex),
 		rootModuleDir:   rootModuleDir,
 		variables:       make(map[string]cty.Value),
 		locals:          make(map[string]cty.Value),
@@ -349,6 +351,23 @@ func (c *Context) SetProvider(name string, value cty.Value) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.providers[name] = value
+}
+
+// WithIteration returns a view of c that shares its evaluation state and lock
+// but carries its own count.index / each.key / each.value, so concurrent
+// registrations bind the iteration goroutine-locally instead of racing on the
+// shared context. A nil index or nil each pair leaves that namespace unbound.
+func (c *Context) WithIteration(index *int, eachKey, eachValue *cty.Value) *Context {
+	view := *c
+	view.count = nil
+	view.each = nil
+	if index != nil {
+		view.count = &CountContext{Index: *index}
+	}
+	if eachKey != nil && eachValue != nil {
+		view.each = &EachContext{Key: *eachKey, Value: *eachValue}
+	}
+	return &view
 }
 
 // SetCount sets the count context for count iteration.
@@ -642,6 +661,7 @@ func (c *Context) Clone() *Context {
 	}
 
 	clone := &Context{
+		mu:                new(sync.RWMutex),
 		rootModuleDir:     c.rootModuleDir,
 		providerFunctions: c.providerFunctions,
 		variables:         maps.Clone(c.variables),

--- a/pkg/hcl/eval/iteration_test.go
+++ b/pkg/hcl/eval/iteration_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eval
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// countIndexOf reads count.index out of a context's HCL variable table, the way
+// a resource's config expression (`element(x, count.index)`) resolves it.
+func countIndexOf(t *testing.T, c *Context) int64 {
+	t.Helper()
+	v, ok := c.HCLContext().Variables["count"]
+	require.Truef(t, ok && !v.IsNull(), "count is unbound")
+	i, _ := v.GetAttr("index").AsBigFloat().Int64()
+	return i
+}
+
+// TestWithIterationIsolatesConcurrentIterations pins the property that fixes the
+// shared-context count race: two registrations that run concurrently against the
+// same base context must each observe their own count.index, never the other's.
+//
+// The channels force exactly the interleaving that corrupts a shared binding —
+// goroutine A takes its view, then B takes and reads its own view (a different
+// index), and only then does A read. If the iteration were stored on the shared
+// base context (the old SetCount/ClearCount approach), A would read B's index
+// here. The gate makes that failure deterministic rather than timing-dependent;
+// no sleeps involved.
+func TestWithIterationIsolatesConcurrentIterations(t *testing.T) {
+	t.Parallel()
+
+	base, err := NewContext("/tmp", "/tmp", "/tmp", "", "", "")
+	require.NoError(t, err)
+
+	aTookView := make(chan struct{})
+	bRead := make(chan struct{})
+	aFinished := make(chan struct{})
+
+	var aIndex int64
+	go func() {
+		defer close(aFinished)
+		idx := 3
+		a := base.WithIteration(&idx, nil, nil)
+		close(aTookView)
+		<-bRead
+		aIndex = countIndexOf(t, a)
+	}()
+
+	<-aTookView
+	idx := 7
+	b := base.WithIteration(&idx, nil, nil)
+	bIndex := countIndexOf(t, b)
+	close(bRead)
+	<-aFinished
+
+	require.Equal(t, int64(3), aIndex, "A observed B's count.index — the iteration binding is shared, not per-view")
+	require.Equal(t, int64(7), bIndex)
+}
+
+// TestWithIterationIsolatesConcurrentForEach is the each.key/each.value analogue
+// of TestWithIterationIsolatesConcurrentIterations, guarding the same fix on the
+// for_each path.
+func TestWithIterationIsolatesConcurrentForEach(t *testing.T) {
+	t.Parallel()
+
+	base, err := NewContext("/tmp", "/tmp", "/tmp", "", "", "")
+	require.NoError(t, err)
+
+	eachKeyOf := func(c *Context) string {
+		v, ok := c.HCLContext().Variables["each"]
+		require.Truef(t, ok && !v.IsNull(), "each is unbound")
+		return v.GetAttr("key").AsString()
+	}
+
+	aTookView := make(chan struct{})
+	bRead := make(chan struct{})
+	aFinished := make(chan struct{})
+
+	var aKey string
+	go func() {
+		defer close(aFinished)
+		key, val := cty.StringVal("a"), cty.StringVal("va")
+		a := base.WithIteration(nil, &key, &val)
+		close(aTookView)
+		<-bRead
+		aKey = eachKeyOf(a)
+	}()
+
+	<-aTookView
+	key, val := cty.StringVal("b"), cty.StringVal("vb")
+	b := base.WithIteration(nil, &key, &val)
+	bKey := eachKeyOf(b)
+	close(bRead)
+	<-aFinished
+
+	require.Equal(t, "a", aKey, "A observed B's each.key — the iteration binding is shared, not per-view")
+	require.Equal(t, "b", bKey)
+}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1094,8 +1094,8 @@ func (e *Engine) registerProviderInContext(
 	typeToken := "pulumi:providers:" + provider.Name
 
 	if inst != nil {
-		evalCtx.SetEach(cty.StringVal(inst.key), inst.value)
-		defer evalCtx.ClearEach()
+		key := cty.StringVal(inst.key)
+		evalCtx = evalCtx.WithIteration(nil, &key, &inst.value)
 	}
 
 	hclCtx := evalCtx.HCLContext()
@@ -1395,14 +1395,7 @@ func (e *Engine) registerResourceInstanceInContext(
 	parentURN urn.URN,
 	modInst *moduleInstance,
 ) error {
-	if instance.Index != nil {
-		evalCtx.SetCount(*instance.Index)
-		defer evalCtx.ClearCount()
-	}
-	if instance.EachKey != nil && instance.EachValue != nil {
-		evalCtx.SetEach(*instance.EachKey, *instance.EachValue)
-		defer evalCtx.ClearEach()
-	}
+	evalCtx = evalCtx.WithIteration(instance.Index, instance.EachKey, instance.EachValue)
 
 	hclCtx := evalCtx.HCLContext()
 
@@ -2773,21 +2766,9 @@ func (e *Engine) processRangedDataSource(
 	isForEach := ds.ForEach != nil
 
 	for _, instance := range result.Instances {
-		if instance.Index != nil {
-			evalCtx.SetCount(*instance.Index)
-		}
-		if instance.EachKey != nil && instance.EachValue != nil {
-			evalCtx.SetEach(*instance.EachKey, *instance.EachValue)
-		}
+		instCtx := evalCtx.WithIteration(instance.Index, instance.EachKey, instance.EachValue)
 
-		ctyOut, invokeErr := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx)
-
-		if instance.Index != nil {
-			evalCtx.ClearCount()
-		}
-		if instance.EachKey != nil {
-			evalCtx.ClearEach()
-		}
+		ctyOut, invokeErr := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, instCtx)
 
 		if invokeErr != nil {
 			return invokeErr

--- a/tests/tfcompat/l2_module_inherited_provider_passthrough_test.go
+++ b/tests/tfcompat/l2_module_inherited_provider_passthrough_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ModuleInheritedProviderPassthrough asserts parity on a module that
+// inherits the root's default provider (no `providers` block on its call) and
+// then tries to pass that inherited default down to its own child via a
+// `providers` block. OpenTofu rejects this — a module can only pass on a provider
+// that was explicitly passed into it, not one it merely inherited — and
+// pulumi-hcl must reproduce the same `missing provider` error.
+func TestL2ModuleInheritedProviderPassthrough(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_inherited_provider_passthrough", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			ExpectErr: `missing provider module.child.provider`,
+		}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_module_inherited_provider_passthrough/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_inherited_provider_passthrough/main.tf
@@ -1,0 +1,14 @@
+provider "simple" {
+  prefix = "root-prefix"
+}
+
+# `child` gets no `providers` block on this call, so it inherits the root
+# default `simple`. `child` then passes that inherited default down to its own
+# child via a `providers` block — the case the Materialize wrapper hits.
+module "child" {
+  source = "./modules/child"
+}
+
+output "result" {
+  value = module.child.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_inherited_provider_passthrough/modules/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_inherited_provider_passthrough/modules/child/main.tf
@@ -1,0 +1,20 @@
+# child declares `simple` (like the Materialize module declares helm/kubernetes)
+# but does not configure it — the config is inherited from the root default.
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+module "gc" {
+  source = "./modules/gc"
+  providers = {
+    simple = simple
+  }
+}
+
+output "result" {
+  value = module.gc.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_inherited_provider_passthrough/modules/child/modules/gc/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_inherited_provider_passthrough/modules/child/modules/gc/main.tf
@@ -1,0 +1,10 @@
+resource "simple_resource" "r" {
+  input_one = "x"
+  input_two = true
+}
+
+# prefix_result folds in the provider's configured `prefix`, so the output also
+# proves the *inherited* config (prefix = "root-prefix") reached this resource.
+output "result" {
+  value = simple_resource.r.prefix_result
+}


### PR DESCRIPTION
## What

Resource, data source, and provider `for_each` registration bound `count.index` / `each.*` by mutating the **shared** per-module `eval.Context` and then snapshotting it for expression evaluation. Because the dependency graph is walked concurrently, sibling `count`/`for_each` nodes that register at the same time raced on that single binding: one registration could observe another's index, or a transiently cleared one.

The cleared-index case surfaced as `Error: There is no variable named "count"` when evaluating a counted resource's config (e.g. `element(var.azs, count.index)`); the wrong-index case is a silent mis-binding. It reproduced most readily on `destroy --run-program`, which re-registers every instance of the program at once.

## Fix

Add `eval.Context.WithIteration`, which returns a lightweight view that shares the context's maps and lock but carries its own `count`/`each`. The three concurrent registration sites — resource, data source, and provider `for_each` — now derive a per-instance view instead of mutating shared state, so the iteration binding is goroutine-local.

`Context.mu` becomes a `*sync.RWMutex` so a view shares the lock with the context it derives from (keeping the shared maps coordinated; no `copylock`). Module-instance expansion keeps `SetCount`/`SetEach` — it binds a fresh private context per module instance, which is never shared.

## Test

`pkg/hcl/eval/iteration_test.go` drives two concurrent registrations against one base context, using channels (no sleeps) to force the exact interleaving that corrupts a shared binding, and asserts each observes its own `count.index` / `each.key`. It fails deterministically if `WithIteration` is reverted to shared mutation and passes with the fix — verified both ways. Covers `count` and `for_each`.

`go vet` clean; 522 `pkg/hcl` unit tests and the tfcompat count/for_each/module/data-source suite pass.

## Note

The second commit adds an unrelated tfcompat parity test (`l2_module_inherited_provider_passthrough`) that was already staged locally; it pins OpenTofu's `missing provider module.child.provider` behaviour for a module forwarding an inherited-only default provider.