### PR TITLE
Keep for_each instances distinct when a key contains a bracket

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-374.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-374.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Keep `for_each` instances distinct when a key contains a `[` character
+time: 2026-07-15T14:00:00Z
+custom:
+    Component: runtime
+    PR: "374"

--- a/pkg/hcl/graph/expand.go
+++ b/pkg/hcl/graph/expand.go
@@ -167,47 +167,13 @@ func (e *ResourceExpander) Expand(node *Node) *ExpandResult {
 	}
 }
 
-// InstanceKey generates an instance key for a resource with count or for_each.
-func InstanceKey(resourceKey string, index *int, eachKey *cty.Value) string {
-	if index != nil {
-		return fmt.Sprintf("%s[%d]", resourceKey, *index)
+// EachKeyString returns the for_each instance key as a plain string, or nil for
+// count or single instances. for_each keys are always strings, so no ambiguous
+// re-parsing of the instance's Key is needed.
+func (r *ExpandedResource) EachKeyString() *string {
+	if r.EachKey == nil {
+		return nil
 	}
-	if eachKey != nil && eachKey.Type() == cty.String {
-		return fmt.Sprintf("%s[%q]", resourceKey, eachKey.AsString())
-	}
-	return resourceKey
-}
-
-// ParseInstanceKey parses an instance key back into its components.
-// Returns the base key, optional index, and optional each key.
-func ParseInstanceKey(instanceKey string) (baseKey string, index *int, eachKey *string) {
-	// Look for [...]
-	bracketStart := -1
-	for i := len(instanceKey) - 1; i >= 0; i-- {
-		if instanceKey[i] == '[' {
-			bracketStart = i
-			break
-		}
-	}
-
-	if bracketStart == -1 {
-		return instanceKey, nil, nil
-	}
-
-	baseKey = instanceKey[:bracketStart]
-	indexPart := instanceKey[bracketStart+1 : len(instanceKey)-1]
-
-	// Check if it's a number
-	var idx int
-	if _, err := fmt.Sscanf(indexPart, "%d", &idx); err == nil {
-		return baseKey, &idx, nil
-	}
-
-	// Must be a string key (with quotes)
-	if len(indexPart) >= 2 && indexPart[0] == '"' && indexPart[len(indexPart)-1] == '"' {
-		key := indexPart[1 : len(indexPart)-1]
-		return baseKey, nil, &key
-	}
-
-	return instanceKey, nil, nil
+	s := r.EachKey.AsString()
+	return &s
 }

--- a/pkg/hcl/graph/graph_test.go
+++ b/pkg/hcl/graph/graph_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func ptr[T any](v T) *T { return &v }
-
 func TestBuildFromConfig(t *testing.T) {
 	t.Parallel()
 	src := []byte(`
@@ -222,55 +220,4 @@ func TestResourceExpander(t *testing.T) {
 			}
 		}
 	})
-}
-
-func TestParseInstanceKey(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		input       string
-		wantBase    string
-		wantIndex   *int
-		wantEachKey *string
-	}{
-		{
-			input:    "aws_instance.web",
-			wantBase: "aws_instance.web",
-		},
-		{
-			input:     "aws_instance.web[0]",
-			wantBase:  "aws_instance.web",
-			wantIndex: ptr(0),
-		},
-		{
-			input:     "aws_instance.web[42]",
-			wantBase:  "aws_instance.web",
-			wantIndex: ptr(42),
-		},
-		{
-			input:       `aws_instance.web["a"]`,
-			wantBase:    "aws_instance.web",
-			wantEachKey: ptr("a"),
-		},
-		{
-			input:       `aws_instance.web["my-key"]`,
-			wantBase:    "aws_instance.web",
-			wantEachKey: ptr("my-key"),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			t.Parallel()
-			base, idx, key := ParseInstanceKey(tt.input)
-			if base != tt.wantBase {
-				t.Errorf("base: got %q, want %q", base, tt.wantBase)
-			}
-			if (idx == nil) != (tt.wantIndex == nil) || (idx != nil && *idx != *tt.wantIndex) {
-				t.Errorf("index: got %v, want %v", idx, tt.wantIndex)
-			}
-			if (key == nil) != (tt.wantEachKey == nil) || (key != nil && *key != *tt.wantEachKey) {
-				t.Errorf("eachKey: got %v, want %v", key, tt.wantEachKey)
-			}
-		})
-	}
 }

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1490,7 +1489,7 @@ func (e *Engine) registerResourceInstanceInContext(
 
 	opts.PackageRef = e.packageRefForType(res.Type)
 
-	resourceName := e.extractModuleResourceName(res.Name, instance.Key, node.ModuleInfo, modInst)
+	resourceName := e.extractModuleResourceName(res.Name, instance.Index, instance.EachKeyString(), modInst)
 
 	if len(res.Preconditions) > 0 {
 		if err := e.bindPreconditionHooks(ctx, res, instance, evalCtx, opts, resourceName); err != nil {
@@ -1728,7 +1727,7 @@ func (e *Engine) buildResourceOptionsInContext(
 	}
 
 	// Handle moved blocks - resolve aliases from moved blocks that target this resource
-	movedAliases := e.resolveMovedAliases(ctx, res, instance.Key, modInfo, modInst)
+	movedAliases := e.resolveMovedAliases(ctx, res, instance.Index, instance.EachKeyString(), modInst)
 	opts.Aliases = append(opts.Aliases, movedAliases...)
 
 	// Handle aliases attribute
@@ -1900,11 +1899,15 @@ func (e *Engine) buildResourceOptionsInContext(
 // followed by an optional resource. A whole-module-call address (e.g.
 // `module.a`) has an empty Type.
 type movedAddr struct {
-	modules []modulepath.Step // module-call steps, outermost first
-	Type    string            // resource type, or "" for a whole-module-call address
-	Name    string            // resource name
-	key     string            // instance-key bracket content ("0" or `"k"`), or ""
+	modules  []modulepath.Step // module-call steps, outermost first
+	Type     string            // resource type, or "" for a whole-module-call address
+	Name     string            // resource name
+	keyIndex *int              // count instance key, if the address is keyed by count
+	keyEach  *string           // for_each instance key, if the address is keyed by for_each
 }
+
+// keyed reports whether the address names a specific count/for_each instance.
+func (a movedAddr) keyed() bool { return a.keyIndex != nil || a.keyEach != nil }
 
 // parseMovedAddr decodes a `moved` from/to traversal into its module-call steps
 // and (optional) resource. It returns false for a traversal it cannot model.
@@ -1967,11 +1970,28 @@ func parseMovedAddr(t hcl.Traversal) (movedAddr, bool) {
 	a.Type, a.Name = typ, name
 	if i < len(t) {
 		if idx, ok := t[i].(hcl.TraverseIndex); ok {
-			a.key = movedKeyToken(idx.Key)
+			a.keyIndex, a.keyEach = instanceKeyFromCty(idx.Key)
 			i++
 		}
 	}
 	return a, i == len(t)
+}
+
+// instanceKeyFromCty decodes an instance-key value into its typed components: a
+// count index for a number, a for_each key for a string. Both are nil for any
+// other type, which the caller treats as an unkeyed address.
+func instanceKeyFromCty(v cty.Value) (index *int, eachKey *string) {
+	switch v.Type() {
+	case cty.Number:
+		iv, _ := v.AsBigFloat().Int64()
+		n := int(iv)
+		return &n, nil
+	case cty.String:
+		s := v.AsString()
+		return nil, &s
+	default:
+		return nil, nil
+	}
 }
 
 // moduleStepFor builds a module-call path step for `module.<name>[<key>]`,
@@ -1992,20 +2012,6 @@ func moduleStepFor(name string, key cty.Value) (modulepath.Step, bool) {
 	}
 }
 
-// movedKeyToken renders an instance-key value as it appears in a node key's
-// `[...]` suffix: a bare integer for count, or a Go-quoted string for for_each.
-func movedKeyToken(v cty.Value) string {
-	switch v.Type() {
-	case cty.Number:
-		iv, _ := v.AsBigFloat().Int64()
-		return strconv.FormatInt(iv, 10)
-	case cty.String:
-		return strconv.Quote(v.AsString())
-	default:
-		return ""
-	}
-}
-
 // resolveMovedAliases finds the `moved` blocks that rename the resource instance
 // being registered and returns the aliases recording its prior addresses, so a
 // rename is treated as a move rather than a replacement.
@@ -2018,7 +2024,7 @@ func movedKeyToken(v cty.Value) string {
 // enclosing module call is renamed or re-keyed (the matching component alias is
 // attached in processModuleInit).
 func (e *Engine) resolveMovedAliases(
-	ctx context.Context, res *ast.Resource, instanceKey string, modInfo *graph.ModuleInfo, modInst *moduleInstance,
+	ctx context.Context, res *ast.Resource, index *int, eachKey *string, modInst *moduleInstance,
 ) []Alias {
 	var aliases []Alias
 
@@ -2028,7 +2034,6 @@ func (e *Engine) resolveMovedAliases(
 	if modInst != nil {
 		resPath = modInst.Path
 	}
-	_, instIdx, instEach := graph.ParseInstanceKey(instanceKey)
 
 	for _, scope := range ancestorPaths(resPath) {
 		for _, moved := range e.graph.MovedBlocks(scope) {
@@ -2049,28 +2054,20 @@ func (e *Engine) resolveMovedAliases(
 			// Determine the prior instance key. A keyed `to` targets one specific
 			// instance and takes the prior key from `from`; an unkeyed `to` is a
 			// whole-resource rename that maps every instance to the same key.
-			var priorKey string
-			if to.key != "" {
-				if !instanceKeyMatches(instIdx, instEach, to.key) {
+			var priorIdx *int
+			var priorEach *string
+			if to.keyed() {
+				if !instanceKeysEqual(index, eachKey, to.keyIndex, to.keyEach) {
 					continue
 				}
-				priorKey = from.key
+				priorIdx, priorEach = from.keyIndex, from.keyEach
 			} else {
-				switch {
-				case instIdx != nil:
-					priorKey = strconv.Itoa(*instIdx)
-				case instEach != nil:
-					priorKey = strconv.Quote(*instEach)
-				}
-			}
-			keyBracket := from.Name
-			if priorKey != "" {
-				keyBracket += "[" + priorKey + "]"
+				priorIdx, priorEach = index, eachKey
 			}
 
 			// The prior name is the resource's own name under its prior module
 			// path; the prior parent is described relative to where it is now.
-			name := buildResourceName(from.Name, keyBracket)
+			name := buildResourceName(from.Name, priorIdx, priorEach)
 			if !fromPath.IsRoot() {
 				name = fromPath.LogicalName() + "-" + name
 			}
@@ -2105,11 +2102,7 @@ func (e *Engine) resolveMovedAliases(
 	// aliased to the name it had under the prior module path; Pulumi combines
 	// that with the renamed component's own alias to recover the old URN.
 	if oldPath := e.oldModulePath(resPath); oldPath != resPath {
-		bareKey := instanceKey
-		if modInfo != nil {
-			bareKey = strings.TrimPrefix(instanceKey, modInfo.Prefix())
-		}
-		name := buildResourceName(res.Name, bareKey)
+		name := buildResourceName(res.Name, index, eachKey)
 		if !oldPath.IsRoot() {
 			name = oldPath.LogicalName() + "-" + name
 		}
@@ -2244,14 +2237,15 @@ func appendModuleSteps(base modulepath.Path, steps []modulepath.Step) modulepath
 	return base
 }
 
-// instanceKeyMatches reports whether the instance identified by idx/each is the
-// one named by a `[...]` key token (e.g. "0" or `"k"`).
-func instanceKeyMatches(idx *int, each *string, token string) bool {
+// instanceKeysEqual reports whether two resource instance keys name the same
+// instance. Keys of different kinds (count vs for_each) never match, and two
+// unkeyed (single-instance) addresses do not either.
+func instanceKeysEqual(aIdx *int, aEach *string, bIdx *int, bEach *string) bool {
 	switch {
-	case idx != nil:
-		return token == strconv.Itoa(*idx)
-	case each != nil:
-		return token == strconv.Quote(*each)
+	case aIdx != nil && bIdx != nil:
+		return *aIdx == *bIdx
+	case aEach != nil && bEach != nil:
+		return *aEach == *bEach
 	default:
 		return false
 	}
@@ -2372,19 +2366,18 @@ func (e *Engine) hasFailedDependency(res *ast.Resource) bool {
 	return false
 }
 
-// buildResourceName builds the Pulumi resource name from the logical name and instance key.
-// Single instances use the logical name as-is. Count instances get a "-N" suffix.
-// ForEach instances get a "-key" suffix.
-func buildResourceName(logicalName, instanceKey string) string {
-	_, index, eachKey := graph.ParseInstanceKey(instanceKey)
-
-	if index != nil {
+// buildResourceName builds the Pulumi resource name from the logical name and
+// instance key. Single instances use the logical name as-is. Count instances get
+// a "-N" suffix. ForEach instances get a "-key" suffix.
+func buildResourceName(logicalName string, index *int, eachKey *string) string {
+	switch {
+	case index != nil:
 		return fmt.Sprintf("%s-%d", logicalName, *index)
-	}
-	if eachKey != nil {
+	case eachKey != nil:
 		return fmt.Sprintf("%s-%s", logicalName, *eachKey)
+	default:
+		return logicalName
 	}
-	return logicalName
 }
 
 // extractModuleResourceName computes the Pulumi resource name for a resource inside a module.
@@ -2392,20 +2385,14 @@ func buildResourceName(logicalName, instanceKey string) string {
 // For example, resource "res" inside component "comp" becomes "comp-res",
 // and inside "comp[0]" becomes "comp[0]-res".
 func (*Engine) extractModuleResourceName(
-	logicalName, instanceKey string, modInfo *graph.ModuleInfo, modInst *moduleInstance,
+	logicalName string, index *int, eachKey *string, modInst *moduleInstance,
 ) string {
-	if modInfo == nil || modInst == nil {
-		return buildResourceName(logicalName, instanceKey)
+	bareResourceName := buildResourceName(logicalName, index, eachKey)
+	if modInst == nil {
+		return bareResourceName
 	}
-
-	// Strip the module prefix to get the bare instance key (e.g., "simple_resource.name").
-	bareKey := strings.TrimPrefix(instanceKey, modInfo.Prefix())
-	bareResourceName := buildResourceName(logicalName, bareKey)
-
-	// Extract the module instance name (e.g., "many" or "many[0]").
-	modInstanceName := modInst.Path.LogicalName()
-
-	return modInstanceName + "-" + bareResourceName
+	// Prefix with the module instance name (e.g., "many" or "many[0]").
+	return modInst.Path.LogicalName() + "-" + bareResourceName
 }
 
 // translateAttrPathTraversal formats an attribute-path traversal (e.g. an

--- a/tests/tfcompat/l2_for_each_bracket_key_test.go
+++ b/tests/tfcompat/l2_for_each_bracket_key_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A `for_each` key containing a `[` character. OpenTofu treats the key as an
+// opaque string and creates one instance per key. pulumi-hcl derives the
+// per-instance Pulumi resource name by re-parsing the instance address and
+// scanning for `[` from the end, which misreads a bracket inside the key. Both
+// keys collapse to the bare logical name `web`, so the second instance fails
+// with "Duplicate resource URN".
+func TestL2ForEachBracketKey(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_for_each_bracket_key", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_for_each_bracket_key/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_for_each_bracket_key/main.tf
@@ -1,0 +1,12 @@
+# `for_each` keys are opaque strings in OpenTofu, so keys that contain a
+# `[` character followed by non-numeric text still address distinct
+# instances (`web["group[a"]` / `web["group[b"]`) and apply cleanly.
+resource "simple_resource" "web" {
+  for_each  = toset(["group[a", "group[b"])
+  input_one = each.key
+  input_two = false
+}
+
+output "web" {
+  value = { for k, v in simple_resource.web : k => v.result }
+}


### PR DESCRIPTION
## Divergence

A `for_each` key containing a `[` followed by non-numeric text, e.g. `toset(["group[a", "group[b"])`:

- **OpenTofu**: keys are opaque strings; each addresses a distinct instance. Applies cleanly.
- **pulumi-hcl**: errored `Duplicate resource URN '...::Resource::web'` — distinct instances collapsed onto the bare logical name.

Root cause: instance identity was carried as a serialized string like `web["group[a"]` and later re-parsed by `ParseInstanceKey`, which scanned for the instance-key `[` **from the end** of the address. For `web["group[a"]` it stopped at the `[` *inside the key*, the quoted-string branch failed, and it returned a nil key — so `buildResourceName` emitted the bare name `web` for every such instance. (Keys of the form `x[<digits>` accidentally dodged the bug because the misparsed remainder parsed as a numeric index.)

## Fix

Remove the construct-a-string-then-parse-it-back round-trip entirely. The instance-key components are already available as real typed values on `ExpandedResource` (`Index *int`, `EachKey *cty.Value`) and on `movedAddr`, so thread those directly through `buildResourceName`, `extractModuleResourceName`, and `resolveMovedAliases` instead of re-deriving them from the string.

- Deleted `graph.InstanceKey` / `graph.ParseInstanceKey` (the string encoder/decoder).
- `movedAddr` now stores its instance key as typed `keyIndex *int` / `keyEach *string`, decoded straight from the traversal value; the `movedKeyToken` string round-trip and the token-comparing `instanceKeyMatches` are replaced by a typed `instanceKeysEqual`.
- Added `ExpandedResource.EachKeyString()` to expose the for_each key (always a string) without ambiguous parsing.

The serialized `Key` string remains only as an opaque map key for instance bookkeeping — it is never parsed for its components again.

## Test

`TestL2ForEachBracketKey` — `for_each = toset(["group[a", "group[b"])` on `simple_resource.web`. Fails on `master` with the duplicate-URN error; passes with this fix. Full tfcompat suite (158) and the graph/run unit suites (186) pass.
