### PR TITLE
Accept OpenSSH-format private keys in rsadecrypt

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-368.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-368.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Accept OpenSSH-format private keys in `rsadecrypt`
+time: 2026-07-15T12:30:00Z
+custom:
+    Component: runtime
+    PR: "368"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -24,11 +24,10 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
-	"crypto/x509"
+	"encoding/asn1"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -64,6 +63,7 @@ import (
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/crypto/ssh"
 	"golang.org/x/text/encoding/ianaindex"
 )
 
@@ -1877,24 +1877,24 @@ var rsaDecryptFunc = function.New(&function.Spec{
 			return cty.NilVal, fmt.Errorf("invalid base64 ciphertext: %w", err)
 		}
 
-		// Parse PEM-encoded private key
-		block, _ := pem.Decode([]byte(privateKeyPEM))
-		if block == nil {
-			return cty.NilVal, fmt.Errorf("invalid PEM-encoded private key")
-		}
-
-		// Parse the private key (supports PKCS1 and PKCS8)
-		var privKey *rsa.PrivateKey
-		if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
-			privKey = key
-		} else if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
-			var ok bool
-			privKey, ok = key.(*rsa.PrivateKey)
-			if !ok {
-				return cty.NilVal, fmt.Errorf("private key is not an RSA key")
+		// Parse the private key. ssh.ParseRawPrivateKey accepts PKCS#1,
+		// PKCS#8, SEC1, and OpenSSH-format PEM blocks.
+		rawKey, err := ssh.ParseRawPrivateKey([]byte(privateKeyPEM))
+		if err != nil {
+			var errStr string
+			switch e := err.(type) {
+			case asn1.SyntaxError:
+				errStr = strings.ReplaceAll(e.Error(), "asn1: syntax error", "invalid ASN1 data in the given private key")
+			case asn1.StructuralError:
+				errStr = strings.ReplaceAll(e.Error(), "asn1: structure error", "invalid ASN1 data in the given private key")
+			default:
+				errStr = fmt.Sprintf("invalid private key: %s", e)
 			}
-		} else {
-			return cty.NilVal, fmt.Errorf("failed to parse private key")
+			return cty.NilVal, errors.New(errStr)
+		}
+		privKey, ok := rawKey.(*rsa.PrivateKey)
+		if !ok {
+			return cty.NilVal, fmt.Errorf("invalid private key type %T", rawKey)
 		}
 
 		// Decrypt using PKCS1v15 (Terraform's default)

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
+	"golang.org/x/crypto/ssh"
 )
 
 func evalExpr(t *testing.T, baseDir, src string) cty.Value {
@@ -648,6 +649,51 @@ func TestRsaDecryptPKCS8(t *testing.T) {
 	}
 }
 
+func TestRsaDecryptOpenSSH(t *testing.T) {
+	t.Parallel()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA key: %v", err)
+	}
+
+	message := "openssh secret"
+
+	//nolint:staticcheck // SA1019: Using deprecated function for Terraform compatibility testing
+	ciphertext, err := rsa.EncryptPKCS1v15(rand.Reader, &privateKey.PublicKey, []byte(message))
+	if err != nil {
+		t.Fatalf("Failed to encrypt: %v", err)
+	}
+	ciphertextB64 := base64.StdEncoding.EncodeToString(ciphertext)
+
+	block, err := ssh.MarshalPrivateKey(privateKey, "")
+	if err != nil {
+		t.Fatalf("Failed to marshal OpenSSH key: %v", err)
+	}
+	pemStr := string(pem.EncodeToMemory(block))
+
+	ctx := &hcl.EvalContext{
+		Functions: Functions("/tmp"),
+		Variables: map[string]cty.Value{
+			"ciphertext": cty.StringVal(ciphertextB64),
+			"privatekey": cty.StringVal(pemStr),
+		},
+	}
+
+	expr, diags := hclsyntax.ParseExpression([]byte(`rsadecrypt(ciphertext, privatekey)`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		t.Fatalf("Failed to parse expression: %s", diags.Error())
+	}
+
+	result, diags := expr.Value(ctx)
+	if diags.HasErrors() {
+		t.Fatalf("Failed to evaluate rsadecrypt with OpenSSH key: %s", diags.Error())
+	}
+
+	if result.AsString() != message {
+		t.Errorf("Expected %q, got %q", message, result.AsString())
+	}
+}
+
 func TestRsaDecryptErrors(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -666,7 +712,7 @@ func TestRsaDecryptErrors(t *testing.T) {
 			name:       "invalid pem",
 			ciphertext: "aGVsbG8=",
 			privatekey: "not a pem key",
-			errContain: "invalid PEM",
+			errContain: "invalid private key",
 		},
 	}
 

--- a/tests/tfcompat/l1_rsadecrypt_openssh_test.go
+++ b/tests/tfcompat/l1_rsadecrypt_openssh_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// rsadecrypt should accept an OpenSSH-format RSA private key, as OpenTofu does
+// via ssh.ParseRawPrivateKey. pulumi-hcl only parses PKCS#1/PKCS#8 keys, so it
+// fails to parse the key and errors instead of decrypting.
+func TestL1RsadecryptOpenssh(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_rsadecrypt_openssh", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_rsadecrypt_openssh/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_rsadecrypt_openssh/main.tf
@@ -1,0 +1,41 @@
+# `rsadecrypt` decrypts a base64-encoded RSA-PKCS1v15 ciphertext with the
+# given PEM private key. OpenTofu parses the key via ssh.ParseRawPrivateKey,
+# which accepts the OpenSSH private-key format ("BEGIN OPENSSH PRIVATE KEY")
+# in addition to PKCS#1 and PKCS#8. The ciphertext below was produced by
+# encrypting "hello-rsadecrypt" with the matching RSA public key.
+locals {
+  ciphertext = "BQVXU38vaY5d1Unt31rC8i/jN3EgZndLwutYcy0ZXNwJdHE5DGjyw5feoWg5CX23LHirFkNraDslnIbUcudMxSkXr9eBf1GDZwpoAkS+cQ0YSRULFE1l9noiaK9UGpkcMNMu2AyzPUEMzjBlKDlbAYD+/t1SNR1aqvMYfp3MXxBwiy+ylg4ZG1Y/viIrJJP8mQgaNr48IJNfkG4+bMT+z2eXpyfAiWZY1pTbg84GqHXJCUk3qxeCnIBI1skbOk1cGbneIGrTL8xGt2QZ4sap2DjurEPON+7w7XmQ2AvU829ogH9Zs/dlEkZTQacGh+sFR+gu2N4HmYUzOtC462I2wQ=="
+  private_key = <<-EOT
+  -----BEGIN OPENSSH PRIVATE KEY-----
+  b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
+  NhAAAAAwEAAQAAAQEAuQ2nEhILwjrgAr/0fNViWHqTfzuBBsjvqG99RR7at2PEnQqv67Bm
+  SpYK4n/Gd3T9+/b1NA41QP8yiN+q++aHjS5iQw01s4XxX8b75yPSjwKSQUYRLqB45E0YS4
+  1wr/N93URfMArWHluEdiEyX47RbdE6AIRajVFJ70GU2t9bmo1w3j584ahdS/2cr8Db+wRn
+  CB+iJyXwN4OCfb15QKH82POs7AhpHWy9+Gd7SCsJLQjg72uP9mrnU2HryHkbOTLRUEsP7+
+  OwvGFF9N/2PBQQSu91M2lU0hdogSrcvjmn5MDxd34DtMB8ISxsh2BVfv7Gdc6iUq3z0T3K
+  Z0HmgPUx9wAAA9DoGo2U6BqNlAAAAAdzc2gtcnNhAAABAQC5DacSEgvCOuACv/R81WJYep
+  N/O4EGyO+ob31FHtq3Y8SdCq/rsGZKlgrif8Z3dP379vU0DjVA/zKI36r75oeNLmJDDTWz
+  hfFfxvvnI9KPApJBRhEuoHjkTRhLjXCv833dRF8wCtYeW4R2ITJfjtFt0ToAhFqNUUnvQZ
+  Ta31uajXDePnzhqF1L/ZyvwNv7BGcIH6InJfA3g4J9vXlAofzY86zsCGkdbL34Z3tIKwkt
+  CODva4/2audTYevIeRs5MtFQSw/v47C8YUX03/Y8FBBK73UzaVTSF2iBKty+OafkwPF3fg
+  O0wHwhLGyHYFV+/sZ1zqJSrfPRPcpnQeaA9TH3AAAAAwEAAQAAAQABMFJDbnQ+4ivwOJV0
+  e9Zu5RKvfY1dosrPVTAD0qfrB6wKqjfpFrABiKc3P0TiHZFIHhUDKZgz+6+ya2VoytlSEd
+  s1vQ78QT8Es32IxZUjsAuKec3Ac+1y4f/m9Fil+LV1R2wpHdi0Rzg5ngr5zCwSPYbW3ALM
+  55nG/K/dHBQ1kPI9viqgsDBoff2P3/8HZWNhggiXMFXGZ748jgZZFmibcix4tWLV5+eAvg
+  7/WsoK8qNdz9kQ4rfhSaeYBe8vkEFjhSWDXacsPz9LreP6HCR3xpzOpR9N/2ZGtppiQ9SN
+  SbFMFZ9EeUS/d+Wzdfq5vSX2X9nsuwDRbhv2EYmbPcfpAAAAgDez0GCF/gmw1tuL4EgPLH
+  uwvQmUH8tYgUBtXJesGLA1YUJdRkBUDKaOZj+LPY0MI1dT328br1TIxK8sYGbfjGTrmNwk
+  Q2Ga4geoppqE/LkuEUDu5pPeXOoH+7BwKN3KtQ3/L8jZI3jUKvBwAbyQn/auslqnlAkYtx
+  9jITJ0tOQOAAAAgQDcH7swgrButn+rdyRVIfS1xP8qBguHR1vvzcYSJM7jAWfdUN11Ob+W
+  1AOhE3i2pZg36duVS+WkzX0BX3POXaB6wFRVyysm/N9JewyEy+T/gut184zJt8Gt2HtCX1
+  4IWVth+/2sNexdjMEgP5FiLFlaGVdgh1Xxylr/VDddp0NOewAAAIEA1zap/WjPIdstpK90
+  c8JPEWbAVVVxYwPn8V23nSi+AP/P9zPhpxghC/5ZEK5xBD9F52FAZT3OXxlU36kn1V9Bfj
+  lKnxOX+4TghB8cA2BNHjVrn5/6+k7PLYRGWMdRF98pnP7lEYImrtqQSaFj0NV1kSLP2qz7
+  2ti3YcTndr4Yj7UAAAAWaWFud2FoYmVATWFjLmZyaXR6LmJveAECAwQF
+  -----END OPENSSH PRIVATE KEY-----
+  EOT
+}
+
+output "decrypted" {
+  value = rsadecrypt(local.ciphertext, local.private_key)
+}


### PR DESCRIPTION
## Divergence

`rsadecrypt(ciphertext, key)` diverged from OpenTofu when the private key was in **OpenSSH format** (`-----BEGIN OPENSSH PRIVATE KEY-----`):

- **OpenTofu**: parses the key with `golang.org/x/crypto/ssh.ParseRawPrivateKey` (handles OpenSSH, PKCS#1, PKCS#8, SEC1) and decrypts.
- **pulumi-hcl**: `rsaDecryptFunc` (`pkg/hcl/eval/functions.go`) only tried `x509.ParsePKCS1PrivateKey` / `x509.ParsePKCS8PrivateKey`, so it errored: `Call to function "rsadecrypt" failed: failed to parse private key.`

This blocked migration of configs that hold OpenSSH-format keys.

## Fix

Parse the private key with `ssh.ParseRawPrivateKey`, which accepts PKCS#1, PKCS#8, SEC1, and OpenSSH PEM blocks, and align the parse-error messages accordingly. The base64 decode and PKCS1v15 decryption are unchanged.

## Test

- `TestL1RsadecryptOpenssh` (tfcompat) — fixture embeds a 2048-bit OpenSSH-format RSA private key and the base64 PKCS1v15 ciphertext of `"hello-rsadecrypt"`. Fails on `master`, passes with this fix.
- `TestRsaDecryptOpenSSH` (unit) — round-trips a freshly generated key through OpenSSH format alongside the existing PKCS#1 / PKCS#8 unit tests.
- The invalid-key error assertion in `TestRsaDecryptErrors` is updated to the new parse-error message.
