### PR TITLE
Run cross-referencing variable validations on their own graph node

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-384.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-384.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Support variable `validation` conditions that reference resources and other objects
+time: 2026-07-15T15:00:00Z
+custom:
+    Component: runtime
+    PR: "384"

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -145,6 +145,7 @@ const (
 	NodeTypeBuiltin
 	NodeTypeCall
 	NodeTypeModuleInit
+	NodeTypeVariableValidation
 )
 
 func (t NodeType) String() string {
@@ -169,6 +170,8 @@ func (t NodeType) String() string {
 		return "call"
 	case NodeTypeModuleInit:
 		return "module_init"
+	case NodeTypeVariableValidation:
+		return "variable_validation"
 	default:
 		return "unknown"
 	}
@@ -415,12 +418,7 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 	// Variable values come from outside, so a variable depends only on whatever
 	// its validation rules reference (e.g. another variable).
 	for name, v := range config.Variables {
-		err := g.AddNode(&Node{
-			Key:      "var." + name,
-			Type:     NodeTypeVariable,
-			Variable: v,
-		}, g.variableValidationDeps(v, "var."+name, ""))
-		if err != nil {
+		if err := g.addVariableNodes("var."+name, v, nil, nil, ""); err != nil {
 			return nil, err
 		}
 	}
@@ -907,6 +905,55 @@ func (g *Graph) variableValidationDeps(v *ast.Variable, key, prefix string) []pd
 	return slices.DeleteFunc(deps, func(n pdag.Node) bool { return n == self })
 }
 
+// variableValueKeySuffix marks the internal value node of a variable whose
+// validation rules were split onto a separate node. "!" cannot appear in an
+// HCL identifier, so the key can never collide with a referenceable node.
+const variableValueKeySuffix = "!value"
+
+// addVariableNodes adds the graph node(s) for one variable declaration. key is
+// the node key consumers reference (prefix + "var." + name); valueDeps are the
+// dependencies of evaluating the variable's value (module init and the input
+// expression from the calling module block).
+//
+// A validation rule may reference other objects — say a resource's computed
+// output — and the rule must then run after that object, while the variable's
+// value must stay available to everything ordered before it (such as nodes on
+// the far side of an InjectAfter barrier). Keeping rules with such references
+// on the value node would turn that ordering into a cycle, so they are split
+// onto a NodeTypeVariableValidation node that owns the public key: consumers
+// wait for the checks, and the value itself is evaluated by an internal value
+// node that carries a copy of the declaration with the split rules removed.
+func (g *Graph) addVariableNodes(key string, v *ast.Variable, modInfo *ModuleInfo, valueDeps []pdag.Node, prefix string) error {
+	validationDeps := g.variableValidationDeps(v, key, prefix)
+	if len(validationDeps) == 0 {
+		return g.AddNode(&Node{
+			Key:        key,
+			Type:       NodeTypeVariable,
+			Variable:   v,
+			ModuleInfo: modInfo,
+		}, valueDeps)
+	}
+
+	valueVar := *v
+	valueVar.Validations = nil
+	valueKey := key + variableValueKeySuffix
+	if err := g.AddNode(&Node{
+		Key:        valueKey,
+		Type:       NodeTypeVariable,
+		Variable:   &valueVar,
+		ModuleInfo: modInfo,
+	}, valueDeps); err != nil {
+		return err
+	}
+	_, valueIdx := g.newNode(valueKey)
+	return g.AddNode(&Node{
+		Key:        key,
+		Type:       NodeTypeVariableValidation,
+		Variable:   v,
+		ModuleInfo: modInfo,
+	}, append(validationDeps, valueIdx))
+}
+
 // exprDeps extracts all dependencies from an expression, applying prefix to resolved keys.
 func (g *Graph) exprDeps(expr hcl.Expression, prefix string) []pdag.Node {
 	return g.exprDepsExcluding(expr, prefix, nil)
@@ -1192,13 +1239,7 @@ func (g *Graph) inlineModule(
 		if inputAttr, ok := moduleInputAttrs[varName]; ok {
 			varDeps = append(varDeps, g.exprDeps(inputAttr.Expr, parentPrefix)...)
 		}
-		varDeps = append(varDeps, g.variableValidationDeps(v, prefix+"var."+varName, prefix)...)
-		if err := g.AddNode(&Node{
-			Key:        prefix + "var." + varName,
-			Type:       NodeTypeVariable,
-			Variable:   v,
-			ModuleInfo: modInfo,
-		}, varDeps); err != nil {
+		if err := g.addVariableNodes(prefix+"var."+varName, v, modInfo, varDeps, prefix); err != nil {
 			return err
 		}
 	}

--- a/pkg/hcl/graph/graph_test.go
+++ b/pkg/hcl/graph/graph_test.go
@@ -86,6 +86,93 @@ output "instance_id" {
 	}
 }
 
+func TestVariableValidationResourceRefSplitsNode(t *testing.T) {
+	t.Parallel()
+	// gate's validation references a resource, so the rules move to a
+	// validation node that owns "var.gate" while an internal value node
+	// evaluates the value. An InjectAfter barrier on variable nodes (as the
+	// runtime adds before walking) must then order value -> barrier ->
+	// resource -> validation without a cycle.
+	src := []byte(`
+resource "simple_resource" "r" {
+  input_one = "a"
+}
+
+variable "gate" {
+  type    = string
+  default = "a"
+
+  validation {
+    condition     = simple_resource.r.result == "${var.gate}-false"
+    error_message = "failed"
+  }
+}
+
+output "gate" {
+  value = var.gate
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.Empty(t, diags)
+
+	g, err := BuildFromConfig(config, nil, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, NodeTypeVariableValidation, g.seen["var.gate"].n.Type)
+	assert.Equal(t, NodeTypeVariable, g.seen["var.gate!value"].n.Type)
+
+	barrierKey := "barrier"
+	require.NoError(t, g.InjectAfter(func(context.Context) error { return nil }, func(n *Node) bool {
+		return n.Type == NodeTypeVariable
+	}))
+
+	var sorted []string
+	err = g.dag.Walk(t.Context(), func(_ context.Context, n dagNode) error {
+		key := n.key
+		if n.exec != nil {
+			key = barrierKey
+		}
+		sorted = append(sorted, key)
+		return nil
+	}, pdag.MaxProcs(1))
+	require.NoError(t, err)
+
+	positions := make(map[string]int)
+	for i, key := range sorted {
+		positions[key] = i
+	}
+	assert.Less(t, positions["var.gate!value"], positions[barrierKey])
+	assert.Less(t, positions[barrierKey], positions["simple_resource.r"])
+	assert.Less(t, positions["simple_resource.r"], positions["var.gate"])
+	assert.Less(t, positions["var.gate"], positions["output.gate"])
+}
+
+func TestVariableValidationSelfRefKeepsSingleNode(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+variable "name" {
+  type = string
+
+  validation {
+    condition     = length(var.name) > 0
+    error_message = "empty"
+  }
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.Empty(t, diags)
+
+	g, err := BuildFromConfig(config, nil, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, NodeTypeVariable, g.seen["var.name"].n.Type)
+	assert.NotContains(t, g.seen, "var.name!value")
+}
+
 func TestForcedCreateBeforeDestroy(t *testing.T) {
 	t.Parallel()
 	// c declares create_before_destroy and depends on b, which depends on a, so

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -658,6 +658,8 @@ func (e *Engine) processNode(ctx context.Context, node *graph.Node) error {
 	switch node.Type {
 	case graph.NodeTypeVariable:
 		return e.processVariable(ctx, node)
+	case graph.NodeTypeVariableValidation:
+		return e.processVariableValidation(node)
 	case graph.NodeTypeLocal:
 		return e.processLocal(ctx, node)
 	case graph.NodeTypeResource:
@@ -707,7 +709,7 @@ func (e *Engine) processVariable(ctx context.Context, node *graph.Node) error {
 		return e.processModuleVariable(node)
 	}
 
-	varName := node.Key[4:] // Remove "var." prefix
+	varName := v.Name
 	var val cty.Value
 	var isSecret bool
 	var valueSource string
@@ -813,6 +815,24 @@ func (e *Engine) processVariable(ctx context.Context, node *graph.Node) error {
 	e.evaluator.Context().SetVariable(varName, val)
 
 	return runVariableValidations(e.evaluator, varName, v.Validations)
+}
+
+// processVariableValidation runs the validation rules of a variable whose
+// rules reference other objects (e.g. a resource's computed output). The rules
+// live on their own graph node, ordered after both the variable's value and
+// the referenced objects, so consumers of the variable only observe a
+// validated value.
+func (e *Engine) processVariableValidation(node *graph.Node) error {
+	v := node.Variable
+	if v == nil {
+		return fmt.Errorf("variable validation node missing Variable field")
+	}
+	if node.ModuleInfo != nil {
+		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
+			return runVariableValidations(eval.NewEvaluator(inst.EvalCtx), v.Name, v.Validations)
+		})
+	}
+	return runVariableValidations(e.evaluator, v.Name, v.Validations)
 }
 
 // runVariableValidations evaluates a variable's `validation` rules against ev
@@ -3408,7 +3428,7 @@ func (e *Engine) forEachModuleInstance(node *graph.Node, fn func(inst *moduleIns
 func (e *Engine) processModuleVariable(node *graph.Node) error {
 	v := node.Variable
 	modInfo := node.ModuleInfo
-	varName := strings.TrimPrefix(node.Key, modInfo.Prefix()+"var.")
+	varName := v.Name
 
 	moduleInputAttrs, _ := modInfo.Module.Config.JustAttributes()
 	inputAttr, hasInput := moduleInputAttrs[varName]

--- a/tests/tfcompat/l2_var_validation_resource_ref_test.go
+++ b/tests/tfcompat/l2_var_validation_resource_ref_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2VarValidation_ResourceRef covers a variable validation whose condition
+// references the variable itself and a managed resource's computed output
+// (allowed by OpenTofu as long as the condition also refers to the variable).
+// OpenTofu orders the rule after the resource and applies cleanly; pulumi-hcl
+// fails the whole operation with "Cycle found".
+func TestL2VarValidation_ResourceRef(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_var_validation_resource_ref", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_var_validation_resource_ref_test.go
+++ b/tests/tfcompat/l2_var_validation_resource_ref_test.go
@@ -22,13 +22,24 @@ import (
 )
 
 // TestL2VarValidation_ResourceRef covers a variable validation whose condition
-// references the variable itself and a managed resource's computed output
-// (allowed by OpenTofu as long as the condition also refers to the variable).
-// OpenTofu orders the rule after the resource and applies cleanly; pulumi-hcl
-// fails the whole operation with "Cycle found".
+// references the variable itself and a managed resource's computed output.
+// The rule is ordered after the resource (deferred at preview, checked at
+// apply) and the program applies cleanly, matching OpenTofu.
 func TestL2VarValidation_ResourceRef(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_var_validation_resource_ref", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}
+
+// TestL2ModuleVarValidation_ResourceRef asserts the same for a variable
+// declared in a child module whose validation references a resource in that
+// module.
+func TestL2ModuleVarValidation_ResourceRef(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_var_validation_resource_ref", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},

--- a/tests/tfcompat/testdata/cases/l2_module_var_validation_resource_ref/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_var_validation_resource_ref/child/main.tf
@@ -1,0 +1,21 @@
+resource "simple_resource" "r" {
+  input_one = "a"
+}
+
+variable "gate" {
+  type    = string
+  default = "a"
+
+  validation {
+    condition     = simple_resource.r.result == "${var.gate}-false"
+    error_message = "MODULE_GATE_VALIDATION_FAILED"
+  }
+}
+
+output "gate" {
+  value = var.gate
+}
+
+output "result" {
+  value = simple_resource.r.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_var_validation_resource_ref/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_var_validation_resource_ref/main.tf
@@ -1,0 +1,11 @@
+module "child" {
+  source = "./child"
+}
+
+output "gate" {
+  value = module.child.gate
+}
+
+output "result" {
+  value = module.child.result
+}

--- a/tests/tfcompat/testdata/cases/l2_var_validation_resource_ref/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_var_validation_resource_ref/main.tf
@@ -1,0 +1,21 @@
+resource "simple_resource" "r" {
+  input_one = "a"
+}
+
+variable "gate" {
+  type    = string
+  default = "a"
+
+  validation {
+    condition     = simple_resource.r.result == "${var.gate}-false"
+    error_message = "GATE_VALIDATION_FAILED"
+  }
+}
+
+output "gate" {
+  value = var.gate
+}
+
+output "result" {
+  value = simple_resource.r.result
+}


### PR DESCRIPTION
## Bug

A `variable` whose `validation` `condition` references both the variable itself and a managed resource's computed output (e.g. `simple_resource.r.result == "${var.gate}-false"`) is accepted by OpenTofu: the rule is ordered after the resource — deferred at plan, evaluated at apply — and the program applies cleanly. pulumi-hcl turned the validation→resource dependency into a graph cycle and aborted the whole operation with `error: an unhandled error occurred: Cycle found`.

## Root cause

The runtime injects a `checkPulumiVersion` barrier ordered after every root variable node and before the rest of the graph. Validation dependencies were hung on the variable node itself, so the variable depended on the resource while the barrier ordered the resource after the variable — a cycle.

## Fix

Mirror OpenTofu's `nodeVariableReference` split. When a validation rule references anything beyond the variable itself, the graph now builds two nodes:

- an internal value node (`var.<name>!value`) that evaluates and publishes the value, ordered before the barrier as usual;
- a `NodeTypeVariableValidation` node that owns the public `var.<name>` key and depends on the value node plus the rule's references. Consumers of the variable depend on it, so they only observe a validated value; conditions unknown at preview stay deferred to apply.

Variables whose rules reference nothing else keep the single-node shape, so failing static validations still abort before any resource is created. Module variables get the same treatment. If a resource consumes the variable while the validation references that resource, this still reports a cycle — OpenTofu rejects that shape too.

## Testing

- `TestL2VarValidation_ResourceRef` (the reproducer) now passes.
- Added `TestL2ModuleVarValidation_ResourceRef` covering the module-scope variant (already passing before the fix — the barrier only spans root variables — kept as regression coverage of the split path).
- Added graph unit tests for the node split and for the unchanged single-node shape of self-only validations.
- Full `./pkg/...` and tfcompat suites pass.