### PR TITLE
Failing test: integer attribute above 2^53 loses precision

### DIFF
--- a/tests/tfcompat/l2_int_attr_precision_test.go
+++ b/tests/tfcompat/l2_int_attr_precision_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2IntAttrPrecision asserts that a large integer literal assigned to a
+// TypeInt resource attribute reaches the provider with full precision. OpenTofu
+// delivers 9007199254740993 (2^53+1) exactly; pulumi-hcl coerces the value
+// through a float64 and the provider receives 9007199254740992 instead.
+func TestL2IntAttrPrecision(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_int_attr_precision", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "collections", Factory: providers.CollectionsProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_int_attr_precision/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_int_attr_precision/main.tf
@@ -1,0 +1,12 @@
+# An integer literal that fits in int64 but exceeds the exact-integer range of
+# a float64 (2^53 + 1 = 9007199254740993). OpenTofu carries resource-attribute
+# numbers as big.Float and hands the provider the exact value; a resource input
+# that round-trips through a float64 loses the low bit and the provider instead
+# receives 9007199254740992.
+resource "collections_thing" "big" {
+  ports = [9007199254740993]
+}
+
+output "summary" {
+  value = collections_thing.big.summary
+}


### PR DESCRIPTION
## Divergence

A large but **in-range** `int64` literal (`2^53 + 1 = 9007199254740993`) assigned to an integer resource attribute:

- **OpenTofu**: the provider receives `9007199254740993` intact.
- **pulumi-hcl**: the provider receives `9007199254740992` — the value round-trips through a `float64` at the resource-input boundary and loses its low bit.

Both runtimes apply successfully; only the value the provider receives differs. This is the value class used by Snowflake IDs, Unix-nanosecond timestamps, etc.

Direction: OpenTofu preserves the value / pulumi-hcl silently corrupts it.

### Distinct from #371

[#371](https://github.com/pulumi-labs/pulumi-hcl/pull/371) is **magnitude overflow to +Inf** for values beyond the largest finite `float64`, observed on the **stack-output** path. This bug is **silent precision loss on an in-range, valid `int64`**, observed on the **resource-input (provider gRPC)** path — a different boundary and a different symptom, though both trace back to Pulumi's `float64` number representation.

## Test

`TestL2IntAttrPrecision` — the integer reaches the provider, which folds it into a string `summary` output (so the loss is baked into a string and survives, rather than being masked by float64 output normalization).

**This PR is intentionally failing CI** — it adds only the failing test that proves the bug.