### PR TITLE
Key resource-hook names per instance so repeated modules don't collide

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-358.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-358.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Fix "resource hook already registered" when a module with a provisioner, precondition, or postcondition is instantiated more than once via `for_each`/`count`
+time: 2026-07-13T16:00:05Z
+custom:
+    Component: runtime
+    PR: "358"

--- a/pkg/hcl/run/provisioner.go
+++ b/pkg/hcl/run/provisioner.go
@@ -43,6 +43,7 @@ func (e *Engine) bindProvisionerHooks(
 	instance *graph.ExpandedResource,
 	evalCtx *eval.Context,
 	opts *ResourceOptions,
+	resourceName string,
 ) error {
 	if len(res.Provisioners) == 0 {
 		return nil
@@ -66,7 +67,7 @@ func (e *Engine) bindProvisionerHooks(
 		}
 		onFailureContinue := prov.OnFailure == "continue"
 		useOldOutputs := when == "destroy"
-		hookName := fmt.Sprintf("%s:provisioner:%d", instance.Key, i)
+		hookName := fmt.Sprintf("%s.%s:provisioner:%d", res.Type, resourceName, i)
 
 		callback := func(hookCtx context.Context, args *ResourceHookArgs) error {
 			outputs := args.NewOutputs

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1481,25 +1481,25 @@ func (e *Engine) registerResourceInstanceInContext(
 
 	opts.PackageRef = e.packageRefForType(res.Type)
 
+	resourceName := e.extractModuleResourceName(res.Name, instance.Key, node.ModuleInfo, modInst)
+
 	if len(res.Preconditions) > 0 {
-		if err := e.bindPreconditionHooks(ctx, res, instance, evalCtx, opts); err != nil {
+		if err := e.bindPreconditionHooks(ctx, res, instance, evalCtx, opts, resourceName); err != nil {
 			return err
 		}
 	}
 
 	if len(res.Postconditions) > 0 {
-		if err := e.bindPostconditionHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts); err != nil {
+		if err := e.bindPostconditionHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName); err != nil {
 			return err
 		}
 	}
 
 	if len(res.Provisioners) > 0 {
-		if err := e.bindProvisionerHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts); err != nil {
+		if err := e.bindProvisionerHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName); err != nil {
 			return err
 		}
 	}
-
-	resourceName := e.extractModuleResourceName(res.Name, instance.Key, node.ModuleInfo, modInst)
 
 	urn, id, outputs, err := e.registerResource(ctx, res.Type, resSchema.Token, resourceName, resourceInputs, opts)
 	if err != nil {
@@ -3947,6 +3947,7 @@ func (e *Engine) bindPreconditionHooks(
 	instance *graph.ExpandedResource,
 	evalCtx *eval.Context,
 	opts *ResourceOptions,
+	resourceName string,
 ) error {
 	if opts.Hooks == nil {
 		opts.Hooks = &ResourceHookBinding{}
@@ -3954,7 +3955,7 @@ func (e *Engine) bindPreconditionHooks(
 	hclSnapshot := evalCtx.HCLContext()
 	for i, rule := range res.Preconditions {
 		rule, index := rule, i+1
-		hookName := fmt.Sprintf("%s:precondition:%d", instance.Key, i)
+		hookName := fmt.Sprintf("%s.%s:precondition:%d", res.Type, resourceName, i)
 		callback := func(_ context.Context, _ *ResourceHookArgs) error {
 			return evaluatePrecondition(rule, hclSnapshot, index, instance.Key)
 		}
@@ -3982,6 +3983,7 @@ func (e *Engine) bindPostconditionHooks(
 	instance *graph.ExpandedResource,
 	evalCtx *eval.Context,
 	opts *ResourceOptions,
+	resourceName string,
 ) error {
 	if opts.Hooks == nil {
 		opts.Hooks = &ResourceHookBinding{}
@@ -3990,7 +3992,7 @@ func (e *Engine) bindPostconditionHooks(
 	dryRun := e.dryRun
 	for i, rule := range res.Postconditions {
 		rule, index := rule, i+1
-		hookName := fmt.Sprintf("%s:postcondition:%d", instance.Key, i)
+		hookName := fmt.Sprintf("%s.%s:postcondition:%d", res.Type, resourceName, i)
 		callback := func(_ context.Context, args *ResourceHookArgs) error {
 			return evaluatePostcondition(rule, hclSnapshot, args.NewOutputs, resSchema, mapping, dryRun, index, instance.Key)
 		}

--- a/tests/tfcompat/l2_module_repeated_hooks_test.go
+++ b/tests/tfcompat/l2_module_repeated_hooks_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A resource-level provisioner / precondition / postcondition each registers a
+// resource hook whose name must be unique per instance. When the resource lives
+// in a module instantiated multiple times (for_each/count), a hook name derived
+// from the in-module resource address alone collides across instances and
+// pulumi-hcl fails with "resource hook already registered". Terraform has no
+// such restriction, so these cases guard the fix that keys hook names by the
+// per-instance Pulumi resource name.
+
+func TestL2Module_ProvisionerForEach(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_provisioner_for_each", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}
+
+func TestL2Module_PreconditionForEach(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_precondition_for_each", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}
+
+func TestL2Module_PostconditionForEach(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_postcondition_for_each", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_module_postcondition_for_each/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_postcondition_for_each/main.tf
@@ -1,0 +1,13 @@
+# Regression: a module carrying a resource-level postcondition, instantiated
+# more than once via for_each. Each instance must register a distinct
+# postcondition hook; a name derived from the in-module resource address alone
+# collides.
+module "checks" {
+  source   = "./runner"
+  for_each = toset(["a", "b"])
+  name     = each.key
+}
+
+output "results" {
+  value = { for k, m in module.checks : k => m.result }
+}

--- a/tests/tfcompat/testdata/cases/l2_module_postcondition_for_each/runner/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_postcondition_for_each/runner/main.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  type = string
+}
+
+resource "simple_resource" "r" {
+  input_one = var.name
+  input_two = false
+
+  lifecycle {
+    postcondition {
+      condition     = self.result == "${var.name}-false"
+      error_message = "unexpected result"
+    }
+  }
+}
+
+output "result" {
+  value = simple_resource.r.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_precondition_for_each/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_precondition_for_each/main.tf
@@ -1,0 +1,12 @@
+# Regression: a module carrying a resource-level precondition, instantiated more
+# than once via for_each. Each instance must register a distinct precondition
+# hook; a name derived from the in-module resource address alone collides.
+module "guards" {
+  source   = "./runner"
+  for_each = toset(["a", "b"])
+  name     = each.key
+}
+
+output "results" {
+  value = { for k, m in module.guards : k => m.result }
+}

--- a/tests/tfcompat/testdata/cases/l2_module_precondition_for_each/runner/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_precondition_for_each/runner/main.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  type = string
+}
+
+resource "simple_resource" "r" {
+  input_one = var.name
+  input_two = false
+
+  lifecycle {
+    precondition {
+      condition     = var.name != ""
+      error_message = "name must be set"
+    }
+  }
+}
+
+output "result" {
+  value = simple_resource.r.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_provisioner_for_each/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_provisioner_for_each/main.tf
@@ -1,0 +1,13 @@
+# Regression: a module carrying a resource-level provisioner, instantiated more
+# than once via for_each. Each instance must register a distinct provisioner
+# hook. A hook name derived from the in-module resource address alone (without
+# the module instance key) collides across the two instances.
+module "runners" {
+  source   = "./runner"
+  for_each = toset(["a", "b"])
+  name     = each.key
+}
+
+output "results" {
+  value = { for k, m in module.runners : k => m.result }
+}

--- a/tests/tfcompat/testdata/cases/l2_module_provisioner_for_each/runner/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_provisioner_for_each/runner/main.tf
@@ -1,0 +1,16 @@
+variable "name" {
+  type = string
+}
+
+resource "simple_resource" "r" {
+  input_one = var.name
+  input_two = false
+
+  provisioner "local-exec" {
+    command = "true"
+  }
+}
+
+output "result" {
+  value = simple_resource.r.result
+}


### PR DESCRIPTION
## Problem

A module that carries a resource-level `provisioner`, `precondition`, or `postcondition` and is instantiated more than once (via `for_each` or `count`) fails registration:

```
error: an unhandled error occurred: registering module.nodepool.terraform_data.destroyer:
  registering provisioner hook: ... resource hook already registered for name
  "module.nodepool.terraform_data.destroyer:provisioner:0"
```

Each such block registers a resource hook whose name must be unique across the program. The name was built from the resource's **in-module** address (`instance.Key`, e.g. `module.nodepool.terraform_data.destroyer`), which does not include the module instance key. Two instances of the same module therefore generated identical hook names and collided. Terraform imposes no such restriction.

## Fix

Key hook names by `res.Type` + the per-instance Pulumi resource name from `extractModuleResourceName` (which already disambiguates module instances and count/for_each indices — it is what the registered resource is named). The `resourceName` computation is moved above the three hook-binding calls so `bindProvisionerHooks`, `bindPreconditionHooks`, and `bindPostconditionHooks` all share it.

## Tests

Three tfcompat cases exercising a module instantiated twice via `for_each`, each carrying a provisioner / precondition / postcondition respectively (`l2_module_{provisioner,precondition,postcondition}_for_each`). Verified they fail without the fix (hook-name collision) and pass with it; the tfcompat suite is otherwise green.

## How it was found

Deploying `MaterializeInc/materialize-terraform-self-managed` (the AWS `stack` root module) via `runtime: hcl`: its `karpenter-nodepool` module — which has a `terraform_data.destroyer` provisioner — is instantiated once per entry of `for_each = var.cluster_config.karpenter_node_pools`.