### PR TITLE
Derive injective module-nested names; add `pulumi.module.name` and module `pulumi { name }`

### DIFF
--- a/.changes/unreleased/codegen-Improvements-391.yaml
+++ b/.changes/unreleased/codegen-Improvements-391.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Pin the Pulumi logical names of resources and module calls inside generated component sources via `pulumi { name = "${pulumi.module.name}-..." }`
+time: 2026-07-15T20:30:00Z
+custom:
+    Component: codegen
+    PR: "391"

--- a/.changes/unreleased/runtime-Improvements-391.yaml
+++ b/.changes/unreleased/runtime-Improvements-391.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Join module-nested names with `.` so distinct addresses cannot collide; add `pulumi.module.name` and a module-block `pulumi { name = ... }`; a resource's `pulumi { name }` is now the full logical name
+time: 2026-07-15T20:30:00Z
+custom:
+    Component: runtime
+    PR: "391"

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -1996,6 +1996,68 @@ output "name" {
 	assert.Equal(t, property.New("my-bucket"), result)
 }
 
+// TestComponentRangedResourceNames verifies that a ranged resource inside a
+// component pins its per-instance names by combining the enclosing instance's
+// name with the range key ("${pulumi.module.name}-<label>-${each.key}"), and
+// that the runtime evaluates the pin to the "<parent>-<child>-<key>" names
+// the other languages' generated programs produce. The golden component
+// source records the combined template.
+func TestComponentRangedResourceNames(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Item": {
+				InputProperties: map[string]schema.PropertySpec{
+					"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	componentPCL := `resource "keyed" "test:index:Item" {
+  options {
+    range = {
+      x = "alpha"
+      y = "bravo"
+    }
+  }
+  name = range.value
+}
+
+resource "counted" "test:index:Item" {
+  options {
+    range = 2
+  }
+  name = "item-${range.value}"
+}
+`
+	parentPCL := `component "mod" "./mod" {
+}
+`
+	mock := testConvertedPCLWithComponent(t, parentPCL, map[string]string{
+		"./mod": componentPCL,
+	}, nil, testSchema)
+
+	names := []string{}
+	for _, r := range mock.RegisteredResources {
+		if r.Type == "test:index:Item" {
+			names = append(names, r.Name)
+		}
+	}
+	assert.ElementsMatch(t, []string{
+		"mod-keyed-x", "mod-keyed-y",
+		"mod-counted-0", "mod-counted-1",
+	}, names)
+}
+
 // TestNestedModuleVariableResolution verifies that a nested module (a module
 // called from within another module) can receive inputs from its parent module's
 // scope. This reproduces https://github.com/pulumi-labs/pulumi-hcl/issues/78.

--- a/cmd/pulumi-language-hcl/testdata/TestComponentRangedResourceNames/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/TestComponentRangedResourceNames/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+module "mod" {
+  source = "./mod"
+}

--- a/cmd/pulumi-language-hcl/testdata/TestComponentRangedResourceNames/mod/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/TestComponentRangedResourceNames/mod/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+resource "test_item" "keyed" {
+  for_each = {
+    "x" = "alpha"
+    "y" = "bravo"
+  }
+  pulumi {
+    name ="${pulumi.module.name}-keyed-${each.key}"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = each.value
+}
+resource "test_item" "counted" {
+  count = 2
+  pulumi {
+    name ="${pulumi.module.name}-counted-${count.index}"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  name ="item-${count.index}"
+}

--- a/cmd/pulumi-language-hcl/testdata/TestModuleResourceVariableResolution/mod/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/TestModuleResourceVariableResolution/mod/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "test_bucket" "bucket" {
+  pulumi {
+    name ="${pulumi.module.name}-bucket"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/TestNestedModuleVariableResolution/inner/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/TestNestedModuleVariableResolution/inner/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "test_bucket" "bucket" {
+  pulumi {
+    name ="${pulumi.module.name}-bucket"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/TestNestedModuleVariableResolution/outer/inner/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/TestNestedModuleVariableResolution/outer/inner/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "test_bucket" "bucket" {
+  pulumi {
+    name ="${pulumi.module.name}-bucket"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/TestNestedModuleVariableResolution/outer/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/TestNestedModuleVariableResolution/outer/main.tf
@@ -12,7 +12,10 @@ variable "name" {
 }
 module "inner" {
   source = "./inner"
-  name   ="outer(${var.name})"
+  pulumi {
+    name ="${pulumi.module.name}-inner"
+  }
+  name ="outer(${var.name})"
 }
 output "bucketName" {
   value = module.inner.bucketName

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-objects/primitiveComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-objects/primitiveComponent/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "primitive_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-primitives/primitiveComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-config-primitives/primitiveComponent/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "primitive_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/innerComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/innerComponent/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "simple_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/outerComponent/innerComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/outerComponent/innerComponent/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "simple_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/outerComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-nested/outerComponent/main.tf
@@ -13,7 +13,10 @@ variable "input" {
 }
 module "innerComponent" {
   source = "./innerComponent"
-  input  = ! var.input
+  pulumi {
+    name ="${pulumi.module.name}-innerComponent"
+  }
+  input = ! var.input
 }
 output "output" {
   value = module.innerComponent.output

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-primitive-conversions/conversionComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-primitive-conversions/conversionComponent/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "primitive_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-provider/providerComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-provider/providerComponent/main.tf
@@ -12,6 +12,9 @@ provider "config" {
   name  = "my config"
 }
 resource "config_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   provider = config.prov
   lifecycle {
     create_before_destroy = true

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/first/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/first/main.tf
@@ -8,12 +8,18 @@ terraform {
 }
 
 resource "simple_resource" "first-untainted" {
+  pulumi {
+    name ="${pulumi.module.name}-first-untainted"
+  }
   lifecycle {
     create_before_destroy = true
   }
   value = true
 }
 resource "simple_resource" "first-tainted" {
+  pulumi {
+    name ="${pulumi.module.name}-first-tainted"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/main.tf
@@ -27,5 +27,8 @@ module "another" {
 module "many" {
   source = "./second"
   count  = 2
-  input  = module.another.untainted
+  pulumi {
+    name ="many-${count.index}"
+  }
+  input = module.another.untainted
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/second/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-deferred-outputs/second/main.tf
@@ -8,12 +8,18 @@ terraform {
 }
 
 resource "simple_resource" "second-untainted" {
+  pulumi {
+    name ="${pulumi.module.name}-second-untainted"
+  }
   lifecycle {
     create_before_destroy = true
   }
   value = true
 }
 resource "simple_resource" "second-tainted" {
+  pulumi {
+    name ="${pulumi.module.name}-second-tainted"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-resource-keyword-overlap/keywordComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-resource-keyword-overlap/keywordComponent/main.tf
@@ -12,6 +12,9 @@ terraform {
 # resource variable (e.g. to `_this`) while keeping the `parent: this` pointer
 # intact.
 resource "simple_resource" "this" {
+  pulumi {
+    name ="${pulumi.module.name}-this"
+  }
   lifecycle {
     create_before_destroy = true
   }
@@ -21,6 +24,9 @@ resource "simple_resource" "this" {
 # just the declaration. The name `parent` also overlaps with the `parent`
 # resource-option key, which must not be confused with this resource variable.
 resource "simple_resource" "parent" {
+  pulumi {
+    name ="${pulumi.module.name}-parent"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-rewrite-conversions/converted/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-rewrite-conversions/converted/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "primitive_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-objects/primitiveComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-objects/primitiveComponent/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "primitive_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-primitives/primitiveComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-config-primitives/primitiveComponent/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "primitive_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/innerComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/innerComponent/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "simple_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/outerComponent/innerComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/outerComponent/innerComponent/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "simple_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/outerComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-nested/outerComponent/main.tf
@@ -13,7 +13,10 @@ variable "input" {
 }
 module "innerComponent" {
   source = "./innerComponent"
-  input  = ! var.input
+  pulumi {
+    name ="${pulumi.module.name}-innerComponent"
+  }
+  input = ! var.input
 }
 output "output" {
   value = module.innerComponent.output

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-primitive-conversions/conversionComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-primitive-conversions/conversionComponent/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "primitive_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-provider/providerComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-provider/providerComponent/main.tf
@@ -12,6 +12,9 @@ provider "config" {
   name  = "my config"
 }
 resource "config_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   provider = config.prov
   lifecycle {
     create_before_destroy = true

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/first/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/first/main.tf
@@ -8,12 +8,18 @@ terraform {
 }
 
 resource "simple_resource" "first-untainted" {
+  pulumi {
+    name ="${pulumi.module.name}-first-untainted"
+  }
   lifecycle {
     create_before_destroy = true
   }
   value = true
 }
 resource "simple_resource" "first-tainted" {
+  pulumi {
+    name ="${pulumi.module.name}-first-tainted"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/main.tf
@@ -27,5 +27,8 @@ module "another" {
 module "many" {
   source = "./second"
   count  = 2
-  input  = module.another.untainted
+  pulumi {
+    name ="many-${count.index}"
+  }
+  input = module.another.untainted
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/second/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-deferred-outputs/second/main.tf
@@ -8,12 +8,18 @@ terraform {
 }
 
 resource "simple_resource" "second-untainted" {
+  pulumi {
+    name ="${pulumi.module.name}-second-untainted"
+  }
   lifecycle {
     create_before_destroy = true
   }
   value = true
 }
 resource "simple_resource" "second-tainted" {
+  pulumi {
+    name ="${pulumi.module.name}-second-tainted"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-resource-keyword-overlap/keywordComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-resource-keyword-overlap/keywordComponent/main.tf
@@ -12,6 +12,9 @@ terraform {
 # resource variable (e.g. to `_this`) while keeping the `parent: this` pointer
 # intact.
 resource "simple_resource" "this" {
+  pulumi {
+    name ="${pulumi.module.name}-this"
+  }
   lifecycle {
     create_before_destroy = true
   }
@@ -21,6 +24,9 @@ resource "simple_resource" "this" {
 # just the declaration. The name `parent` also overlaps with the `parent`
 # resource-option key, which must not be confused with this resource variable.
 resource "simple_resource" "parent" {
+  pulumi {
+    name ="${pulumi.module.name}-parent"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-rewrite-conversions/converted/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-rewrite-conversions/converted/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 resource "primitive_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
   lifecycle {
     create_before_destroy = true
   }

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -324,7 +324,7 @@ resource "aws_instance" "web" {
 
 | Attribute                   | Type         | Description                                                                                       |
 |-----------------------------|--------------|---------------------------------------------------------------------------------------------------|
-| `name`                      | string       | Override the Pulumi logical name (evaluated per instance, with `count.index`/`each.key` in scope) |
+| `name`                      | string       | Override the full Pulumi logical name (evaluated per instance, with `count.index`/`each.key` and `pulumi.module.name` in scope; null means no override) |
 | `parent`                    | reference    | Parent resource for component hierarchy                                                           |
 | `additional_secret_outputs` | list(string) | Output properties to encrypt in state                                                             |
 | `retain_on_delete`          | bool         | Keep the cloud resource when removed from the program                                             |
@@ -554,6 +554,22 @@ Remote modules are cached in `~/.pulumi/modules/`.
 
 Module outputs are referenced as `module.<name>.<output_name>`.
 
+Like resources, a module block accepts a nested `pulumi` block; its `name`
+attribute overrides the Pulumi logical name of each module instance
+(evaluated per instance, with `count.index`/`each.key` in scope). The
+overridden name also prefixes the derived names of everything inside the
+instance, and is visible to the module source as `pulumi.module.name`.
+
+```hcl
+module "vpc" {
+  source = "./modules/vpc"
+
+  pulumi {
+    name = "vpc-primary"
+  }
+}
+```
+
 ## Call Blocks
 
 Call blocks invoke methods on existing resources. This is a Pulumi-specific extension with no Terraform equivalent.
@@ -694,6 +710,7 @@ EOF
 | `pulumi.stack`           | Current stack name                 |
 | `pulumi.project`         | Current project name               |
 | `pulumi.organization`    | Current organization name          |
+| `pulumi.module.name`     | Pulumi logical name of the enclosing module instance (null at the root) |
 
 ### Operators
 

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -44,6 +44,15 @@ type GenerateProgramOption func(*generateProgramOptions)
 
 type generateProgramOptions struct {
 	skipRequiredProvidersVersion bool
+	insideComponent              bool
+}
+
+// insideComponentSource marks the generated program as a component's module
+// source: every resource and nested module call pins its Pulumi logical name
+// (prefixed via pulumi.module.name) so instances keep the "<parent>-<child>"
+// names PCL codegen produces in every other language.
+func insideComponentSource() GenerateProgramOption {
+	return func(o *generateProgramOptions) { o.insideComponent = true }
 }
 
 // SkipRequiredProvidersVersion omits the `version` attribute from each entry
@@ -75,6 +84,7 @@ func GenerateProgram(program *pcl.Program, opts ...GenerateProgramOption) (map[s
 		program:                      program,
 		comments:                     buildProgramComments(program),
 		skipRequiredProvidersVersion: o.skipRequiredProvidersVersion,
+		insideComponent:              o.insideComponent,
 	}
 
 	for _, node := range program.Nodes {
@@ -187,7 +197,7 @@ func GenerateProgram(program *pcl.Program, opts ...GenerateProgramOption) (map[s
 	}
 
 	for componentDir, component := range program.CollectComponents() {
-		subFiles, d, err := GenerateProgram(component.Program)
+		subFiles, d, err := GenerateProgram(component.Program, insideComponentSource())
 		diags = append(diags, d...)
 		if err != nil {
 			return nil, diags, err
@@ -324,6 +334,9 @@ type generator struct {
 	// skipRequiredProvidersVersion suppresses the `version` attribute on
 	// each `required_providers` entry. See SkipRequiredProvidersVersion.
 	skipRequiredProvidersVersion bool
+	// insideComponent marks this program as a component's module source.
+	// See insideComponentSource.
+	insideComponent bool
 }
 
 // buildProgramComments parses the source of every PCL file in the program and
@@ -1284,23 +1297,30 @@ func (g *generator) genResourceOptions(body *hclwrite.Body, r *pcl.Resource) hcl
 		}
 	}
 
+	// Pin per-instance names to the "<parent>-<name>-<key>" scheme the other
+	// languages' generated programs use; the runtime would otherwise derive
+	// Terraform-style "<parent>.<name>[<key>]" names.
+	pinName := func(naming instanceNaming) {
+		if tokens := pinnedNameTokens(g.insideComponent, r.LogicalName(), naming); tokens != nil {
+			pulumiBody().SetAttributeRaw("name", tokens)
+		}
+	}
+
 	if opts == nil {
+		pinName(instanceNamingNone)
 		emitReplaceOnChanges()
 		g.genLifecycleBlock(body, nil, &diags)
 		return diags
 	}
 
 	// Terraform-standard meta-arguments stay at the top level.
+	naming := instanceNamingNone
 	if opts.Range != nil {
-		naming, d := g.genRange(body, opts.Range)
+		var d hcl.Diagnostics
+		naming, d = g.genRange(body, opts.Range)
 		diags = append(diags, d...)
-		// Pin per-instance names to the "<name>-<key>" scheme the other
-		// languages' generated programs use; the runtime would otherwise
-		// derive Terraform-style "<name>[<key>]" names.
-		if tokens := instanceNameTokens(naming, r.LogicalName()); tokens != nil {
-			pulumiBody().SetAttributeRaw("name", tokens)
-		}
 	}
+	pinName(naming)
 
 	if opts.Provider != nil {
 		tokens, d := g.exprTokens(opts.Provider, schema.AnyType)
@@ -1482,22 +1502,31 @@ func (g *generator) genRange(body *hclwrite.Body, rangeExpr model.Expression) (i
 	}
 }
 
-// instanceNameTokens builds the `pulumi { name = ... }` template that pins a
-// ranged resource's per-instance Pulumi names to the "<name>-<key>" scheme
-// PCL codegen produces in every other language (e.g. "res-${count.index}").
-// Returns nil when the range creates a single unsuffixed instance.
-func instanceNameTokens(naming instanceNaming, logicalName string) hclwrite.Tokens {
-	var key string
+// pinnedNameTokens builds the `pulumi { name = ... }` template that pins a
+// generated resource's or module call's Pulumi logical names to the scheme
+// PCL codegen produces in every other language: inside a component source the
+// name is prefixed with the enclosing instance's name via pulumi.module.name,
+// and ranged blocks get a "-${count.index}" / "-${each.key}" suffix (e.g.
+// "${pulumi.module.name}-res-${each.key}"). Returns nil when the derived
+// runtime name already matches (a root-level block with no range, or with a
+// bool range's single unsuffixed instance).
+func pinnedNameTokens(insideComponent bool, logicalName string, naming instanceNaming) hclwrite.Tokens {
+	prefix := ""
+	if insideComponent {
+		prefix = "${pulumi.module.name}-"
+	}
+	suffix := ""
 	switch naming {
 	case instanceNamingIndex:
-		key = "count.index"
+		suffix = "-${count.index}"
 	case instanceNamingKey:
-		key = "each.key"
-	default:
+		suffix = "-${each.key}"
+	}
+	if prefix == "" && suffix == "" {
 		return nil
 	}
 	return hclwrite.Tokens{
-		{Type: hclsyntax.TokenQuotedLit, Bytes: fmt.Appendf(nil, `"%s-${%s}"`, logicalName, key)},
+		{Type: hclsyntax.TokenQuotedLit, Bytes: fmt.Appendf(nil, `"%s%s%s"`, prefix, logicalName, suffix)},
 	}
 }
 
@@ -1952,9 +1981,17 @@ func (g *generator) genModule(body *hclwrite.Body, c *pcl.Component) hcl.Diagnos
 	block.Body().SetAttributeValue("source", cty.StringVal(source))
 	var diags hcl.Diagnostics
 
+	naming := instanceNamingNone
 	if c.Options != nil && c.Options.Range != nil {
-		_, d := g.genRange(block.Body(), c.Options.Range)
+		var d hcl.Diagnostics
+		naming, d = g.genRange(block.Body(), c.Options.Range)
 		diags = append(diags, d...)
+	}
+	// Pin the component instances' names the same way ranged resources are
+	// pinned, so nested components keep the "<parent>-<child>" names the
+	// other languages produce.
+	if tokens := pinnedNameTokens(g.insideComponent, c.LogicalName(), naming); tokens != nil {
+		block.Body().AppendNewBlock("pulumi", nil).Body().SetAttributeRaw("name", tokens)
 	}
 
 	for _, attr := range c.Inputs {

--- a/pkg/hcl/ast/module.go
+++ b/pkg/hcl/ast/module.go
@@ -68,6 +68,11 @@ type Module struct {
 	// Each expression is evaluated at runtime to obtain the provider URN/ID.
 	Providers map[string]hcl.Expression
 
+	// PulumiName, if present, overrides the Pulumi logical name of each
+	// instance of this module call. It is evaluated per instance in the
+	// calling scope, with count.index/each.key in scope.
+	PulumiName hcl.Expression
+
 	// DeclRange is the source range of the module block.
 	DeclRange hcl.Range
 }

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -121,6 +121,10 @@ type PulumiContext struct {
 	Project string
 	// Organization is the current organization name
 	Organization string
+	// ModuleName is the resolved Pulumi logical name of the module instance
+	// this context evaluates, exposed as pulumi.module.name. Nil at the root,
+	// where pulumi.module.name is null.
+	ModuleName *string
 }
 
 // CountContext contains count iteration context.
@@ -398,6 +402,14 @@ func (c *Context) ClearEach() {
 	c.each = nil
 }
 
+// SetModuleName records the resolved Pulumi logical name of the module
+// instance this context evaluates, exposed as pulumi.module.name.
+func (c *Context) SetModuleName(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pulumi.ModuleName = &name
+}
+
 // SetSelf sets the self reference (for provisioner expressions).
 func (c *Context) SetSelf(value cty.Value) {
 	c.mu.Lock()
@@ -560,10 +572,15 @@ func (c *Context) HCLContext() *hcl.EvalContext {
 	})
 
 	// Add pulumi.* namespace
+	moduleName := cty.NullVal(cty.String)
+	if c.pulumi.ModuleName != nil {
+		moduleName = cty.StringVal(*c.pulumi.ModuleName)
+	}
 	vars["pulumi"] = cty.ObjectVal(map[string]cty.Value{
 		"stack":        cty.StringVal(c.pulumi.Stack),
 		"project":      cty.StringVal(c.pulumi.Project),
 		"organization": cty.StringVal(c.pulumi.Organization),
+		"module":       cty.ObjectVal(map[string]cty.Value{"name": moduleName}),
 	})
 
 	// terraform.workspace is the stack name: a Pulumi stack, like a Terraform

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -983,7 +983,7 @@ func (g *Graph) exprDepsExcluding(expr hcl.Expression, prefix string, exclude ma
 			if len(parts) >= 1 {
 				dep = fmt.Sprintf("%slocal.%s", prefix, parts[0])
 			}
-		case "path", "terraform", "count", "each", "self":
+		case "path", "terraform", "count", "each", "self", "pulumi":
 			continue
 		case "data":
 			if len(parts) >= 2 {
@@ -1068,7 +1068,7 @@ func formatTraversal(traversal hcl.Traversal) string {
 	namespace, parts := eval.ParseTraversal(traversal)
 
 	switch namespace {
-	case "var", "local", "path", "terraform", "count", "each", "self":
+	case "var", "local", "path", "terraform", "count", "each", "self", "pulumi":
 		// These are handled differently
 		if namespace == "local" && len(parts) >= 1 {
 			return "local." + parts[0]

--- a/pkg/hcl/modulepath/modulepath.go
+++ b/pkg/hcl/modulepath/modulepath.go
@@ -206,27 +206,26 @@ func (p Path) Steps(yield func(Step) bool) {
 	}
 }
 
-// LogicalName returns the canonical Pulumi resource name for this path
-// (joining each step's [Step.LogicalName] with "-").
+// LogicalName returns the canonical derived Pulumi resource name for this
+// path (joining each step's [Step.LogicalName] with ".").
 //
 //	Root                              -> ""
 //	["outer"]                         -> "outer"
-//	["outer", "inner"]                -> "outer-inner"
-//	["outer"[0], "inner"]             -> "outer[0]-inner"
-//	["outer"["a"], "inner"]           -> `outer["a"]-inner`
+//	["outer", "inner"]                -> "outer.inner"
+//	["outer"[0], "inner"]             -> "outer[0].inner"
+//	["outer"["a"], "inner"]           -> `outer["a"].inner`
 //
-// Instance keys are bracket-quoted and "[" cannot appear in an HCL label, so
-// distinct instance keys always produce distinct logical names. The "-"
-// joiner itself is legal in labels, however, so a logical name produced by
-// this function is a one-way derivation, not a round-trippable encoding of
-// the path: ["a", "b-c"] and ["a-b", "c"] collide. Use the path itself
-// ([Path] equality / map-key) when collision safety is required.
+// HCL block labels cannot contain ".", "[", or `"`, and instance keys are
+// bracket-quoted, so distinct paths built from valid HCL labels always
+// produce distinct logical names. Labels that themselves contain "." (which
+// HCL cannot express) are not escaped; for such pathological labels this is
+// a one-way derivation, not a round-trippable encoding of the path.
 func (p Path) LogicalName() string {
 	var b strings.Builder
 	first := true
 	for s := range p.Steps {
 		if !first {
-			b.WriteByte('-')
+			b.WriteByte('.')
 		}
 		b.WriteString(s.LogicalName())
 		first = false

--- a/pkg/hcl/modulepath/modulepath_test.go
+++ b/pkg/hcl/modulepath/modulepath_test.go
@@ -91,7 +91,7 @@ func TestPath_Append(t *testing.T) {
 	p := modulepath.Root().Append(modulepath.NewStep("a")).Append(modulepath.NewStep("b"))
 	assert.Equal(t, 2, p.Len())
 	assert.False(t, p.IsRoot())
-	assert.Equal(t, "a-b", p.LogicalName())
+	assert.Equal(t, "a.b", p.LogicalName())
 }
 
 func TestPath_AppendDoesNotMutate(t *testing.T) {
@@ -101,7 +101,7 @@ func TestPath_AppendDoesNotMutate(t *testing.T) {
 	p2 := p1.Append(modulepath.NewStep("b"))
 	// p1 must still be just "a".
 	assert.Equal(t, "a", p1.LogicalName())
-	assert.Equal(t, "a-b", p2.LogicalName())
+	assert.Equal(t, "a.b", p2.LogicalName())
 }
 
 func TestPath_LogicalName_RoundTripsDottedLabels(t *testing.T) {
@@ -111,7 +111,7 @@ func TestPath_LogicalName_RoundTripsDottedLabels(t *testing.T) {
 	p := modulepath.Root().
 		Append(modulepath.NewStep("vpc.primary")).
 		Append(modulepath.NewStep("inner"))
-	assert.Equal(t, "vpc.primary-inner", p.LogicalName())
+	assert.Equal(t, "vpc.primary.inner", p.LogicalName())
 }
 
 func TestPath_LogicalName_MixedExpansions(t *testing.T) {
@@ -120,7 +120,7 @@ func TestPath_LogicalName_MixedExpansions(t *testing.T) {
 	p := modulepath.Root().
 		Append(modulepath.NewIndexedStep("outer", 2)).
 		Append(modulepath.NewKeyedStep("inner", "prod"))
-	assert.Equal(t, `outer[2]-inner["prod"]`, p.LogicalName())
+	assert.Equal(t, `outer[2].inner["prod"]`, p.LogicalName())
 }
 
 func TestPath_Parent(t *testing.T) {
@@ -209,6 +209,9 @@ func TestPath_NoCollisionAcrossDottedLabels(t *testing.T) {
 
 	// "a.b" / "c" must not collide with "a" / "b.c" — the bug we set out
 	// to fix. With length-prefixed encoding, these produce distinct paths.
+	// (Their logical names DO collide — labels containing "." cannot be
+	// written in HCL, so LogicalName documents this as a one-way
+	// derivation — but the paths themselves stay distinct.)
 	p1 := modulepath.Root().
 		Append(modulepath.NewStep("a.b")).
 		Append(modulepath.NewStep("c"))
@@ -217,8 +220,8 @@ func TestPath_NoCollisionAcrossDottedLabels(t *testing.T) {
 		Append(modulepath.NewStep("b.c"))
 
 	assert.False(t, p1 == p2)
-	assert.Equal(t, "a.b-c", p1.LogicalName())
-	assert.Equal(t, "a-b.c", p2.LogicalName())
+	assert.Equal(t, "a.b.c", p1.LogicalName())
+	assert.Equal(t, "a.b.c", p2.LogicalName())
 }
 
 func TestPath_LogicalName_NoCollisionAcrossDashedKeys(t *testing.T) {

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -1310,6 +1310,16 @@ func (p *Parser) parseModuleBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 		}
 	}
 
+	for _, subBlock := range content.Blocks {
+		if subBlock.Type == "pulumi" {
+			optContent, optDiags := subBlock.Body.Content(pulumiModuleOptionsSchema)
+			diags = append(diags, optDiags...)
+			if attr, ok := optContent.Attributes["name"]; ok {
+				module.PulumiName = attr.Expr
+			}
+		}
+	}
+
 	config.Modules[name] = module
 	return diags
 }

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -241,7 +241,9 @@ var provisionerSchema = &hcl.BodySchema{
 	},
 }
 
-// moduleSchema defines the structure of a module block.
+// moduleSchema defines the structure of a module block. The nested `pulumi`
+// block holds Pulumi-specific options so they cannot collide with the
+// module's own input variables.
 var moduleSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{Name: "source", Required: true},
@@ -250,6 +252,17 @@ var moduleSchema = &hcl.BodySchema{
 		{Name: "for_each"},
 		{Name: "depends_on"},
 		{Name: "providers"},
+	},
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "pulumi"},
+	},
+}
+
+// pulumiModuleOptionsSchema defines the Pulumi-specific options allowed
+// inside a module block's nested `pulumi` block.
+var pulumiModuleOptionsSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "name"},
 	},
 }
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -249,8 +249,14 @@ type CallResponse struct {
 type moduleInstance struct {
 	// Path identifies this instance within the module nesting tree. The
 	// leaf [modulepath.Step] carries the count index or for_each key, if
-	// any. Path.LogicalName() is the canonical Pulumi component name.
-	Path    modulepath.Path
+	// any.
+	Path modulepath.Path
+	// Name is the resolved Pulumi logical name of this instance's component:
+	// a `pulumi { name = ... }` override when present, else the parent
+	// instance's Name joined to this instance's step with ".". It prefixes
+	// the derived names of everything inside the instance and is exposed to
+	// the instance as pulumi.module.name.
+	Name    string
 	EvalCtx *eval.Context        // per-instance evaluation context
 	URN     urn.URN              // component URN
 	Parent  *moduleInstance      // enclosing module instance (nil for root-level calls)
@@ -283,6 +289,32 @@ func instancePath(parentPath modulepath.Path, name string, index *int, eachKey *
 	default:
 		return parentPath.Append(modulepath.NewStep(name))
 	}
+}
+
+// moduleInstanceName resolves the Pulumi logical name of one module instance:
+// a `pulumi { name = ... }` override evaluated in the calling scope (with the
+// instance's count.index/each.key in scope) is the full name; a null or
+// absent override derives the name from the parent instance's resolved name
+// joined to this instance's own step with ".".
+func moduleInstanceName(
+	mod *ast.Module, parentEvalCtx *eval.Context, parentName string,
+	instPath modulepath.Path, index *int, eachKey, eachVal *cty.Value,
+) (string, error) {
+	if mod.PulumiName != nil {
+		hclCtx := parentEvalCtx.HCLContextWithIteration(index, eachKey, eachVal)
+		name, ok, err := evaluatePulumiName(mod.PulumiName, hclCtx, "module "+mod.Name)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return name, nil
+		}
+	}
+	_, leaf, ok := instPath.Parent()
+	if !ok {
+		return "", fmt.Errorf("module %s: instance path is empty", mod.Name)
+	}
+	return joinModuleName(parentName, leaf.LogicalName()), nil
 }
 
 // inheritableOpts holds the resource options that child resources can inherit from their parent.
@@ -1179,7 +1211,7 @@ func (e *Engine) registerProviderInContext(
 		logicalName = buildResourceName(logicalName, nil, &inst.key)
 	}
 	if modInst != nil {
-		logicalName = prefixWithModulePath(modInst.Path, logicalName)
+		logicalName = joinModuleName(modInst.Name, logicalName)
 	}
 
 	// Version comes from an explicit attribute, else required_providers.
@@ -2480,39 +2512,68 @@ func buildResourceName(logicalName string, index *int, eachKey *string) string {
 }
 
 // prefixWithModulePath prefixes name with the logical name of the module
-// instance path it lives in, joined with "-" (the cross-language Pulumi
-// convention for component-child names).
+// instance path it lives in, joined with ".". The "." separator cannot appear
+// in an HCL label, so the module prefix cannot collide with a dash in a
+// sibling's label or for_each key. Used where only a path (not a resolved
+// [moduleInstance]) is available — the moved-block alias reconstruction; live
+// instances prefix with [joinModuleName] on the instance's resolved Name.
 func prefixWithModulePath(path modulepath.Path, name string) string {
 	if path.IsRoot() {
 		return name
 	}
-	return path.LogicalName() + "-" + name
+	return joinModuleName(path.LogicalName(), name)
+}
+
+// joinModuleName joins an enclosing module instance's resolved name and a
+// child name with ".". An empty parent (the root) leaves the name bare.
+func joinModuleName(parentName, name string) string {
+	if parentName == "" {
+		return name
+	}
+	return parentName + "." + name
+}
+
+// evaluatePulumiName evaluates a `pulumi { name = ... }` override expression.
+// ok is false when the expression evaluates to null, which means "no
+// override"; subject names the block for error messages.
+func evaluatePulumiName(expr hcl.Expression, hclCtx *hcl.EvalContext, subject string) (name string, ok bool, err error) {
+	val, diags := expr.Value(hclCtx)
+	if diags.HasErrors() {
+		return "", false, fmt.Errorf("evaluating pulumi name for %s: %s", subject, diags.Error())
+	}
+	val, _ = val.Unmark()
+	if val.IsNull() {
+		return "", false, nil
+	}
+	if !val.IsKnown() || val.Type() != cty.String {
+		return "", false, fmt.Errorf("pulumi name for %s must be a known string", subject)
+	}
+	return val.AsString(), true, nil
 }
 
 // resourceInstanceName computes the Pulumi resource name for one resource
 // instance. A `pulumi { name = ... }` override is evaluated per instance
-// (count.index/each.key are in scope) and replaces the derived instance name.
-// Either way the name is prefixed with the module instance name (e.g. "many"
-// or "many[0]") when the resource lives inside a module.
+// (count.index/each.key and pulumi.module.name are in scope) and is the full
+// logical name — no module prefix is applied; a null override falls back to
+// the derived name. Derived names are prefixed with the enclosing module
+// instance's resolved name (e.g. "many" or "many[0]") joined with ".".
 func (*Engine) resourceInstanceName(
 	res *ast.Resource, instance *graph.ExpandedResource, hclCtx *hcl.EvalContext, modInst *moduleInstance,
 ) (string, error) {
-	name := buildResourceName(res.Name, instance.Index, instance.EachKeyString())
 	if res.PulumiName != nil {
-		val, diags := res.PulumiName.Value(hclCtx)
-		if diags.HasErrors() {
-			return "", fmt.Errorf("evaluating pulumi name for %s.%s: %s", res.Type, res.Name, diags.Error())
+		name, ok, err := evaluatePulumiName(res.PulumiName, hclCtx, res.Type+"."+res.Name)
+		if err != nil {
+			return "", err
 		}
-		val, _ = val.Unmark()
-		if !val.IsKnown() || val.IsNull() || val.Type() != cty.String {
-			return "", fmt.Errorf("pulumi name for %s.%s must be a known string", res.Type, res.Name)
+		if ok {
+			return name, nil
 		}
-		name = val.AsString()
 	}
+	name := buildResourceName(res.Name, instance.Index, instance.EachKeyString())
 	if modInst == nil {
 		return name, nil
 	}
-	return prefixWithModulePath(modInst.Path, name), nil
+	return joinModuleName(modInst.Name, name), nil
 }
 
 // translateAttrPathTraversal formats an attribute-path traversal (e.g. an
@@ -3636,9 +3697,9 @@ func (e *Engine) initModuleCallIn(
 	modInfo := node.ModuleInfo
 	mod := modInfo.Module
 
-	parentURN, parentEvalCtx, parentPath := e.stackURN, e.evaluator.Context(), modulepath.Root()
+	parentURN, parentEvalCtx, parentPath, parentName := e.stackURN, e.evaluator.Context(), modulepath.Root(), ""
 	if parent != nil {
-		parentURN, parentEvalCtx, parentPath = parent.URN, parent.EvalCtx, parent.Path
+		parentURN, parentEvalCtx, parentPath, parentName = parent.URN, parent.EvalCtx, parent.Path, parent.Name
 	}
 
 	// Evaluate module inputs for the component resource registration
@@ -3663,9 +3724,13 @@ func (e *Engine) initModuleCallIn(
 
 	newInstance := func(index *int, eachKey, eachVal *cty.Value) (*moduleInstance, error) {
 		instPath := instancePath(parentPath, modInfo.ModuleName(), index, eachKey)
+		instName, err := moduleInstanceName(mod, parentEvalCtx, parentName, instPath, index, eachKey, eachVal)
+		if err != nil {
+			return nil, err
+		}
 		componentOpts := &ResourceOptions{Parent: parentURN}
 		componentOpts.Aliases = e.moduleComponentAliases(instPath)
-		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, instPath.LogicalName(), property.NewMap(inputs), componentOpts)
+		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, instName, property.NewMap(inputs), componentOpts)
 		if err != nil {
 			return nil, fmt.Errorf("registering module component %s: %w", instPath.String(), err)
 		}
@@ -3677,8 +3742,10 @@ func (e *Engine) initModuleCallIn(
 			return nil, fmt.Errorf("creating the module evaluation context: %w", err)
 		}
 		instCtx.SetProviderFunctions(moduleFunctions)
+		instCtx.SetModuleName(instName)
 		return &moduleInstance{
 			Path:    instPath,
+			Name:    instName,
 			EvalCtx: instCtx,
 			URN:     componentURN,
 			Parent:  parent,

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -403,6 +403,185 @@ resource "aws_instance" "single" {
 	}, names)
 }
 
+// A module's `pulumi { name = ... }` pins the component instance's name, the
+// pinned name prefixes derived child names and is exposed inside the module
+// as pulumi.module.name, and a resource override is absolute (no module
+// prefix). A null override means no override.
+func TestEngine_PulumiNameOverrideModules(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	moduleDir := tmpDir + "/modules/child"
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+
+	moduleMain := `
+resource "aws_instance" "derived" {
+  ami = "ami-derived"
+}
+
+resource "aws_instance" "pinned" {
+  ami = "ami-pinned"
+
+  pulumi {
+    name = "${pulumi.module.name}-pinned"
+  }
+}
+
+resource "aws_instance" "null_override" {
+  ami = "ami-null"
+
+  pulumi {
+    name = null
+  }
+}
+`
+	require.NoError(t, os.WriteFile(moduleDir+"/main.tf", []byte(moduleMain), 0o644))
+
+	rootMain := `
+module "plain" {
+  source = "./modules/child"
+}
+
+module "named" {
+  source = "./modules/child"
+
+  pulumi {
+    name = "renamed"
+  }
+}
+
+module "keyed" {
+  source   = "./modules/child"
+  for_each = toset(["k"])
+
+  pulumi {
+    name = "keyed-${each.key}"
+  }
+}
+`
+	require.NoError(t, os.WriteFile(tmpDir+"/main.tf", []byte(rootMain), 0o644))
+
+	p := parser.NewParser()
+	config, diags := p.ParseDirectory(tmpDir)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testLiveModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         tmpDir,
+		RootDir:         tmpDir,
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "aws",
+			Resources: map[string]schema.ResourceSpec{
+				"aws:index:Instance": {
+					InputProperties: map[string]schema.PropertySpec{
+						"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	componentNames := []string{}
+	instanceNames := []string{}
+	for _, req := range mock.RegisteredResources {
+		switch {
+		case strings.HasPrefix(req.Type, "components:index:"):
+			componentNames = append(componentNames, req.Name)
+		case req.Type == "aws:index:Instance":
+			instanceNames = append(instanceNames, req.Name)
+		}
+	}
+	assert.ElementsMatch(t, []string{"plain", "renamed", "keyed-k"}, componentNames)
+	assert.ElementsMatch(t, []string{
+		"plain.derived", "plain-pinned", "plain.null_override",
+		"renamed.derived", "renamed-pinned", "renamed.null_override",
+		"keyed-k.derived", "keyed-k-pinned", "keyed-k.null_override",
+	}, instanceNames)
+}
+
+// Distinct addresses must derive distinct names even when labels and keys
+// contain dashes: instance keys are bracket-quoted and module prefixes join
+// with ".", neither of which can appear in an HCL label.
+func TestEngine_ModuleResourceNamesDoNotCollide(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	moduleDir := tmpDir + "/modules/child"
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+
+	moduleMain := `
+resource "aws_instance" "r" {
+  ami = "ami-r"
+}
+
+resource "aws_instance" "b-r" {
+  ami = "ami-b-r"
+}
+`
+	require.NoError(t, os.WriteFile(moduleDir+"/main.tf", []byte(moduleMain), 0o644))
+
+	rootMain := `
+module "a" {
+  source = "./modules/child"
+}
+
+module "a-b" {
+  source = "./modules/child"
+}
+`
+	require.NoError(t, os.WriteFile(tmpDir+"/main.tf", []byte(rootMain), 0o644))
+
+	p := parser.NewParser()
+	config, diags := p.ParseDirectory(tmpDir)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testLiveModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         tmpDir,
+		RootDir:         tmpDir,
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "aws",
+			Resources: map[string]schema.ResourceSpec{
+				"aws:index:Instance": {
+					InputProperties: map[string]schema.PropertySpec{
+						"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	names := []string{}
+	for _, req := range mock.RegisteredResources {
+		if req.Type == "aws:index:Instance" {
+			names = append(names, req.Name)
+		}
+	}
+	assert.ElementsMatch(t, []string{"a.r", "a.b-r", "a-b.r", "a-b.b-r"}, names)
+}
+
 func TestEngine_PulumiResourceNamePreviewUnknown(t *testing.T) {
 	t.Parallel()
 
@@ -2514,7 +2693,7 @@ module "child" {
 			"modulePath": property.New(tmpDir),
 			"rootPath":   property.New(tmpDir),
 		}),
-		"child-inner": property.NewMap(map[string]property.Value{
+		"child.inner": property.NewMap(map[string]property.Value{
 			"modulePath": property.New(moduleDir),
 			"rootPath":   property.New(tmpDir),
 		}),
@@ -2596,7 +2775,7 @@ module "vpc.primary" {
 		}
 	}
 	require.NotNil(t, vpcResource, "expected aws:index:Vpc resource to be registered")
-	assert.Equal(t, "vpc.primary-main", vpcResource.Name)
+	assert.Equal(t, "vpc.primary.main", vpcResource.Name)
 }
 
 // TestEngine_ResourceTypeWithDot verifies that a resource whose HCL type label
@@ -2922,8 +3101,8 @@ output "all" {
 		assert.Equal(t, map[string]urn.URN{
 			"outer[0]":       stackURN,
 			"outer[1]":       stackURN,
-			"outer[0]-inner": "urn:pulumi:test::project::components:index:Outer::outer[0]",
-			"outer[1]-inner": "urn:pulumi:test::project::components:index:Outer::outer[1]",
+			"outer[0].inner": "urn:pulumi:test::project::components:index:Outer::outer[0]",
+			"outer[1].inner": "urn:pulumi:test::project::components:index:Outer::outer[1]",
 		}, componentParents(mock))
 	})
 
@@ -2949,8 +3128,8 @@ output "all" {
 		assert.Equal(t, map[string]urn.URN{
 			`outer["x"]`:       stackURN,
 			`outer["y"]`:       stackURN,
-			`outer["x"]-inner`: `urn:pulumi:test::project::components:index:Outer::outer["x"]`,
-			`outer["y"]-inner`: `urn:pulumi:test::project::components:index:Outer::outer["y"]`,
+			`outer["x"].inner`: `urn:pulumi:test::project::components:index:Outer::outer["x"]`,
+			`outer["y"].inner`: `urn:pulumi:test::project::components:index:Outer::outer["y"]`,
 		}, componentParents(mock))
 	})
 }
@@ -4352,8 +4531,8 @@ module "child" {
 	}
 
 	upstream := find("upstream")
-	first := find("child-first[0]")
-	second := find("child-second")
+	first := find("child.first[0]")
+	second := find("child.second")
 	require.NotNil(t, upstream, "upstream resource should be registered")
 	require.NotNil(t, first, "child-first resource should be registered")
 	require.NotNil(t, second, "child-second resource should be registered")


### PR DESCRIPTION
Follow-up to https://github.com/pulumi-labs/pulumi-hcl/pull/382, closing the residual collision it documented. Intended to land in the same release so URNs break once.

## Bug

Derived Pulumi names joined a module instance's name and its contents with `-`, which is legal inside HCL labels. Two calls to the *same* module source labeled `a` and `a-b`, whose source contains resources `b-r` and `r`, both derived `a-b-r` — same component type (same source), same URN.

## Fix

**Derived names now copy Terraform's address structure end-to-end.** #382 made instance keys unambiguous (`r["a-b"]`); this PR joins module segments and the resource with `.` (Terraform's own separator, impossible in a label): `module "m" (key "k")` containing `r` derives `m["k"].r`, and the example above derives `a.b-r` vs `a-b.r`. Derived names are now injective for everything expressible in HCL.

## New surface

- **`pulumi.module.name`** — joins `pulumi.stack/project/organization` in the eval namespace: the resolved Pulumi logical name of the enclosing module instance (null at the root). This is the module-identity value Terraform never shipped (https://github.com/hashicorp/terraform/issues/24146); the runtime can supply it because it derives the names itself.
- **Module-block `pulumi { name = ... }`** — pins a component instance's logical name, evaluated per instance in the calling scope (`count.index`/`each.key` in scope). The resolved name prefixes the derived names of everything inside the instance.
- **Resource `pulumi { name }` is now absolute** — the evaluated string is the full logical name with no module prefix (it can reference `pulumi.module.name` to opt back in), and a `null` result means "no override" on both blocks.

## Converted programs

The conformance suite pins the cross-language naming for generated programs (`outerComponent-innerComponent-res`, `numResource-0`). Codegen now pins the name of every resource and nested module call inside a generated component source as `"${pulumi.module.name}-<label>"` (plus the existing `-${count.index}`/`-${each.key}` suffix for ranged blocks, now also applied to ranged root module calls), reproducing exactly what PCL codegen emits in every other language. Eject drops the pinned names (not expressible in PCL) and regeneration re-injects them, so round-trips are stable.

## Compatibility

Module-nested derived names change again relative to #382 (`child-first[0]` → `child.first[0]`); both are unreleased, so shipping them in one release keeps the URN break singular.

## Testing

- New unit coverage: `TestEngine_PulumiNameOverrideModules` (module pins, `pulumi.module.name`, absolute + null overrides), `TestEngine_ModuleResourceNamesDoNotCollide` (the collision this PR closes), updated modulepath/naming assertions.
- Full `TestLanguage` conformance suite passes (regenerated project/round-trip snapshots verified stable without accept mode); `./pkg/...`, `./tests/...`, `./cmd/...` all pass with `-count=1`; lint clean.
