### PR TITLE
Materialize TypeSet fields as cty sets on output re-expansion

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-386.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-386.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Materialize `TypeSet` blocks and attributes as cty sets
+time: 2026-07-15T20:50:53Z
+custom:
+    Component: runtime
+    PR: "386"

--- a/pkg/hcl/bridge/mapping.go
+++ b/pkg/hcl/bridge/mapping.go
@@ -34,6 +34,9 @@ type FieldMapping struct {
 	// MaxItemsOne is true when a TF block is projected to Pulumi as a single
 	// object rather than a list of objects. Only meaningful when TFBlock.
 	MaxItemsOne bool
+	// TFSet is true when the TF schema types this field as TypeSet — an
+	// unordered collection — whether a set of blocks or a set-typed attribute.
+	TFSet bool
 	// Nested is the inner-body mapping for fields with named nested fields:
 	// blocks (TFBlock) and object-typed attributes (nested attributes).
 	Nested *BodyMapping
@@ -133,6 +136,7 @@ func bodyMappingFromSchema(sm shim.SchemaMap, overrides map[string]*tfbridge.Sch
 		fm := &FieldMapping{
 			TFName:     tfName,
 			PulumiName: tfbridge.TerraformToPulumiNameV2(tfName, sm, overrides),
+			TFSet:      sch.Type() == shim.TypeSet,
 		}
 		if elemRes, isBlock := elemAsResource(sch); isBlock {
 			fm.TFBlock = true

--- a/pkg/hcl/bridge/mapping_test.go
+++ b/pkg/hcl/bridge/mapping_test.go
@@ -108,6 +108,66 @@ func TestResourceBodyMapping_RepeatedBlockProjectedAsList(t *testing.T) {
 	require.False(t, tag.MaxItemsOne, "no MaxItems set, so the bridge keeps it as a list")
 }
 
+func TestResourceBodyMapping_SetFields(t *testing.T) {
+	t.Parallel()
+	sdk := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"test_thing": {
+				Schema: map[string]*schema.Schema{
+					"filter": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {Type: schema.TypeString, Required: true},
+							},
+						},
+					},
+					"ports": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem:     &schema.Schema{Type: schema.TypeInt},
+					},
+					"tag": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"key": {Type: schema.TypeString, Required: true},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	info := newTestProvider(t, sdk, nil)
+	m := bridge.ResourceBodyMapping(info, "test_thing")
+	require.NotNil(t, m)
+
+	filter := m.Lookup("filter")
+	require.NotNil(t, filter)
+	require.Equal(t, &bridge.FieldMapping{
+		TFName:     "filter",
+		PulumiName: "filters",
+		TFBlock:    true,
+		TFSet:      true,
+		Nested:     filter.Nested,
+	}, filter)
+
+	ports := m.Lookup("ports")
+	require.NotNil(t, ports)
+	require.Equal(t, &bridge.FieldMapping{
+		TFName:     "ports",
+		PulumiName: "ports",
+		TFSet:      true,
+	}, ports)
+
+	tag := m.Lookup("tag")
+	require.NotNil(t, tag)
+	require.False(t, tag.TFSet, "a TypeList block is ordered, not a set")
+}
+
 func TestResourceBodyMapping_ExplicitMaxItemsOneOverride(t *testing.T) {
 	t.Parallel()
 	sdk := &schema.Provider{

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -1175,6 +1175,11 @@ func propertyObjectToCtyMap(path string, m property.Map, properties []*schema.Pr
 		// re-wrap them as singleton lists on output so HCL source like
 		// `r.settings[0].x` resolves the same way as in TF.
 		singularBlock := mapping != nil && fieldIsSingularBlock(mapping, p.Name)
+		// A TF TypeSet field (set block or set attribute) materializes as a
+		// cty set, so set semantics — content-based, order-independent
+		// equality — match TF. The Pulumi wire encoding carries it as an
+		// ordered array; re-type it on the way back out.
+		setField := mapping != nil && fieldIsSet(mapping, p.Name)
 		v, ok := m.GetOk(p.Name)
 		// During preview, required properties that are null are treated as unknown.
 		// This is because resource.Computed{} (the SDK's representation of an unknown value)
@@ -1185,6 +1190,9 @@ func propertyObjectToCtyMap(path string, m property.Map, properties []*schema.Pr
 			t := ctyTypeFromType(p.Type, nested)
 			if singularBlock && !t.IsListType() && !t.IsTupleType() {
 				t = cty.List(t)
+			}
+			if setField && t.IsListType() {
+				t = cty.Set(t.ElementType())
 			}
 			if dryRun {
 				result[hclName] = cty.UnknownVal(t)
@@ -1218,6 +1226,9 @@ func propertyObjectToCtyMap(path string, m property.Map, properties []*schema.Pr
 				convertedV = cty.TupleVal([]cty.Value{convertedV})
 			}
 		}
+		if setField {
+			convertedV = ctySetFromSequence(convertedV)
+		}
 		result[hclName] = convertedV
 	}
 
@@ -1236,6 +1247,46 @@ func fieldIsSingularBlock(mapping *bridge.BodyMapping, pulumiName string) bool {
 		}
 	}
 	return false
+}
+
+// fieldIsSet reports whether the Pulumi property is a TF TypeSet field per
+// the bridge mapping.
+func fieldIsSet(mapping *bridge.BodyMapping, pulumiName string) bool {
+	if mapping == nil {
+		return false
+	}
+	for _, fm := range mapping.Fields {
+		if fm.PulumiName == pulumiName {
+			return fm.TFSet
+		}
+	}
+	return false
+}
+
+// ctySetFromSequence re-types a re-expanded TF TypeSet field from the ordered
+// list/tuple the Pulumi wire encoding carries to the cty set TF materializes.
+// A tuple whose element types cannot unify keeps its original type. Sets
+// cannot carry per-element marks, so element marks are lifted to the set.
+func ctySetFromSequence(v cty.Value) cty.Value {
+	v, marks := v.Unmark()
+	t := v.Type()
+	switch {
+	case t.IsListType() && !v.IsKnown():
+		v = cty.UnknownVal(cty.Set(t.ElementType()))
+	case t.IsListType() && v.IsNull():
+		v = cty.NullVal(cty.Set(t.ElementType()))
+	case t.IsListType():
+		if converted, err := convert.Convert(v, cty.Set(t.ElementType())); err == nil {
+			v = converted
+		}
+	case t.IsTupleType():
+		// A tuple has no single element type; a dynamic-element set asks
+		// convert to unify the per-element types.
+		if converted, err := convert.Convert(v, cty.Set(cty.DynamicPseudoType)); err == nil {
+			v = converted
+		}
+	}
+	return v.WithMarks(marks)
 }
 
 func convertToSchemaCtyType(path string, val cty.Value, typ schema.Type) (cty.Value, error) {
@@ -1389,6 +1440,10 @@ func ctyObjectTypeRec(
 		// types the same way it resolves at runtime (see propertyObjectToCtyMap).
 		if fieldIsSingularBlock(mapping, p.Name) && !t.IsListType() && !t.IsTupleType() {
 			t = cty.List(t)
+		}
+		// A TF TypeSet field is set-typed; see propertyObjectToCtyMap.
+		if fieldIsSet(mapping, p.Name) && t.IsListType() {
+			t = cty.Set(t.ElementType())
 		}
 		attrs[key] = t
 	}

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -1028,6 +1028,111 @@ func TestResourceOutputToCtySingularBlockPlaceholder(t *testing.T) {
 	})
 }
 
+// TestResourceOutputToCtySetField pins that a TF TypeSet field — a set block
+// or a set-typed attribute — re-expands as a cty set (content-based,
+// order-independent equality), not an ordered list/tuple.
+func TestResourceOutputToCtySetField(t *testing.T) {
+	t.Parallel()
+
+	elemObj := &schema.ObjectType{
+		Properties: []*schema.Property{
+			{Name: "name", Type: schema.StringType},
+		},
+	}
+	res := &schema.Resource{
+		Token: "test:index:R",
+		Properties: []*schema.Property{
+			{Name: "filters", Type: &schema.ArrayType{ElementType: elemObj}},
+			{Name: "ports", Type: &schema.ArrayType{ElementType: schema.NumberType}},
+		},
+	}
+	mapping := &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+		"filter": {
+			TFName:     "filter",
+			PulumiName: "filters",
+			TFBlock:    true,
+			TFSet:      true,
+			Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+				"name": {TFName: "name", PulumiName: "name"},
+			}},
+		},
+		"ports": {TFName: "ports", PulumiName: "ports", TFSet: true},
+	}}
+	filterSet := cty.Set(cty.Object(map[string]cty.Type{"name": cty.String}))
+
+	t.Run("elements", func(t *testing.T) {
+		t.Parallel()
+		outputs := property.NewMap(map[string]property.Value{
+			"filters": property.New([]property.Value{
+				property.New(property.NewMap(map[string]property.Value{"name": property.New("zebra")})),
+				property.New(property.NewMap(map[string]property.Value{"name": property.New("apple")})),
+			}),
+			"ports": property.New([]property.Value{property.New(443.0), property.New(80.0)}),
+		})
+		r, err := ResourceOutputToCty(outputs, res, mapping, false)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]cty.Value{
+			"filter": cty.SetVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{"name": cty.StringVal("apple")}),
+				cty.ObjectVal(map[string]cty.Value{"name": cty.StringVal("zebra")}),
+			}),
+			"ports": cty.SetVal([]cty.Value{cty.NumberFloatVal(80), cty.NumberFloatVal(443)}),
+		}, r)
+	})
+
+	t.Run("missing during preview", func(t *testing.T) {
+		t.Parallel()
+		r, err := ResourceOutputToCty(property.Map{}, res, mapping, true)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]cty.Value{
+			"filter": cty.UnknownVal(filterSet),
+			"ports":  cty.UnknownVal(cty.Set(cty.Number)),
+		}, r)
+	})
+
+	t.Run("missing during apply", func(t *testing.T) {
+		t.Parallel()
+		r, err := ResourceOutputToCty(property.Map{}, res, mapping, false)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]cty.Value{
+			"filter": cty.NullVal(filterSet),
+			"ports":  cty.NullVal(cty.Set(cty.Number)),
+		}, r)
+	})
+
+	t.Run("secret element lifts to the set", func(t *testing.T) {
+		t.Parallel()
+		outputs := property.NewMap(map[string]property.Value{
+			"ports": property.New([]property.Value{property.New(443.0).WithSecret(true)}),
+		})
+		r, err := ResourceOutputToCty(outputs, res, mapping, false)
+		require.NoError(t, err)
+		assert.Equal(t,
+			cty.SetVal([]cty.Value{cty.NumberFloatVal(443)}).Mark(eval.SensitiveMark),
+			r["ports"])
+	})
+}
+
+// TestResourceReferenceTypeSetField pins that the static type of a reference
+// to a resource types TF TypeSet fields as cty sets, matching the runtime
+// values ResourceOutputToCty produces.
+func TestResourceReferenceTypeSetField(t *testing.T) {
+	t.Parallel()
+
+	res := &schema.Resource{
+		Token: "test:index:R",
+		Properties: []*schema.Property{
+			{Name: "ports", Type: &schema.ArrayType{ElementType: schema.NumberType}},
+		},
+	}
+	mapping := &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+		"ports": {TFName: "ports", PulumiName: "ports", TFSet: true},
+	}}
+
+	typ := ResourceReferenceType(res, mapping)
+	assert.Equal(t, cty.Set(cty.Number), typ.AttributeType("ports"))
+}
+
 // TestResourceOutputToCtySchemaSecretElided pins that a schema-secret output
 // keeps its sensitive mark even when the provider elides the (unknown) value
 // during preview, so a downstream stack output stays secret.

--- a/tests/tfcompat/l2_set_block_equality_test.go
+++ b/tests/tfcompat/l2_set_block_equality_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2SetBlockEquality exercises the runtime type of a repeating TypeSet
+// nested block (`filter`). OpenTofu materializes it as a cty set, so
+// `filter == toset([...same elements...])` is true (set equality is
+// content-based and order-independent). pulumi-hcl materializes the set block
+// as an ordered tuple, so the same comparison is a tuple-vs-set type mismatch
+// and yields false — diverging on both the same-order and reordered outputs.
+func TestL2SetBlockEquality(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_set_block_equality", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "blocky", Factory: providers.BlockyProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_set_block_equality/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_set_block_equality/main.tf
@@ -1,0 +1,34 @@
+# `filter` is a repeating TypeSet nested block on blocky_thing. In OpenTofu a
+# set block materializes as a cty *set*, whose equality is content-based and
+# order-independent. pulumi-hcl materializes it as an ordered tuple, so
+# comparing it against a `toset(...)` of the same elements diverges.
+resource "blocky_thing" "t" {
+  name = "seteq"
+  filter {
+    name   = "zebra"
+    values = "z"
+  }
+  filter {
+    name   = "apple"
+    values = "a"
+  }
+}
+
+# Same elements in the same written order. A set equals the set of its
+# elements, so OpenTofu yields true; pulumi-hcl compares a tuple to a set and
+# yields false.
+output "eq_same" {
+  value = blocky_thing.t.filter == toset([
+    { name = "zebra", values = "z" },
+    { name = "apple", values = "a" },
+  ])
+}
+
+# Same elements, reordered literal. Set equality ignores order, so OpenTofu
+# still yields true; pulumi-hcl still yields false.
+output "eq_reordered" {
+  value = blocky_thing.t.filter == toset([
+    { name = "apple", values = "a" },
+    { name = "zebra", values = "z" },
+  ])
+}


### PR DESCRIPTION
## Divergence

A TF `TypeSet` field — a set of blocks or a set-typed attribute — materialized as an ordered cty list/tuple in pulumi-hcl, while OpenTofu materializes it as a cty **set**. Set equality is content-based and order-independent, so `blocky_thing.t.filter == toset([...same elements...])` was `true` in OpenTofu and `false` in pulumi-hcl (a tuple-vs-set type mismatch), even with identical element order.

## Fix

The bridge `FieldMapping` never recorded set-ness, so the transform layer had no way to tell a set field from a list field:

- `pkg/hcl/bridge`: add `FieldMapping.TFSet`, true when the shim schema type is `TypeSet`. This covers repeating set blocks, `MaxItems=1` set blocks, and set-typed attributes (e.g. a `TypeSet` of strings).
- `pkg/hcl/transform`: output re-expansion (`propertyObjectToCtyMap`) re-types set fields as cty sets — known lists convert to `cty.Set(elementType)`, tuples with divergent element types unify through a dynamic-element set target (falling back to the original value if unification fails), and null/unknown placeholders become null/unknown of set type. Element marks lift to the set, since cty sets cannot carry per-element marks. Static resource-reference types (`ctyObjectTypeRec`) declare set types to match the runtime values.

## Test

`TestL2SetBlockEquality` (added failing on master) now passes: both `eq_same` and `eq_reordered` evaluate to `true`, matching OpenTofu. Unit coverage pins the mapping (`TestResourceBodyMapping_SetFields`) and the re-expanded values, placeholders, mark lifting, and reference typing (`TestResourceOutputToCtySetField`, `TestResourceReferenceTypeSetField`).

Full tfcompat suite (167), root module (1426 tests, 45 packages), and smoke tests pass.
