### PR TITLE
Propagate schema-declared secret output properties to stack outputs

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-362.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-362.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Propagate schema-declared `secret` output properties to stack outputs
+time: 2026-07-14T12:00:00Z
+custom:
+    Component: runtime
+    PR: "362"

--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -143,8 +143,6 @@ var expectedFailures = map[string]string{
 		" is reserved as the namespace for resource method calls in HCL",
 	"l2-config-default-from-invoke": "HCL codegen does not support a config variable whose" +
 		" default is sourced from an invoke result",
-	"l2-resource-schema-secret": "HCL runtime does not propagate a schema-declared `secret`" +
-		" property to stack outputs",
 	"l2-extension-and-base-resource": "extension parameterization is not yet supported by the" +
 		" HCL language host (the test expects the extension package among required packages)",
 	"l2-extension-parameterized-resource": "extension parameterization is not yet supported by" +

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-schema-secret/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-schema-secret/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-schema-secret
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-schema-secret/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-schema-secret/main.pp
@@ -1,0 +1,29 @@
+resource "provElided" "pulumi:providers:output" {
+  elideUnknowns = true
+}
+
+resource "provNotElided" "pulumi:providers:output" {
+}
+
+resource "topLevelElided" "output:index:Resource" {
+  value = 1
+  options {
+    provider = provElided
+  }
+}
+
+resource "topLevelNotElided" "output:index:Resource" {
+  value = 1
+  options {
+    provider = provNotElided
+  }
+}
+
+output "topLevelElided" {
+  value = topLevelElided.secretOutput
+}
+
+output "topLevelNotElided" {
+  value = topLevelNotElided.secretOutput
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-schema-secret/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-schema-secret/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-schema-secret
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-schema-secret/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-schema-secret/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    output = {
+      source  = "pulumi/output"
+      version = "23.0.0"
+    }
+  }
+}
+
+provider "output" {
+  alias          = "provElided"
+  elide_unknowns = true
+}
+provider "output" {
+  alias = "provNotElided"
+}
+resource "output_resource" "topLevelElided" {
+  provider = output.provElided
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = 1
+}
+resource "output_resource" "topLevelNotElided" {
+  provider = output.provNotElided
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = 1
+}
+output "topLevelElided" {
+  value = output_resource.topLevelElided.secret_output
+}
+output "topLevelNotElided" {
+  value = output_resource.topLevelNotElided.secret_output
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-schema-secret/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-schema-secret/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-schema-secret
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-schema-secret/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-schema-secret/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    output = {
+      source  = "pulumi/output"
+      version = "23.0.0"
+    }
+  }
+}
+
+provider "output" {
+  alias          = "provElided"
+  elide_unknowns = true
+}
+provider "output" {
+  alias = "provNotElided"
+}
+resource "output_resource" "topLevelElided" {
+  provider = output.provElided
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = 1
+}
+resource "output_resource" "topLevelNotElided" {
+  provider = output.provNotElided
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = 1
+}
+output "topLevelElided" {
+  value = output_resource.topLevelElided.secret_output
+}
+output "topLevelNotElided" {
+  value = output_resource.topLevelNotElided.secret_output
+}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1743,6 +1743,14 @@ func (e *Engine) buildResourceOptionsInContext(
 		opts.AdditionalSecretOutputs = append(opts.AdditionalSecretOutputs, name)
 	}
 
+	// Properties the schema declares as secret are marked as secret outputs, so
+	// the engine stores and surfaces them as secrets just as the generated SDKs do.
+	for _, p := range outputProps {
+		if p.Secret && !slices.Contains(opts.AdditionalSecretOutputs, p.Name) {
+			opts.AdditionalSecretOutputs = append(opts.AdditionalSecretOutputs, p.Name)
+		}
+	}
+
 	if res.RetainOnDelete != nil {
 		val, diags := res.RetainOnDelete.Value(hclCtx)
 		val, _ = val.Unmark()

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -1187,6 +1187,12 @@ func propertyObjectToCtyMap(path string, m property.Map, properties []*schema.Pr
 			} else {
 				result[hclName] = cty.NullVal(t)
 			}
+			// A property the schema declares secret stays secret even when the
+			// provider elided its (unknown) value, matching the secret marking a
+			// known value carries in through propertyValueToCtyWithMapping.
+			if p.Secret {
+				result[hclName] = result[hclName].Mark(eval.SensitiveMark)
+			}
 			continue
 		}
 		var vPath string

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -1028,6 +1028,26 @@ func TestResourceOutputToCtySingularBlockPlaceholder(t *testing.T) {
 	})
 }
 
+// TestResourceOutputToCtySchemaSecretElided pins that a schema-secret output
+// keeps its sensitive mark even when the provider elides the (unknown) value
+// during preview, so a downstream stack output stays secret.
+func TestResourceOutputToCtySchemaSecretElided(t *testing.T) {
+	t.Parallel()
+
+	res := &schema.Resource{
+		Token: "test:index:R",
+		Properties: []*schema.Property{
+			{Name: "secretOutput", Type: schema.StringType, Secret: true},
+		},
+	}
+
+	r, err := ResourceOutputToCty(property.Map{}, res, nil, true)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]cty.Value{
+		"secret_output": cty.UnknownVal(cty.String).Mark(eval.SensitiveMark),
+	}, r)
+}
+
 func TestResourceOutputToCtyUnionTypeCollapse(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
A provider schema property marked `secret: true` was not surfaced as a
secret. Two runtime gaps: resource registration never added schema-secret
properties to `additionalSecretOutputs` (so the engine returned present
output values unmarked), and `propertyObjectToCtyMap` dropped the secret
when the provider elided an unknown value during preview.

Declare schema-secret outputs at registration (as the generated SDKs do)
and mark elided schema-secret outputs sensitive in the cty transform.
Enable the l2-resource-schema-secret conformance test.