### PR TITLE
Support extension-parameterized packages

### DIFF
--- a/.changes/unreleased/runtime-Improvements-367.yaml
+++ b/.changes/unreleased/runtime-Improvements-367.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Support extension-parameterized packages, whose resources and functions extend a base provider's namespace
+time: 2026-07-14T16:30:00Z
+custom:
+    Component: runtime
+    PR: "367"

--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -143,10 +143,6 @@ var expectedFailures = map[string]string{
 		" is reserved as the namespace for resource method calls in HCL",
 	"l2-config-default-from-invoke": "HCL codegen does not support a config variable whose" +
 		" default is sourced from an invoke result",
-	"l2-extension-and-base-resource": "extension parameterization is not yet supported by the" +
-		" HCL language host (the test expects the extension package among required packages)",
-	"l2-extension-parameterized-resource": "extension parameterization is not yet supported by" +
-		" the HCL language host (the test expects the extension package among required packages)",
 }
 
 // expectedEjectFailures lists tests whose eject (HCL→PCL conversion) step is

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-extension-and-base-resource/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-extension-and-base-resource/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-extension-and-base-resource
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-extension-and-base-resource/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-extension-and-base-resource/main.pp
@@ -1,0 +1,26 @@
+package {
+  baseProviderName    = "extbase"
+  baseProviderVersion = "45.0.0"
+  parameterization {
+    name    = "myext"
+    version = "2.0.0"
+    value   = "SGVsbG8="
+  }
+}
+
+// An extension resource (Greeting) and a base-provider resource (Base) used
+// together; both live in the base provider's namespace ("extbase").
+resource "greeting" "extbase:index:Greeting" {
+}
+
+resource "base" "extbase:index:Base" {
+}
+
+output "parameterValue" {
+  value = greeting.parameterValue
+}
+
+output "baseValue" {
+  value = base.baseValue
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-extension-parameterized-resource/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-extension-parameterized-resource/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-extension-parameterized-resource
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-extension-parameterized-resource/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-extension-parameterized-resource/main.pp
@@ -1,0 +1,32 @@
+package {
+  baseProviderName    = "extbase"
+  baseProviderVersion = "45.0.0"
+  parameterization {
+    name    = "myext"
+    version = "2.0.0"
+    value   = "SGVsbG8="
+  }
+}
+
+// Extension parameterization: the SDK is published as "myext" but the resource
+// tokens live in the base provider's namespace ("extbase").
+resource "greeting" "extbase:index:Greeting" {
+}
+
+resource "greetingComp" "extbase:index:GreetingComponent" {
+}
+
+output "parameterValue" {
+  value = greeting.parameterValue
+}
+
+output "parameterValueFromComponent" {
+  value = greetingComp.parameterValue
+}
+
+output "invokeGreeting" {
+  value = invoke("extbase:index:greet", {
+    name = "Pulumi"
+  }).greeting
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-extension-and-base-resource/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-extension-and-base-resource/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-extension-and-base-resource
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-extension-and-base-resource/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-extension-and-base-resource/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    extbase = {
+      source  = "pulumi/extbase"
+      version = "45.0.0"
+    }
+    myext = {
+      source  = "pulumi/myext"
+      version = "2.0.0"
+    }
+  }
+}
+
+// An extension resource (Greeting) and a base-provider resource (Base) used
+// together; both live in the base provider's namespace ("extbase").
+resource "extbase_greeting" "greeting" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+resource "extbase_base" "base" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+output "parameterValue" {
+  value = extbase_greeting.greeting.parameter_value
+}
+output "baseValue" {
+  value = extbase_base.base.base_value
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-extension-and-base-resource/sdks/myext/hcl.sdk.json
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-extension-and-base-resource/sdks/myext/hcl.sdk.json
@@ -1,0 +1,13 @@
+{
+  "Name": "extbase",
+  "Kind": "resource",
+  "Version": "45.0.0",
+  "PluginDownloadURL": "",
+  "Checksums": null,
+  "Parameterization": null,
+  "ExtensionParameterization": {
+    "Name": "myext",
+    "Version": "2.0.0",
+    "Value": "SGVsbG8="
+  }
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-extension-parameterized-resource/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-extension-parameterized-resource/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-extension-parameterized-resource
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-extension-parameterized-resource/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-extension-parameterized-resource/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    myext = {
+      source  = "pulumi/myext"
+      version = "2.0.0"
+    }
+  }
+}
+
+data "extbase_greet" "invoke_0" {
+  name = "Pulumi"
+}
+
+// Extension parameterization: the SDK is published as "myext" but the resource
+// tokens live in the base provider's namespace ("extbase").
+resource "extbase_greeting" "greeting" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+resource "extbase_greeting_component" "greetingComp" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+output "parameterValue" {
+  value = extbase_greeting.greeting.parameter_value
+}
+output "parameterValueFromComponent" {
+  value = extbase_greeting_component.greetingComp.parameter_value
+}
+output "invokeGreeting" {
+  value = data.extbase_greet.invoke_0.greeting
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-extension-parameterized-resource/sdks/myext/hcl.sdk.json
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-extension-parameterized-resource/sdks/myext/hcl.sdk.json
@@ -1,0 +1,13 @@
+{
+  "Name": "extbase",
+  "Kind": "resource",
+  "Version": "45.0.0",
+  "PluginDownloadURL": "",
+  "Checksums": null,
+  "Parameterization": null,
+  "ExtensionParameterization": {
+    "Name": "myext",
+    "Version": "2.0.0",
+    "Value": "SGVsbG8="
+  }
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-extension-and-base-resource/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-extension-and-base-resource/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-extension-and-base-resource
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-extension-and-base-resource/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-extension-and-base-resource/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    extbase = {
+      source  = "pulumi/extbase"
+      version = "45.0.0"
+    }
+    myext = {
+      source  = "pulumi/myext"
+      version = "2.0.0"
+    }
+  }
+}
+
+// An extension resource (Greeting) and a base-provider resource (Base) used
+// together; both live in the base provider's namespace ("extbase").
+resource "extbase_greeting" "greeting" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+resource "extbase_base" "base" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+output "parameterValue" {
+  value = extbase_greeting.greeting.parameter_value
+}
+output "baseValue" {
+  value = extbase_base.base.base_value
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-extension-and-base-resource/sdks/myext/hcl.sdk.json
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-extension-and-base-resource/sdks/myext/hcl.sdk.json
@@ -1,0 +1,13 @@
+{
+  "Name": "extbase",
+  "Kind": "resource",
+  "Version": "45.0.0",
+  "PluginDownloadURL": "",
+  "Checksums": null,
+  "Parameterization": null,
+  "ExtensionParameterization": {
+    "Name": "myext",
+    "Version": "2.0.0",
+    "Value": "SGVsbG8="
+  }
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-extension-parameterized-resource/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-extension-parameterized-resource/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-extension-parameterized-resource
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-extension-parameterized-resource/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-extension-parameterized-resource/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    myext = {
+      source  = "pulumi/myext"
+      version = "2.0.0"
+    }
+  }
+}
+
+data "extbase_greet" "invoke_0" {
+  name = "Pulumi"
+}
+
+// Extension parameterization: the SDK is published as "myext" but the resource
+// tokens live in the base provider's namespace ("extbase").
+resource "extbase_greeting" "greeting" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+resource "extbase_greeting_component" "greetingComp" {
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+output "parameterValue" {
+  value = extbase_greeting.greeting.parameter_value
+}
+output "parameterValueFromComponent" {
+  value = extbase_greeting_component.greetingComp.parameter_value
+}
+output "invokeGreeting" {
+  value = data.extbase_greet.invoke_0.greeting
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-extension-parameterized-resource/sdks/myext/hcl.sdk.json
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-extension-parameterized-resource/sdks/myext/hcl.sdk.json
@@ -1,0 +1,13 @@
+{
+  "Name": "extbase",
+  "Kind": "resource",
+  "Version": "45.0.0",
+  "PluginDownloadURL": "",
+  "Checksums": null,
+  "Parameterization": null,
+  "ExtensionParameterization": {
+    "Name": "myext",
+    "Version": "2.0.0",
+    "Value": "SGVsbG8="
+  }
+}

--- a/cmd/pulumi-language-hcl/testdata/sdks/extbase-45.0.0/hcl.sdk.json
+++ b/cmd/pulumi-language-hcl/testdata/sdks/extbase-45.0.0/hcl.sdk.json
@@ -1,0 +1,9 @@
+{
+  "Name": "extbase",
+  "Kind": "resource",
+  "Version": "45.0.0",
+  "PluginDownloadURL": "",
+  "Checksums": null,
+  "Parameterization": null,
+  "ExtensionParameterization": null
+}

--- a/cmd/pulumi-language-hcl/testdata/sdks/myext-2.0.0/hcl.sdk.json
+++ b/cmd/pulumi-language-hcl/testdata/sdks/myext-2.0.0/hcl.sdk.json
@@ -1,0 +1,13 @@
+{
+  "Name": "extbase",
+  "Kind": "resource",
+  "Version": "45.0.0",
+  "PluginDownloadURL": "",
+  "Checksums": null,
+  "Parameterization": null,
+  "ExtensionParameterization": {
+    "Name": "myext",
+    "Version": "2.0.0",
+    "Value": "SGVsbG8="
+  }
+}

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -2290,19 +2290,27 @@ func sortedKeys[V any](m map[string]V) []string {
 }
 
 // emitPackageBlock writes a PCL "package" block from a workspace.PackageDescriptor.
+// A replacement parameterization is labelled with the package alias; an
+// extension keeps the base provider's namespace and so is written label-less,
+// which is how PCL tells the two apart.
 func emitPackageBlock(out *hclwrite.Body, alias string, desc workspace.PackageDescriptor) {
-	if desc.Parameterization == nil {
+	param := desc.Parameterization
+	labels := []string{alias}
+	if desc.ExtensionParameterization != nil {
+		param, labels = desc.ExtensionParameterization, nil
+	}
+	if param == nil {
 		return
 	}
-	blk := out.AppendNewBlock("package", []string{alias})
+	blk := out.AppendNewBlock("package", labels)
 	blk.Body().SetAttributeValue("baseProviderName", cty.StringVal(desc.Name))
 	if desc.Version != nil {
 		blk.Body().SetAttributeValue("baseProviderVersion", cty.StringVal(desc.Version.String()))
 	}
 	paramBlk := blk.Body().AppendNewBlock("parameterization", nil)
-	paramBlk.Body().SetAttributeValue("name", cty.StringVal(desc.Parameterization.Name))
-	paramBlk.Body().SetAttributeValue("version", cty.StringVal(desc.Parameterization.Version.String()))
-	paramBlk.Body().SetAttributeValue("value", cty.StringVal(base64.StdEncoding.EncodeToString(desc.Parameterization.Value)))
+	paramBlk.Body().SetAttributeValue("name", cty.StringVal(param.Name))
+	paramBlk.Body().SetAttributeValue("version", cty.StringVal(param.Version.String()))
+	paramBlk.Body().SetAttributeValue("value", cty.StringVal(base64.StdEncoding.EncodeToString(param.Value)))
 	out.AppendNewline()
 }
 

--- a/pkg/hcl/packages/packages.go
+++ b/pkg/hcl/packages/packages.go
@@ -197,12 +197,48 @@ func ResolveResource(ctx context.Context, loader schema.ReferenceLoader, knownPr
 
 	res, err := findResource(pkg, knownProviders, token)
 	if err != nil {
+		if extPkg, ok := extensionReference(ctx, loader, knownProviders, token); ok {
+			if extRes, extErr := findResource(extPkg, knownProviders, token); extErr == nil {
+				res, err = extRes, nil
+			}
+		}
+	}
+	if err != nil {
 		return nil, err
 	}
 	if res != nil && res.IsProvider {
 		return nil, &ProviderAsResourceError{Token: res.Token}
 	}
 	return res, nil
+}
+
+// extensionAwareLoader is implemented by loaders that can supply the schema an
+// extension contributes to a base provider's namespace.
+type extensionAwareLoader interface {
+	LoadExtensionReference(ctx context.Context, baseName string) (schema.PackageReference, bool, error)
+}
+
+// extensionReference returns the extension schema for token's package, when the
+// loader knows of an extension applied to that base provider. An extension's
+// resources and functions share the base provider's namespace but are served
+// only via the extension parameterization, so a token missing from the base
+// schema may still be defined by an extension.
+func extensionReference(
+	ctx context.Context, loader schema.ReferenceLoader, knownProviders []string, token string,
+) (schema.PackageReference, bool) {
+	el, ok := loader.(extensionAwareLoader)
+	if !ok {
+		return nil, false
+	}
+	pkgName, err := PackageFromToken(knownProviders, token)
+	if err != nil {
+		return nil, false
+	}
+	ref, found, err := el.LoadExtensionReference(ctx, pkgName)
+	if err != nil || !found {
+		return nil, false
+	}
+	return ref, true
 }
 
 // resolvePackageForToken collapses package-load failures to ErrNotFound;
@@ -350,6 +386,40 @@ func (l *ParameterizationAwareLoader) enrich(descriptor *schema.PackageDescripto
 	}
 }
 
+// LoadExtensionReference loads the schema an extension contributes to baseName's
+// namespace, or (nil, false) when no extension applies. An extension's resource
+// tokens live in the base provider's namespace but are served only when the base
+// provider is parameterized with the extension, so the extension schema is loaded
+// by treating the extension as a parameterization of the base provider.
+func (l *ParameterizationAwareLoader) LoadExtensionReference(
+	ctx context.Context, baseName string,
+) (schema.PackageReference, bool, error) {
+	for _, desc := range l.aliases {
+		if desc.ExtensionParameterization == nil || desc.Name != baseName {
+			continue
+		}
+		var baseVersion *semver.Version
+		if desc.Version != nil {
+			v := *desc.Version
+			baseVersion = &v
+		}
+		ref, err := l.inner.LoadPackageReferenceV2(ctx, &schema.PackageDescriptor{
+			Name:    baseName,
+			Version: baseVersion,
+			Parameterization: &schema.ParameterizationDescriptor{
+				Name:    desc.ExtensionParameterization.Name,
+				Version: desc.ExtensionParameterization.Version,
+				Value:   desc.ExtensionParameterization.Value,
+			},
+		})
+		if err != nil {
+			return nil, false, err
+		}
+		return ref, true, nil
+	}
+	return nil, false, nil
+}
+
 func (l *ParameterizationAwareLoader) LoadPackage(pkg string, version *semver.Version) (*schema.Package, error) {
 	return l.LoadPackageV2(context.TODO(), &schema.PackageDescriptor{Name: pkg, Version: version})
 }
@@ -394,12 +464,6 @@ func ResolveFunction(ctx context.Context, loader schema.ReferenceLoader, knownPr
 	suffixParts := strings.Split(suffix, "_")
 
 	key := strings.ReplaceAll(suffix, "_", "")
-	for iter := pkg.Functions().Range(); iter.Next(); {
-		if tokenSearchKey(pkg, iter.Token()) == key {
-			return iter.Function()
-		}
-	}
-
 	// Allow omitting the "get" on Pulumi datasources. Try two placements:
 	// after the first segment (for `<mod>_<name>` HCL forms — e.g.
 	// "aws_iam_role" → "iamgetrole") and prepended to the whole suffix (for
@@ -410,11 +474,26 @@ func ResolveFunction(ctx context.Context, loader schema.ReferenceLoader, knownPr
 		suffixParts[0] + "get" + strings.Join(suffixParts[1:], ""),
 		"get" + strings.Join(suffixParts, ""),
 	}
-	for _, implicitGetKey := range implicitGetKeys {
-		for iter := pkg.Functions().Range(); iter.Next(); {
-			if tokenSearchKey(pkg, iter.Token()) == implicitGetKey {
-				return iter.Function()
+	search := func(pkg schema.PackageReference) (*schema.Function, bool) {
+		for _, k := range append([]string{key}, implicitGetKeys...) {
+			for iter := pkg.Functions().Range(); iter.Next(); {
+				if tokenSearchKey(pkg, iter.Token()) == k {
+					fn, err := iter.Function()
+					if err == nil {
+						return fn, true
+					}
+				}
 			}
+		}
+		return nil, false
+	}
+
+	if fn, ok := search(pkg); ok {
+		return fn, nil
+	}
+	if extPkg, ok := extensionReference(ctx, loader, knownProviders, token); ok {
+		if fn, ok := search(extPkg); ok {
+			return fn, nil
 		}
 	}
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1488,7 +1488,7 @@ func (e *Engine) registerResourceInstanceInContext(
 		opts.PluginDownloadURL = resSchema.PackageReference.PluginDownloadURL()
 	}
 
-	opts.PackageRef = e.packageRefForType(res.Type)
+	opts.PackageRef = e.packageRefForResource(res.Type, resSchema)
 
 	resourceName := e.extractModuleResourceName(res.Name, instance.Key, node.ModuleInfo, modInst)
 
@@ -2330,6 +2330,20 @@ func packageNameFromResourceType(token string) string {
 // packageRefForType returns the RegisterPackage ref for the given HCL resource type, or empty if none.
 func (e *Engine) packageRefForType(hclToken string) PackageRef {
 	return e.packageRefs[packageNameFromResourceType(hclToken)]
+}
+
+// packageRefForResource returns the registered package ref for a resource. An
+// extension resource's token lives in the base provider's namespace, but its
+// resolved schema names the extension package (e.g. "myext"), which is the one
+// registered as a parameterized package — using it lets the engine record the
+// resource's ExtensionRef.
+func (e *Engine) packageRefForResource(hclToken string, resSchema *schema.Resource) PackageRef {
+	if resSchema != nil && resSchema.PackageReference != nil {
+		if ref, ok := e.packageRefs[resSchema.PackageReference.Name()]; ok {
+			return ref
+		}
+	}
+	return e.packageRefForType(hclToken)
 }
 
 func knownProviders(tfBlock *ast.Terraform) []string {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -196,7 +196,8 @@ func (host *LanguageHost) GetRequiredPackages(
 		// parameterization that a `required_providers` entry alone lacks. Prefer
 		// it even for pulumi-sourced packages, whose parameterized form resolves
 		// to a base provider plus parameter rather than a plain dependency. The
-		// raw source it shadows must not also be installed.
+		// raw source it shadows must not also be installed. An extension package
+		// reports its base provider with the parameter in the extension slot.
 		info, ok := paramInfos[alias]
 		if !ok {
 			continue
@@ -206,11 +207,21 @@ func (host *LanguageHost) GetRequiredPackages(
 			Version:          versionString(info.Version),
 			Kind:             "resource",
 			Parameterization: parameterizationProto(info.Parameterization),
+			Extension:        parameterizationProto(info.ExtensionParameterization),
 		})
 		req := aliases[alias]
 		delete(tfSpecs, tfProviderSource(alias, req))
 		if req.IsPulumi() {
 			delete(pulumiPkgs, pulumiPackageName(alias, req.Source))
+		}
+		// An extension's resource tokens live in the base provider's namespace,
+		// so a program that uses only extension resources infers a bare
+		// terraform-provider requirement for the base. That base is served by
+		// the extension reported above, so drop the inferred spec. A base that
+		// is separately declared in required_providers (used directly by a base
+		// resource) stays in pulumiPkgs and is still reported.
+		if info.ExtensionParameterization != nil {
+			delete(tfSpecs, tfProviderSource(info.Name, aliases[info.Name]))
 		}
 	}
 
@@ -319,11 +330,28 @@ func missingNonPulumiSDKs(
 		if isBuiltinProvider(alias) || aliases[alias].IsPulumi() {
 			continue
 		}
-		if _, ok := sdks[alias]; !ok {
-			missing = append(missing, alias)
+		if _, ok := sdks[alias]; ok {
+			continue
 		}
+		// An extension resource's type namespace is its base provider name; the
+		// base is served by the extension's SDK, so it is not itself missing.
+		if isExtensionBase(sdks, alias) {
+			continue
+		}
+		missing = append(missing, alias)
 	}
 	return missing
+}
+
+// isExtensionBase reports whether name is the base provider of some extension
+// package described in sdks.
+func isExtensionBase(sdks map[string]workspace.PackageDescriptor, name string) bool {
+	for _, d := range sdks {
+		if d.ExtensionParameterization != nil && d.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func isBuiltinProvider(alias string) bool { return alias == "pulumi" || alias == "terraform" }
@@ -537,9 +565,12 @@ func (host *LanguageHost) Run(
 		}, nil
 	}
 
-	loader := schema.ReferenceLoader(schemaLoader)
+	// Cache the underlying loader, then wrap with the parameterization-aware
+	// loader so it stays the outermost layer — the resolver type-asserts it to
+	// discover extension schemas that a token's base package omits.
+	loader := schema.ReferenceLoader(schema.NewCachedLoader(schemaLoader))
 	if len(paramDescriptors) > 0 {
-		loader = packages.NewParameterizationAwareLoader(schemaLoader, paramDescriptors)
+		loader = packages.NewParameterizationAwareLoader(loader, paramDescriptors)
 	}
 
 	req.Parallel = max(req.Parallel, 1) // (req.Parallel <= 1) => serial
@@ -562,7 +593,7 @@ func (host *LanguageHost) Run(
 		Config:                  configMap,
 		DryRun:                  req.DryRun,
 		ResourceMonitor:         resmon,
-		SchemaLoader:            schema.NewCachedLoader(loader),
+		SchemaLoader:            loader,
 		ProviderInfoSource:      providerInfoSource,
 		WorkDir:                 req.Info.ProgramDirectory,
 		RootDir:                 req.Info.RootDirectory,
@@ -930,7 +961,7 @@ func (host *LanguageHost) GenerateProject(
 		if err := json.Unmarshal(data, &desc); err != nil {
 			continue
 		}
-		if desc.Parameterization == nil {
+		if desc.Parameterization == nil && desc.ExtensionParameterization == nil {
 			continue
 		}
 		sdkDir := filepath.Join(programDir, "sdks", alias)
@@ -1011,6 +1042,24 @@ func packageDescriptorFromSchema(schemaJSON []byte) (workspace.PackageDescriptor
 			Value:   spec.Parameterization.Parameter,
 		}
 		desc.Name = spec.Parameterization.BaseProvider.Name
+		desc.Version = &baseVersion
+	}
+
+	// An extension parameterizes a base provider without replacing it: its
+	// resource tokens live in the base provider's namespace, so the descriptor
+	// names the base provider and carries the extension in the extension slot.
+	if spec.ExtensionParameterization != nil {
+		baseVersion, err := semver.Parse(spec.ExtensionParameterization.BaseProvider.Version)
+		if err != nil {
+			return workspace.PackageDescriptor{}, fmt.Errorf(
+				"parsing base provider version %q: %w", spec.ExtensionParameterization.BaseProvider.Version, err)
+		}
+		desc.ExtensionParameterization = &workspace.Parameterization{
+			Name:    desc.Name,
+			Version: *desc.Version,
+			Value:   spec.ExtensionParameterization.Parameter,
+		}
+		desc.Name = spec.ExtensionParameterization.BaseProvider.Name
 		desc.Version = &baseVersion
 	}
 
@@ -1095,6 +1144,13 @@ func registerPackage(
 			Name:    pkg.Parameterization.Name,
 			Version: pkg.Parameterization.Version.String(),
 			Value:   pkg.Parameterization.Value,
+		}
+	}
+	if pkg.ExtensionParameterization != nil {
+		req.Extension = &pulumirpc.Parameterization{
+			Name:    pkg.ExtensionParameterization.Name,
+			Version: pkg.ExtensionParameterization.Version.String(),
+			Value:   pkg.ExtensionParameterization.Value,
 		}
 	}
 	resp, err := client.RegisterPackage(ctx, req)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -19,8 +19,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/run"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
@@ -694,4 +696,35 @@ data "terraform_remote_state" "rs" {
 		Version: run.TerraformStatePackageVersion,
 		Kind:    "resource",
 	}, resp.Packages[0])
+}
+
+// TestPackageDescriptorFromSchemaExtension verifies that an extension
+// parameterization in a package schema is read into the descriptor's extension
+// slot, naming the base provider (whose namespace the extension's tokens use).
+func TestPackageDescriptorFromSchemaExtension(t *testing.T) {
+	t.Parallel()
+
+	desc, err := packageDescriptorFromSchema([]byte(`{
+		"name": "myext",
+		"version": "2.0.0",
+		"extensionParameterization": {
+			"baseProvider": {"name": "extbase", "version": "45.0.0"},
+			"parameter": "SGVsbG8="
+		}
+	}`))
+	require.NoError(t, err)
+
+	baseVersion := semver.MustParse("45.0.0")
+	assert.Equal(t, workspace.PackageDescriptor{
+		PluginDescriptor: workspace.PluginDescriptor{
+			Name:    "extbase",
+			Kind:    apitype.ResourcePlugin,
+			Version: &baseVersion,
+		},
+		ExtensionParameterization: &workspace.Parameterization{
+			Name:    "myext",
+			Version: semver.MustParse("2.0.0"),
+			Value:   []byte("Hello"),
+		},
+	}, desc)
 }


### PR DESCRIPTION
An extension parameterizes a base provider without replacing it: the
extension's resource and function tokens live in the base provider's
namespace but are served only when the provider is parameterized with the
extension. Wire this through every layer:

- packageDescriptorFromSchema reads a schema's extensionParameterization
  into the descriptor's extension slot (naming the base provider).
- GetRequiredPackages reports the base provider with the extension in the
  extension slot, drops the bare terraform-provider requirement inferred
  for a base used only via extension tokens, and GenerateProject writes
  the extension SDK descriptor.
- The runtime resolves an extension token missing from the base schema by
  loading the extension schema (the parameterization-aware loader stays
  the outermost loader so the resolver can reach it), registers the
  extension package with its extension parameterization, and registers
  extension resources under it so the engine records their ExtensionRef.
- The converter ejects the extension as a label-less PCL package block.

Enable the l2-extension-and-base-resource and
l2-extension-parameterized-resource conformance tests.