### PR TITLE
Honor lifecycle attribute paths that index a MaxItems=1 block

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-370.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-370.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Honor lifecycle attribute paths that index a `MaxItems=1` block (e.g. `ignore_changes = [settings[0].mode]`)
+time: 2026-07-15T12:00:00Z
+custom:
+    Component: runtime
+    PR: "370"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2420,21 +2420,33 @@ func translateAttrPathTraversal(
 	}
 	segments := make([]property.GlobSegment, 0, len(traversal))
 	resolver := attrPathNameResolver{mapping: mapping, props: props}
+	prevSingularBlock := false
 	for _, step := range traversal {
 		switch s := step.(type) {
 		case hcl.TraverseRoot:
-			name, err := resolver.next(s.Name)
+			name, singularBlock, err := resolver.next(s.Name)
 			if err != nil {
 				return property.Glob{}, err
 			}
 			segments = append(segments, property.NewSegment(name))
+			prevSingularBlock = singularBlock
 		case hcl.TraverseAttr:
-			name, err := resolver.next(s.Name)
+			name, singularBlock, err := resolver.next(s.Name)
 			if err != nil {
 				return property.Glob{}, err
 			}
 			segments = append(segments, property.NewSegment(name))
+			prevSingularBlock = singularBlock
 		case hcl.TraverseIndex:
+			// The bridge flattens a MaxItems=1 block to a single object, so the
+			// TF list index addressing it (settings[0]) has no Pulumi
+			// counterpart: the flattened object property already stands in for
+			// the sole element, and the index is dropped so the translated path
+			// (settings.mode) matches.
+			if prevSingularBlock {
+				prevSingularBlock = false
+				continue
+			}
 			// Index segments are dynamic map keys or list indices, not schema
 			// properties: they are emitted verbatim and not validated (the
 			// preceding attribute already advanced the resolver past the
@@ -2479,7 +2491,8 @@ func translateSecretOutputName(
 		return "", fmt.Errorf("invalid additional_secret_outputs entry: expected a property name")
 	}
 	resolver := attrPathNameResolver{mapping: mapping, props: props}
-	return resolver.next(name)
+	pulumiName, _, err := resolver.next(name)
+	return pulumiName, err
 }
 
 // formatAttrTraversal renders an attribute-path traversal as a dotted/bracketed
@@ -2517,26 +2530,29 @@ type attrPathNameResolver struct {
 }
 
 // next translates one TF (snake_case) attribute-name segment to its Pulumi name
-// and advances the resolver into the nested schema for the following segment.
-func (r *attrPathNameResolver) next(tfName string) (string, error) {
+// and advances the resolver into the nested schema for the following segment. It
+// reports whether the resolved field is a MaxItems=1 block flattened to a single
+// Pulumi object, so the caller can drop the TF list index that follows it.
+func (r *attrPathNameResolver) next(tfName string) (name string, singularBlock bool, err error) {
 	if fm := r.mapping.Lookup(tfName); fm != nil {
 		if fm.Nested != nil {
 			r.mapping, r.props = fm.Nested, nil
 		} else {
 			r.mapping, r.props = nil, nil
 		}
-		return fm.PulumiName, nil
+		return fm.PulumiName, fm.TFBlock && fm.MaxItemsOne, nil
 	}
 	pulumiName, prop := transform.PulumiCaseFromSnakeCase(tfName, r.props)
 	if prop != nil {
 		r.mapping, r.props = nil, objectProperties(prop.Type)
-		return pulumiName, nil
+		_, isObject := codegen.UnwrapType(prop.Type).(*schema.ObjectType)
+		return pulumiName, isObject, nil
 	}
 	if r.mapping != nil || len(r.props) > 0 {
-		return "", fmt.Errorf("unknown property %q", tfName)
+		return "", false, fmt.Errorf("unknown property %q", tfName)
 	}
 	r.mapping, r.props = nil, nil
-	return tfName, nil
+	return tfName, false, nil
 }
 
 // objectProperties returns the nested properties of an object-typed schema,

--- a/tests/tfcompat/l2_ignore_changes_nested_block_test.go
+++ b/tests/tfcompat/l2_ignore_changes_nested_block_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2IgnoreChangesNestedBlock exercises `ignore_changes` on an attribute
+// inside a MaxItems=1 nested block. In TF the block is list-shaped, so the
+// path is written `settings[0].mode`; the bridge flattens the block to a
+// single Pulumi object (`settings.mode`), so the list index must be dropped
+// when translating the ignore_changes path. Stage 1 changes only the ignored
+// attribute, so OpenTofu plans no update and the stored value stays "a".
+func TestL2IgnoreChangesNestedBlock(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_ignore_changes_nested_block", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "blocky", Factory: providers.BlockyProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_ignore_changes_nested_block/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ignore_changes_nested_block/0/main.tf
@@ -1,0 +1,17 @@
+# Stage 0: create with settings.mode = "a". `settings` is a MaxItems=1 nested
+# block, so in TF it is addressed with list-index notation (settings[0].mode).
+resource "blocky_thing" "t" {
+  name = "thing"
+  settings {
+    mode    = "a"
+    verbose = false
+  }
+
+  lifecycle {
+    ignore_changes = [settings[0].mode]
+  }
+}
+
+output "mode" {
+  value = blocky_thing.t.settings[0].mode
+}

--- a/tests/tfcompat/testdata/cases/l2_ignore_changes_nested_block/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ignore_changes_nested_block/1/main.tf
@@ -1,0 +1,18 @@
+# Stage 1: settings.mode changes "a" -> "b". Nothing else changes, and the only
+# changed attribute is covered by ignore_changes, so OpenTofu plans no update and
+# the stored mode stays "a". pulumi-hcl must ignore the same path.
+resource "blocky_thing" "t" {
+  name = "thing"
+  settings {
+    mode    = "b"
+    verbose = false
+  }
+
+  lifecycle {
+    ignore_changes = [settings[0].mode]
+  }
+}
+
+output "mode" {
+  value = blocky_thing.t.settings[0].mode
+}


### PR DESCRIPTION
## Divergence

`lifecycle { ignore_changes = [settings[0].mode] }` where `settings` is a `MaxItems=1` nested block (list-shaped in TF, so the attribute path is written `settings[0].mode`):

- **Expected**: the ignore is honored — the changed attribute is not applied; `mode` stays `"a"`.
- **Before this fix**: pulumi-hcl applied the change anyway; `mode` became `"b"`.

## Root cause

`translateAttrPathTraversal` (`pkg/hcl/run/run.go`) turns a TF attribute path into the glob the engine matches lifecycle options against. The bridge flattens a `MaxItems=1` block to a single object (`settings.mode`), but the translator emitted the TF list index `[0]` verbatim — producing `settings[0].mode`, which never matched, so the option was silently dropped.

## The fix

`next` now reports whether the segment it resolved is a flattened `MaxItems=1` block; the traversal loop drops the list index that immediately follows one (`settings[0].mode` → `settings.mode`). A plural block stays list-shaped in Pulumi, so its `[0]` is preserved. The fix covers `ignore_changes`, `replace_on_changes`, and `hide_diffs`, which all share this translator.

## Test

`TestL2IgnoreChangesNestedBlock` — two stages: create with `mode = "a"`, then change to `mode = "b"` under `ignore_changes`. Uses `providers.BlockyProvider` (`settings` is `TypeList MaxItems=1`). Stack output is now `mode=a`.
