### PR TITLE
Honor whole-resource replace_triggered_by when the resource is replaced

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-383.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-383.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Replace a resource whose `replace_triggered_by` names a whole resource when that resource is replaced, even if its value is unchanged
+time: 2026-07-15T18:30:00Z
+custom:
+    Component: runtime
+    PR: "383"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1866,6 +1866,13 @@ func (e *Engine) buildResourceOptionsInContext(
 	// replacement. A single-element list is unwrapped to a scalar so the
 	// trigger value round-trips with Pulumi's scalar `replacementTrigger`.
 	// A reference in a trigger also establishes a dependency, as in TF.
+	//
+	// An element whose value is a whole resource is action-based, not
+	// value-based: it must fire when the referenced resource is replaced even
+	// if every attribute value is unchanged. The value trigger covers in-place
+	// updates (an update implies the object value changed); the replacement
+	// action is covered by also listing the referenced instances' URNs in
+	// ReplaceWith.
 	if res.Lifecycle != nil && len(res.Lifecycle.ReplaceTriggeredBy) > 0 {
 		vals := make([]cty.Value, 0, len(res.Lifecycle.ReplaceTriggeredBy))
 		for _, expr := range res.Lifecycle.ReplaceTriggeredBy {
@@ -1880,6 +1887,7 @@ func (e *Engine) buildResourceOptionsInContext(
 				}
 			}
 			vals = append(vals, val)
+			opts.ReplaceWith = append(opts.ReplaceWith, resourceURNsFromValue(val)...)
 		}
 		var triggerVal cty.Value
 		if len(vals) == 1 {
@@ -4358,6 +4366,29 @@ func ptr[T any](v T) *T { return &v }
 // ctyAsString reads a cty value as a string, tolerating marks (resource
 // output leaves carry DepMarks) and returning "" for null / unknown /
 // non-string. Use the cty API directly if you need to distinguish those.
+// resourceURNsFromValue extracts the URNs of the resource instances val
+// represents when it is a whole-resource value: a single instance carries a
+// resource reference mark, while a reference to a resource with count or
+// for_each yields a tuple or object of such instance values. An attribute of a
+// resource inherits the mark but not its hash, so it yields no URNs.
+func resourceURNsFromValue(val cty.Value) []string {
+	if u, ok := eval.ResourceReferenceURN(val); ok {
+		return []string{string(u)}
+	}
+	val, _ = val.Unmark()
+	if val.IsNull() || !val.IsKnown() || !val.CanIterateElements() {
+		return nil
+	}
+	var urns []string
+	for it := val.ElementIterator(); it.Next(); {
+		_, el := it.Element()
+		if u, ok := eval.ResourceReferenceURN(el); ok {
+			urns = append(urns, string(u))
+		}
+	}
+	return urns
+}
+
 func ctyAsString(v cty.Value) string {
 	if v.IsMarked() {
 		v, _ = v.Unmark()

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -3527,6 +3527,90 @@ resource "test_resource" "res" {
 		"expected replacement_trigger to be set from lifecycle.replace_triggered_by")
 }
 
+// TestEngine_ReplaceTriggeredByWholeResource covers the action-based half of a
+// whole-resource replace_triggered_by element: the referenced instance's URN
+// must be recorded in ReplaceWith so the engine replaces the dependent whenever
+// the referenced resource is replaced, even if its value is unchanged. The
+// detection is value-based, so a local aliasing the resource behaves the same,
+// while an attribute of the resource stays purely value-triggered.
+func TestEngine_ReplaceTriggeredByWholeResource(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "test_resource" "middle" {
+  field = "const"
+}
+
+locals {
+  indirect = test_resource.middle
+}
+
+resource "test_resource" "byWhole" {
+  field = "dep"
+
+  lifecycle {
+    replace_triggered_by = [test_resource.middle]
+  }
+}
+
+resource "test_resource" "byLocal" {
+  field = "dep"
+
+  lifecycle {
+    replace_triggered_by = [local.indirect]
+  }
+}
+
+resource "test_resource" "byAttr" {
+  field = "dep"
+
+  lifecycle {
+    replace_triggered_by = [test_resource.middle.field]
+  }
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader:    schemaloader.New(t, testSchema()),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	byName := make(map[string]run.RegisterResourceRequest)
+	for _, req := range mock.RegisteredResources {
+		byName[req.Name] = req
+	}
+
+	middleURN := "urn:pulumi:test::project::test:index:Resource::middle"
+
+	byWhole, ok := byName["byWhole"]
+	require.True(t, ok, "expected byWhole to be registered")
+	assert.Equal(t, []string{middleURN}, byWhole.ReplaceWith)
+	assert.False(t, byWhole.ReplacementTrigger.IsNull(),
+		"a whole-resource reference keeps its value trigger to cover in-place updates")
+
+	byLocal, ok := byName["byLocal"]
+	require.True(t, ok, "expected byLocal to be registered")
+	assert.Equal(t, []string{middleURN}, byLocal.ReplaceWith,
+		"a local aliasing a whole resource behaves like the resource itself")
+
+	byAttr, ok := byName["byAttr"]
+	require.True(t, ok, "expected byAttr to be registered")
+	assert.Empty(t, byAttr.ReplaceWith, "an attribute reference is value-based only")
+	assert.False(t, byAttr.ReplacementTrigger.IsNull())
+}
+
 // TestEngine_HetListOutputRoundTrip drives the engine against a mock provider whose
 // resource output is a list of objects with a nested optional object populated in some
 // elements and absent in others.

--- a/tests/testutil/tfcompat/providers/replacer.go
+++ b/tests/testutil/tfcompat/providers/replacer.go
@@ -1,0 +1,57 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ReplacerProvider exposes `replacer_resource`, a resource that can be forced
+// to be replaced. Its `force` attribute is ForceNew, so changing it destroys
+// and recreates the resource. `note` is an ordinary in-place-updatable input.
+// `result` is a computed value recomputed on both create and update, so the
+// resource's referenced value tracks its inputs (unlike SimpleProvider, whose
+// no-op Update leaves computed fields stale). The id is a constant, so a
+// replacement leaves the resource's id unchanged.
+func ReplacerProvider() *schema.Provider {
+	compute := func(d *schema.ResourceData) diag.Diagnostics {
+		force, _ := d.Get("force").(string)
+		note, _ := d.Get("note").(string)
+		return diag.FromErr(d.Set("result", force+"/"+note))
+	}
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"replacer_resource": {
+				Schema: map[string]*schema.Schema{
+					"force":  {Type: schema.TypeString, Optional: true, ForceNew: true},
+					"note":   {Type: schema.TypeString, Optional: true},
+					"result": {Type: schema.TypeString, Computed: true},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("replacer-id")
+					return compute(d)
+				},
+				ReadContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				UpdateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					return compute(d)
+				},
+				DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+			},
+		},
+	}
+}

--- a/tests/tfcompat/l2_replace_triggered_by_whole_resource_test.go
+++ b/tests/tfcompat/l2_replace_triggered_by_whole_resource_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ReplaceTriggeredByWholeResource proves that a whole-resource reference
+// in `lifecycle.replace_triggered_by` is action-based in OpenTofu but
+// value-based in pulumi-hcl.
+//
+// `dependent` references the entire `middle` resource (not one of its
+// attributes). Across the two stages `middle` is replaced -- but its inputs are
+// constant, so every attribute of `middle` is identical before and after.
+// OpenTofu replaces `dependent` because `middle` is planned for replacement;
+// pulumi-hcl does not, because `middle`'s serialized value never changes. The
+// provider-op traces therefore differ (tofu records an extra replace of
+// `dependent`), and the harness fails.
+func TestL2ReplaceTriggeredByWholeResource(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_replace_triggered_by_whole_resource", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "replacer", Factory: providers.ReplacerProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_replace_triggered_by_whole_resource/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_replace_triggered_by_whole_resource/0/main.tf
@@ -1,0 +1,40 @@
+# `dependent` lists the WHOLE `middle` resource in replace_triggered_by, not
+# one of its attributes. Per OpenTofu, a whole-instance reference triggers
+# replacement whenever the referenced instance is planned to be updated or
+# replaced -- the decision is based on the planned action, not on whether any
+# attribute value changes.
+#
+# `middle` is itself replaced across the two stages (via replace_triggered_by
+# on `driver.result`), but `middle`'s own inputs are constant, so all of
+# `middle`'s attributes are identical before and after that replacement.
+
+resource "replacer_resource" "driver" {
+  force = "a"
+}
+
+resource "replacer_resource" "middle" {
+  force = "const"
+  lifecycle {
+    replace_triggered_by = [replacer_resource.driver.result]
+  }
+}
+
+resource "replacer_resource" "dependent" {
+  force = "dep"
+  note  = "x"
+  lifecycle {
+    replace_triggered_by = [replacer_resource.middle]
+  }
+}
+
+output "driver_result" {
+  value = replacer_resource.driver.result
+}
+
+output "middle_result" {
+  value = replacer_resource.middle.result
+}
+
+output "dependent_result" {
+  value = replacer_resource.dependent.result
+}

--- a/tests/tfcompat/testdata/cases/l2_replace_triggered_by_whole_resource/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_replace_triggered_by_whole_resource/1/main.tf
@@ -1,0 +1,40 @@
+# Stage 1: `driver.force` changes a -> b. Because `force` is ForceNew, `driver`
+# is replaced, so `driver.result` changes, which replaces `middle` via its
+# replace_triggered_by. `middle`'s own inputs are unchanged, so after the
+# replacement every attribute of `middle` is identical to before.
+#
+# OpenTofu: `middle` is planned to be replaced, so the whole-instance reference
+# in `dependent.replace_triggered_by` forces `dependent` to be replaced too.
+# pulumi-hcl: the reference is compared by value; `middle`'s value is
+# unchanged, so `dependent` is NOT replaced.
+
+resource "replacer_resource" "driver" {
+  force = "b"
+}
+
+resource "replacer_resource" "middle" {
+  force = "const"
+  lifecycle {
+    replace_triggered_by = [replacer_resource.driver.result]
+  }
+}
+
+resource "replacer_resource" "dependent" {
+  force = "dep"
+  note  = "x"
+  lifecycle {
+    replace_triggered_by = [replacer_resource.middle]
+  }
+}
+
+output "driver_result" {
+  value = replacer_resource.driver.result
+}
+
+output "middle_result" {
+  value = replacer_resource.middle.result
+}
+
+output "dependent_result" {
+  value = replacer_resource.dependent.result
+}


### PR DESCRIPTION
## Divergence

A **whole-resource** reference in `lifecycle { replace_triggered_by = [x.middle] }`:

- **OpenTofu**: action-based — replaces the dependent whenever the referenced instance is planned for update or replacement (`Update`, `DeleteThenCreate`, `CreateThenDelete`), never comparing values.
- **pulumi-hcl** (before this PR): value-based — fed the referenced resource's serialized value as `ReplacementTrigger`. When the referenced resource was replaced but its value was unchanged, pulumi-hcl did not replace the dependent.

## Fix

Each `replace_triggered_by` element whose evaluated value is a whole resource now also contributes the referenced instances' URNs to the engine's `ReplaceWith` resource option, which replaces the dependent whenever any listed resource is replaced — value change or not. The value-based `ReplacementTrigger` is kept to cover the update half: an in-place update by definition changes the resource's object value.

Detection is on the value, not the reference syntax, using the existing hash-checked resource reference mark (`eval.ResourceReferenceURN`), with one level of element iteration for `count`/`for_each` collections. A local aliasing a whole resource therefore behaves like the resource itself (OpenTofu rejects such indirection outright, so this is a compatible extension), while an attribute of a resource inherits the mark but not its hash and stays value-triggered.

## Tests

- `TestL2ReplaceTriggeredByWholeResource` (added on this branch as the failing reproducer) now passes: a 3-resource chain where `middle` is replaced with constant inputs, and the whole-resource trigger on `dependent` must fire.
- `TestEngine_ReplaceTriggeredByWholeResource` (unit): asserts `ReplaceWith` carries the referenced instance's URN for a direct whole-resource element and for a local alias, and stays empty for an attribute element.
- Full tfcompat suite (166 tests) and `./pkg/...` pass.