### PR TITLE
Support plantimestamp()

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-369.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-369.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Support `plantimestamp()`, returning the current time (Pulumi has no plan/apply split)
+time: 2026-07-15T13:00:00Z
+custom:
+    Component: runtime
+    PR: "369"

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -804,7 +804,6 @@ These Terraform functions have no equivalent:
 
 | Function          | Reason                                        |
 |-------------------|-----------------------------------------------|
-| `plantimestamp`   | No Pulumi equivalent for plan-time timestamps |
 | `ephemeralasnull` | Pulumi has no ephemeral value concept         |
 
 ## Stack References

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -33,7 +33,6 @@ Pulumi HCL supports nearly all of Terraform's built-in functions with identical 
 
 | Function          | Category        | Notes                                                                         |
 |-------------------|-----------------|-------------------------------------------------------------------------------|
-| `plantimestamp`   | Date and Time   | Returns the timestamp at the start of a plan, which has no Pulumi equivalent. |
 | `ephemeralasnull` | Type Conversion | Replaces ephemeral values with `null`; Pulumi has no ephemeral value concept. |
 
 The `provider::terraform::*` provider functions and `terraform.applying` are Terraform-internal and have no equivalent here.

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -177,6 +177,9 @@ func Functions(baseDir string) map[string]function.Function {
 		"timeadd":    timeAddFunc,
 		"timecmp":    timeCmpFunc,
 		"timestamp":  timestampFunc,
+		// Pulumi has no plan/apply split, so there is no distinct plan-time
+		// clock: plantimestamp resolves to the current time like timestamp.
+		"plantimestamp": timestampFunc,
 
 		// Hash and crypto functions
 		"base64sha256":     base64Sha256Func,

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -1080,6 +1080,15 @@ func TestDateTimeFunctions(t *testing.T) {
 			},
 		},
 		{
+			"plantimestamp format",
+			`plantimestamp()`,
+			func(v cty.Value) bool {
+				// Resolves to the current time in RFC3339 format.
+				s := v.AsString()
+				return len(s) > 0 && s[4] == '-' && s[10] == 'T'
+			},
+		},
+		{
 			"timeadd",
 			`timeadd("2023-01-01T00:00:00Z", "24h")`,
 			is(cty.StringVal("2023-01-02T00:00:00Z")),

--- a/tests/tfcompat/l1_plantimestamp_test.go
+++ b/tests/tfcompat/l1_plantimestamp_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1PlanTimestamp exercises the `plantimestamp` built-in. OpenTofu evaluates
+// it to the plan-time RFC3339 timestamp; the outputs derive deterministic facts
+// from that value so both runtimes can be compared.
+func TestL1PlanTimestamp(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_plantimestamp", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_plantimestamp/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_plantimestamp/main.tf
@@ -1,0 +1,15 @@
+# `plantimestamp` returns the plan-time RFC3339 timestamp. Its value is
+# nondeterministic, so the outputs derive deterministic facts from it: the
+# RFC3339 second-precision string is always 20 characters, and the year is a
+# number greater than 2000.
+locals {
+  now = plantimestamp()
+}
+
+output "len" {
+  value = length(local.now)
+}
+
+output "year_gt_2000" {
+  value = tonumber(formatdate("YYYY", local.now)) > 2000
+}


### PR DESCRIPTION
## Gap

`plantimestamp()` is an OpenTofu built-in returning a plan-time RFC3339 timestamp. It was not registered in `pkg/hcl/eval/functions.go`, so evaluating it failed: `Call to unknown function; There is no function named "plantimestamp".`

## Fix

Register `plantimestamp` as an alias of the existing `timestamp` function, returning the current UTC RFC3339 time. Pulumi has no plan/apply separation, so there is no distinct plan-time clock — the current time is the correct equivalent. `plantimestamp` is dropped from the unsupported-function tables in `docs/language-reference.md` and `docs/terraform-compatibility.md`.

## Test

- `TestL1PlanTimestamp` (tfcompat) — derives deterministic, comparable outputs from the nondeterministic timestamp (`length(plantimestamp()) == 20`, `tonumber(formatdate("YYYY", plantimestamp())) > 2000`), so pulumi-hcl matches OpenTofu's outputs exactly. Fails on `master`, passes with this fix.
- `plantimestamp format` (unit) — added alongside the existing `timestamp format` case, asserting an RFC3339 result.
