### PR TITLE
Fix data race on MockResourceMonitor's hooks map

### DIFF
--- a/tests/testutil/monitor.go
+++ b/tests/testutil/monitor.go
@@ -60,7 +60,6 @@ func (m *MockResourceMonitor) RegisterResource(ctx context.Context, req run.Regi
 	if req.Type == "pulumi:pulumi:Stack" {
 		m.stackURN = resURN
 	}
-	hooks := m.hooks
 	m.mu.Unlock()
 
 	// The mock has no state, so every registration is treated as a create.
@@ -71,7 +70,7 @@ func (m *MockResourceMonitor) RegisterResource(ctx context.Context, req run.Regi
 		NewInputs: req.Inputs,
 	}
 	if req.Hooks != nil {
-		if err := m.runHooks(ctx, hooks, req.Hooks.BeforeCreate, args); err != nil {
+		if err := m.runHooks(ctx, req.Hooks.BeforeCreate, args); err != nil {
 			return nil, err
 		}
 	}
@@ -99,7 +98,7 @@ func (m *MockResourceMonitor) RegisterResource(ctx context.Context, req run.Regi
 	if req.Hooks != nil {
 		args.NewOutputs = resp.Outputs
 		args.ID = resp.ID
-		if err := m.runHooks(ctx, hooks, req.Hooks.AfterCreate, args); err != nil {
+		if err := m.runHooks(ctx, req.Hooks.AfterCreate, args); err != nil {
 			return resp, err
 		}
 	}
@@ -125,11 +124,20 @@ func (m *MockResourceMonitor) ReadResource(ctx context.Context, req run.ReadReso
 	}, nil
 }
 
+// getHook looks up a registered hook under the lock. Hook callbacks must run
+// outside the lock because they can re-enter the monitor.
+func (m *MockResourceMonitor) getHook(name string) (registeredHook, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	h, ok := m.hooks[name]
+	return h, ok
+}
+
 func (m *MockResourceMonitor) runHooks(
-	ctx context.Context, hooks map[string]registeredHook, names []string, args *run.ResourceHookArgs,
+	ctx context.Context, names []string, args *run.ResourceHookArgs,
 ) error {
 	for _, name := range names {
-		h, ok := hooks[name]
+		h, ok := m.getHook(name)
 		if !ok {
 			return fmt.Errorf("hook %q not registered", name)
 		}


### PR DESCRIPTION
## Summary

Fixes the data race that failed the `ci / test (unit, go-test-unit, true)` job on https://github.com/pulumi-labs/pulumi-hcl/actions/runs/29449378242/job/87467831388 (seen on https://github.com/pulumi-labs/pulumi-hcl/pull/392, but pre-existing).

`MockResourceMonitor.RegisterResource` snapshotted the `hooks` map reference under `m.mu` and then read it in `runHooks` outside the lock. A Go map assignment copies the reference, not the contents, so the unlocked read raced with `RegisterResourceHook` mutating the same map under the lock. The engine's graph walk registers resources concurrently, so one node could be inside `RegisterResource` → `runHooks` while another was inside `bindPreconditionHooks` → `RegisterResourceHook` — the race detector then failed whichever engine tests were running.

The fix looks up each hook under the lock via a `getHook` helper. This is also semantically better than a true snapshot: hooks bound during the same walk are now visible to registrations that entered `RegisterResource` before the hook was bound (the old snapshot could be stale or `nil`). Hook callbacks still run outside the lock because they can re-enter the monitor.

## Verification

Reproduced on this branch's parent with `go test -race -run TestEngine_LifecycleRefDependencies -count=50 ./pkg/hcl/run/` (1/50 failed with the same trace). After the fix, 100 stress runs of the previously racing tests and a full `go test -race ./pkg/hcl/run/ ./tests/...` pass clean.