### PR TITLE
Failing test: numbers above float64 max collapse to +Inf

### DIFF
--- a/tests/tfcompat/l1_number_overflow_test.go
+++ b/tests/tfcompat/l1_number_overflow_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1NumberOverflow checks that a numeric value exceeding the float64 range
+// keeps its finite arbitrary-precision value. OpenTofu evaluates 1e400 (and
+// 1e308*100) to a finite cty big.Float; pulumi-hcl must not collapse it to
+// +Infinity when serializing the stack output.
+func TestL1NumberOverflow(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_number_overflow", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_number_overflow/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_number_overflow/main.tf
@@ -1,0 +1,14 @@
+# A numeric literal larger than the largest finite float64 (~1.8e308).
+# OpenTofu keeps numbers as arbitrary-precision cty big.Float values, so this
+# evaluates to the finite integer 10^400 and is stored as such. pulumi-hcl
+# collapses every number to float64 when producing a stack output, so the same
+# literal overflows to IEEE-754 +Infinity instead of the finite value.
+output "overflow_literal" {
+  value = 1e400
+}
+
+# The same divergence reached through the multiplication operator: 1e308 * 100
+# is finite in big.Float (1e310) but overflows float64.
+output "overflow_mul" {
+  value = 1e308 * 100
+}


### PR DESCRIPTION
## Divergence

A numeric value exceeding the largest finite `float64` (~1.8e308):

- **OpenTofu**: numbers are arbitrary-precision `big.Float`, so `1e400` evaluates to the finite integer 10^400 and `1e308 * 100` to 1e310, each output in full decimal.
- **pulumi-hcl**: collapses every `cty.Number` to `float64` when producing a stack output, so both overflow to IEEE-754 **+Infinity** (`0x7ff0000000000000`, Pulumi's special-value sentinel).

Direction: OpenTofu succeeds with a finite value / pulumi-hcl produces the wrong value (+Inf).

## Test

`TestL1NumberOverflow` — outputs a huge integer literal and a multiplication overflow. tofu emits the 401-/311-digit finite integers; pulumi emits the +Inf sentinel.

This is a *category* difference (finite → infinity) that survives float64 normalization, unlike ordinary sub-16-digit precision loss which is unobservable on both harness paths.

**This PR is intentionally failing CI** — it adds only the failing test that proves the bug.