### PR TITLE
Resolve terraform_remote_state workspace on the local backend

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-380.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-380.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Support `workspace` on `terraform_remote_state` with the local backend
+time: 2026-07-15T20:49:34Z
+custom:
+    Component: runtime
+    PR: "380"

--- a/pkg/hcl/run/terraform_remote_state.go
+++ b/pkg/hcl/run/terraform_remote_state.go
@@ -17,6 +17,7 @@ package run
 import (
 	"fmt"
 	"maps"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -37,12 +38,14 @@ const (
 // serves no other backend, so any other backend is rejected; support can be added
 // as the package gains backends.
 //
-// On the remote backend the top-level `workspace` is resolved like OpenTofu's
-// remote backend: with config.workspaces.prefix the read workspace is
-// `<prefix><workspace>` (combined into the invoke's `workspaces.name`); with
-// config.workspaces.name only the implicit "default" workspace exists, so
-// `workspace` must be "default". It is unsupported on the local backend
-// (getLocalReference has no workspace input).
+// The top-level `workspace` is resolved the way OpenTofu's backends do, since
+// neither invoke takes a workspace name. On the local backend a non-default
+// workspace's state lives at `<workspace_dir>/<workspace>/terraform.tfstate`
+// (`path` applies only to the default workspace), so it is resolved into the
+// invoke's `path`. On the remote backend, config.workspaces.prefix makes the
+// read workspace `<prefix><workspace>` (combined into the invoke's
+// `workspaces.name`); with config.workspaces.name only the implicit "default"
+// workspace exists, so `workspace` must be "default".
 //
 // `defaults` is returned for applyRemoteStateDefaults to overlay on the invoke
 // result; it is the zero Map when absent.
@@ -73,9 +76,6 @@ func lowerRemoteStateInvoke(tfType string, req InvokeRequest) (InvokeRequest, pr
 	var fields map[string]string // recognized config keys -> invoke argument names
 	switch backend {
 	case "local":
-		if hasWorkspace {
-			return req, property.Map{}, fmt.Errorf("terraform_remote_state: the local backend does not support the workspace attribute")
-		}
 		token = packages.LocalReferenceToken
 		desc = "the local backend"
 		fields = map[string]string{"path": "path", "workspace_dir": "workspaceDir"}
@@ -113,26 +113,41 @@ func lowerRemoteStateInvoke(tfType string, req InvokeRequest) (InvokeRequest, pr
 		)
 	}
 
-	// Resolve the top-level `workspace` the way OpenTofu's remote backend does:
-	//   - config.workspaces.prefix + workspace -> read `<prefix><workspace>`
-	//   - config.workspaces.name exposes only the implicit "default" workspace,
+	// Resolve the top-level `workspace` the way OpenTofu's backends do:
+	//   - local: a non-default workspace's state is at
+	//     `<workspace_dir>/<workspace>/terraform.tfstate` and `path` applies only
+	//     to the default workspace; "default" (or "") reads as if it were absent
+	//   - remote: config.workspaces.prefix + workspace -> read `<prefix><workspace>`;
+	//     config.workspaces.name exposes only the implicit "default" workspace,
 	//     so workspace must be "default" (or absent); anything else is an error
 	if hasWorkspace {
-		ws, ok := args["workspaces"]
-		if !ok || !ws.IsMap() {
-			return req, property.Map{}, fmt.Errorf("terraform_remote_state: workspace requires config.workspaces.prefix")
-		}
-		switch wsMap := ws.AsMap(); {
-		case wsMap.Get("name").IsString():
-			if workspace != "default" {
-				return req, property.Map{}, fmt.Errorf(
-					"terraform_remote_state: workspace %q is invalid with config.workspaces.name (only \"default\" is)", workspace,
-				)
+		switch backend {
+		case "local":
+			if workspace != "default" && workspace != "" {
+				dir := "terraform.tfstate.d"
+				if d, ok := args["workspaceDir"]; ok && d.IsString() {
+					dir = d.AsString()
+				}
+				delete(args, "workspaceDir")
+				args["path"] = property.New(filepath.Join(dir, workspace, "terraform.tfstate"))
 			}
-		case wsMap.Get("prefix").IsString():
-			args["workspaces"] = property.New(map[string]property.Value{"name": property.New(wsMap.Get("prefix").AsString() + workspace)})
-		default:
-			return req, property.Map{}, fmt.Errorf("terraform_remote_state: workspace requires config.workspaces.prefix")
+		case "remote":
+			ws, ok := args["workspaces"]
+			if !ok || !ws.IsMap() {
+				return req, property.Map{}, fmt.Errorf("terraform_remote_state: workspace requires config.workspaces.prefix")
+			}
+			switch wsMap := ws.AsMap(); {
+			case wsMap.Get("name").IsString():
+				if workspace != "default" {
+					return req, property.Map{}, fmt.Errorf(
+						"terraform_remote_state: workspace %q is invalid with config.workspaces.name (only \"default\" is)", workspace,
+					)
+				}
+			case wsMap.Get("prefix").IsString():
+				args["workspaces"] = property.New(map[string]property.Value{"name": property.New(wsMap.Get("prefix").AsString() + workspace)})
+			default:
+				return req, property.Map{}, fmt.Errorf("terraform_remote_state: workspace requires config.workspaces.prefix")
+			}
 		}
 	}
 

--- a/pkg/hcl/run/terraform_remote_state_test.go
+++ b/pkg/hcl/run/terraform_remote_state_test.go
@@ -15,6 +15,7 @@
 package run
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
@@ -210,16 +211,64 @@ func TestLowerRemoteStateInvoke(t *testing.T) {
 			`terraform_remote_state: workspace "prod" is invalid with config.workspaces.name (only "default" is)`)
 	})
 
-	t.Run("workspace is rejected on the local backend", func(t *testing.T) {
+	t.Run("local workspace resolves to a path under workspace_dir", func(t *testing.T) {
 		t.Parallel()
-		_, _, err := lowerRemoteStateInvoke(packages.RemoteStateType, InvokeRequest{
+		got, _, err := lowerRemoteStateInvoke(packages.RemoteStateType, InvokeRequest{
+			Args: property.NewMap(map[string]property.Value{
+				"backend":   property.New("local"),
+				"workspace": property.New("staging"),
+				"config": property.New(map[string]property.Value{
+					"path":          property.New("state.tfstate"),
+					"workspace_dir": property.New("envs"),
+				}),
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, InvokeRequest{
+			Token: packages.LocalReferenceToken,
+			Args: property.NewMap(map[string]property.Value{
+				"path": property.New(filepath.Join("envs", "staging", "terraform.tfstate")),
+			}),
+		}, got)
+	})
+
+	t.Run("local workspace defaults workspace_dir to terraform.tfstate.d", func(t *testing.T) {
+		t.Parallel()
+		got, _, err := lowerRemoteStateInvoke(packages.RemoteStateType, InvokeRequest{
 			Args: property.NewMap(map[string]property.Value{
 				"backend":   property.New("local"),
 				"workspace": property.New("staging"),
 			}),
 		})
-		require.EqualError(t, err,
-			`terraform_remote_state: the local backend does not support the workspace attribute`)
+		require.NoError(t, err)
+		assert.Equal(t, InvokeRequest{
+			Token: packages.LocalReferenceToken,
+			Args: property.NewMap(map[string]property.Value{
+				"path": property.New(filepath.Join("terraform.tfstate.d", "staging", "terraform.tfstate")),
+			}),
+		}, got)
+	})
+
+	t.Run("local workspace=default reads path as if unset", func(t *testing.T) {
+		t.Parallel()
+		got, _, err := lowerRemoteStateInvoke(packages.RemoteStateType, InvokeRequest{
+			Args: property.NewMap(map[string]property.Value{
+				"backend":   property.New("local"),
+				"workspace": property.New("default"),
+				"config": property.New(map[string]property.Value{
+					"path":          property.New("state.tfstate"),
+					"workspace_dir": property.New("envs"),
+				}),
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, InvokeRequest{
+			Token: packages.LocalReferenceToken,
+			Args: property.NewMap(map[string]property.Value{
+				"path":         property.New("state.tfstate"),
+				"workspaceDir": property.New("envs"),
+			}),
+		}, got)
 	})
 
 	t.Run("other data sources are untouched", func(t *testing.T) {

--- a/tests/tfcompat/l2_terraform_remote_state_local_workspace_test.go
+++ b/tests/tfcompat/l2_terraform_remote_state_local_workspace_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL2TerraformRemoteStateLocalWorkspace reads a non-default workspace's
+// state through the builtin terraform_remote_state data source on the local
+// backend. OpenTofu's local backend supports named workspaces: with
+// `workspace = "staging"` it reads `<workspace_dir>/staging/terraform.tfstate`.
+// pulumi-language-hcl rejects the `workspace` attribute on the local backend
+// outright, so both paths should agree but do not.
+func TestL2TerraformRemoteStateLocalWorkspace(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_terraform_remote_state_local_workspace", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_remote_state_local_workspace/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_remote_state_local_workspace/main.tf
@@ -1,0 +1,20 @@
+# OpenTofu's local backend supports named workspaces: with a non-default
+# `workspace`, terraform_remote_state reads `<workspace_dir>/<workspace>/
+# terraform.tfstate` instead of the default `path`. This fixture reads the
+# "staging" workspace's state from states/staging/terraform.tfstate. Both
+# runtimes must surface identical outputs.
+data "terraform_remote_state" "rs" {
+  backend   = "local"
+  workspace = "staging"
+  config = {
+    workspace_dir = "states"
+  }
+}
+
+output "who" {
+  value = data.terraform_remote_state.rs.outputs.who
+}
+
+output "num" {
+  value = data.terraform_remote_state.rs.outputs.num
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_remote_state_local_workspace/states/staging/terraform.tfstate
+++ b/tests/tfcompat/testdata/cases/l2_terraform_remote_state_local_workspace/states/staging/terraform.tfstate
@@ -1,0 +1,12 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 1,
+  "lineage": "3d6f6d7b-4429-46cb-d10f-10ab291859f7",
+  "outputs": {
+    "who": { "value": "from-staging-workspace", "type": "string" },
+    "num": { "value": 7, "type": "number" }
+  },
+  "resources": [],
+  "check_results": null
+}


### PR DESCRIPTION
## Bug

`data "terraform_remote_state"` with `backend = "local"` and a non-default `workspace` errored (`the local backend does not support the workspace attribute`), while OpenTofu reads that workspace's state from `<workspace_dir>/<workspace>/terraform.tfstate`.

## Fix

The pulumi-terraform `getLocalReference` invoke has no workspace-name input, but the local backend's workspace resolution is deterministic (OpenTofu `internal/backend/local/backend.go`, `StatePaths`):

- a non-default workspace's state is `<workspace_dir>/<workspace>/terraform.tfstate`, with `workspace_dir` defaulting to `terraform.tfstate.d`;
- `path` applies only to the default workspace;
- `"default"` (or `""`) behaves as if `workspace` were unset.

`lowerRemoteStateInvoke` now resolves the workspace into the invoke's `path` argument, mirroring how it already combines the remote backend's `workspaces.prefix` with `workspace` into `workspaces.name`. As part of this, `workspace = "default"` on the local backend — which OpenTofu accepts — is now accepted instead of rejected.

## Test

- `TestL2TerraformRemoteStateLocalWorkspace` (tfcompat): reads the `staging` workspace's outputs through the local backend; both runtimes now surface identical outputs.
- Unit tests in `pkg/hcl/run/terraform_remote_state_test.go` cover workspace-to-path resolution with an explicit and a default `workspace_dir`, and `workspace = "default"` passthrough.