### PR TITLE
Materialize an unset optional+computed MaxItems=1 list block as null instead of []

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-397.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-397.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Materialize an unset `Optional+Computed` `MaxItems=1` list block as `null` rather than `[]`
+time: 2026-07-16T10:00:00Z
+custom:
+    Component: runtime
+    PR: "397"

--- a/pkg/hcl/bridge/mapping.go
+++ b/pkg/hcl/bridge/mapping.go
@@ -37,6 +37,10 @@ type FieldMapping struct {
 	// TFSet is true when the TF schema types this field as TypeSet — an
 	// unordered collection — whether a set of blocks or a set-typed attribute.
 	TFSet bool
+	// TFComputed is true when the TF schema marks this field Computed. An
+	// unset computed block materializes as null (the provider controls it),
+	// where an omitted purely-optional block is an empty list.
+	TFComputed bool
 	// Nested is the inner-body mapping for fields with named nested fields:
 	// blocks (TFBlock) and object-typed attributes (nested attributes).
 	Nested *BodyMapping
@@ -137,6 +141,7 @@ func bodyMappingFromSchema(sm shim.SchemaMap, overrides map[string]*tfbridge.Sch
 			TFName:     tfName,
 			PulumiName: tfbridge.TerraformToPulumiNameV2(tfName, sm, overrides),
 			TFSet:      sch.Type() == shim.TypeSet,
+			TFComputed: sch.Computed(),
 		}
 		if elemRes, isBlock := elemAsResource(sch); isBlock {
 			fm.TFBlock = true

--- a/pkg/hcl/bridge/mapping_test.go
+++ b/pkg/hcl/bridge/mapping_test.go
@@ -288,6 +288,7 @@ func TestResourceBodyMapping_NestedObjectAttributes(t *testing.T) {
 	require.Equal(t, &bridge.FieldMapping{
 		TFName:     "attr",
 		PulumiName: "attrs",
+		TFComputed: true,
 		Nested:     attrFM.Nested, // verified next
 	}, attrFM)
 	require.NotNil(t, attrFM.Nested)
@@ -297,6 +298,7 @@ func TestResourceBodyMapping_NestedObjectAttributes(t *testing.T) {
 	require.Equal(t, &bridge.FieldMapping{
 		TFName:     "nested_attr",
 		PulumiName: "nestedAttrs",
+		TFComputed: true,
 		Nested:     nestedFM.Nested, // verified next
 	}, nestedFM)
 	require.NotNil(t, nestedFM.Nested)

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -1219,9 +1219,16 @@ func propertyObjectToCtyMap(path string, m property.Map, properties []*schema.Pr
 		}
 		if singularBlock && !convertedV.Type().IsListType() && !convertedV.Type().IsTupleType() {
 			if convertedV.IsNull() {
-				// An omitted MaxItems=1 block is an empty list of blocks, not a
-				// single-element list holding null, so `length(r.block)` is 0.
-				convertedV = cty.ListValEmpty(convertedV.Type())
+				if fieldIsComputed(mapping, p.Name) && !setField {
+					// An unset Computed list block is provider-controlled:
+					// absence means null, so `r.block == null` holds. Unset
+					// set blocks materialize as empty either way.
+					convertedV = cty.NullVal(cty.List(convertedV.Type()))
+				} else {
+					// An omitted MaxItems=1 block is an empty list of blocks, not a
+					// single-element list holding null, so `length(r.block)` is 0.
+					convertedV = cty.ListValEmpty(convertedV.Type())
+				}
 			} else {
 				convertedV = cty.TupleVal([]cty.Value{convertedV})
 			}
@@ -1244,6 +1251,20 @@ func fieldIsSingularBlock(mapping *bridge.BodyMapping, pulumiName string) bool {
 	for _, fm := range mapping.Fields {
 		if fm.PulumiName == pulumiName {
 			return fm.TFBlock && fm.MaxItemsOne
+		}
+	}
+	return false
+}
+
+// fieldIsComputed reports whether the Pulumi property is Computed in the TF
+// schema per the bridge mapping.
+func fieldIsComputed(mapping *bridge.BodyMapping, pulumiName string) bool {
+	if mapping == nil {
+		return false
+	}
+	for _, fm := range mapping.Fields {
+		if fm.PulumiName == pulumiName {
+			return fm.TFComputed
 		}
 	}
 	return false

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -1242,46 +1242,41 @@ func propertyObjectToCtyMap(path string, m property.Map, properties []*schema.Pr
 	return result, nil
 }
 
+func fieldIsQuery[T any](mapping *bridge.BodyMapping, pulumiName string, query func(*bridge.FieldMapping) T) T {
+	if mapping != nil {
+		for _, fm := range mapping.Fields {
+			if fm.PulumiName == pulumiName {
+				return query(fm)
+			}
+		}
+	}
+
+	var t T
+	return t
+}
+
 // fieldIsSingularBlock reports whether the Pulumi property is a TF
 // MaxItemsOne block per the bridge mapping.
 func fieldIsSingularBlock(mapping *bridge.BodyMapping, pulumiName string) bool {
-	if mapping == nil {
-		return false
-	}
-	for _, fm := range mapping.Fields {
-		if fm.PulumiName == pulumiName {
-			return fm.TFBlock && fm.MaxItemsOne
-		}
-	}
-	return false
+	return fieldIsQuery(mapping, pulumiName, func(fm *bridge.FieldMapping) bool {
+		return fm.TFBlock && fm.MaxItemsOne
+	})
 }
 
 // fieldIsComputed reports whether the Pulumi property is Computed in the TF
 // schema per the bridge mapping.
 func fieldIsComputed(mapping *bridge.BodyMapping, pulumiName string) bool {
-	if mapping == nil {
-		return false
-	}
-	for _, fm := range mapping.Fields {
-		if fm.PulumiName == pulumiName {
-			return fm.TFComputed
-		}
-	}
-	return false
+	return fieldIsQuery(mapping, pulumiName, func(fm *bridge.FieldMapping) bool {
+		return fm.TFComputed
+	})
 }
 
 // fieldIsSet reports whether the Pulumi property is a TF TypeSet field per
 // the bridge mapping.
 func fieldIsSet(mapping *bridge.BodyMapping, pulumiName string) bool {
-	if mapping == nil {
-		return false
-	}
-	for _, fm := range mapping.Fields {
-		if fm.PulumiName == pulumiName {
-			return fm.TFSet
-		}
-	}
-	return false
+	return fieldIsQuery(mapping, pulumiName, func(fm *bridge.FieldMapping) bool {
+		return fm.TFSet
+	})
 }
 
 // ctySetFromSequence re-types a re-expanded TF TypeSet field from the ordered

--- a/tests/testutil/tfcompat/providers/optcompblock.go
+++ b/tests/testutil/tfcompat/providers/optcompblock.go
@@ -1,0 +1,56 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// OptCompBlockProvider exposes an Optional+Computed MaxItems=1 block that the
+// provider leaves entirely unset at create time. It probes the materialized
+// shape of a computed singular block that received no value: OpenTofu keeps it
+// null, so an `== null` guard and jsonencode observe the divergence.
+func OptCompBlockProvider() *schema.Provider {
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"optcomp_thing": {
+				Schema: map[string]*schema.Schema{
+					"name": {Type: schema.TypeString, Required: true},
+					"identity": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Computed: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"issuer": {Type: schema.TypeString, Computed: true},
+							},
+						},
+					},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("optcomp-id")
+					return nil
+				},
+				ReadContext:   func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				UpdateContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+			},
+		},
+	}
+}

--- a/tests/testutil/tfcompat/providers/optcompblock.go
+++ b/tests/testutil/tfcompat/providers/optcompblock.go
@@ -42,6 +42,19 @@ func OptCompBlockProvider() *schema.Provider {
 							},
 						},
 					},
+					// The TypeSet twin of `identity`: an unset computed *set*
+					// block materializes as an empty set, not null.
+					"identity_set": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Computed: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"issuer": {Type: schema.TypeString, Computed: true},
+							},
+						},
+					},
 				},
 				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
 					d.SetId("optcomp-id")

--- a/tests/tfcompat/l2_optional_computed_block_unset_test.go
+++ b/tests/tfcompat/l2_optional_computed_block_unset_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+func TestL2OptionalComputedBlockUnset(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_optional_computed_block_unset", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "optcomp", Factory: providers.OptCompBlockProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_optional_computed_block_unset/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_optional_computed_block_unset/main.tf
@@ -15,3 +15,13 @@ output "identity_is_null" {
 output "identity_json" {
   value = jsonencode(optcomp_thing.t.identity)
 }
+
+# The TypeSet twin stays an empty set when unset: `== null` is false and
+# jsonencode yields "[]" in both OpenTofu and pulumi-hcl.
+output "identity_set_is_null" {
+  value = optcomp_thing.t.identity_set == null
+}
+
+output "identity_set_json" {
+  value = jsonencode(optcomp_thing.t.identity_set)
+}

--- a/tests/tfcompat/testdata/cases/l2_optional_computed_block_unset/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_optional_computed_block_unset/main.tf
@@ -1,0 +1,17 @@
+# `identity` is an Optional+Computed MaxItems=1 nested block that the provider
+# leaves entirely unset at create time. In OpenTofu an unset optional+computed
+# singular block materializes as null, so `== null` is true and jsonencode
+# yields "null". pulumi-hcl materializes it as an empty list [] instead, so the
+# guard flips and downstream `identity[0]` indexing no longer errors the way a
+# migrated OpenTofu program expects.
+resource "optcomp_thing" "t" {
+  name = "probe"
+}
+
+output "identity_is_null" {
+  value = optcomp_thing.t.identity == null
+}
+
+output "identity_json" {
+  value = jsonencode(optcomp_thing.t.identity)
+}


### PR DESCRIPTION
## Divergence

An **Optional+Computed** MaxItems=1 nested block that the provider leaves entirely unset at create time:

- **Expected**: materializes as `null` — `block == null` is `true`, `jsonencode(block)` is `"null"`.
- **Before this fix**: pulumi-hcl materialized it as an empty list `[]` — `block == null` was `false`, `jsonencode(block)` was `"[]"`.

This flipped a migrated program's `block == null` guard and changed how `block[0]` indexing behaves.

## Root cause

On output, `propertyObjectToCtyMap` re-expands the bridge's flattened `MaxItemsOne` blocks back into the list-of-blocks representation. [#376](https://github.com/pulumi-labs/pulumi-hcl/pull/376) made a null singular block expand to `[]`, which is correct for a purely-optional block (omission in config means an empty list of blocks) but over-applied to the Optional+Computed case: there the provider controls the value, an SDKv2 provider that leaves it unset produces null state (no count key in the legacy flatmap), and that null survives apply — OpenTofu only normalizes null blocks to empty on refresh (`NormalizeObjectFromLegacySDK`).

The fix carries the TF schema's `Computed` flag through the bridge mapping (`FieldMapping.TFComputed`) and keeps the null when the singular block is computed.

Set-typed blocks are excluded from the null case: an unset computed **TypeSet** MaxItems=1 block materializes as an empty set either way (verified against real `tofu apply`), so it keeps the `[]` expansion.

## Sweep

The sibling shapes were probed against real tofu and already match, so no further change: unset computed repeated list block (`null` on both sides), omitted purely-optional repeated list block (`[]` on both), omitted purely-optional MaxItems=1 block at top level (`[]` on both, #376), and unset computed set blocks with and without MaxItems=1 (`[]` on both).

## Test

`TestL2OptionalComputedBlockUnset` — `OptCompBlockProvider` exposes `identity` (Optional+Computed, MaxItems=1, unset by the provider) and its TypeSet twin `identity_set`; the program outputs `== null` and `jsonencode` for both. Fails on master for the list block, passes with this fix. `TestL2OmittedNestedBlock` (#376) still passes; full tfcompat suite (182 tests) and `./pkg/...` unit tests pass.