### PR TITLE
Reject both count and for_each on one block

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-378.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-378.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Reject setting both `count` and `for_each` on one resource, data source, or module
+time: 2026-07-15T14:30:00Z
+custom:
+    Component: runtime
+    PR: "378"

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -623,6 +623,22 @@ func (p *Parser) parseLocalsBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	return diags
 }
 
+// countForEachConflict returns a diagnostic when a block sets both count and
+// for_each, which are mutually exclusive; it returns nil when at most one is
+// set. The diagnostic is anchored at the for_each expression.
+func countForEachConflict(count, forEach hcl.Expression) *hcl.Diagnostic {
+	if count == nil || forEach == nil {
+		return nil
+	}
+	return &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  `Invalid combination of "count" and "for_each"`,
+		Detail: `The "count" and "for_each" meta-arguments are mutually-exclusive. ` +
+			`Only one may be used to be explicit about the number of resources to be created.`,
+		Subject: forEach.Range().Ptr(),
+	}
+}
+
 // parseResourceBlock parses a resource or data block and records it in the
 // config's Resources or DataSources map.
 func (p *Parser) parseResourceBlock(config *ast.Config, block *hcl.Block, isDataSource bool) hcl.Diagnostics {
@@ -679,6 +695,10 @@ func (p *Parser) decodeResourceBlock(block *hcl.Block, isDataSource bool) (*ast.
 
 	if attr, ok := content.Attributes["for_each"]; ok {
 		resource.ForEach = attr.Expr
+	}
+
+	if d := countForEachConflict(resource.Count, resource.ForEach); d != nil {
+		diags = append(diags, d)
 	}
 
 	if attr, ok := content.Attributes["depends_on"]; ok {
@@ -1250,6 +1270,10 @@ func (p *Parser) parseModuleBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 
 	if attr, ok := content.Attributes["for_each"]; ok {
 		module.ForEach = attr.Expr
+	}
+
+	if d := countForEachConflict(module.Count, module.ForEach); d != nil {
+		diags = append(diags, d)
 	}
 
 	if attr, ok := content.Attributes["depends_on"]; ok {

--- a/tests/tfcompat/l2_count_and_for_each_test.go
+++ b/tests/tfcompat/l2_count_and_for_each_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2CountAndForEach asserts that setting both `count` and `for_each` on one
+// resource is rejected by both runtimes: the two meta-arguments are mutually
+// exclusive.
+func TestL2CountAndForEach(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_count_and_for_each", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			Mode:      tfcompat.StageApply,
+			ExpectErr: `Invalid combination of "count" and "for_each"`,
+		}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_count_and_for_each/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_count_and_for_each/main.tf
@@ -1,0 +1,9 @@
+# `count` and `for_each` are mutually exclusive on a single resource block.
+# OpenTofu rejects the combination at plan time; pulumi-hcl must reject it too
+# rather than silently letting one meta-argument win.
+resource "simple_resource" "web" {
+  count     = 2
+  for_each  = toset(["a", "b"])
+  input_one = "x"
+  input_two = false
+}


### PR DESCRIPTION
## Divergence

Setting both `count` and `for_each` on a single resource, data source, or module block:

- **OpenTofu**: rejects the configuration — `Invalid combination of "count" and "for_each"` — the two meta-arguments are mutually exclusive.
- **pulumi-hcl**: recorded both independently and the expander silently let `count` win, so the config applied instead of failing.

## Fix

Emit a parse-time error when a block sets both meta-arguments, anchored at the `for_each` expression, matching the message and detail OpenTofu produces. The check is applied to resource and data blocks (in `parseResourceBlock`) and to module blocks.

## Test

`TestL2CountAndForEach` — a `simple_resource` with both `count` and `for_each`; asserts both runtimes reject it with `Invalid combination of "count" and "for_each"`.
