### PR TITLE
Preserve nested element types of heterogeneous collections

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-398.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-398.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Preserve nested element types of heterogeneous collections (e.g. `terraform_remote_state` outputs mixing `set(number)` and `set(string)`)
+time: 2026-07-16T07:30:38Z
+custom:
+    Component: runtime
+    PR: "398"

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -1529,18 +1529,65 @@ func unifyOrObject(m map[string]cty.Value) cty.Value {
 }
 
 // isLossyPrimitiveUnification reports whether unifying to unified would coerce
-// elements between primitive types — e.g. collapsing [number, string, bool] to
-// string. Such a unification erases each element's own type, so a heterogeneous
-// value must stay a tuple/object rather than be flattened to a list/map. A
-// structural unification (e.g. object -> map) keeps a non-primitive target and
-// is left to proceed.
+// elements between primitive types at any depth — e.g. collapsing [number,
+// string, bool] to string, or [list(number), list(string)] to list(string).
+// Such a unification erases an element's own type, so a heterogeneous value
+// must stay a tuple/object rather than be flattened to a list/map. A
+// structural unification (e.g. object -> map) whose primitive leaves are
+// untouched is left to proceed.
 func isLossyPrimitiveUnification(unified cty.Type, types []cty.Type) bool {
-	if !unified.IsPrimitiveType() {
+	for _, t := range types {
+		if isLossyConversion(t, unified) {
+			return true
+		}
+	}
+	return false
+}
+
+// isLossyConversion reports whether converting from to to would coerce a
+// primitive leaf to a different primitive type.
+func isLossyConversion(from, to cty.Type) bool {
+	if from.Equals(to) || from == cty.DynamicPseudoType || to == cty.DynamicPseudoType {
 		return false
 	}
-	for _, t := range types {
-		if !t.Equals(unified) {
-			return true
+	switch {
+	case to.IsPrimitiveType():
+		return true
+	case to.IsListType(), to.IsSetType():
+		elem := to.ElementType()
+		switch {
+		case from.IsListType(), from.IsSetType():
+			return isLossyConversion(from.ElementType(), elem)
+		case from.IsTupleType():
+			return slices.ContainsFunc(from.TupleElementTypes(), func(t cty.Type) bool {
+				return isLossyConversion(t, elem)
+			})
+		}
+	case to.IsMapType():
+		elem := to.ElementType()
+		switch {
+		case from.IsMapType():
+			return isLossyConversion(from.ElementType(), elem)
+		case from.IsObjectType():
+			return slices.ContainsFunc(slices.Collect(maps.Values(from.AttributeTypes())), func(t cty.Type) bool {
+				return isLossyConversion(t, elem)
+			})
+		}
+	case to.IsObjectType() && from.IsObjectType():
+		for name, at := range from.AttributeTypes() {
+			if ot, ok := to.AttributeTypes()[name]; ok && isLossyConversion(at, ot) {
+				return true
+			}
+		}
+	case to.IsTupleType() && from.IsTupleType():
+		fromElems, toElems := from.TupleElementTypes(), to.TupleElementTypes()
+		if len(fromElems) != len(toElems) {
+			return false
+		}
+		for i, ft := range fromElems {
+			if isLossyConversion(ft, toElems[i]) {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -2006,3 +2006,33 @@ func TestConformCtyToType_UnknownAndNull(t *testing.T) {
 		assert.Equal(t, val, conformCtyToType(val, cty.Map(cty.String)))
 	}
 }
+
+// TestUnifyPreservesNestedElementTypes pins that a heterogeneous collection
+// whose unification would coerce primitive leaves — at any depth — keeps its
+// per-element types instead of collapsing to a common type. cty unifies
+// list(number) and list(string) to list(string), which would stringify the
+// numbers (observable via jsonencode); OpenTofu keeps each element's own type.
+func TestUnifyPreservesNestedElementTypes(t *testing.T) {
+	t.Parallel()
+
+	nums := cty.ListVal([]cty.Value{cty.NumberIntVal(1), cty.NumberIntVal(2)})
+	strs := cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")})
+
+	assert.Equal(t,
+		cty.ObjectVal(map[string]cty.Value{"nums": nums, "strs": strs}),
+		unifyOrObject(map[string]cty.Value{"nums": nums, "strs": strs}))
+	assert.Equal(t,
+		cty.TupleVal([]cty.Value{nums, strs}),
+		unifyOrTuple([]cty.Value{nums, strs}))
+
+	// A structural unification whose primitive leaves are untouched still
+	// collapses: object{a:string} and map(string) unify to map(string).
+	obj := cty.ObjectVal(map[string]cty.Value{"a": cty.StringVal("x")})
+	mp := cty.MapVal(map[string]cty.Value{"b": cty.StringVal("y")})
+	assert.Equal(t,
+		cty.MapVal(map[string]cty.Value{
+			"o": cty.MapVal(map[string]cty.Value{"a": cty.StringVal("x")}),
+			"m": mp,
+		}),
+		unifyOrObject(map[string]cty.Value{"o": obj, "m": mp}))
+}

--- a/tests/tfcompat/l2_remote_state_set_output_test.go
+++ b/tests/tfcompat/l2_remote_state_set_output_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL2RemoteStateSetOutput reads a terraform_remote_state output typed
+// `set(string)` whose stored array order is not sorted. OpenTofu reconstructs
+// it as a cty set, so referencing the output renders in canonical sorted order
+// regardless of storage order. Both paths must agree.
+func TestL2RemoteStateSetOutput(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_remote_state_set_output", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_remote_state_set_output/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_remote_state_set_output/main.tf
@@ -1,0 +1,18 @@
+# The referenced state stores two set-typed outputs with different element
+# types: a set(number) and a set(string). OpenTofu preserves each output's own
+# type, so the number set stays numeric (and renders in sorted numeric order).
+data "terraform_remote_state" "rs" {
+  backend = "local"
+  config = {
+    path = "remote.tfstate"
+  }
+}
+
+# jsonencode makes the element type observable: numbers render unquoted.
+output "nums_json" {
+  value = jsonencode(data.terraform_remote_state.rs.outputs.nums)
+}
+
+output "strs_json" {
+  value = jsonencode(data.terraform_remote_state.rs.outputs.strs)
+}

--- a/tests/tfcompat/testdata/cases/l2_remote_state_set_output/remote.tfstate
+++ b/tests/tfcompat/testdata/cases/l2_remote_state_set_output/remote.tfstate
@@ -1,0 +1,18 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 1,
+  "lineage": "3d6f6d7b-4429-46cb-d10f-10ab291859f7",
+  "outputs": {
+    "nums": {
+      "value": [10, 2, 1, 30, 21],
+      "type": ["set", "number"]
+    },
+    "strs": {
+      "value": ["charlie", "alpha", "bravo"],
+      "type": ["set", "string"]
+    }
+  },
+  "resources": [],
+  "check_results": null
+}


### PR DESCRIPTION
## Bug

A `terraform_remote_state` data source referencing a state with two collection outputs of different element types — `set(number)` and `set(string)` — had the number set's elements coerced to strings:

- **OpenTofu**: `outputs` is a cty object with per-output types, so each output keeps its own type. `jsonencode(...outputs.nums)` → `[1,2,10,21,30]`.
- **pulumi-hcl**: `["1","2","10","21","30"]`.

The root cause is not remote-state-specific: re-expanding any dynamically-typed property value unifies sibling elements with `convert.UnifyUnsafe`, and the guard from https://github.com/pulumi-labs/pulumi-hcl/pull/256 only rejected a unification whose *target* is a primitive type. `set(number)` + `set(string)` unifies to `set(string)` — a non-primitive target — so the coercion happened one level down. A `list(number)` + `list(string)` pair triggers the identical coercion.

OpenTofu never unifies on this path: `terraform_remote_state` decodes each output with its stored cty type and wraps them in `cty.ObjectVal` (`internal/builtin/providers/tf/data_source_state.go`), and cty's own type-free JSON decoding (`ctyjson.ImpliedType`) likewise produces tuples/objects with per-element types. The unification step exists only because values crossing the Pulumi property protocol are untyped; it must never change what a program can observe.

## Fix

Make the lossiness check recursive (`isLossyConversion`): a unification is rejected when it would coerce a primitive leaf at **any** depth, keeping the value a `cty.ObjectVal`/`cty.TupleVal` that preserves per-element types. Structural collapse whose primitive leaves are untouched (e.g. object → map of the same primitive, used to collapse union-typed members into TF map-typed attributes) still proceeds — the pinning tests for that behavior (`TestResourceOutputToCtyUnionTypeCollapseNested`) are unchanged and pass.

## Tests

- `TestL2RemoteStateSetOutput` (tfcompat): failing on master, passes here.
- `TestUnifyPreservesNestedElementTypes` (unit): pins the nested rejection and the allowed structural collapse.
- Full `pkg/...` unit suite (1063 tests) and the entire tfcompat suite (182 tests) are green.