### PR TITLE
Record provisioner and connection references as resource dependencies (destroy order)

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-395.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-395.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Record a dependency for a resource referenced only through a `provisioner` or `connection` block, so create and destroy order is honored
+time: 2026-07-16T00:00:00Z
+custom:
+    Component: runtime
+    PR: "395"

--- a/.changes/unreleased/runtime-bug-fixes-395.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-395.yaml
@@ -1,5 +1,5 @@
 kind: bug-fixes
-body: Record a dependency for a resource referenced only through a `provisioner` or `connection` block, so create and destroy order is honored
+body: Record a dependency for a resource referenced only through a `provisioner` or `connection` block, so destroy order is honored
 time: 2026-07-16T00:00:00Z
 custom:
     Component: runtime

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -778,6 +778,27 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node 
 			seen[dep] = true
 		}
 	}
+	// A reference in a connection block or a create-time provisioner
+	// establishes a dependency. Destroy-time provisioners may only reference
+	// the resource itself, so they contribute no edges.
+	if resource.Connection != nil {
+		for _, dep := range g.bodyDeps(resource.Connection.Config, prefix, nil) {
+			seen[dep] = true
+		}
+	}
+	for _, prov := range resource.Provisioners {
+		if prov.When == "destroy" {
+			continue
+		}
+		if prov.Connection != nil {
+			for _, dep := range g.bodyDeps(prov.Connection.Config, prefix, nil) {
+				seen[dep] = true
+			}
+		}
+		for _, dep := range g.bodyDeps(prov.Config, prefix, nil) {
+			seen[dep] = true
+		}
+	}
 	if resource.DeletedWith != nil {
 		if dep := formatTraversal(resource.DeletedWith); dep != "" {
 			g.recordRef(prefix+dep, resource.DeletedWith.SourceRange())

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -778,27 +778,6 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node 
 			seen[dep] = true
 		}
 	}
-	// A reference in a connection block or a create-time provisioner
-	// establishes a dependency. Destroy-time provisioners may only reference
-	// the resource itself, so they contribute no edges.
-	if resource.Connection != nil {
-		for _, dep := range g.bodyDeps(resource.Connection.Config, prefix, nil) {
-			seen[dep] = true
-		}
-	}
-	for _, prov := range resource.Provisioners {
-		if prov.When == "destroy" {
-			continue
-		}
-		if prov.Connection != nil {
-			for _, dep := range g.bodyDeps(prov.Connection.Config, prefix, nil) {
-				seen[dep] = true
-			}
-		}
-		for _, dep := range g.bodyDeps(prov.Config, prefix, nil) {
-			seen[dep] = true
-		}
-	}
 	if resource.DeletedWith != nil {
 		if dep := formatTraversal(resource.DeletedWith); dep != "" {
 			g.recordRef(prefix+dep, resource.DeletedWith.SourceRange())

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1543,12 +1543,14 @@ func (e *Engine) registerResourceInstanceInContext(
 			}
 		}
 	}
-	// count/for_each and lifecycle precondition/postcondition references are
-	// not tied to any body property, so they stay out of PropertyDependencies
-	// but still gate ordering through DependsOn.
+	// count/for_each, lifecycle precondition/postcondition, and
+	// provisioner/connection references are not tied to any body property, so
+	// they stay out of PropertyDependencies but still gate ordering through
+	// DependsOn.
 	checkDeps := checkRuleDeps(res.Preconditions, hclCtx)
 	checkDeps = append(checkDeps, checkRuleDeps(res.Postconditions, hclCtx)...)
-	for _, dep := range slices.Concat(metaArgDeps, checkDeps) {
+	provDeps := provisionerDeps(res, hclCtx)
+	for _, dep := range slices.Concat(metaArgDeps, checkDeps, provDeps) {
 		if !slices.Contains(opts.DependsOn, dep) {
 			opts.DependsOn = append(opts.DependsOn, dep)
 		}
@@ -4115,6 +4117,44 @@ func checkRuleDeps(rules []*ast.CheckRule, hclCtx *hcl.EvalContext) []string {
 				deps = append(deps, eval.CollectDepURNs(val)...)
 			}
 		}
+	}
+	return deps
+}
+
+func provisionerDeps(res *ast.Resource, hclCtx *hcl.EvalContext) []string {
+	var deps []string
+	var collect func(body hcl.Body)
+	collect = func(body hcl.Body) {
+		if body == nil {
+			return
+		}
+		attrs, _ := body.JustAttributes()
+		for _, attr := range attrs {
+			for _, traversal := range attr.Expr.Variables() {
+				val, diags := traversal.TraverseAbs(hclCtx)
+				if diags.HasErrors() {
+					continue
+				}
+				deps = append(deps, eval.CollectDepURNs(val)...)
+			}
+		}
+		if syntaxBody, ok := body.(*hclsyntax.Body); ok {
+			for _, block := range syntaxBody.Blocks {
+				collect(block.Body)
+			}
+		}
+	}
+	if res.Connection != nil {
+		collect(res.Connection.Config)
+	}
+	for _, prov := range res.Provisioners {
+		if prov.When == "destroy" {
+			continue
+		}
+		if prov.Connection != nil {
+			collect(prov.Connection.Config)
+		}
+		collect(prov.Config)
 	}
 	return deps
 }

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -5390,3 +5390,81 @@ resource "aws_instance" "reader" {
 	assert.Equal(t, []string{firstURN}, reader.Dependencies)
 	assert.Equal(t, map[string][]string{"ami": {firstURN}}, reader.PropertyDependencies)
 }
+
+// TestEngine_ProvisionerRefDependencies: a resource referenced only from a
+// provisioner command, a resource-level connection block, or a provisioner's
+// connection override establishes a dependency — directly and through a local
+// — while staying out of PropertyDependencies (no body property carries it).
+// The referent is declared last so the edge, not source order, must sequence
+// its evaluation before the referencing resources register. `self` in a
+// create-time provisioner is not a reference and must not break dep
+// collection; a destroy-time provisioner may only reference the resource
+// itself and contributes no dependency.
+func TestEngine_ProvisionerRefDependencies(t *testing.T) {
+	t.Parallel()
+
+	mock, err := tryExpansion(t, `
+resource "aws_instance" "prov" {
+  ami = "ami-prov"
+  provisioner "local-exec" {
+    command = "echo ${aws_instance.first.ami} ${self.id}"
+  }
+}
+
+resource "aws_instance" "conn" {
+  ami = "ami-conn"
+  connection {
+    host = aws_instance.first.ami
+  }
+}
+
+resource "aws_instance" "provconn" {
+  ami = "ami-provconn"
+  provisioner "local-exec" {
+    command = "echo provconn"
+    connection {
+      host = local.first_ami
+    }
+  }
+}
+
+resource "aws_instance" "dprov" {
+  ami = "ami-dprov"
+  provisioner "local-exec" {
+    when    = destroy
+    command = "echo ${aws_instance.first.ami}"
+  }
+}
+
+locals {
+  first_ami = aws_instance.first.ami
+}
+
+resource "aws_instance" "first" {
+  ami = "ami-first"
+}
+`, false, false)
+	require.NoError(t, err)
+
+	find := func(name string) *run.RegisterResourceRequest {
+		for i := range mock.RegisteredResources {
+			r := &mock.RegisteredResources[i]
+			if r.Type == "aws:index:Instance" && r.Name == name {
+				return r
+			}
+		}
+		return nil
+	}
+	firstURN := "urn:pulumi:test::project::aws:index:Instance::first"
+
+	for _, name := range []string{"prov", "conn", "provconn"} {
+		r := find(name)
+		require.NotNilf(t, r, "%s resource should be registered", name)
+		assert.Equal(t, []string{firstURN}, r.Dependencies)
+		assert.Empty(t, r.PropertyDependencies)
+	}
+
+	dprov := find("dprov")
+	require.NotNil(t, dprov, "dprov resource should be registered")
+	assert.Empty(t, dprov.Dependencies)
+}

--- a/tests/tfcompat/l2_provisioner_ref_destroy_order_test.go
+++ b/tests/tfcompat/l2_provisioner_ref_destroy_order_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ProvisionerRefDestroyOrder proves that a reference expressed only
+// through a resource's provisioner block establishes a dependency that governs
+// create and destroy ordering. `b`'s provisioner command references `a`;
+// nothing in `b`'s body, meta-arguments, or lifecycle references `a`. Terraform
+// derives the dependency, so the recorded sequence is [create a, create b,
+// delete b, delete a]; OrderDeterministic asserts it, with the op that must
+// complete first in each phase delayed so a missing edge flips the recorded
+// order deterministically.
+func TestL2ProvisionerRefDestroyOrder(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_provisioner_ref_destroy_order", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply},
+			{Mode: tfcompat.StageDestroy},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_ref_destroy_order/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_ref_destroy_order/main.tf
@@ -1,0 +1,24 @@
+resource "order_resource" "a" {
+  name         = "a"
+  delay_create = true
+}
+
+# `b` references `a` ONLY through a provisioner's command, with no body-input,
+# count/for_each, depends_on, or lifecycle link. Terraform derives a dependency
+# from the provisioner reference, so the recorded sequence is [create a, create
+# b, delete b, delete a]. A runtime that collects dependencies only from a
+# resource's body/meta-arguments and skips provisioner blocks will miss the
+# edge; the op that must complete first in each phase is delayed, so a missing
+# edge flips the recorded order deterministically.
+resource "order_resource" "b" {
+  name         = "b"
+  delay_delete = true
+
+  provisioner "local-exec" {
+    command = "echo ${order_resource.a.result}"
+  }
+}
+
+output "a_result" {
+  value = order_resource.a.result
+}


### PR DESCRIPTION
## Divergence

A reference that appears **only** inside a resource's `provisioner` block (its `command`) — `b`'s provisioner references `a`, nothing else in `b` does:

- **OpenTofu**: records the edge `b → a` from the provisioner reference, ordering create `[a, b]` and destroy `[b, a]`.
- **pulumi-hcl** (before this PR): the dependency graph already had the edge — `bodyDeps` walks the blocks `PartialContent` hides from `resource.Config`, pinned by `pkg/hcl/graph/provisioner_reference_test.go` — so creates were ordered. But the runtime never carried the referenced URNs onto the registered resource: the state recorded no dependency, and destroys ran unordered.

Same missing-reference-channel family as https://github.com/pulumi-labs/pulumi-hcl/pull/372 and https://github.com/pulumi-labs/pulumi-hcl/pull/379, but for the provisioner/connection channel.

## Fix

`pkg/hcl/run/run.go`: a new `provisionerDeps` helper (the body-walking analog of `checkRuleDeps`) collects the URNs referenced by the resource-level `connection` block and by each create-time provisioner's `config` and `connection` bodies — resolving each traversal through the eval context, so nothing evaluates early and `self` (not in scope until the hook fires) is skipped — and merges them into `DependsOn`. The recorded state then carries the edge and destroy order is honored. The deps stay out of `PropertyDependencies` since no body property carries them.

Destroy-time provisioners (`when = destroy`) contribute nothing: they may only reference the resource itself, so their references are excluded from dependency collection (OpenTofu likewise skips them when collecting references). The resource-level `connection` block counts unconditionally.

## Tests

- `TestL2ProvisionerRefDestroyOrder` (tfcompat) — failed 3/3 on master, passes 3/3 with the fix.
- `TestEngine_ProvisionerRefDependencies` (`pkg/hcl/run/run_test.go`) — covers the reference via provisioner command, resource-level connection, provisioner-level connection through a local, `self` in a create-time provisioner not breaking collection, and a destroy-time provisioner recording no dependency.

## History

https://github.com/pulumi-labs/pulumi-hcl/pull/333 originally recorded these references as `DependsOn` and the recording was dropped in review (`d558ed7`) on the rationale that the graph walk already orders the referent's registration before the dependent binds its hooks. That holds for creates, but destroys follow the dependencies recorded in state, which is the divergence `TestL2ProvisionerRefDestroyOrder` proves. This PR reinstates the recording in the `checkRuleDeps` shape that #379 established for the other hook-driven channels (which record `DependsOn` for the same reason).
