### PR TITLE
Support recover() for continue-on-error recovery

### DIFF
--- a/.changes/unreleased/runtime-Improvements-366.yaml
+++ b/.changes/unreleased/runtime-Improvements-366.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Support `recover(value, recovery)` for recovering from failed resources under continue-on-error
+time: 2026-07-14T15:00:00Z
+custom:
+    Component: runtime
+    PR: "366"

--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -147,8 +147,6 @@ var expectedFailures = map[string]string{
 		" HCL language host (the test expects the extension package among required packages)",
 	"l2-extension-parameterized-resource": "extension parameterization is not yet supported by" +
 		" the HCL language host (the test expects the extension package among required packages)",
-	"l2-failed-create-recover-continue-on-error": "HCL has no `recover` function or `error`" +
-		" scope variable, so the recover-from-failed-create fixture cannot be expressed",
 }
 
 // expectedEjectFailures lists tests whose eject (HCL→PCL conversion) step is

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-failed-create-recover-continue-on-error/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-failed-create-recover-continue-on-error/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-failed-create-recover-continue-on-error
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-failed-create-recover-continue-on-error/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-failed-create-recover-continue-on-error/main.pp
@@ -1,0 +1,16 @@
+resource "failing" "fail_on_create:index:Resource" {
+  value = false
+}
+
+resource "recovered_value" "simple:index:Resource" {
+  value = recover(failing.value, error != "")
+}
+
+resource "independent" "simple:index:Resource" {
+  value = true
+}
+
+output "recovered" {
+  value = recover(failing.urn, "recovered: ${error}")
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-failed-create-recover-continue-on-error/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-failed-create-recover-continue-on-error/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-failed-create-recover-continue-on-error
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-failed-create-recover-continue-on-error/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-failed-create-recover-continue-on-error/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    fail_on_create = {
+      source  = "pulumi/fail_on_create"
+      version = "4.0.0"
+    }
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "fail_on_create_resource" "failing" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = false
+}
+resource "simple_resource" "recovered_value" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = recover(fail_on_create_resource.failing.value, error != "")
+}
+resource "simple_resource" "independent" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = true
+}
+output "recovered" {
+  value = recover(fail_on_create_resource.failing.urn, "recovered: ${error}")
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-failed-create-recover-continue-on-error/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-failed-create-recover-continue-on-error/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-failed-create-recover-continue-on-error
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-failed-create-recover-continue-on-error/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-failed-create-recover-continue-on-error/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    fail_on_create = {
+      source  = "pulumi/fail_on_create"
+      version = "4.0.0"
+    }
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "fail_on_create_resource" "failing" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = false
+}
+resource "simple_resource" "recovered_value" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = recover(fail_on_create_resource.failing.value, error != "")
+}
+resource "simple_resource" "independent" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = true
+}
+output "recovered" {
+  value = recover(fail_on_create_resource.failing.urn, "recovered: ${error}")
+}

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -2366,6 +2366,7 @@ var pclSupportedFunctions = func() map[string]bool {
 		"range",
 		"readDir",
 		"readFile",
+		"recover",
 		"remoteArchive",
 		"remoteAsset",
 		"rootDirectory",

--- a/pkg/hcl/eval/evaluator.go
+++ b/pkg/hcl/eval/evaluator.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
@@ -300,39 +301,83 @@ func ParseTraversal(traversal hcl.Traversal) (namespace string, parts []string) 
 func ExtractDependencies(expr hcl.Expression) []string {
 	var deps []string
 	seen := make(map[string]bool)
-
 	for _, traversal := range expr.Variables() {
-		namespace, parts := ParseTraversal(traversal)
-
-		var dep string
-		switch namespace {
-		case "var", "local", "path", "terraform", "count", "each", "self":
-			// These are not resource dependencies
-			continue
-		case "data":
-			// Data source reference: data.type.name
-			if len(parts) >= 2 {
-				dep = fmt.Sprintf("data.%s.%s", parts[0], parts[1])
-			}
-		case "module":
-			// Module reference: module.name
-			if len(parts) >= 1 {
-				dep = fmt.Sprintf("module.%s", parts[0])
-			}
-		default:
-			// Resource reference: type.name (namespace is the type)
-			if len(parts) >= 1 {
-				dep = fmt.Sprintf("%s.%s", namespace, parts[0])
-			}
-		}
-
-		if dep != "" && !seen[dep] {
+		if dep := traversalToDep(traversal); dep != "" && !seen[dep] {
 			deps = append(deps, dep)
 			seen[dep] = true
 		}
 	}
-
 	return deps
+}
+
+// NonRecoverableDependencies is ExtractDependencies restricted to references
+// that are not the recoverable value argument of a recover(value, recovery)
+// call. A dependency reached only through such an argument does not gate the
+// referencing node: if the dependency fails, recover() substitutes the recovery
+// value rather than failing the node.
+func NonRecoverableDependencies(expr hcl.Expression) []string {
+	recoverArgRanges := recoverValueArgRanges(expr)
+	var deps []string
+	seen := make(map[string]bool)
+	for _, traversal := range expr.Variables() {
+		if within(traversal.SourceRange(), recoverArgRanges) {
+			continue
+		}
+		if dep := traversalToDep(traversal); dep != "" && !seen[dep] {
+			deps = append(deps, dep)
+			seen[dep] = true
+		}
+	}
+	return deps
+}
+
+// recoverValueArgRanges returns the source ranges of the first (value) argument
+// of every recover(...) call in expr.
+func recoverValueArgRanges(expr hcl.Expression) []hcl.Range {
+	node, ok := expr.(hclsyntax.Node)
+	if !ok {
+		return nil
+	}
+	var ranges []hcl.Range
+	_ = hclsyntax.VisitAll(node, func(n hclsyntax.Node) hcl.Diagnostics {
+		if call, ok := n.(*hclsyntax.FunctionCallExpr); ok && call.Name == "recover" && len(call.Args) >= 1 {
+			ranges = append(ranges, call.Args[0].Range())
+		}
+		return nil
+	})
+	return ranges
+}
+
+func within(r hcl.Range, ranges []hcl.Range) bool {
+	for _, outer := range ranges {
+		if outer.ContainsOffset(r.Start.Byte) {
+			return true
+		}
+	}
+	return false
+}
+
+// traversalToDep converts a traversal to its resource/data/module dependency
+// key, or "" when the traversal is not a dependency (var, local, count, ...).
+func traversalToDep(traversal hcl.Traversal) string {
+	namespace, parts := ParseTraversal(traversal)
+	switch namespace {
+	case "var", "local", "path", "terraform", "count", "each", "self":
+		return ""
+	case "data":
+		if len(parts) >= 2 {
+			return fmt.Sprintf("data.%s.%s", parts[0], parts[1])
+		}
+	case "module":
+		if len(parts) >= 1 {
+			return fmt.Sprintf("module.%s", parts[0])
+		}
+	default:
+		if len(parts) >= 1 {
+			return fmt.Sprintf("%s.%s", namespace, parts[0])
+		}
+	}
+	return ""
 }
 
 // IsKnown returns true if the value is fully known (not unknown).

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -205,6 +205,7 @@ func Functions(baseDir string) map[string]function.Function {
 
 		// Type conversion functions
 		"can":          canFunc,
+		"recover":      recoverFunc,
 		"issensitive":  issensitiveFunc,
 		"nonsensitive": nonsensitiveFunc,
 		"sensitive":    sensitiveFunc,
@@ -245,6 +246,49 @@ func Functions(baseDir string) map[string]function.Function {
 	funcs["templatestring"] = templateStringFunc(nestedTemplateFuncs)
 
 	return funcs
+}
+
+// recoverFunc implements PCL's recover(value, recovery): it returns value if
+// value evaluates successfully, and otherwise evaluates recovery with the
+// variable `error` bound to the failure message. It mirrors try()/can() by
+// taking its arguments as unevaluated expression closures so it can catch the
+// evaluation error of value — which happens when value references a resource
+// that failed to create under continue-on-error.
+var recoverFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{Name: "value", Type: customdecode.ExpressionClosureType},
+		{Name: "recovery", Type: customdecode.ExpressionClosureType},
+	},
+	Type: func(args []cty.Value) (cty.Type, error) {
+		v, err := recoverImpl(args)
+		if err != nil {
+			return cty.NilType, err
+		}
+		return v.Type(), nil
+	},
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		return recoverImpl(args)
+	},
+})
+
+func recoverImpl(args []cty.Value) (cty.Value, error) {
+	value := customdecode.ExpressionClosureFromVal(args[0])
+	v, diags := value.Value()
+	if !diags.HasErrors() {
+		// value resolved (possibly to an unknown during preview); use it.
+		return v, nil
+	}
+
+	// value failed to evaluate — recover by evaluating the recovery expression
+	// with `error` bound to the failure message.
+	recovery := customdecode.ExpressionClosureFromVal(args[1])
+	childCtx := recovery.EvalContext.NewChild()
+	childCtx.Variables = map[string]cty.Value{"error": cty.StringVal(diags.Error())}
+	rv, rdiags := recovery.Expression.Value(childCtx)
+	if rdiags.HasErrors() {
+		return cty.NilVal, rdiags
+	}
+	return rv, nil
 }
 
 var canFunc = function.New(&function.Spec{

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -47,6 +48,23 @@ func evalExpr(t *testing.T, baseDir, src string) cty.Value {
 		t.Fatalf("Failed to evaluate expression %q: %s", src, diags.Error())
 	}
 	return val
+}
+
+func TestRecoverFunction(t *testing.T) {
+	t.Parallel()
+
+	// When the value evaluates successfully, recover returns it and never
+	// evaluates the recovery expression.
+	assert.Equal(t, cty.StringVal("ok"), evalExpr(t, "/tmp", `recover("ok", "fallback")`))
+
+	// When the value fails (here, an undefined reference), recover evaluates the
+	// recovery expression with `error` bound to a non-empty failure message.
+	assert.Equal(t, cty.True, evalExpr(t, "/tmp", `recover(missing.thing, error != "")`))
+
+	got := evalExpr(t, "/tmp", `recover(missing.thing, "recovered: ${error}")`)
+	require.Equal(t, cty.String, got.Type())
+	assert.True(t, strings.HasPrefix(got.AsString(), "recovered: "))
+	assert.Greater(t, len(got.AsString()), len("recovered: "), "error message should be non-empty")
 }
 
 func TestStringFunctions(t *testing.T) {

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -53,18 +52,33 @@ func evalExpr(t *testing.T, baseDir, src string) cty.Value {
 func TestRecoverFunction(t *testing.T) {
 	t.Parallel()
 
+	// thing has a "present" attribute but not "missing", so `thing.missing` is an
+	// evaluation error that recover catches — standing in for a reference to a
+	// resource that failed to create.
+	thing := cty.ObjectVal(map[string]cty.Value{"present": cty.StringVal("v")})
+	eval := func(src string) cty.Value {
+		expr, diags := hclsyntax.ParseExpression([]byte(src), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		require.False(t, diags.HasErrors(), diags.Error())
+		val, diags := expr.Value(&hcl.EvalContext{
+			Functions: Functions("/tmp"),
+			Variables: map[string]cty.Value{"thing": thing},
+		})
+		require.False(t, diags.HasErrors(), diags.Error())
+		return val
+	}
+
 	// When the value evaluates successfully, recover returns it and never
 	// evaluates the recovery expression.
-	assert.Equal(t, cty.StringVal("ok"), evalExpr(t, "/tmp", `recover("ok", "fallback")`))
+	assert.Equal(t, cty.StringVal("v"), eval(`recover(thing.present, "fallback")`))
 
-	// When the value fails (here, an undefined reference), recover evaluates the
-	// recovery expression with `error` bound to a non-empty failure message.
-	assert.Equal(t, cty.True, evalExpr(t, "/tmp", `recover(missing.thing, error != "")`))
+	// When the value fails, recover evaluates the recovery expression with
+	// `error` bound to the value's actual evaluation error.
+	assert.Equal(t, cty.StringVal(
+		`recovered: test.hcl:1,14-22: Unsupported attribute; `+
+			`This object does not have an attribute named "missing".`),
+		eval(`recover(thing.missing, "recovered: ${error}")`))
 
-	got := evalExpr(t, "/tmp", `recover(missing.thing, "recovered: ${error}")`)
-	require.Equal(t, cty.String, got.Type())
-	assert.True(t, strings.HasPrefix(got.AsString(), "recovered: "))
-	assert.Greater(t, len(got.AsString()), len("recovered: "), "error message should be non-empty")
+	assert.Equal(t, cty.True, eval(`recover(thing.missing, error != "")`))
 }
 
 func TestStringFunctions(t *testing.T) {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -586,18 +586,21 @@ func (e *Engine) Run(ctx context.Context) error {
 	// Collect errors from resources that failed to register but were not fatal
 	// (i.e., we continued processing to allow independent resources to proceed).
 	nodeErrs := slices.Collect(e.failedNodes.Values())
-	if len(nodeErrs) > 0 {
-		return errors.Join(nodeErrs...)
-	}
 
 	// Evaluate check blocks after the program has exited.
-	if err := e.evaluateChecks(ctx); err != nil {
+	if err := e.evaluateChecks(ctx); err != nil && len(nodeErrs) == 0 {
 		return err
 	}
 
-	// Process outputs (collect them into stackOutputs)
+	// Process outputs (collect them into stackOutputs). Under continue-on-error
+	// some resources failed but recover() can still surface fallback values, so
+	// outputs are computed regardless; an output that cannot be computed on a
+	// failed run is dropped rather than masking the resource failures below.
 	for name, output := range e.config.Outputs {
 		if err := e.processOutput(ctx, name, output); err != nil {
+			if len(nodeErrs) > 0 {
+				continue
+			}
 			return fmt.Errorf("processing output %s: %w", name, err)
 		}
 	}
@@ -605,6 +608,12 @@ func (e *Engine) Run(ctx context.Context) error {
 	// Register stack outputs
 	if err := e.registerStackOutputs(ctx); err != nil {
 		return fmt.Errorf("registering stack outputs: %w", err)
+	}
+
+	// Surface resource failures; the engine turns these into a bail under
+	// continue-on-error, after the recovered outputs above are registered.
+	if len(nodeErrs) > 0 {
+		return errors.Join(nodeErrs...)
 	}
 
 	return nil
@@ -2347,11 +2356,13 @@ func (e *Engine) hasFailedDependency(res *ast.Resource) bool {
 			}
 		}
 	}
-	// Check resource body expressions.
+	// Check resource body expressions. A dependency reached only through a
+	// recover(value, recovery) value argument does not gate the resource: if it
+	// failed, recover() supplies the recovery value instead.
 	if res.Config != nil {
 		attrs, _ := res.Config.JustAttributes()
 		for _, attr := range attrs {
-			for _, depKey := range eval.ExtractDependencies(attr.Expr) {
+			for _, depKey := range eval.NonRecoverableDependencies(attr.Expr) {
 				if _, failed := e.failedNodes.Get(depKey); failed {
 					return true
 				}


### PR DESCRIPTION
Implement PCL's recover(value, recovery) in the HCL runtime as a
function that takes its arguments as expression closures (like try/can):
it returns value when value evaluates successfully, and otherwise
evaluates recovery with the variable `error` bound to the failure
message. A reference to a resource that failed to create is an
evaluation error, which recover catches.

So a resource whose input recovers from a failed dependency is not
skipped, dependency-failure detection ignores references reached only
through a recover value argument. Outputs are now evaluated even when
some resources failed, so a continue-on-error run can register recovered
stack outputs before the resource failures surface as a bail.

The converter ejects recover() as a supported PCL function. Enable the
l2-failed-create-recover-continue-on-error conformance test.