### PR TITLE
Replace terraform_data when triggers_replace is set or cleared

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-381.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-381.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Replace `terraform_data` when `triggers_replace` is set or cleared
+time: 2026-07-15T15:00:00Z
+custom:
+    Component: runtime
+    PR: "381"

--- a/pkg/hcl/run/terraform_data.go
+++ b/pkg/hcl/run/terraform_data.go
@@ -27,6 +27,14 @@ import (
 // plain input change is an in-place update with a stable id. Its dependencies
 // are already folded into DependsOn, so the property-level entry is dropped too.
 //
+// The engine treats a null trigger on either side of a diff as "no trigger",
+// so a bare triggers_replace value could never diff against an absent one:
+// setting or clearing triggers_replace would go unnoticed. terraform_data
+// therefore always registers a non-null trigger, the fixed 2-tuple
+// [triggers_replace, replace_triggered_by trigger] (each null when absent),
+// which also keeps triggers_replace from clobbering a replace_triggered_by
+// trigger already captured on the options.
+//
 // input is optional in terraform_data but required by Stash, so an omitted input
 // is supplied as an explicit null: Stash stores it and mirrors it back as a null
 // output, matching terraform_data used purely for its triggers_replace lifecycle.
@@ -34,11 +42,10 @@ func lowerTerraformDataInputs(resType string, inputs property.Map, opts *Resourc
 	if resType != packages.TerraformDataType {
 		return inputs
 	}
-	if t, ok := inputs.GetOk("triggers_replace"); ok {
-		opts.ReplacementTrigger = t
-		inputs = inputs.Delete("triggers_replace")
-	}
+	triggers := inputs.Get("triggers_replace")
+	inputs = inputs.Delete("triggers_replace")
 	delete(opts.PropertyDependencies, "triggers_replace")
+	opts.ReplacementTrigger = property.New([]property.Value{triggers, opts.ReplacementTrigger})
 	if _, ok := inputs.GetOk("input"); !ok {
 		inputs = inputs.Set("input", property.New(property.Null))
 	}
@@ -50,11 +57,11 @@ func lowerTerraformDataInputs(resType string, inputs property.Map, opts *Resourc
 //
 // terraform_data's `output` mirrors `input`, read back from Stash's tracking
 // `input` output; `triggers_replace` is not a Stash output, so it is echoed
-// from the replacement trigger captured by lowerTerraformDataInputs.
+// from the trigger tuple encoded by lowerTerraformDataInputs.
 func lowerTerraformDataOutputs(resType string, outputs property.Map, opts *ResourceOptions) property.Map {
 	if resType != packages.TerraformDataType {
 		return outputs
 	}
 	outputs = outputs.Set("output", outputs.Get("input"))
-	return outputs.Set("triggers_replace", opts.ReplacementTrigger)
+	return outputs.Set("triggers_replace", opts.ReplacementTrigger.AsArray().Get(0))
 }

--- a/pkg/hcl/run/terraform_data_internal_test.go
+++ b/pkg/hcl/run/terraform_data_internal_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
+)
+
+func TestLowerTerraformDataInputs(t *testing.T) {
+	t.Parallel()
+
+	null := property.New(property.Null)
+
+	tests := []struct {
+		name        string
+		inputs      property.Map
+		opts        ResourceOptions
+		wantInputs  property.Map
+		wantTrigger property.Value
+	}{
+		{
+			name: "triggers_replace present",
+			inputs: property.NewMap(map[string]property.Value{
+				"input":            property.New("a"),
+				"triggers_replace": property.New("x"),
+			}),
+			wantInputs: property.NewMap(map[string]property.Value{
+				"input": property.New("a"),
+			}),
+			wantTrigger: property.New([]property.Value{property.New("x"), null}),
+		},
+		{
+			name: "triggers_replace absent still registers a non-null trigger",
+			inputs: property.NewMap(map[string]property.Value{
+				"input": property.New("a"),
+			}),
+			wantInputs: property.NewMap(map[string]property.Value{
+				"input": property.New("a"),
+			}),
+			wantTrigger: property.New([]property.Value{null, null}),
+		},
+		{
+			name:   "omitted input is materialized as null",
+			inputs: property.Map{},
+			wantInputs: property.NewMap(map[string]property.Value{
+				"input": null,
+			}),
+			wantTrigger: property.New([]property.Value{null, null}),
+		},
+		{
+			name: "replace_triggered_by trigger is preserved alongside triggers_replace",
+			inputs: property.NewMap(map[string]property.Value{
+				"input":            property.New("a"),
+				"triggers_replace": property.New("x"),
+			}),
+			opts: ResourceOptions{ReplacementTrigger: property.New("lifecycle")},
+			wantInputs: property.NewMap(map[string]property.Value{
+				"input": property.New("a"),
+			}),
+			wantTrigger: property.New([]property.Value{
+				property.New("x"), property.New("lifecycle"),
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := lowerTerraformDataInputs(packages.TerraformDataType, tt.inputs, &tt.opts)
+			assert.Equal(t, tt.wantInputs, got)
+			assert.Equal(t, tt.wantTrigger, tt.opts.ReplacementTrigger)
+		})
+	}
+
+	t.Run("other types are untouched", func(t *testing.T) {
+		t.Parallel()
+
+		inputs := property.NewMap(map[string]property.Value{
+			"triggers_replace": property.New("x"),
+		})
+		opts := ResourceOptions{}
+		got := lowerTerraformDataInputs("random_pet", inputs, &opts)
+		assert.Equal(t, inputs, got)
+		assert.Equal(t, ResourceOptions{}, opts)
+	})
+}
+
+func TestLowerTerraformDataOutputs(t *testing.T) {
+	t.Parallel()
+
+	null := property.New(property.Null)
+	inputs := property.NewMap(map[string]property.Value{
+		"input":            property.New("a"),
+		"triggers_replace": property.New("x"),
+	})
+	opts := ResourceOptions{}
+	lowerTerraformDataInputs(packages.TerraformDataType, inputs, &opts)
+
+	outputs := property.NewMap(map[string]property.Value{
+		"input": property.New("a"),
+	})
+	got := lowerTerraformDataOutputs(packages.TerraformDataType, outputs, &opts)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"input":            property.New("a"),
+		"output":           property.New("a"),
+		"triggers_replace": property.New("x"),
+	}), got)
+
+	t.Run("absent triggers_replace echoes null", func(t *testing.T) {
+		t.Parallel()
+
+		opts := ResourceOptions{}
+		lowerTerraformDataInputs(packages.TerraformDataType, property.Map{}, &opts)
+		got := lowerTerraformDataOutputs(packages.TerraformDataType, property.Map{}, &opts)
+		assert.Equal(t, property.NewMap(map[string]property.Value{
+			"output":           null,
+			"triggers_replace": null,
+		}), got)
+	})
+}

--- a/tests/tfcompat/l2_terraform_data_trigger_removal_test.go
+++ b/tests/tfcompat/l2_terraform_data_trigger_removal_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2TerraformDataTriggerRemoval removes terraform_data's triggers_replace
+// between two stages ("x" -> absent). OpenTofu treats clearing this ForceNew
+// attribute as a change and replaces the resource, rolling its id and replacing
+// the dependent that watches it via replace_triggered_by. Both runtimes must
+// produce the same simple provider op trace.
+func TestL2TerraformDataTriggerRemoval(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_terraform_data_trigger_removal", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_terraform_data_trigger_removal_test.go
+++ b/tests/tfcompat/l2_terraform_data_trigger_removal_test.go
@@ -22,9 +22,10 @@ import (
 )
 
 // TestL2TerraformDataTriggerRemoval removes terraform_data's triggers_replace
-// between two stages ("x" -> absent). OpenTofu treats clearing this ForceNew
-// attribute as a change and replaces the resource, rolling its id and replacing
-// the dependent that watches it via replace_triggered_by. Both runtimes must
+// between stages 0 and 1 ("x" -> absent), then re-adds it in stage 2
+// (absent -> "y"). OpenTofu treats clearing or setting this ForceNew attribute
+// as a change and replaces the resource, rolling its id and replacing the
+// dependent that watches it via replace_triggered_by. Both runtimes must
 // produce the same simple provider op trace.
 func TestL2TerraformDataTriggerRemoval(t *testing.T) {
 	t.Parallel()

--- a/tests/tfcompat/testdata/cases/l2_terraform_data_trigger_removal/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_data_trigger_removal/0/main.tf
@@ -1,0 +1,19 @@
+# Stage 0: create. terraform_data.t has triggers_replace = "x".
+# simple_resource.dependent watches terraform_data.t.id via replace_triggered_by,
+# so the simple provider's op trace witnesses whether terraform_data is replaced
+# across stages (its id is a random uuid, not comparable cross-path directly).
+resource "terraform_data" "t" {
+  input            = "constant"
+  triggers_replace = "x"
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "dependent_result" {
+  value = simple_resource.dependent.result
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_data_trigger_removal/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_data_trigger_removal/1/main.tf
@@ -1,0 +1,18 @@
+# Stage 1: triggers_replace is removed entirely ("x" -> null). OpenTofu treats
+# clearing this ForceNew attribute as a change, so terraform_data.t is replaced,
+# its id rolls, and simple_resource.dependent is replaced (Delete+Create on the
+# simple provider). Input is unchanged.
+resource "terraform_data" "t" {
+  input = "constant"
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "dependent_result" {
+  value = simple_resource.dependent.result
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_data_trigger_removal/2/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_data_trigger_removal/2/main.tf
@@ -1,0 +1,19 @@
+# Stage 2: triggers_replace is re-added (null -> "y"), the inverse of stage 1.
+# OpenTofu treats setting this ForceNew attribute as a change, so terraform_data.t
+# is replaced again, its id rolls, and simple_resource.dependent is replaced
+# (Delete+Create on the simple provider). Input is unchanged.
+resource "terraform_data" "t" {
+  input            = "constant"
+  triggers_replace = "y"
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "dependent_result" {
+  value = simple_resource.dependent.result
+}


### PR DESCRIPTION
## Divergence

When `terraform_data`'s `triggers_replace` transitions to or from absent between two applies (e.g. `triggers_replace = "x"` → attribute deleted, `input` unchanged):

- **OpenTofu**: setting or clearing this ForceNew attribute is a change, so it **replaces** the resource (new `id`).
- **pulumi-hcl**: performed an **in-place update** with a stable `id` — no replacement. Anything watching `terraform_data.x.id` via `replace_triggered_by` was wrongly left untouched.

## Root cause

`terraform_data`'s `triggers_replace` is lowered onto the engine's `ReplacementTrigger`, but the engine treats a null trigger on *either* side of a diff as "no trigger" (`shouldTriggerReplace` in the step generator). `lowerTerraformDataInputs` only set the trigger when the attribute was present, so a null↔value transition in either direction never diffed.

## Fix

`terraform_data` now always registers a non-null trigger: the fixed 2-tuple `[triggers_replace, replace_triggered_by trigger]`, with null elements when absent. Null↔value transitions of `triggers_replace` now diff (`[null, null]` vs `["x", null]`), while "never had a trigger" remains a no-op. As a side effect, `triggers_replace` no longer clobbers a `replace_triggered_by` trigger on the same `terraform_data` resource, which the old code overwrote. The `triggers_replace` output echo unwraps the first tuple element.

Note: stacks deployed with the old scalar encoding will see a one-time replacement of `terraform_data` resources that have `triggers_replace` set on their first update after this change (the tuple never equals the old scalar).

## Testing

- `TestL2TerraformDataTriggerRemoval` (tfcompat): three stages — create with `triggers_replace = "x"`, clear it (replace), re-add as `"y"` (replace) — witnessed by a `replace_triggered_by` dependent's provider op trace matching OpenTofu.
- Unit tests for `lowerTerraformDataInputs`/`lowerTerraformDataOutputs` covering the tuple encoding, the absent-trigger case, lifecycle-trigger preservation, and the output echo.
- Existing `TestL2TerraformData`, `TestL2TerraformDataLifecycle`, full `pkg/hcl/run` and `pkg/server` suites, and `TestSmokeDestroyHooks` all pass.