### PR TITLE
Record lifecycle check-rule and replace_triggered_by references as resource dependencies (destroy order)

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-379.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-379.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Record a dependency for a resource referenced only through a lifecycle `precondition`, `postcondition`, or `replace_triggered_by`, so destroy order is honored
+time: 2026-07-15T15:00:00Z
+custom:
+    Component: runtime
+    PR: "379"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1479,9 +1479,12 @@ func (e *Engine) registerResourceInstanceInContext(
 			}
 		}
 	}
-	// count/for_each references are not tied to any body property, so they stay
-	// out of PropertyDependencies but still gate ordering through DependsOn.
-	for _, dep := range metaArgDeps {
+	// count/for_each and lifecycle precondition/postcondition references are
+	// not tied to any body property, so they stay out of PropertyDependencies
+	// but still gate ordering through DependsOn.
+	checkDeps := checkRuleDeps(res.Preconditions, hclCtx)
+	checkDeps = append(checkDeps, checkRuleDeps(res.Postconditions, hclCtx)...)
+	for _, dep := range slices.Concat(metaArgDeps, checkDeps) {
 		if !slices.Contains(opts.DependsOn, dep) {
 			opts.DependsOn = append(opts.DependsOn, dep)
 		}
@@ -1829,6 +1832,7 @@ func (e *Engine) buildResourceOptionsInContext(
 	// ReplacementTrigger property value: any element flipping triggers a
 	// replacement. A single-element list is unwrapped to a scalar so the
 	// trigger value round-trips with Pulumi's scalar `replacementTrigger`.
+	// A reference in a trigger also establishes a dependency, as in TF.
 	if res.Lifecycle != nil && len(res.Lifecycle.ReplaceTriggeredBy) > 0 {
 		vals := make([]cty.Value, 0, len(res.Lifecycle.ReplaceTriggeredBy))
 		for _, expr := range res.Lifecycle.ReplaceTriggeredBy {
@@ -1836,6 +1840,11 @@ func (e *Engine) buildResourceOptionsInContext(
 			if diags.HasErrors() {
 				return nil, fmt.Errorf("evaluating replace_triggered_by on %q: %s",
 					res.Type+"."+res.Name, diags.Error())
+			}
+			for _, dep := range eval.CollectDepURNs(val) {
+				if !slices.Contains(opts.DependsOn, dep) {
+					opts.DependsOn = append(opts.DependsOn, dep)
+				}
 			}
 			vals = append(vals, val)
 		}
@@ -2873,6 +2882,16 @@ func (e *Engine) invokeDataSourceOnce(
 			return
 		}
 		depMarks[eval.DepMark(urn)] = struct{}{}
+	}
+
+	// Check-rule references establish dependencies, as in TF; carry them on
+	// the outputs alongside the input-derived deps so downstream readers
+	// inherit them.
+	for _, urn := range checkRuleDeps(ds.Preconditions, hclCtx) {
+		addURN(urn)
+	}
+	for _, urn := range checkRuleDeps(ds.Postconditions, hclCtx) {
+		addURN(urn)
 	}
 
 	dataSourceMapping := e.resolver.DataSourceBodyMapping(ctx, ds.Type)
@@ -3980,6 +3999,33 @@ func Validate(config *ast.Config) []error {
 	// TODO: Type checking, schema validation, etc.
 
 	return errs
+}
+
+// checkRuleDeps collects the URNs of the resources referenced by the condition
+// and error_message expressions of the given check rules. A reference in a
+// precondition/postcondition establishes a dependency, as in TF, even though
+// the rules themselves are only evaluated later by hooks. Each referenced
+// variable is resolved through the eval context instead of evaluating the
+// expression, so no function fires early while values reached through locals
+// still carry their DepMarks. Traversals that do not resolve are skipped —
+// notably self, which is only in scope once a postcondition hook fires.
+func checkRuleDeps(rules []*ast.CheckRule, hclCtx *hcl.EvalContext) []string {
+	var deps []string
+	for _, rule := range rules {
+		for _, expr := range []hcl.Expression{rule.Condition, rule.ErrorMessage} {
+			if expr == nil {
+				continue
+			}
+			for _, traversal := range expr.Variables() {
+				val, diags := traversal.TraverseAbs(hclCtx)
+				if diags.HasErrors() {
+					continue
+				}
+				deps = append(deps, eval.CollectDepURNs(val)...)
+			}
+		}
+	}
+	return deps
 }
 
 // bindPreconditionHooks registers a hook per precondition and binds it to

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -4741,3 +4741,88 @@ resource "aws_instance" "base" {
 		require.NoError(t, err)
 	})
 }
+
+// TestEngine_LifecycleRefDependencies: a resource referenced only from a
+// lifecycle precondition/postcondition/replace_triggered_by establishes a
+// dependency, as in TF — directly, through a local, and through a data
+// source's check rule — while staying out of PropertyDependencies (no body
+// property carries it). `self` in a postcondition is not a reference and
+// must not break dep collection.
+func TestEngine_LifecycleRefDependencies(t *testing.T) {
+	t.Parallel()
+
+	mock, err := tryExpansion(t, `
+resource "aws_instance" "first" {
+  ami = "ami-first"
+}
+
+locals {
+  first_id = aws_instance.first.id
+}
+
+resource "aws_instance" "pre" {
+  ami = "ami-pre"
+  lifecycle {
+    precondition {
+      condition     = aws_instance.first.id != ""
+      error_message = "first must exist"
+    }
+  }
+}
+
+resource "aws_instance" "post" {
+  ami = "ami-post"
+  lifecycle {
+    postcondition {
+      condition     = self.ami != "" && local.first_id != ""
+      error_message = "self and first must exist"
+    }
+  }
+}
+
+resource "aws_instance" "replace" {
+  ami = "ami-replace"
+  lifecycle {
+    replace_triggered_by = [aws_instance.first.id]
+  }
+}
+
+data "aws_instance" "d" {
+  filter = "static"
+  lifecycle {
+    precondition {
+      condition     = aws_instance.first.id != ""
+      error_message = "first must exist"
+    }
+  }
+}
+
+resource "aws_instance" "reader" {
+  ami = data.aws_instance.d.result
+}
+`, false, false)
+	require.NoError(t, err)
+
+	find := func(name string) *run.RegisterResourceRequest {
+		for i := range mock.RegisteredResources {
+			r := &mock.RegisteredResources[i]
+			if r.Type == "aws:index:Instance" && r.Name == name {
+				return r
+			}
+		}
+		return nil
+	}
+	firstURN := "urn:pulumi:test::project::aws:index:Instance::first"
+
+	for _, name := range []string{"pre", "post", "replace"} {
+		r := find(name)
+		require.NotNilf(t, r, "%s resource should be registered", name)
+		assert.Equal(t, []string{firstURN}, r.Dependencies)
+		assert.Empty(t, r.PropertyDependencies)
+	}
+
+	reader := find("reader")
+	require.NotNil(t, reader, "reader resource should be registered")
+	assert.Equal(t, []string{firstURN}, reader.Dependencies)
+	assert.Equal(t, map[string][]string{"ami": {firstURN}}, reader.PropertyDependencies)
+}

--- a/tests/testutil/tfcompat/providers/destroyordering.go
+++ b/tests/testutil/tfcompat/providers/destroyordering.go
@@ -1,0 +1,79 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// DestroyOrderingProvider exposes `destroyorder_resource`, whose Delete
+// holds for a few seconds and fails if another Delete is in flight at the same
+// time. Create is cheap and never asserts, so apply always succeeds; only the
+// destroy ordering is observed. Chaining two of these so that the dependent
+// references the dependency asserts serialized destruction: when the ordering
+// is honored the two Deletes never overlap; when the dependency edge is missing
+// the two Deletes start concurrently and both error.
+//
+// The in-flight counter is captured per provider instance (one factory call per
+// runtime), so a runtime's own resources share it while the concurrently-run
+// Terraform and pulumi runtimes keep separate counters.
+func DestroyOrderingProvider() *schema.Provider {
+	var mu sync.Mutex
+	inFlight := 0
+
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"destroyorder_resource": {
+				Schema: map[string]*schema.Schema{
+					"name": {Type: schema.TypeString, Optional: true},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("destroy-ordering-id")
+					return nil
+				},
+				ReadContext:   func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				UpdateContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				DeleteContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					mu.Lock()
+					inFlight++
+					overlapped := inFlight > 1
+					mu.Unlock()
+					defer func() {
+						mu.Lock()
+						inFlight--
+						mu.Unlock()
+					}()
+
+					if overlapped {
+						name, _ := d.Get("name").(string)
+						return diag.Errorf(
+							"destroyorder_resource %q deleted while another delete was still in "+
+								"flight: dependency destroy ordering was not honored", name)
+					}
+
+					// Hold the slot open long enough that an unordered second
+					// delete reliably starts within this window.
+					time.Sleep(3 * time.Second)
+					return nil
+				},
+			},
+		},
+	}
+}

--- a/tests/tfcompat/l2_postcondition_ref_destroy_order_test.go
+++ b/tests/tfcompat/l2_postcondition_ref_destroy_order_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// `second` references `first` only through a postcondition condition. Terraform
+// derives an implicit dependency from that reference, so on destroy `second`
+// is deleted before `first`. destroyorder_resource errors if a second delete
+// starts while the first is still in flight, so a missing dependency edge
+// surfaces as overlapping deletes. The case applies both resources, then
+// destroys them.
+func TestL2PostconditionRefDestroyOrder(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_postcondition_ref_destroy_order", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "destroyorder", Factory: providers.DestroyOrderingProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply},
+			{Mode: tfcompat.StageDestroy},
+		},
+	})
+}

--- a/tests/tfcompat/l2_precondition_ref_destroy_order_test.go
+++ b/tests/tfcompat/l2_precondition_ref_destroy_order_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// `second` references `first` only through a precondition condition. Terraform
+// derives an implicit dependency from that reference, so on destroy `second`
+// is deleted before `first`. destroy_ordering_resource errors if a second
+// delete starts while the first is still in flight, so a missing dependency
+// edge surfaces as overlapping deletes. The case applies both resources, then
+// destroys them.
+func TestL2PreconditionRefDestroyOrder(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_precondition_ref_destroy_order", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "destroyorder", Factory: providers.DestroyOrderingProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply},
+			{Mode: tfcompat.StageDestroy},
+		},
+	})
+}

--- a/tests/tfcompat/l2_replace_triggered_by_ref_destroy_order_test.go
+++ b/tests/tfcompat/l2_replace_triggered_by_ref_destroy_order_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// `second` references `first` only through replace_triggered_by. Terraform
+// derives an implicit dependency from that reference, so on destroy `second`
+// is deleted before `first`. destroyorder_resource errors if a second delete
+// starts while the first is still in flight, so a missing dependency edge
+// surfaces as overlapping deletes. The case applies both resources, then
+// destroys them.
+func TestL2ReplaceTriggeredByRefDestroyOrder(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_replace_triggered_by_ref_destroy_order", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "destroyorder", Factory: providers.DestroyOrderingProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply},
+			{Mode: tfcompat.StageDestroy},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_postcondition_ref_destroy_order/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_postcondition_ref_destroy_order/main.tf
@@ -1,0 +1,17 @@
+resource "destroyorder_resource" "first" {
+  name = "first"
+}
+
+# `second` references `first` ONLY through a postcondition condition, with no
+# body-input, count/for_each, or depends_on link. Terraform derives a
+# dependency from the postcondition reference, so `second` is destroyed before
+# `first` and the two deletes never overlap.
+resource "destroyorder_resource" "second" {
+  name = "second"
+  lifecycle {
+    postcondition {
+      condition     = destroyorder_resource.first.id != ""
+      error_message = "first must exist"
+    }
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_precondition_ref_destroy_order/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_precondition_ref_destroy_order/main.tf
@@ -1,0 +1,17 @@
+resource "destroyorder_resource" "first" {
+  name = "first"
+}
+
+# `second` references `first` ONLY through a precondition condition, with no
+# body-input, count/for_each, or depends_on link. Terraform derives a
+# dependency from the precondition reference, so `second` is destroyed before
+# `first` and the two deletes never overlap.
+resource "destroyorder_resource" "second" {
+  name = "second"
+  lifecycle {
+    precondition {
+      condition     = destroyorder_resource.first.id != ""
+      error_message = "first must exist"
+    }
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_replace_triggered_by_ref_destroy_order/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_replace_triggered_by_ref_destroy_order/main.tf
@@ -1,0 +1,14 @@
+resource "destroyorder_resource" "first" {
+  name = "first"
+}
+
+# `second` references `first` ONLY through replace_triggered_by, with no
+# body-input, count/for_each, or depends_on link. Terraform derives a
+# dependency from the trigger reference, so `second` is destroyed before
+# `first` and the two deletes never overlap.
+resource "destroyorder_resource" "second" {
+  name = "second"
+  lifecycle {
+    replace_triggered_by = [destroyorder_resource.first.id]
+  }
+}


### PR DESCRIPTION
## Divergence

When resource `second` references resource `first` **only** inside a `lifecycle` block — a `precondition`/`postcondition` check rule or `replace_triggered_by`, with nothing in `second`'s body, `depends_on`, or `count`/`for_each` referencing `first`:

- **OpenTofu**: the reference establishes an implicit dependency `second → first`, so on destroy `second` is deleted before `first`. Succeeds.
- **Before this fix**: pulumi-hcl derived the registered `DependsOn` (which governs destroy ordering) only from body inputs, explicit `depends_on`, and count/for_each references ([#372](https://github.com/pulumi-labs/pulumi-hcl/pull/372)). Lifecycle-only references added no edge, so it deleted both concurrently and the delete failed.

## Root cause

OpenTofu collects check-rule references (both `condition` and `error_message`) and `replace_triggered_by` expressions into the resource node's graph references, and `AttachDependenciesTransformer` records the graph *ancestors* — transitive through locals and data sources — into state for destroy ordering. pulumi-hcl's create-side graph already sequenced these references, but nothing threaded them into the registered `DependsOn`.

## The fix

- `checkRuleDeps` collects the URNs a check rule references by resolving each referenced traversal through the eval context (`TraverseAbs`) instead of evaluating the expression: no function fires before the hook does, and a reference that runs through a `local` still carries its `DepMark`. `self` — only in scope once a postcondition hook fires — is skipped. `registerResourceInstanceInContext` merges these into `DependsOn` for both preconditions and postconditions, kept out of `PropertyDependencies` since they aren't tied to a body property.
- `replace_triggered_by` expressions were already evaluated when building resource options; their dep URNs are now collected from that single evaluation and merged into `DependsOn`.
- Same root cause on the data-source path: a data source's check-rule references now join the dep marks carried on its outputs, so a resource reading `data.X.Y` inherits the transitive edge.

## Tests

- `TestL2PreconditionRefDestroyOrder`, `TestL2PostconditionRefDestroyOrder`, `TestL2ReplaceTriggeredByRefDestroyOrder` — tfcompat cases on `DestroyOrderingProvider`, whose `Delete` fails if another delete is in flight. `StageApply` then `StageDestroy`; both runtimes now serialize the deletes.
- `TestEngine_LifecycleRefDependencies` — unit test pinning the registered `Dependencies`/`PropertyDependencies` for a direct precondition reference, a postcondition reference through a local (with `self` in the same condition), `replace_triggered_by`, and the data-source path via a downstream reader.

The data-source path has no tfcompat case: the harness destroys with `pulumi destroy --run-program`, which re-runs the program and re-invokes data sources, while `tofu destroy -refresh=false` does not re-read them — any data source + destroy-stage case records a spurious extra read op. That read-timing divergence is pre-existing and independent of this fix.
