### PR TITLE
Accept WinRM-only attributes in provisioner connection blocks

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-396.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-396.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Accept WinRM-only `connection` attributes (`https`, `insecure`, `cacert`, `use_ntlm`)
+time: 2026-07-16T10:00:00Z
+custom:
+    Component: runtime
+    PR: "396"

--- a/pkg/provisioner/communicator/shared/shared.go
+++ b/pkg/provisioner/communicator/shared/shared.go
@@ -40,7 +40,7 @@ func (s *connectionSchema) CoerceValue(in cty.Value) (cty.Value, error) {
 	return out, nil
 }
 
-// Mirrors upstream's ConnectionBlockSupersetSchema minus WinRM attributes.
+// Mirrors upstream's ConnectionBlockSupersetSchema.
 var ConnectionBlockSupersetSchema = &connectionSchema{
 	objectType: cty.ObjectWithOptionalAttrs(
 		map[string]cty.Type{
@@ -69,6 +69,11 @@ var ConnectionBlockSupersetSchema = &connectionSchema{
 			"bastion_password":    cty.String,
 			"bastion_private_key": cty.String,
 			"bastion_certificate": cty.String,
+			// For type=winrm only (enforced in winrm communicator)
+			"https":    cty.Bool,
+			"insecure": cty.Bool,
+			"cacert":   cty.String,
+			"use_ntlm": cty.Bool,
 		},
 		// Every attribute except host is optional.
 		[]string{
@@ -78,6 +83,7 @@ var ConnectionBlockSupersetSchema = &connectionSchema{
 			"proxy_port", "proxy_user_name", "proxy_user_password",
 			"bastion_host", "bastion_host_key", "bastion_port", "bastion_user",
 			"bastion_password", "bastion_private_key", "bastion_certificate",
+			"https", "insecure", "cacert", "use_ntlm",
 		},
 	),
 }

--- a/pkg/provisioner/runtime/connection.go
+++ b/pkg/provisioner/runtime/connection.go
@@ -75,6 +75,12 @@ func connectionDecodeSpec() hcldec.Spec {
 		"bastion_password":    {cty.String, false},
 		"bastion_private_key": {cty.String, false},
 		"bastion_certificate": {cty.String, false},
+		// WinRM-only attributes; the ssh communicator ignores them, but the
+		// superset schema accepts them on any connection type.
+		"https":    {cty.Bool, false},
+		"insecure": {cty.Bool, false},
+		"cacert":   {cty.String, false},
+		"use_ntlm": {cty.Bool, false},
 	}
 	specs := hcldec.ObjectSpec{}
 	for name, a := range attrs {

--- a/pkg/provisioner/runtime/connection_test.go
+++ b/pkg/provisioner/runtime/connection_test.go
@@ -51,3 +51,19 @@ password = secret
 	assert.Equal(t, "10.0.0.2", connVal.GetAttr("host").AsString())
 	assert.Equal(t, "hunter2", connVal.GetAttr("password").AsString())
 }
+
+func TestEvalConnectionAcceptsWinRMAttrs(t *testing.T) {
+	t.Parallel()
+	body := parseBody(t, `
+host     = "10.0.0.2"
+type     = "ssh"
+use_ntlm = true
+https    = false
+insecure = true
+cacert   = "pem"
+`)
+
+	connVal, err := evalConnection(body, &hcl.EvalContext{})
+	require.NoError(t, err)
+	assert.Equal(t, cty.True, connVal.GetAttr("use_ntlm"))
+}

--- a/tests/tfcompat/l2_provisioner_connection_winrm_attr_test.go
+++ b/tests/tfcompat/l2_provisioner_connection_winrm_attr_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/sshd"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// OpenTofu validates a connection block against a superset schema that
+// includes WinRM-only attributes, and the SSH communicator ignores the ones
+// it does not use. pulumi-hcl decodes against a spec that omits them and
+// rejects the argument, so an SSH connection carrying a WinRM attribute
+// applies in OpenTofu but errors in pulumi-hcl.
+func TestL2ProvisionerConnectionWinRMAttr(t *testing.T) {
+	t.Parallel()
+	c := sshd.Start(t.Context(), t)
+	tfcompat.RunCase(t, "l2_provisioner_connection_winrm_attr", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Config: map[string]string{
+			"host":     c.Host,
+			"port":     strconv.Itoa(c.Port),
+			"user":     c.User,
+			"password": c.Password,
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_connection_winrm_attr/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_connection_winrm_attr/main.tf
@@ -1,0 +1,25 @@
+variable "host" { type = string }
+variable "port" { type = number }
+variable "user" { type = string }
+variable "password" { type = string }
+
+# OpenTofu's connection block is validated against the superset schema, which
+# includes winrm-only attributes (https/insecure/use_ntlm/cacert). On an ssh
+# connection the ssh communicator simply ignores them, so the provisioner runs.
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  connection {
+    type     = "ssh"
+    host     = var.host
+    port     = var.port
+    user     = var.user
+    password = var.password
+    timeout  = "30s"
+    use_ntlm = true
+  }
+
+  provisioner "remote-exec" {
+    inline = ["echo hello-from-remote-exec"]
+  }
+}


### PR DESCRIPTION
## Bug

A provisioner `connection` block on an SSH connection that also carries a WinRM-only attribute (`use_ntlm`, `https`, `insecure`, `cacert`):

- **OpenTofu**: validates the connection body against its `ConnectionBlockSupersetSchema` (which includes the WinRM attributes); the SSH communicator's `parseConnectionInfo` silently ignores the ones it doesn't use, so the provisioner runs and apply succeeds. Confirmed empirically against OpenTofu v1.12.3: apply succeeds with zero warnings.
- **pulumi-hcl**: decoded the connection body via `hcldec.Decode` against a spec that omitted every WinRM attribute, rejecting the argument: `An argument named "use_ntlm" is not expected here`.

A real config that applies under Terraform/OpenTofu broke under pulumi-hcl.

## Fix

Add the four WinRM-only attributes (`https`, `insecure`, `cacert`, `use_ntlm`) to the runtime decode spec (`pkg/provisioner/runtime/connection.go`) and the reimplemented superset schema (`pkg/provisioner/communicator/shared/shared.go`), with types matching upstream (`Bool`, `Bool`, `String`, `Bool`). The vendored SSH communicator already ignores attributes it doesn't handle, so no other change is needed. The parser-level schema already accepted these attributes; only the runtime decode path was missing them.

## Tests

- `TestL2ProvisionerConnectionWinRMAttr` (tfcompat, sshd container harness): an SSH `connection` with `use_ntlm = true` plus a `remote-exec` provisioner. Failed on master, passes with the fix.
- `TestEvalConnectionAcceptsWinRMAttrs` (unit): `evalConnection` accepts all four WinRM attributes on an SSH connection.