### PR TITLE
Add transitive and cross-module create_before_destroy regression tests

### DIFF
--- a/tests/tfcompat/l2_cbd_propagation_cross_module_test.go
+++ b/tests/tfcompat/l2_cbd_propagation_cross_module_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2CBDPropagationCrossModule checks that create_before_destroy propagates
+// across a module boundary. The declaring resource is inside a child module and
+// depends on a root resource through a module input; changing the root
+// resource's ForceNew label replaces both, so the behaviour must reach the root
+// resource. The in-module child records witness = 2 when every create runs
+// before any delete, and a larger number otherwise.
+func TestL2CBDPropagationCrossModule(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_cbd_propagation_cross_module", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "cascade", Factory: providers.CascadeProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_cbd_propagation_transitive_test.go
+++ b/tests/tfcompat/l2_cbd_propagation_transitive_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2CBDPropagationTransitive checks that create_before_destroy propagates
+// across more than one dependency hop. Only the top of a base <- middle <- top
+// chain declares it; changing base's ForceNew label replaces all three, and the
+// behaviour must reach both middle and base so every create runs before any
+// delete. The top records witness = 3 when it does, and a larger number when a
+// hop is left at delete-before-replace.
+func TestL2CBDPropagationTransitive(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_cbd_propagation_transitive", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "cascade", Factory: providers.CascadeProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_cbd_propagation_cross_module/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_cbd_propagation_cross_module/0/main.tf
@@ -1,0 +1,17 @@
+# The create_before_destroy resource lives inside a child module and depends on
+# a root resource through a module input. Changing base's ForceNew label
+# replaces base and (through the ForceNew module input) the in-module child, so
+# create_before_destroy must propagate across the module boundary to base. When
+# it does, every create runs before any delete and the child records witness = 2.
+resource "cascade_parent" "base" {
+  label = "L1"
+}
+
+module "mod" {
+  source = "./modules/child"
+  parent = cascade_parent.base.result
+}
+
+output "witness" {
+  value = module.mod.witness
+}

--- a/tests/tfcompat/testdata/cases/l2_cbd_propagation_cross_module/0/modules/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_cbd_propagation_cross_module/0/modules/child/main.tf
@@ -1,0 +1,15 @@
+variable "parent" {
+  type = string
+}
+
+resource "cascade_child" "top" {
+  parent = var.parent
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "witness" {
+  value = cascade_child.top.witness
+}

--- a/tests/tfcompat/testdata/cases/l2_cbd_propagation_cross_module/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_cbd_propagation_cross_module/1/main.tf
@@ -1,0 +1,17 @@
+# The create_before_destroy resource lives inside a child module and depends on
+# a root resource through a module input. Changing base's ForceNew label
+# replaces base and (through the ForceNew module input) the in-module child, so
+# create_before_destroy must propagate across the module boundary to base. When
+# it does, every create runs before any delete and the child records witness = 2.
+resource "cascade_parent" "base" {
+  label = "L2"
+}
+
+module "mod" {
+  source = "./modules/child"
+  parent = cascade_parent.base.result
+}
+
+output "witness" {
+  value = module.mod.witness
+}

--- a/tests/tfcompat/testdata/cases/l2_cbd_propagation_cross_module/1/modules/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_cbd_propagation_cross_module/1/modules/child/main.tf
@@ -1,0 +1,15 @@
+variable "parent" {
+  type = string
+}
+
+resource "cascade_child" "top" {
+  parent = var.parent
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "witness" {
+  value = cascade_child.top.witness
+}

--- a/tests/tfcompat/testdata/cases/l2_cbd_propagation_transitive/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_cbd_propagation_transitive/0/main.tf
@@ -1,0 +1,23 @@
+# A three-resource dependency chain base <- middle <- top, where only the top
+# declares create_before_destroy. Changing base's ForceNew label replaces all
+# three. create_before_destroy must propagate transitively to middle and base,
+# so every create runs before any delete and top records witness = 3.
+resource "cascade_parent" "base" {
+  label = "L1"
+}
+
+resource "cascade_parent" "middle" {
+  label = cascade_parent.base.result
+}
+
+resource "cascade_child" "top" {
+  parent = cascade_parent.middle.result
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "witness" {
+  value = cascade_child.top.witness
+}

--- a/tests/tfcompat/testdata/cases/l2_cbd_propagation_transitive/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_cbd_propagation_transitive/1/main.tf
@@ -1,0 +1,23 @@
+# A three-resource dependency chain base <- middle <- top, where only the top
+# declares create_before_destroy. Changing base's ForceNew label replaces all
+# three. create_before_destroy must propagate transitively to middle and base,
+# so every create runs before any delete and top records witness = 3.
+resource "cascade_parent" "base" {
+  label = "L2"
+}
+
+resource "cascade_parent" "middle" {
+  label = cascade_parent.base.result
+}
+
+resource "cascade_child" "top" {
+  parent = cascade_parent.middle.result
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "witness" {
+  value = cascade_child.top.witness
+}


### PR DESCRIPTION
Follow-up regression coverage for #375 (`create_before_destroy` propagation to dependencies), which was tested end-to-end only by a single-hop, root-only case.

## Tests

- **`TestL2CBDPropagationTransitive`** — a `base ← middle ← top` chain where only `top` declares `create_before_destroy`. Changing `base`'s ForceNew label replaces all three; propagation must reach `middle` and `base` so every create precedes every delete. `top` records `witness = 3`.
- **`TestL2CBDPropagationCrossModule`** — the `create_before_destroy` resource lives inside a child module and depends on a root resource through a module input. Propagation must cross the module boundary to the root resource; the in-module child records `witness = 2`.

Both reuse the existing `CascadeProvider`.

## Meaningful, not trivial

Both pass on `master`. Confirmed they exercise the propagation by temporarily disabling it, which makes each diverge from OpenTofu — transitive `witness` 3 vs 6, cross-module 2 vs 4 — then restored and both pass.

Test-only; no changelog fragment (labeled `impact/no-changelog-required`).
