### PR TITLE
Record count/for_each references as resource dependencies (destroy order)

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-372.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-372.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Record a dependency for a resource referenced only through `count` or `for_each`, so destroy order is honored
+time: 2026-07-15T12:00:00Z
+custom:
+    Component: runtime
+    PR: "372"

--- a/pkg/hcl/eval/evaluator.go
+++ b/pkg/hcl/eval/evaluator.go
@@ -123,43 +123,46 @@ func SensitiveArgumentDiagnostic(argName string, expr hcl.Expression) *hcl.Diagn
 }
 
 // EvaluateCount evaluates a count expression and returns
-// (count, isBool, unknown, diags). isBool is true when the expression
+// (count, isBool, unknown, deps, diags). isBool is true when the expression
 // evaluated to a boolean (true→1, false→0), which suppresses the numeric
 // index suffix on resource names. unknown is true when the expression reads
 // values the current operation has not yet produced, so the number of
-// instances cannot be determined.
-// Returns (1, false, false, nil) if expr is nil (no count specified).
-func (e *Evaluator) EvaluateCount(expr hcl.Expression) (int, bool, bool, hcl.Diagnostics) {
+// instances cannot be determined. deps holds the URNs of the resources the
+// expression references — even though count itself is not applied, a
+// reference in it establishes a dependency, as in TF.
+// Returns (1, false, false, nil, nil) if expr is nil (no count specified).
+func (e *Evaluator) EvaluateCount(expr hcl.Expression) (count int, isBool bool, unknown bool, deps []string, diags hcl.Diagnostics) {
 	if expr == nil {
-		return 1, false, false, nil
+		return 1, false, false, nil, nil
 	}
 
 	val, diags := e.Evaluate(expr)
 	if diags.HasErrors() {
-		return 0, false, false, diags
+		return 0, false, false, nil, diags
 	}
+	deps = CollectDepURNs(val)
 
 	if val.HasMark(SensitiveMark) {
-		return 0, false, false, hcl.Diagnostics{SensitiveArgumentDiagnostic("count", expr)}
+		return 0, false, false, deps, hcl.Diagnostics{SensitiveArgumentDiagnostic("count", expr)}
 	}
 
-	// Count never flows into deps, so drop marks; AsBigFloat / True panic on them.
+	// Count never flows into inputs, so drop marks; AsBigFloat / True panic on them.
 	val, _ = val.Unmark()
 
 	if !val.IsKnown() {
-		return 0, false, true, nil
+		return 0, false, true, deps, nil
 	}
 
 	if val.Type() == cty.Bool {
 		if val.True() {
-			return 1, true, false, nil
+			return 1, true, false, deps, nil
 		}
-		return 0, true, false, nil
+		return 0, true, false, deps, nil
 	}
 
 	converted, err := convert.Convert(val, cty.Number)
 	if err != nil {
-		return 0, false, false, hcl.Diagnostics{{
+		return 0, false, false, deps, hcl.Diagnostics{{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid count value",
 			Detail:   fmt.Sprintf("Count must be a number or boolean, got %s.", val.Type().FriendlyName()),
@@ -168,10 +171,10 @@ func (e *Evaluator) EvaluateCount(expr hcl.Expression) (int, bool, bool, hcl.Dia
 	}
 	bf := converted.AsBigFloat()
 	i64, _ := bf.Int64()
-	count := int(i64)
+	count = int(i64)
 
 	if count < 0 {
-		return 0, false, false, hcl.Diagnostics{{
+		return 0, false, false, deps, hcl.Diagnostics{{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid count value",
 			Detail:   "Count must be a non-negative integer.",
@@ -179,28 +182,30 @@ func (e *Evaluator) EvaluateCount(expr hcl.Expression) (int, bool, bool, hcl.Dia
 		}}
 	}
 
-	return count, false, false, nil
+	return count, false, false, deps, nil
 }
 
 // EvaluateForEach evaluates a for_each expression and returns
-// (result, unknown, diags). unknown is true when the collection — or, for a
-// set, any of its elements, since those become instance keys — reads values
+// (result, unknown, deps, diags). unknown is true when the collection — or, for
+// a set, any of its elements, since those become instance keys — reads values
 // the current operation has not yet produced, so the instances cannot be
 // enumerated. Map and object values may be unknown as long as their keys are
-// known.
+// known. deps holds the URNs of the resources the expression references, so a
+// reference in for_each establishes a dependency, as in TF.
 // Returns a nil map if expr is nil (no for_each specified).
-func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (map[string]cty.Value, bool, hcl.Diagnostics) {
+func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (result map[string]cty.Value, unknown bool, deps []string, diags hcl.Diagnostics) {
 	if expr == nil {
-		return nil, false, nil
+		return nil, false, nil, nil
 	}
 
 	val, diags := e.Evaluate(expr)
 	if diags.HasErrors() {
-		return nil, false, diags
+		return nil, false, nil, diags
 	}
+	deps = CollectDepURNs(val)
 
 	if val.HasMark(SensitiveMark) {
-		return nil, false, hcl.Diagnostics{SensitiveArgumentDiagnostic("for_each", expr)}
+		return nil, false, deps, hcl.Diagnostics{SensitiveArgumentDiagnostic("for_each", expr)}
 	}
 
 	// Unmark only the container — per-element DepMarks must survive on the
@@ -208,7 +213,7 @@ func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (map[string]cty.Value, 
 	val, _ = val.Unmark()
 
 	if !val.IsKnown() {
-		return nil, true, nil
+		return nil, true, deps, nil
 	}
 
 	if val.IsNull() {
@@ -218,11 +223,11 @@ func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (map[string]cty.Value, 
 			Detail:   "for_each cannot be null.",
 			Subject:  expr.Range().Ptr(),
 		})
-		return nil, false, diags
+		return nil, false, deps, diags
 	}
 
 	ty := val.Type()
-	result := make(map[string]cty.Value)
+	result = make(map[string]cty.Value)
 
 	switch {
 	case ty.IsMapType() || ty.IsObjectType():
@@ -241,10 +246,10 @@ func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (map[string]cty.Value, 
 				Detail:   "for_each set must contain strings.",
 				Subject:  expr.Range().Ptr(),
 			})
-			return nil, false, diags
+			return nil, false, deps, diags
 		}
 		if !val.IsWhollyKnown() {
-			return nil, true, nil
+			return nil, true, deps, nil
 		}
 		for it := val.ElementIterator(); it.Next(); {
 			_, v := it.Element()
@@ -258,10 +263,10 @@ func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (map[string]cty.Value, 
 			Detail:   fmt.Sprintf("for_each must be a map or set, not %s.", ty.FriendlyName()),
 			Subject:  expr.Range().Ptr(),
 		})
-		return nil, false, diags
+		return nil, false, deps, diags
 	}
 
-	return result, false, diags
+	return result, false, deps, diags
 }
 
 // GetReferencedVariables returns all variables referenced by an expression.

--- a/pkg/hcl/eval/evaluator_test.go
+++ b/pkg/hcl/eval/evaluator_test.go
@@ -92,7 +92,7 @@ func TestEvaluateCount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			expr := parseExpr(t, tt.expr)
-			result, isBool, unknown, diags := eval.EvaluateCount(expr)
+			result, isBool, unknown, _, diags := eval.EvaluateCount(expr)
 			if tt.expectErr {
 				if !diags.HasErrors() {
 					t.Error("Expected error, got none")
@@ -126,7 +126,7 @@ func TestEvaluateCount_MarkedKnownValue(t *testing.T) {
 	))
 	eval := NewEvaluator(ctx)
 
-	result, isBool, unknown, diags := eval.EvaluateCount(parseExpr(t, `var.n`))
+	result, isBool, unknown, _, diags := eval.EvaluateCount(parseExpr(t, `var.n`))
 	require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
 	assert.Equal(t, 3, result)
 	assert.False(t, isBool)
@@ -144,7 +144,7 @@ func TestEvaluateForEach_MarkedContainer(t *testing.T) {
 	}).WithMarks(cty.NewValueMarks(DepMark("urn:pulumi:dev::p::aws:ec2/vpc:Vpc::test"))))
 	eval := NewEvaluator(ctx)
 
-	result, unknown, diags := eval.EvaluateForEach(parseExpr(t, `var.m`))
+	result, unknown, _, diags := eval.EvaluateForEach(parseExpr(t, `var.m`))
 	require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
 	assert.False(t, unknown)
 	assert.Equal(t, map[string]cty.Value{
@@ -158,7 +158,7 @@ func TestEvaluateCountNil(t *testing.T) {
 	require.NoError(t, err)
 	eval := NewEvaluator(ctx)
 
-	result, isBool, unknown, diags := eval.EvaluateCount(nil)
+	result, isBool, unknown, _, diags := eval.EvaluateCount(nil)
 	if diags.HasErrors() {
 		t.Errorf("Unexpected error: %s", diags.Error())
 	}
@@ -182,7 +182,7 @@ func TestEvaluateForEach(t *testing.T) {
 	t.Run("map", func(t *testing.T) {
 		t.Parallel()
 		expr := parseExpr(t, `{a = "x", b = "y"}`)
-		result, unknown, diags := eval.EvaluateForEach(expr)
+		result, unknown, _, diags := eval.EvaluateForEach(expr)
 		if diags.HasErrors() {
 			t.Errorf("Unexpected error: %s", diags.Error())
 		}
@@ -198,7 +198,7 @@ func TestEvaluateForEach(t *testing.T) {
 	t.Run("set of strings", func(t *testing.T) {
 		t.Parallel()
 		expr := parseExpr(t, `toset(["a", "b", "c"])`)
-		result, unknown, diags := eval.EvaluateForEach(expr)
+		result, unknown, _, diags := eval.EvaluateForEach(expr)
 		if diags.HasErrors() {
 			t.Errorf("Unexpected error: %s", diags.Error())
 		}
@@ -210,7 +210,7 @@ func TestEvaluateForEach(t *testing.T) {
 
 	t.Run("nil returns nil", func(t *testing.T) {
 		t.Parallel()
-		result, unknown, diags := eval.EvaluateForEach(nil)
+		result, unknown, _, diags := eval.EvaluateForEach(nil)
 		if diags.HasErrors() {
 			t.Errorf("Unexpected error: %s", diags.Error())
 		}
@@ -223,7 +223,7 @@ func TestEvaluateForEach(t *testing.T) {
 	t.Run("list rejected", func(t *testing.T) {
 		t.Parallel()
 		expr := parseExpr(t, `["a", "b"]`)
-		_, _, diags := eval.EvaluateForEach(expr)
+		_, _, _, diags := eval.EvaluateForEach(expr)
 		if !diags.HasErrors() {
 			t.Error("Expected error for list for_each, got none")
 		}
@@ -235,7 +235,7 @@ func TestEvaluateForEach(t *testing.T) {
 		require.NoError(t, err)
 		unknownCtx.SetVariable("m", cty.UnknownVal(cty.Map(cty.String)))
 
-		result, unknown, diags := NewEvaluator(unknownCtx).EvaluateForEach(parseExpr(t, `var.m`))
+		result, unknown, _, diags := NewEvaluator(unknownCtx).EvaluateForEach(parseExpr(t, `var.m`))
 		require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
 		assert.True(t, unknown)
 		assert.Nil(t, result)
@@ -247,7 +247,7 @@ func TestEvaluateForEach(t *testing.T) {
 		require.NoError(t, err)
 		unknownCtx.SetVariable("s", cty.UnknownVal(cty.String))
 
-		result, unknown, diags := NewEvaluator(unknownCtx).EvaluateForEach(parseExpr(t, `toset([var.s, "known"])`))
+		result, unknown, _, diags := NewEvaluator(unknownCtx).EvaluateForEach(parseExpr(t, `toset([var.s, "known"])`))
 		require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
 		assert.True(t, unknown)
 		assert.Nil(t, result)

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -946,7 +946,7 @@ func (e *Engine) registerProvider(
 		return e.registerProviderInContext(ctx, node, provider, evalCtx, parentURN, modInst, nil)
 	}
 
-	forEach, unknown, diags := eval.NewEvaluator(evalCtx).EvaluateForEach(provider.ForEach)
+	forEach, unknown, _, diags := eval.NewEvaluator(evalCtx).EvaluateForEach(provider.ForEach)
 	if diags.HasErrors() {
 		return fmt.Errorf("evaluating for_each for provider %s: %s", node.Key, diags.Error())
 	}
@@ -1315,12 +1315,17 @@ func (e *Engine) processResourceInContext(
 
 	expander := graph.NewResourceExpander()
 
+	// A reference in count/for_each establishes a dependency (as in TF) that
+	// governs destroy ordering, even when nothing in the body references the
+	// target. Collect those references so every instance depends on them.
+	var metaArgDeps []string
 	unknownArg := ""
 	if res.Count != nil {
-		count, isBool, unknown, diags := tempEvaluator.EvaluateCount(res.Count)
+		count, isBool, unknown, deps, diags := tempEvaluator.EvaluateCount(res.Count)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating count: %s", diags.Error())
 		}
+		metaArgDeps = append(metaArgDeps, deps...)
 		switch {
 		case unknown:
 			unknownArg = "count"
@@ -1332,10 +1337,11 @@ func (e *Engine) processResourceInContext(
 	}
 
 	if res.ForEach != nil {
-		forEach, unknown, diags := tempEvaluator.EvaluateForEach(res.ForEach)
+		forEach, unknown, deps, diags := tempEvaluator.EvaluateForEach(res.ForEach)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating for_each: %s", diags.Error())
 		}
+		metaArgDeps = append(metaArgDeps, deps...)
 		if unknown {
 			unknownArg = "for_each"
 		} else {
@@ -1367,7 +1373,7 @@ func (e *Engine) processResourceInContext(
 			continue
 		}
 		if err := e.registerResourceInstanceInContext(
-			ctx, node, res, resSchema, instance, evalCtx, parentURN, modInst,
+			ctx, node, res, resSchema, instance, evalCtx, parentURN, modInst, metaArgDeps,
 		); err != nil {
 			return fmt.Errorf("registering %s: %w", instance.Key, err)
 		}
@@ -1403,6 +1409,7 @@ func (e *Engine) registerResourceInstanceInContext(
 	evalCtx *eval.Context,
 	parentURN urn.URN,
 	modInst *moduleInstance,
+	metaArgDeps []string,
 ) error {
 	evalCtx = evalCtx.WithIteration(instance.Index, instance.EachKey, instance.EachValue)
 
@@ -1471,6 +1478,13 @@ func (e *Engine) registerResourceInstanceInContext(
 			if !slices.Contains(opts.DependsOn, dep) {
 				opts.DependsOn = append(opts.DependsOn, dep)
 			}
+		}
+	}
+	// count/for_each references are not tied to any body property, so they stay
+	// out of PropertyDependencies but still gate ordering through DependsOn.
+	for _, dep := range metaArgDeps {
+		if !slices.Contains(opts.DependsOn, dep) {
+			opts.DependsOn = append(opts.DependsOn, dep)
 		}
 	}
 	slices.Sort(opts.DependsOn)
@@ -2742,7 +2756,7 @@ func (e *Engine) processRangedDataSource(
 
 	unknownArg := ""
 	if ds.Count != nil {
-		count, isBool, unknown, diags := tempEvaluator.EvaluateCount(ds.Count)
+		count, isBool, unknown, _, diags := tempEvaluator.EvaluateCount(ds.Count)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating count: %s", diags.Error())
 		}
@@ -2757,7 +2771,7 @@ func (e *Engine) processRangedDataSource(
 	}
 
 	if ds.ForEach != nil {
-		forEach, unknown, diags := tempEvaluator.EvaluateForEach(ds.ForEach)
+		forEach, unknown, _, diags := tempEvaluator.EvaluateForEach(ds.ForEach)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating for_each: %s", diags.Error())
 		}
@@ -3537,7 +3551,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 	}
 
 	if mod.Count != nil {
-		count, _, unknown, diags := eval.NewEvaluator(parentEvalCtx).EvaluateCount(mod.Count)
+		count, _, unknown, _, diags := eval.NewEvaluator(parentEvalCtx).EvaluateCount(mod.Count)
 		if diags.HasErrors() {
 			return fmt.Errorf("evaluating module count: %s", diags.Error())
 		}
@@ -3576,7 +3590,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 		return nil
 	}
 
-	forEach, unknown, diags := eval.NewEvaluator(parentEvalCtx).EvaluateForEach(mod.ForEach)
+	forEach, unknown, _, diags := eval.NewEvaluator(parentEvalCtx).EvaluateForEach(mod.ForEach)
 	if diags.HasErrors() {
 		return fmt.Errorf("evaluating module for_each: %s", diags.Error())
 	}

--- a/tests/testutil/tfcompat/providers/ordering.go
+++ b/tests/testutil/tfcompat/providers/ordering.go
@@ -74,3 +74,59 @@ func OrderingProvider() *schema.Provider {
 		},
 	}
 }
+
+// OrderDepProvider exposes `orderdep_resource`, which enforces destroy
+// ordering. Each resource has a `name` and an optional `needs` (the name of the
+// resource it depends on). A resource that declares `needs` sleeps during its
+// own Delete and then asserts its dependency has not been deleted yet, so the
+// dependency must be destroyed *after* the dependent; if it is destroyed first,
+// the dependent's Delete fails.
+//
+// The `deleted` set is captured per factory call (one per runtime), so the
+// concurrently-run Terraform and pulumi runtimes keep independent state.
+func OrderDepProvider() *schema.Provider {
+	var mu sync.Mutex
+	deleted := map[string]bool{}
+
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"orderdep_resource": {
+				Schema: map[string]*schema.Schema{
+					"name":   {Type: schema.TypeString, Required: true},
+					"needs":  {Type: schema.TypeString, Optional: true},
+					"result": {Type: schema.TypeString, Computed: true},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					name, _ := d.Get("name").(string)
+					d.SetId(name)
+					if err := d.Set("result", name); err != nil {
+						return diag.FromErr(err)
+					}
+					return nil
+				},
+				ReadContext:   func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				UpdateContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				DeleteContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					name, _ := d.Get("name").(string)
+					needs, _ := d.Get("needs").(string)
+					if needs != "" {
+						// Give an out-of-order delete of `needs` time to land.
+						time.Sleep(1 * time.Second)
+						mu.Lock()
+						already := deleted[needs]
+						mu.Unlock()
+						if already {
+							return diag.Errorf(
+								"orderdep_resource %q: its dependency %q was destroyed first; "+
+									"destroy order was not honored", name, needs)
+						}
+					}
+					mu.Lock()
+					deleted[name] = true
+					mu.Unlock()
+					return nil
+				},
+			},
+		},
+	}
+}

--- a/tests/tfcompat/l2_count_ref_destroy_order_test.go
+++ b/tests/tfcompat/l2_count_ref_destroy_order_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// orderDepProvider exposes `orderdep_resource`, which enforces destroy
+// ordering. Each resource has a `name` and an optional `needs` (the name of
+// the resource it depends on). A resource that declares `needs` sleeps during
+// its own Delete and then asserts its dependency has not been deleted yet. So
+// the dependency must be destroyed *after* the dependent; if it is destroyed
+// first, the dependent's Delete fails.
+//
+// The `deleted` set is captured per factory call (one per runtime), so the
+// concurrently-run tofu and pulumi runtimes keep independent state, mirroring
+// providers.OrderingProvider.
+func orderDepProvider() *schema.Provider {
+	var mu sync.Mutex
+	deleted := map[string]bool{}
+
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"orderdep_resource": {
+				Schema: map[string]*schema.Schema{
+					"name":   {Type: schema.TypeString, Required: true},
+					"needs":  {Type: schema.TypeString, Optional: true},
+					"result": {Type: schema.TypeString, Computed: true},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					name, _ := d.Get("name").(string)
+					d.SetId(name)
+					if err := d.Set("result", name); err != nil {
+						return diag.FromErr(err)
+					}
+					return nil
+				},
+				ReadContext:   func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				UpdateContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				DeleteContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					name, _ := d.Get("name").(string)
+					needs, _ := d.Get("needs").(string)
+					if needs != "" {
+						// Give an out-of-order delete of `needs` time to land.
+						time.Sleep(3 * time.Second)
+						mu.Lock()
+						already := deleted[needs]
+						mu.Unlock()
+						if already {
+							return diag.Errorf(
+								"orderdep_resource %q: its dependency %q was destroyed first; "+
+									"destroy order was not honored", name, needs)
+						}
+					}
+					mu.Lock()
+					deleted[name] = true
+					mu.Unlock()
+					return nil
+				},
+			},
+		},
+	}
+}
+
+// TestL2CountRefDestroyOrder proves that a reference expressed only through a
+// resource's `count` meta-argument establishes a dependency that governs
+// destroy ordering. `b`'s `count` references `a.result`; nothing in `b`'s body
+// references `a`. On apply both runtimes create `a` before `b` (the count needs
+// `a.result`). On destroy, OpenTofu honors the count-derived dependency and
+// destroys `b` before `a`; pulumi-hcl derives dependencies only from input
+// values and misses the edge, destroying `a` first and failing `b`'s Delete.
+func TestL2CountRefDestroyOrder(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_count_ref_destroy_order", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "orderdep", Factory: orderDepProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply},
+			{Mode: tfcompat.StageDestroy},
+		},
+	})
+}

--- a/tests/tfcompat/l2_count_ref_destroy_order_test.go
+++ b/tests/tfcompat/l2_count_ref_destroy_order_test.go
@@ -15,73 +15,11 @@
 package tfcompat_test
 
 import (
-	"context"
-	"sync"
 	"testing"
-	"time"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
-
-// orderDepProvider exposes `orderdep_resource`, which enforces destroy
-// ordering. Each resource has a `name` and an optional `needs` (the name of
-// the resource it depends on). A resource that declares `needs` sleeps during
-// its own Delete and then asserts its dependency has not been deleted yet. So
-// the dependency must be destroyed *after* the dependent; if it is destroyed
-// first, the dependent's Delete fails.
-//
-// The `deleted` set is captured per factory call (one per runtime), so the
-// concurrently-run tofu and pulumi runtimes keep independent state, mirroring
-// providers.OrderingProvider.
-func orderDepProvider() *schema.Provider {
-	var mu sync.Mutex
-	deleted := map[string]bool{}
-
-	return &schema.Provider{
-		ResourcesMap: map[string]*schema.Resource{
-			"orderdep_resource": {
-				Schema: map[string]*schema.Schema{
-					"name":   {Type: schema.TypeString, Required: true},
-					"needs":  {Type: schema.TypeString, Optional: true},
-					"result": {Type: schema.TypeString, Computed: true},
-				},
-				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
-					name, _ := d.Get("name").(string)
-					d.SetId(name)
-					if err := d.Set("result", name); err != nil {
-						return diag.FromErr(err)
-					}
-					return nil
-				},
-				ReadContext:   func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
-				UpdateContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
-				DeleteContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
-					name, _ := d.Get("name").(string)
-					needs, _ := d.Get("needs").(string)
-					if needs != "" {
-						// Give an out-of-order delete of `needs` time to land.
-						time.Sleep(3 * time.Second)
-						mu.Lock()
-						already := deleted[needs]
-						mu.Unlock()
-						if already {
-							return diag.Errorf(
-								"orderdep_resource %q: its dependency %q was destroyed first; "+
-									"destroy order was not honored", name, needs)
-						}
-					}
-					mu.Lock()
-					deleted[name] = true
-					mu.Unlock()
-					return nil
-				},
-			},
-		},
-	}
-}
 
 // TestL2CountRefDestroyOrder proves that a reference expressed only through a
 // resource's `count` meta-argument establishes a dependency that governs
@@ -94,7 +32,7 @@ func TestL2CountRefDestroyOrder(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_count_ref_destroy_order", tfcompat.Case{
 		Providers: []tfcompat.Provider{
-			{Name: "orderdep", Factory: orderDepProvider},
+			{Name: "orderdep", Factory: providers.OrderDepProvider},
 		},
 		Stages: []tfcompat.Stage{
 			{Mode: tfcompat.StageApply},

--- a/tests/tfcompat/testdata/cases/l2_count_ref_destroy_order/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_count_ref_destroy_order/main.tf
@@ -1,0 +1,17 @@
+resource "orderdep_resource" "a" {
+  name = "a"
+}
+
+# `b` references `a` only through its `count` meta-argument. TF records this as
+# a dependency, so `b` is destroyed before `a`. The reference never appears in
+# `b`'s body, so a runtime that only derives dependencies from input values
+# will miss the edge and destroy `a` before `b`.
+resource "orderdep_resource" "b" {
+  count = orderdep_resource.a.name == "a" ? 1 : 0
+  name  = "b"
+  needs = "a"
+}
+
+output "a_result" {
+  value = orderdep_resource.a.result
+}


### PR DESCRIPTION
## Divergence

When resource `b`'s `count` (or `for_each`) is the *only* place that references resource `a` — nothing in `b`'s body references `a`:

- **Expected**: the meta-argument reference establishes a dependency `b → a`, so on destroy `b` goes before `a`.
- **Before this fix**: pulumi-hcl derived dependencies only from body input values and explicit `depends_on`, so the edge was never recorded. It destroyed `a` first, and `b`'s delete then failed.

## Root cause

The dependency graph already tracked count/for_each references for **create** ordering (`graph.go`), but nothing propagated them to the registered resource's `DependsOn`, which is what governs **destroy** ordering. `EvaluateCount`/`EvaluateForEach` unmarked their result ("count never flows into inputs"), discarding the `DepMark`s that identify the referenced resources.

## The fix

`EvaluateCount` and `EvaluateForEach` now return the URNs their expression references, collected from the single evaluation they already perform (no expression is evaluated twice, so a `timestamp()`/`uuid()`/provider-invoking function fires once). `processResourceInContext` threads those URNs into each instance's `DependsOn` — kept out of `PropertyDependencies`, since they aren't tied to any body property. Covers both `count` and `for_each`.

## Test

`TestL2CountRefDestroyOrder` — an `orderdep` provider whose `Delete` fails if a dependency is destroyed before its dependent. Two stages: `StageApply` then `StageDestroy`. Both runtimes apply identically; destroy now honors the count-derived edge.
