### PR TITLE
Wait for a whole module's resources when depended on via `depends_on`

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-359.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-359.yaml
@@ -3,4 +3,4 @@ body: Wait for a whole module's resources when it is referenced only through `de
 time: 2026-07-14T07:51:39Z
 custom:
     Component: runtime
-    PR: "361"
+    PR: "359"

--- a/.changes/unreleased/runtime-bug-fixes-361.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-361.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Wait for a whole module's resources when it is referenced only through `depends_on`
+time: 2026-07-14T07:51:39Z
+custom:
+    Component: runtime
+    PR: "361"

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -1268,13 +1268,30 @@ func (g *Graph) inlineModule(
 		}
 	}
 
-	// Completion node: depends on all outputs + init. The completion key
-	// is the module call's identifier (without the trailing "."), so that
-	// expressions like `module.<name>` in the parent scope resolve to it.
+	// Completion node: depends on init plus everything the module declares —
+	// its resources, data sources, outputs, and nested module completions. The
+	// completion key is the module call's identifier (without the trailing "."),
+	// so that a whole-module reference like `module.<name>` in the parent scope
+	// (an output-less `depends_on`, in particular) waits for the module's entire
+	// contents, not only the resources that happen to feed an output. Node keys
+	// for the nested modules are forward references resolved once they are
+	// inlined below.
 	completionKey := parentPrefix + "module." + name
 	completionDeps := []pdag.Node{initIdx}
+	for key := range loaded.Config.Resources {
+		_, idx := g.newNode(prefix + key)
+		completionDeps = append(completionDeps, idx)
+	}
+	for key := range loaded.Config.DataSources {
+		_, idx := g.newNode(prefix + "data." + key)
+		completionDeps = append(completionDeps, idx)
+	}
 	for outputName := range loaded.Config.Outputs {
 		_, idx := g.newNode(prefix + "output." + outputName)
+		completionDeps = append(completionDeps, idx)
+	}
+	for nestedName := range loaded.Config.Modules {
+		_, idx := g.newNode(prefix + "module." + nestedName)
 		completionDeps = append(completionDeps, idx)
 	}
 	if err := g.AddNode(&Node{

--- a/tests/testutil/tfcompat/providers/ordering.go
+++ b/tests/testutil/tfcompat/providers/ordering.go
@@ -1,0 +1,76 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// OrderingProvider exposes `ordering_resource`, whose Create holds for a few
+// seconds and fails if another Create is in flight at the same time. Chaining
+// two of these with depends_on asserts serialized creation: when the ordering
+// is honored the two Creates never overlap; when it is not, the second Create
+// starts during the first's window and both error.
+//
+// The in-flight counter is captured per provider instance (one factory call per
+// runtime), so a runtime's own resources share it while the concurrently-run
+// Terraform and pulumi runtimes keep separate counters.
+func OrderingProvider() *schema.Provider {
+	var mu sync.Mutex
+	inFlight := 0
+
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"ordering_resource": {
+				Schema: map[string]*schema.Schema{
+					"name": {Type: schema.TypeString, Optional: true},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					mu.Lock()
+					inFlight++
+					overlapped := inFlight > 1
+					mu.Unlock()
+					defer func() {
+						mu.Lock()
+						inFlight--
+						mu.Unlock()
+					}()
+
+					if overlapped {
+						name, _ := d.Get("name").(string)
+						return diag.Errorf(
+							"ordering_resource %q created while another create was still in flight: "+
+								"depends_on ordering was not honored", name)
+					}
+
+					// Hold the slot open long enough that an unordered second
+					// create reliably starts within this window.
+					time.Sleep(3 * time.Second)
+
+					d.SetId("ordering-id")
+					return nil
+				},
+				ReadContext:   func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				UpdateContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+			},
+		},
+	}
+}

--- a/tests/tfcompat/l2_module_depends_on_ordering_test.go
+++ b/tests/tfcompat/l2_module_depends_on_ordering_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A module referenced only through depends_on (no data flow) must be created
+// before the module that depends on it. ordering_resource fails if a second
+// create starts while the first is still in flight, so honoring the ordering
+// serializes the two creates and both succeed, while ignoring it overlaps them
+// and errors. Terraform serializes on module depends_on.
+func TestL2Module_DependsOnOrdering(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_depends_on_ordering", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "ordering", Factory: providers.OrderingProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_module_depends_on_ordering/consumer/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_depends_on_ordering/consumer/main.tf
@@ -1,0 +1,3 @@
+resource "ordering_resource" "consumer" {
+  name = "consumer"
+}

--- a/tests/tfcompat/testdata/cases/l2_module_depends_on_ordering/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_depends_on_ordering/main.tf
@@ -1,0 +1,13 @@
+# module.consumer depends_on module.producer with no data reference between
+# them, so only the explicit depends_on can order the two ordering_resource
+# creates. Each create fails if another create is in flight, so a violation of
+# the depends_on ordering surfaces as overlapping creates. Terraform serializes
+# the modules and both creates succeed.
+module "producer" {
+  source = "./producer"
+}
+
+module "consumer" {
+  source     = "./consumer"
+  depends_on = [module.producer]
+}

--- a/tests/tfcompat/testdata/cases/l2_module_depends_on_ordering/producer/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_depends_on_ordering/producer/main.tf
@@ -1,0 +1,3 @@
+resource "ordering_resource" "producer" {
+  name = "producer"
+}


### PR DESCRIPTION
## Problem

A `depends_on` on a module resolves to that module's completion node (`module.<name>`). The completion node depended only on the module's init node and its **outputs**, not on its resources. A resource inside the module that feeds no output was therefore absent from the transitive closure of `module.<name>`.

When a consumer depends on such a module purely through `depends_on` (no data flow), both sides unblock at the same time in the parallel graph walk and their creates run concurrently. Terraform/OpenTofu instead serialize on a whole-module dependency.

The chain in the failing test:

```
ordering_resource.consumer → consumer.__init__ → module.producer (completion) → producer.__init__
```

`ordering_resource.producer` hangs off `producer.__init__` on a sibling branch — it is never upstream of `module.producer`, so it is not waited on.

## Fix

The completion node now depends on everything the module declares — its resources, data sources, outputs, and nested-module completions — so a whole-module reference waits for the module's entire contents. This covers every reference site, since `depends_on` on a resource, `depends_on` on a module block, and a bare `module.<name>` in an expression all route through the completion node.

## Test

`TestL2Module_DependsOnOrdering` drives two modules chained only by `depends_on`, using a provider whose `Create` fails if a second create starts while the first is in flight. It failed before and passes now. `./pkg/hcl/graph/...`, `./pkg/hcl/run/...` (192), and all `Module`/`Depends` tfcompat cases (32) pass.