### PR TITLE
Preserve source order across multiple dynamic blocks for one list block

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-373.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-373.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Preserve source order when merging multiple `dynamic` blocks for one list block
+time: 2026-07-15T12:00:00Z
+custom:
+    Component: runtime
+    PR: "373"

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -460,11 +460,15 @@ func evalDynamicBlocks(
 					if unmarked, _ := existing.Unmark(); !unmarked.IsKnown() {
 						continue
 					}
-					// Merge with existing static blocks.
+					// Prepend blocks already accumulated for this property
+					// (earlier static or dynamic blocks) so the expanded groups
+					// keep their source order in the order-significant list.
+					prior := make([]cty.Value, 0, len(values))
 					for it := existing.ElementIterator(); it.Next(); {
 						_, v := it.Element()
-						values = append(values, v)
+						prior = append(prior, v)
 					}
+					values = append(prior, values...)
 				}
 				// Per-element object types can diverge when content sets
 				// disjoint subsets of optional fields (e.g. `lookup(v, "k",

--- a/tests/tfcompat/l2_dynamic_multi_block_order_test.go
+++ b/tests/tfcompat/l2_dynamic_multi_block_order_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2DynamicMultiBlockOrder covers two `dynamic` blocks targeting the same
+// order-significant (TypeList) block. tofu expands them in source order; pulumi-hcl
+// places a later dynamic block's group ahead of an earlier one, reversing the
+// groups. The divergence surfaces in the tag list the provider receives.
+func TestL2DynamicMultiBlockOrder(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_dynamic_multi_block_order", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "blocky", Factory: providers.BlockyProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_dynamic_multi_block_order/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_dynamic_multi_block_order/main.tf
@@ -1,0 +1,27 @@
+# Two `dynamic "tag"` blocks for the same repeating (TypeList) block. tofu
+# expands them in source order, so the provider receives the tags as
+# [a1, a2, b1, b2]. pulumi-hcl merges a later dynamic block ahead of the
+# earlier one, so the provider instead receives [b1, b2, a1, a2] — the block
+# groups are reversed. `tag` is order-significant (TypeList), so this is an
+# observable divergence even though blocky's summary sorts the tags.
+resource "blocky_thing" "x" {
+  name = "y"
+
+  dynamic "tag" {
+    for_each = ["a1", "a2"]
+    content {
+      key   = tag.value
+      value = "v"
+    }
+  }
+
+  dynamic "tag" {
+    for_each = ["b1", "b2"]
+    content {
+      key   = tag.value
+      value = "v"
+    }
+  }
+}
+
+output "summary" { value = blocky_thing.x.summary }


### PR DESCRIPTION
## Divergence

A resource with two `dynamic "tag"` blocks targeting the same `TypeList` (order-significant) block — first `for_each = ["a1","a2"]`, then `["b1","b2"]`:

- **OpenTofu**: expands in source order; the provider receives `tag = [a1, a2, b1, b2]`.
- **pulumi-hcl**: placed the second block's group ahead of the first; the provider received `tag = [b1, b2, a1, a2]`.

Root cause: `evalDynamicBlocks` in `pkg/hcl/transform/transform.go`. When a later `dynamic` block for the same property found an already-accumulated value, it appended those earlier blocks *after* the current block's expansion, reversing the group order.

## Fix

Prepend the already-accumulated blocks (earlier static or dynamic expansions) instead of appending them, so each expanded group keeps its source position in the order-significant list.

This also correctly orders the mixed case where a static block precedes a dynamic block for the same property.

## Test

`TestL2DynamicMultiBlockOrder` — `tag` is `TypeList`, so order matters. The divergence surfaces through the harness's provider-operations recorder (the provider's `summary` sorts tags, so stack outputs alone would hide it). The test fails on `master` and passes with this fix.
