### PR TITLE
Materialize an omitted MaxItems=1 nested block as [] instead of [null]

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-376.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-376.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Materialize an omitted `MaxItems=1` nested block as `[]` rather than `[null]`
+time: 2026-07-15T12:00:00Z
+custom:
+    Component: runtime
+    PR: "376"

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -1206,7 +1206,13 @@ func propertyObjectToCtyMap(path string, m property.Map, properties []*schema.Pr
 			return nil, err
 		}
 		if singularBlock && !convertedV.Type().IsListType() && !convertedV.Type().IsTupleType() {
-			convertedV = cty.TupleVal([]cty.Value{convertedV})
+			if convertedV.IsNull() {
+				// An omitted MaxItems=1 block is an empty list of blocks, not a
+				// single-element list holding null, so `length(r.block)` is 0.
+				convertedV = cty.ListValEmpty(convertedV.Type())
+			} else {
+				convertedV = cty.TupleVal([]cty.Value{convertedV})
+			}
 		}
 		result[hclName] = convertedV
 	}

--- a/tests/tfcompat/l2_omitted_nested_block_test.go
+++ b/tests/tfcompat/l2_omitted_nested_block_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2OmittedNestedBlock exercises an optional nested block (`rule`,
+// MaxItems=1) left out of an enclosing `policy` block. OpenTofu materializes the
+// absent nested block as an empty list of blocks (`[]`, length 0). pulumi-hcl
+// materializes it as a single-element list containing null (`[null]`, length 1),
+// so reading `policy[0].rule` — or `length(policy[0].rule)` — diverges.
+func TestL2OmittedNestedBlock(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_omitted_nested_block", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "blocky", Factory: providers.BlockyProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_omitted_nested_block/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_omitted_nested_block/main.tf
@@ -1,0 +1,16 @@
+resource "blocky_thing" "t" {
+  name = "omit"
+
+  # `rule` (MaxItems=1) is an optional nested block, left out here.
+  policy {
+    effect = "deny"
+  }
+}
+
+output "rule" {
+  value = blocky_thing.t.policy[0].rule
+}
+
+output "rule_len" {
+  value = length(blocky_thing.t.policy[0].rule)
+}


### PR DESCRIPTION
## Divergence

Given a `MaxItems=1` nested block that itself contains an optional `MaxItems=1` nested block, when the inner block is omitted:

- **Expected**: the absent nested block materializes as an **empty list** — `outer[0].inner == []`, `length(...) == 0`.
- **Before this fix**: pulumi-hcl materialized it as a **single-element list containing null** — `outer[0].inner == [null]`, `length(...) == 1`.

Any config reading the nested block — indexing it, taking its `length`, or iterating it — got the wrong result.

## Root cause

On output, `propertyObjectToCtyMap` re-expands the bridge's flattened `MaxItemsOne` blocks back into the list-of-blocks representation, so `r.policy[0].rule` resolves the way it's written. An omitted block comes back as a present-but-null property, and the singular-block value was unconditionally wrapped in a one-element tuple — turning `null` into `[null]`.

The fix expands a null singular block to an empty list instead.

## Test

`TestL2OmittedNestedBlock` — outputs the omitted nested block and its length; now `rule=[]` / `rule_len=0`. (Unset optional *scalar* attributes inside blocks are a separate concern and are deliberately excluded — this isolates the pure block-structure representation.)
