### PR TITLE
Follow chained moved blocks when resolving prior addresses

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-394.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-394.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Follow chained `moved` blocks when resolving resource and module-call renames
+time: 2026-07-16T09:40:00Z
+custom:
+    Component: runtime
+    PR: "394"

--- a/pkg/hcl/modulepath/modulepath.go
+++ b/pkg/hcl/modulepath/modulepath.go
@@ -141,12 +141,13 @@ func (s Step) String() string {
 //
 // The zero value [Path] is the root (no enclosing module). Paths are
 // comparable in Go, hashable as map keys, and immutable.
-//
-// The internal representation is a length-prefixed binary string, an
-// implementation detail. Do not depend on it: there is no marshal API
-// because there is no stable on-disk format. Use [Path.String] for
-// human-readable diagnostics; use the typed methods for everything else.
 type Path struct {
+
+	// The internal representation is a length-prefixed binary string. There
+	// is no marshal API because there is no stable on-disk format. Use
+	// [Path.String] for human-readable diagnostics; use the typed methods
+	// for everything else.
+
 	repr string
 }
 

--- a/pkg/hcl/modulepath/modulepath.go
+++ b/pkg/hcl/modulepath/modulepath.go
@@ -142,7 +142,6 @@ func (s Step) String() string {
 // The zero value [Path] is the root (no enclosing module). Paths are
 // comparable in Go, hashable as map keys, and immutable.
 type Path struct {
-
 	// The internal representation is a length-prefixed binary string. There
 	// is no marshal API because there is no stable on-disk format. Use
 	// [Path.String] for human-readable diagnostics; use the typed methods

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2129,6 +2129,10 @@ func moduleStepFor(name string, key cty.Value) (modulepath.Step, bool) {
 // root and a module or between two modules, and resources carried along when an
 // enclosing module call is renamed or re-keyed (the matching component alias is
 // attached in processModuleInit).
+//
+// Moved blocks chain: a prior address may itself be the `to` of another moved
+// block (a -> b, then b -> c). Every address along the chain is aliased, so the
+// engine matches whichever of them the state holds.
 func (e *Engine) resolveMovedAliases(
 	ctx context.Context, res *ast.Resource, index *int, eachKey *string, modInst *moduleInstance,
 ) []Alias {
@@ -2141,70 +2145,100 @@ func (e *Engine) resolveMovedAliases(
 		resPath = modInst.Path
 	}
 
-	for _, scope := range ancestorPaths(resPath) {
-		for _, moved := range e.graph.MovedBlocks(scope) {
-			to, ok := parseTargetAddr(moved.To)
-			if !ok || to.Type == "" { // skip whole-module-call moves
-				continue
-			}
-			toPath := appendModuleSteps(scope, to.modules)
-			if toPath != resPath || to.Type != res.Type || to.Name != res.Name {
-				continue
-			}
-			from, ok := parseTargetAddr(moved.From)
-			if !ok || from.Type == "" {
-				continue
-			}
-			fromPath := appendModuleSteps(scope, from.modules)
+	// A resource address at some point along the chain of moves.
+	type address struct {
+		path    modulepath.Path
+		typ     string
+		name    string
+		index   *int
+		eachKey *string
+	}
+	type addrKey struct {
+		typ    string
+		prefix string
+	}
+	mkAddrKey := func(a address) addrKey {
+		return addrKey{a.typ, prefixWithModulePath(a.path, buildResourceName(a.name, a.index, a.eachKey))}
+	}
 
-			// Determine the prior instance key. A keyed `to` targets one specific
-			// instance and takes the prior key from `from`; an unkeyed `to` is a
-			// whole-resource rename that maps every instance to the same key.
-			var priorIdx *int
-			var priorEach *string
-			if to.keyed() {
-				if !instanceKeysEqual(index, eachKey, to.keyIndex, to.keyEach) {
+	work := []address{{path: resPath, typ: res.Type, name: res.Name, index: index, eachKey: eachKey}}
+	seen := map[addrKey]bool{mkAddrKey(work[0]): true}
+
+	for len(work) > 0 {
+		cur := work[0]
+		work = work[1:]
+		for _, scope := range ancestorPaths(cur.path) {
+			for _, moved := range e.graph.MovedBlocks(scope) {
+				to, ok := parseTargetAddr(moved.To)
+				if !ok || to.Type == "" { // skip whole-module-call moves
 					continue
 				}
-				priorIdx, priorEach = from.keyIndex, from.keyEach
-			} else {
-				priorIdx, priorEach = index, eachKey
-			}
-
-			// The prior name is the resource's own name under its prior module
-			// path; the prior parent is described relative to where it is now.
-			name := prefixWithModulePath(fromPath, buildResourceName(from.Name, priorIdx, priorEach))
-			parentURN, noParent, ok := e.priorParentSpec(fromPath, resPath, modInst)
-			if !ok {
-				continue
-			}
-
-			// A `moved` may also change the resource's type; the alias then
-			// carries the prior type's token so the engine matches the old URN.
-			var priorType string
-			if from.Type != res.Type {
-				prior, err := e.resolver.ResolveResource(ctx, from.Type)
-				if err != nil {
-					logging.V(5).Infof("moved: cannot resolve prior type %q: %v", from.Type, err)
+				toPath := appendModuleSteps(scope, to.modules)
+				if toPath != cur.path || to.Type != cur.typ || to.Name != cur.name {
 					continue
 				}
-				priorType = prior.Token
-			}
+				from, ok := parseTargetAddr(moved.From)
+				if !ok || from.Type == "" {
+					continue
+				}
+				fromPath := appendModuleSteps(scope, from.modules)
 
-			aliases = append(aliases, Alias{Spec: &AliasSpec{
-				Name:      name,
-				Type:      priorType,
-				ParentURN: parentURN,
-				NoParent:  noParent,
-			}})
+				// Determine the prior instance key. A keyed `to` targets one specific
+				// instance and takes the prior key from `from`; an unkeyed `to` is a
+				// whole-resource rename that maps every instance to the same key.
+				var priorIdx *int
+				var priorEach *string
+				if to.keyed() {
+					if !instanceKeysEqual(cur.index, cur.eachKey, to.keyIndex, to.keyEach) {
+						continue
+					}
+					priorIdx, priorEach = from.keyIndex, from.keyEach
+				} else {
+					priorIdx, priorEach = cur.index, cur.eachKey
+				}
+
+				prior := address{path: fromPath, typ: from.Type, name: from.Name, index: priorIdx, eachKey: priorEach}
+				if seen[mkAddrKey(prior)] {
+					continue
+				}
+				seen[mkAddrKey(prior)] = true
+				work = append(work, prior)
+
+				// The prior name is the resource's own name under its prior module
+				// path; the prior parent is described relative to where it is now.
+				name := prefixWithModulePath(fromPath, buildResourceName(from.Name, priorIdx, priorEach))
+				parentURN, noParent, ok := e.priorParentSpec(fromPath, resPath, modInst)
+				if !ok {
+					continue
+				}
+
+				// A `moved` may also change the resource's type; the alias then
+				// carries the prior type's token so the engine matches the old URN.
+				var priorType string
+				if from.Type != res.Type {
+					priorRes, err := e.resolver.ResolveResource(ctx, from.Type)
+					if err != nil {
+						logging.V(5).Infof("moved: cannot resolve prior type %q: %v", from.Type, err)
+						continue
+					}
+					priorType = priorRes.Token
+				}
+
+				aliases = append(aliases, Alias{Spec: &AliasSpec{
+					Name:      name,
+					Type:      priorType,
+					ParentURN: parentURN,
+					NoParent:  noParent,
+				}})
+			}
 		}
 	}
 
 	// A `moved` block that renames an enclosing module call moves this resource
 	// with it. The resource keeps its own name within the module, so it is
-	// aliased to the name it had under the prior module path; Pulumi combines
+	// aliased to the name it had under each prior module path; Pulumi combines
 	// that with the renamed component's own alias to recover the old URN.
-	if oldPath := e.oldModulePath(resPath); oldPath != resPath {
+	for _, oldPath := range e.oldModulePaths(resPath) {
 		name := prefixWithModulePath(oldPath, buildResourceName(res.Name, index, eachKey))
 		aliases = append(aliases, Alias{Spec: &AliasSpec{Name: name}})
 	}
@@ -2212,10 +2246,28 @@ func (e *Engine) resolveMovedAliases(
 	return aliases
 }
 
-// oldModulePath applies any whole-module-call `moved` blocks that rename a
-// module enclosing (or equal to) path, returning the module path the object
-// lived at before the rename. It returns path unchanged when none applies.
-func (e *Engine) oldModulePath(path modulepath.Path) modulepath.Path {
+// oldModulePaths applies the whole-module-call `moved` blocks that rename a
+// module enclosing (or equal to) path, following chained renames, and returns
+// every prior module path the object lived at, nearest rename first. It
+// returns nil when none applies.
+func (e *Engine) oldModulePaths(path modulepath.Path) []modulepath.Path {
+	var prior []modulepath.Path
+	seen := map[modulepath.Path]bool{path: true}
+	for {
+		next, ok := e.priorModulePath(path)
+		if !ok || seen[next] {
+			return prior
+		}
+		seen[next] = true
+		prior = append(prior, next)
+		path = next
+	}
+}
+
+// priorModulePath applies the first whole-module-call `moved` block that
+// renames a module enclosing (or equal to) path, returning the module path the
+// object lived at before that rename. ok is false when none applies.
+func (e *Engine) priorModulePath(path modulepath.Path) (_ modulepath.Path, ok bool) {
 	for _, scope := range ancestorPaths(path) {
 		for _, moved := range e.graph.MovedBlocks(scope) {
 			to, ok := parseTargetAddr(moved.To)
@@ -2235,21 +2287,21 @@ func (e *Engine) oldModulePath(path modulepath.Path) modulepath.Path {
 			for _, s := range suffix {
 				fromPath = fromPath.Append(s)
 			}
-			return fromPath
+			return fromPath, true
 		}
 	}
-	return path
+	return path, false
 }
 
-// moduleComponentAliases returns the alias for a module instance's component
-// resource when a `moved` block renames its call, so the component (and its
+// moduleComponentAliases returns the aliases for a module instance's component
+// resource when `moved` blocks rename its call, so the component (and its
 // children) are recognized as moved rather than replaced.
 func (e *Engine) moduleComponentAliases(instPath modulepath.Path) []Alias {
-	oldPath := e.oldModulePath(instPath)
-	if oldPath == instPath {
-		return nil
+	var aliases []Alias
+	for _, oldPath := range e.oldModulePaths(instPath) {
+		aliases = append(aliases, Alias{Spec: &AliasSpec{Name: oldPath.LogicalName()}})
 	}
-	return []Alias{{Spec: &AliasSpec{Name: oldPath.LogicalName()}}}
+	return aliases
 }
 
 // priorParentSpec describes the parent of a resource at its prior moved address,

--- a/tests/tfcompat/l2_moved_chained_test.go
+++ b/tests/tfcompat/l2_moved_chained_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2MovedChained covers two `moved` blocks that chain in one config: an
+// object created as `a` is renamed to `b` and then `b` is renamed to `c`.
+// OpenTofu follows the chain (a -> b -> c) and moves the existing object to
+// `c` with no create/delete. The resource must not be destroyed and recreated
+// across the move, so both runtimes must record only the single initial Create.
+func TestL2MovedChained(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_moved_chained", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_moved_chained_test.go
+++ b/tests/tfcompat/l2_moved_chained_test.go
@@ -34,3 +34,16 @@ func TestL2MovedChained(t *testing.T) {
 		},
 	})
 }
+
+// TestL2MovedModuleChained covers two `moved` blocks that chain on a module
+// call: the call created as `module.a` is renamed to `module.b` and then
+// `module.b` is renamed to `module.c`. OpenTofu follows the chain and moves
+// the existing objects to `module.c` with no create/delete.
+func TestL2MovedModuleChained(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_moved_module_chained", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_moved_chained/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_chained/0/main.tf
@@ -1,0 +1,2 @@
+resource "simple_resource" "a" { input_one = "x" }
+output "r" { value = simple_resource.a.result }

--- a/tests/tfcompat/testdata/cases/l2_moved_chained/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_chained/1/main.tf
@@ -1,0 +1,15 @@
+resource "simple_resource" "c" { input_one = "x" }
+
+# Two moved blocks chain in one config: the object created as `a` was renamed to
+# `b`, then `b` was renamed to `c`. OpenTofu follows the chain (a -> b -> c) and
+# moves the existing object to `c` with no create/delete.
+moved {
+  from = simple_resource.a
+  to   = simple_resource.b
+}
+moved {
+  from = simple_resource.b
+  to   = simple_resource.c
+}
+
+output "r" { value = simple_resource.c.result }

--- a/tests/tfcompat/testdata/cases/l2_moved_module_chained/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_module_chained/0/main.tf
@@ -1,0 +1,2 @@
+module "a" { source = "./mod" }
+output "r" { value = module.a.r }

--- a/tests/tfcompat/testdata/cases/l2_moved_module_chained/0/mod/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_module_chained/0/mod/main.tf
@@ -1,0 +1,2 @@
+resource "simple_resource" "res" { input_one = "m" }
+output "r" { value = simple_resource.res.result }

--- a/tests/tfcompat/testdata/cases/l2_moved_module_chained/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_module_chained/1/main.tf
@@ -1,0 +1,16 @@
+module "c" { source = "./mod" }
+
+# Two moved blocks chain in one config: the call created as `module.a` was
+# renamed to `module.b`, then `module.b` was renamed to `module.c`. OpenTofu
+# follows the chain and moves the existing objects to `module.c` with no
+# create/delete.
+moved {
+  from = module.a
+  to   = module.b
+}
+moved {
+  from = module.b
+  to   = module.c
+}
+
+output "r" { value = module.c.r }

--- a/tests/tfcompat/testdata/cases/l2_moved_module_chained/1/mod/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_module_chained/1/mod/main.tf
@@ -1,0 +1,2 @@
+resource "simple_resource" "res" { input_one = "m" }
+output "r" { value = simple_resource.res.result }


### PR DESCRIPTION
## Bug

Two `moved` blocks in one config can chain through an intermediate address — `a → b` then `b → c`, with the resource now named `c`. OpenTofu follows the chain and moves the existing object to `c` with no create/delete. pulumi-hcl only matched `moved` blocks whose `to` equals the resource's current address: `c` got the alias `b`, but the state holds `a`, so no alias matched and the resource was destroyed and recreated instead of moved.

## Fix

`resolveMovedAliases` now walks a worklist of prior addresses: each matched `from` becomes an alias and is itself re-matched against the moved blocks, so every address along the chain (`b` and `a`) is aliased and the engine matches whichever of them the state holds. Aliasing the intermediates also covers a mid-chain apply (state holding `b`). A seen-set guards against cycles.

The same flaw existed for chained whole-module-call renames: `oldModulePath` returned after the first applicable rename. It is now `oldModulePaths`, following the chain and returning every prior module path; both callers (resource aliases and `moduleComponentAliases`) emit one alias per prior path.

## Tests

- `TestL2MovedChained` — resource chain (`a → b → c`); failed on master with Create+Create+Delete vs tofu's single Create, passes now.
- `TestL2MovedModuleChained` — the module-call sibling (`module.a → module.b → module.c`).
- Existing `TestL2Moved` suite (11 cases) and `pkg/hcl/run` unit tests pass.