### PR TITLE
Coerce local-exec provisioner config to its schema types

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-387.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-387.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Coerce provisioner config attributes to their schema types (`environment`, `command`, `interpreter`, `quiet`)
+time: 2026-07-15T12:23:46Z
+custom:
+    Component: runtime
+    PR: "387"

--- a/pkg/provisioner/runtime/local_exec.go
+++ b/pkg/provisioner/runtime/local_exec.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 )
@@ -136,21 +137,34 @@ func configSensitive(content *hcl.BodyContent, hclCtx *hcl.EvalContext) bool {
 // dependencies and sensitivity as cty marks, and marked values panic in
 // AsString and friends.
 
-func evalString(content *hcl.BodyContent, name string, hclCtx *hcl.EvalContext) (string, error) {
+// evalAttr evaluates the named attribute and coerces the result to ty, the
+// way schema-based decoding coerces provisioner config (number 5 and bool
+// true become "5" and "true" under map(string)). Missing attributes and
+// unknown values yield a null of ty.
+func evalAttr(content *hcl.BodyContent, name string, ty cty.Type, hclCtx *hcl.EvalContext) (cty.Value, error) {
 	attr, ok := content.Attributes[name]
 	if !ok {
-		return "", nil
+		return cty.NullVal(ty), nil
 	}
 	val, diags := attr.Expr.Value(hclCtx)
 	if diags.HasErrors() {
-		return "", fmt.Errorf("evaluating %s: %s", name, diags.Error())
+		return cty.NullVal(ty), fmt.Errorf("evaluating %s: %s", name, diags.Error())
 	}
 	val, _ = val.UnmarkDeep()
-	if !val.IsKnown() || val.IsNull() {
-		return "", nil
+	if !val.IsKnown() {
+		return cty.NullVal(ty), nil
 	}
-	if val.Type() != cty.String {
-		return "", fmt.Errorf("%s must be a string, got %s", name, val.Type().FriendlyName())
+	converted, err := convert.Convert(val, ty)
+	if err != nil {
+		return cty.NullVal(ty), fmt.Errorf("%s: %s", name, err)
+	}
+	return converted, nil
+}
+
+func evalString(content *hcl.BodyContent, name string, hclCtx *hcl.EvalContext) (string, error) {
+	val, err := evalAttr(content, name, cty.String, hclCtx)
+	if err != nil || val.IsNull() {
+		return "", err
 	}
 	return val.AsString(), nil
 }
@@ -160,46 +174,23 @@ func evalOptionalString(content *hcl.BodyContent, name string, hclCtx *hcl.EvalC
 }
 
 func evalOptionalBool(content *hcl.BodyContent, name string, hclCtx *hcl.EvalContext) (bool, error) {
-	attr, ok := content.Attributes[name]
-	if !ok {
-		return false, nil
-	}
-	val, diags := attr.Expr.Value(hclCtx)
-	if diags.HasErrors() {
-		return false, fmt.Errorf("evaluating %s: %s", name, diags.Error())
-	}
-	val, _ = val.UnmarkDeep()
-	if !val.IsKnown() || val.IsNull() {
-		return false, nil
-	}
-	if val.Type() != cty.Bool {
-		return false, fmt.Errorf("%s must be a bool, got %s", name, val.Type().FriendlyName())
+	val, err := evalAttr(content, name, cty.Bool, hclCtx)
+	if err != nil || val.IsNull() {
+		return false, err
 	}
 	return val.True(), nil
 }
 
 func evalStringSlice(content *hcl.BodyContent, name string, hclCtx *hcl.EvalContext) ([]string, error) {
-	attr, ok := content.Attributes[name]
-	if !ok {
-		return nil, nil
-	}
-	val, diags := attr.Expr.Value(hclCtx)
-	if diags.HasErrors() {
-		return nil, fmt.Errorf("evaluating %s: %s", name, diags.Error())
-	}
-	val, _ = val.UnmarkDeep()
-	if !val.IsKnown() || val.IsNull() {
-		return nil, nil
-	}
-	if !val.CanIterateElements() {
-		return nil, fmt.Errorf("%s must be a list of strings", name)
+	val, err := evalAttr(content, name, cty.List(cty.String), hclCtx)
+	if err != nil || val.IsNull() {
+		return nil, err
 	}
 	out := make([]string, 0, val.LengthInt())
-	it := val.ElementIterator()
-	for it.Next() {
+	for it := val.ElementIterator(); it.Next(); {
 		_, v := it.Element()
-		if v.Type() != cty.String {
-			return nil, fmt.Errorf("%s elements must be strings", name)
+		if v.IsNull() {
+			continue
 		}
 		out = append(out, v.AsString())
 	}
@@ -207,27 +198,15 @@ func evalStringSlice(content *hcl.BodyContent, name string, hclCtx *hcl.EvalCont
 }
 
 func evalStringMap(content *hcl.BodyContent, name string, hclCtx *hcl.EvalContext) (map[string]string, error) {
-	attr, ok := content.Attributes[name]
-	if !ok {
-		return nil, nil
-	}
-	val, diags := attr.Expr.Value(hclCtx)
-	if diags.HasErrors() {
-		return nil, fmt.Errorf("evaluating %s: %s", name, diags.Error())
-	}
-	val, _ = val.UnmarkDeep()
-	if !val.IsKnown() || val.IsNull() {
-		return nil, nil
-	}
-	if !val.CanIterateElements() {
-		return nil, fmt.Errorf("%s must be a map of strings", name)
+	val, err := evalAttr(content, name, cty.Map(cty.String), hclCtx)
+	if err != nil || val.IsNull() {
+		return nil, err
 	}
 	out := make(map[string]string, val.LengthInt())
-	it := val.ElementIterator()
-	for it.Next() {
+	for it := val.ElementIterator(); it.Next(); {
 		k, v := it.Element()
-		if k.Type() != cty.String || v.Type() != cty.String {
-			return nil, fmt.Errorf("%s keys and values must be strings", name)
+		if v.IsNull() {
+			continue
 		}
 		out[k.AsString()] = v.AsString()
 	}

--- a/pkg/provisioner/runtime/local_exec_test.go
+++ b/pkg/provisioner/runtime/local_exec_test.go
@@ -55,6 +55,65 @@ func TestEvalStringUnmarksDepMarkedValue(t *testing.T) {
 	assert.Equal(t, "echo from-upstream", command)
 }
 
+func TestEvalStringMapCoercesValues(t *testing.T) {
+	t.Parallel()
+	body := parseBody(t, `
+command = "true"
+environment = {
+  COUNT = 5
+  FLAG  = true
+  NAME  = "x"
+  SKIP  = null
+}
+`)
+	content, diags := body.Content(localExecSchema)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	env, err := evalStringMap(content, "environment", &hcl.EvalContext{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"COUNT": "5",
+		"FLAG":  "true",
+		"NAME":  "x",
+	}, env)
+}
+
+func TestEvalStringMapRejectsNonMap(t *testing.T) {
+	t.Parallel()
+	body := parseBody(t, `
+command     = "true"
+environment = "not-a-map"
+`)
+	content, diags := body.Content(localExecSchema)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	_, err := evalStringMap(content, "environment", &hcl.EvalContext{})
+	assert.EqualError(t, err, "environment: map of string required, but have string")
+}
+
+func TestEvalHelpersCoerce(t *testing.T) {
+	t.Parallel()
+	body := parseBody(t, `
+command     = 5
+quiet       = "true"
+interpreter = ["/bin/sh", 42, null]
+`)
+	content, diags := body.Content(localExecSchema)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	command, err := evalString(content, "command", &hcl.EvalContext{})
+	require.NoError(t, err)
+	assert.Equal(t, "5", command)
+
+	quiet, err := evalOptionalBool(content, "quiet", &hcl.EvalContext{})
+	require.NoError(t, err)
+	assert.Equal(t, true, quiet)
+
+	interpreter, err := evalStringSlice(content, "interpreter", &hcl.EvalContext{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/bin/sh", "42"}, interpreter)
+}
+
 func TestConfigSensitive(t *testing.T) {
 	t.Parallel()
 	body := parseBody(t, `command = "echo ${var_secret}"`)

--- a/tests/tfcompat/l2_provisioner_env_coerce_test.go
+++ b/tests/tfcompat/l2_provisioner_env_coerce_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// OpenTofu's local-exec `environment` is a map(string): number and bool
+// values are coerced to strings ("5", "true"). pulumi-hcl's evalStringMap
+// rejects any non-string value, so the provisioner fails.
+func TestL2ProvisionerEnvCoerce(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_provisioner_env_coerce", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_env_coerce/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_env_coerce/main.tf
@@ -1,0 +1,15 @@
+# OpenTofu's local-exec `environment` is a map(string): non-string values are
+# coerced (number 5 -> "5", bool true -> "true"). The command below asserts the
+# coerced values are present in the child process environment.
+
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  provisioner "local-exec" {
+    environment = {
+      COUNT = 5
+      FLAG  = true
+    }
+    command = "test \"$COUNT\" = \"5\" && test \"$FLAG\" = \"true\""
+  }
+}


### PR DESCRIPTION
## Divergence

A `provisioner "local-exec"` with a non-string `environment` value:

```hcl
environment = {
  COUNT = 5
  FLAG  = true
}
```

- **OpenTofu**: `environment` is `map(string)`, so values are coerced (`5` → `"5"`, `true` → `"true"`); the command runs and the resource is created.
- **pulumi-hcl**: `evalStringMap` (`pkg/provisioner/runtime/local_exec.go`) errored on any value whose cty type is not `String`: `environment keys and values must be strings`, and creation failed.

Direction: OpenTofu succeeds / pulumi-hcl errors.

## Fix

OpenTofu decodes provisioner config against the provisioner schema (`command: string`, `interpreter: list(string)`, `environment: map(string)`, `quiet: bool`), which *converts* values to the declared types rather than requiring an exact type match. The eval helpers now route through a shared `evalAttr` that coerces via `convert.Convert`, so the same bug is fixed for `command`/`working_dir`, `interpreter`, and `quiet`, and for the `remote-exec` and `file` provisioners, which share the helpers. (`connection` blocks already coerced via typed `hcldec` specs.)

The map and slice helpers also skip null elements now, as OpenTofu does for `environment` and `interpreter` — previously `environment = { X = null }` panicked in `AsString`.

## Test

`TestL2ProvisionerEnvCoerce` — the fixture's `command` asserts the coerced values (`test "$COUNT" = "5" && test "$FLAG" = "true"`), so it confirms the coercion, not merely non-error. Failed on master; passes with the fix. Unit tests cover map-value coercion and null-skipping, non-map rejection, and coercion of `command`/`quiet`/`interpreter`.