### PR TITLE
Preserve cty types of terraform_data's dynamic attributes on output

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-399.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-399.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Preserve the cty types of `terraform_data`'s dynamic `input`, `output`, and `triggers_replace`
+time: 2026-07-16T08:41:55Z
+custom:
+    Component: runtime
+    PR: "399"

--- a/pkg/hcl/run/provisioner.go
+++ b/pkg/hcl/run/provisioner.go
@@ -132,7 +132,9 @@ func selfBoundEvalCtx(
 	if err != nil {
 		return nil, fmt.Errorf("converting outputs: %w", err)
 	}
-	unwrapTerraformDataOutputs(tfType, outputObj, outputs)
+	if err := unwrapTerraformDataOutputs(tfType, outputObj, outputs); err != nil {
+		return nil, fmt.Errorf("converting outputs: %w", err)
+	}
 	if id != "" {
 		outputObj["id"] = cty.StringVal(id)
 	}

--- a/pkg/hcl/run/provisioner.go
+++ b/pkg/hcl/run/provisioner.go
@@ -44,6 +44,7 @@ func (e *Engine) bindProvisionerHooks(
 	evalCtx *eval.Context,
 	opts *ResourceOptions,
 	resourceName string,
+	tdataEvaluated map[string]cty.Value,
 ) error {
 	if len(res.Provisioners) == 0 {
 		return nil
@@ -71,10 +72,17 @@ func (e *Engine) bindProvisionerHooks(
 
 		callback := func(hookCtx context.Context, args *ResourceHookArgs) error {
 			outputs := args.NewOutputs
+			evaluated := tdataEvaluated
 			if useOldOutputs {
-				outputs = args.OldOutputs
+				// Old outputs predate this run's evaluated values, so a
+				// destroy-time self keeps the state-stored shape untouched.
+				outputs, evaluated = args.OldOutputs, nil
+			} else {
+				// Hooks receive raw engine outputs, so terraform_data's
+				// surface is adapted the same way as on the registration path.
+				outputs = lowerTerraformDataOutputs(res.Type, outputs, opts)
 			}
-			selfCtx, err := selfBoundEvalCtx(hclSnapshot, outputs, args.ID, args.URN, resSchema, mapping, dryRun)
+			selfCtx, err := selfBoundEvalCtx(hclSnapshot, outputs, args.ID, args.URN, res.Type, evaluated, resSchema, mapping, dryRun)
 			if err != nil {
 				return fmt.Errorf("provisioner %d for %s: %w", index, instance.Key, err)
 			}
@@ -118,6 +126,7 @@ func effectiveConnectionBody(prov *ast.Provisioner, res *ast.Resource) hcl.Body 
 // the engine injects elsewhere (see registerResourceInstanceInContext).
 func selfBoundEvalCtx(
 	parent *hcl.EvalContext, outputs property.Map, id, urn string,
+	tfType string, tdataEvaluated map[string]cty.Value,
 	resSchema *schema.Resource, mapping *bridge.BodyMapping, dryRun bool,
 ) (*hcl.EvalContext, error) {
 	if outputs.Len() == 0 && id == "" && urn == "" {
@@ -127,6 +136,7 @@ func selfBoundEvalCtx(
 	if err != nil {
 		return nil, fmt.Errorf("converting outputs: %w", err)
 	}
+	restoreTerraformDataOutputTypes(tfType, outputObj, tdataEvaluated)
 	if id != "" {
 		outputObj["id"] = cty.StringVal(id)
 	}

--- a/pkg/hcl/run/provisioner.go
+++ b/pkg/hcl/run/provisioner.go
@@ -44,7 +44,6 @@ func (e *Engine) bindProvisionerHooks(
 	evalCtx *eval.Context,
 	opts *ResourceOptions,
 	resourceName string,
-	tdataEvaluated map[string]cty.Value,
 ) error {
 	if len(res.Provisioners) == 0 {
 		return nil
@@ -72,17 +71,15 @@ func (e *Engine) bindProvisionerHooks(
 
 		callback := func(hookCtx context.Context, args *ResourceHookArgs) error {
 			outputs := args.NewOutputs
-			evaluated := tdataEvaluated
 			if useOldOutputs {
-				// Old outputs predate this run's evaluated values, so a
-				// destroy-time self keeps the state-stored shape untouched.
-				outputs, evaluated = args.OldOutputs, nil
-			} else {
-				// Hooks receive raw engine outputs, so terraform_data's
-				// surface is adapted the same way as on the registration path.
-				outputs = lowerTerraformDataOutputs(res.Type, outputs, opts)
+				outputs = args.OldOutputs
 			}
-			selfCtx, err := selfBoundEvalCtx(hclSnapshot, outputs, args.ID, args.URN, res.Type, evaluated, resSchema, mapping, dryRun)
+			// Hooks receive raw engine outputs, so terraform_data's surface
+			// is adapted the same way as on the registration path. This holds
+			// for old outputs too: their {type, value} wrappers carry the
+			// state-stored types, so a destroy-time self keeps them.
+			outputs = lowerTerraformDataOutputs(res.Type, outputs, opts)
+			selfCtx, err := selfBoundEvalCtx(hclSnapshot, outputs, args.ID, args.URN, res.Type, resSchema, mapping, dryRun)
 			if err != nil {
 				return fmt.Errorf("provisioner %d for %s: %w", index, instance.Key, err)
 			}
@@ -125,8 +122,7 @@ func effectiveConnectionBody(prov *ast.Provisioner, res *ast.Resource) hcl.Body 
 // selfBoundEvalCtx binds `self` to resource outputs + the synthetic id/urn
 // the engine injects elsewhere (see registerResourceInstanceInContext).
 func selfBoundEvalCtx(
-	parent *hcl.EvalContext, outputs property.Map, id, urn string,
-	tfType string, tdataEvaluated map[string]cty.Value,
+	parent *hcl.EvalContext, outputs property.Map, id, urn string, tfType string,
 	resSchema *schema.Resource, mapping *bridge.BodyMapping, dryRun bool,
 ) (*hcl.EvalContext, error) {
 	if outputs.Len() == 0 && id == "" && urn == "" {
@@ -136,7 +132,7 @@ func selfBoundEvalCtx(
 	if err != nil {
 		return nil, fmt.Errorf("converting outputs: %w", err)
 	}
-	restoreTerraformDataOutputTypes(tfType, outputObj, tdataEvaluated)
+	unwrapTerraformDataOutputs(tfType, outputObj, outputs)
 	if id != "" {
 		outputObj["id"] = cty.StringVal(id)
 	}

--- a/pkg/hcl/run/provisioner.go
+++ b/pkg/hcl/run/provisioner.go
@@ -122,7 +122,7 @@ func effectiveConnectionBody(prov *ast.Provisioner, res *ast.Resource) hcl.Body 
 // selfBoundEvalCtx binds `self` to resource outputs + the synthetic id/urn
 // the engine injects elsewhere (see registerResourceInstanceInContext).
 func selfBoundEvalCtx(
-	parent *hcl.EvalContext, outputs property.Map, id, urn string, tfType string,
+	parent *hcl.EvalContext, outputs property.Map, id, urn, tfType string,
 	resSchema *schema.Resource, mapping *bridge.BodyMapping, dryRun bool,
 ) (*hcl.EvalContext, error) {
 	if outputs.Len() == 0 && id == "" && urn == "" {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1495,7 +1495,7 @@ func (e *Engine) registerResourceInstanceInContext(
 	resourceMapping := e.resolver.ResourceBodyMapping(ctx, res.Type)
 	// terraform_data's attributes are dynamically typed, so their cty types
 	// (e.g. set-ness) survive the Pulumi property round-trip only via the
-	// evaluated values captured here; see restoreTerraformDataOutputTypes.
+	// evaluated values captured here; see wrapTerraformDataInputs.
 	var tdataEvaluated map[string]cty.Value
 	if res.Type == packages.TerraformDataType {
 		tdataEvaluated = map[string]cty.Value{}
@@ -1532,6 +1532,7 @@ func (e *Engine) registerResourceInstanceInContext(
 	if diags.HasErrors() {
 		return diags
 	}
+	resourceInputs = wrapTerraformDataInputs(res.Type, resourceInputs, tdataEvaluated)
 
 	if strings.HasPrefix(res.Type, "pulumi_providers_") && res.PluginDownloadURL != nil {
 		val, valDiags := res.PluginDownloadURL.Value(hclCtx)
@@ -1593,13 +1594,13 @@ func (e *Engine) registerResourceInstanceInContext(
 	}
 
 	if len(res.Postconditions) > 0 {
-		if err := e.bindPostconditionHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName, tdataEvaluated); err != nil {
+		if err := e.bindPostconditionHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName); err != nil {
 			return err
 		}
 	}
 
 	if len(res.Provisioners) > 0 {
-		if err := e.bindProvisionerHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName, tdataEvaluated); err != nil {
+		if err := e.bindProvisionerHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName); err != nil {
 			return err
 		}
 	}
@@ -1621,7 +1622,7 @@ func (e *Engine) registerResourceInstanceInContext(
 	if err != nil {
 		return fmt.Errorf("converting resource outputs to HCL types: %w", err)
 	}
-	restoreTerraformDataOutputTypes(res.Type, outputObj, tdataEvaluated)
+	unwrapTerraformDataOutputs(res.Type, outputObj, outputs)
 	if e.dryRun && id == "" {
 		outputObj["id"] = cty.UnknownVal(cty.String)
 	} else {
@@ -4183,7 +4184,6 @@ func (e *Engine) bindPostconditionHooks(
 	evalCtx *eval.Context,
 	opts *ResourceOptions,
 	resourceName string,
-	tdataEvaluated map[string]cty.Value,
 ) error {
 	if opts.Hooks == nil {
 		opts.Hooks = &ResourceHookBinding{}
@@ -4196,9 +4196,9 @@ func (e *Engine) bindPostconditionHooks(
 		callback := func(_ context.Context, args *ResourceHookArgs) error {
 			// Hooks receive raw engine outputs, so terraform_data's surface is
 			// adapted the same way as on the registration path: property-level
-			// lowering here, cty type restore after re-expansion.
+			// lowering here, wrapper unboxing after re-expansion.
 			outputs := lowerTerraformDataOutputs(res.Type, args.NewOutputs, opts)
-			return evaluatePostcondition(rule, hclSnapshot, outputs, res.Type, tdataEvaluated, resSchema, mapping, dryRun, index, instance.Key)
+			return evaluatePostcondition(rule, hclSnapshot, outputs, res.Type, resSchema, mapping, dryRun, index, instance.Key)
 		}
 		if err := e.resmon.RegisterResourceHook(ctx, hookName, callback, ResourceHookOptions{
 			OnDryRun: true,
@@ -4215,14 +4215,13 @@ func (e *Engine) bindPostconditionHooks(
 // engine-supplied NewOutputs.
 func evaluatePostcondition(
 	rule *ast.CheckRule, hclCtx *hcl.EvalContext, newOutputs property.Map, tfType string,
-	tdataEvaluated map[string]cty.Value,
 	resSchema *schema.Resource, mapping *bridge.BodyMapping, dryRun bool, index int, resourceName string,
 ) error {
 	outputObj, err := transform.ResourceOutputToCty(newOutputs, resSchema, mapping, dryRun)
 	if err != nil {
 		return fmt.Errorf("converting outputs for postcondition %d on %s: %w", index, resourceName, err)
 	}
-	restoreTerraformDataOutputTypes(tfType, outputObj, tdataEvaluated)
+	unwrapTerraformDataOutputs(tfType, outputObj, newOutputs)
 	return evaluatePostconditionValue(rule, hclCtx, cty.ObjectVal(outputObj), index, resourceName)
 }
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1593,13 +1593,13 @@ func (e *Engine) registerResourceInstanceInContext(
 	}
 
 	if len(res.Postconditions) > 0 {
-		if err := e.bindPostconditionHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName); err != nil {
+		if err := e.bindPostconditionHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName, tdataEvaluated); err != nil {
 			return err
 		}
 	}
 
 	if len(res.Provisioners) > 0 {
-		if err := e.bindProvisionerHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName); err != nil {
+		if err := e.bindProvisionerHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName, tdataEvaluated); err != nil {
 			return err
 		}
 	}
@@ -4183,6 +4183,7 @@ func (e *Engine) bindPostconditionHooks(
 	evalCtx *eval.Context,
 	opts *ResourceOptions,
 	resourceName string,
+	tdataEvaluated map[string]cty.Value,
 ) error {
 	if opts.Hooks == nil {
 		opts.Hooks = &ResourceHookBinding{}
@@ -4193,7 +4194,11 @@ func (e *Engine) bindPostconditionHooks(
 		rule, index := rule, i+1
 		hookName := fmt.Sprintf("%s.%s:postcondition:%d", res.Type, resourceName, i)
 		callback := func(_ context.Context, args *ResourceHookArgs) error {
-			return evaluatePostcondition(rule, hclSnapshot, args.NewOutputs, resSchema, mapping, dryRun, index, instance.Key)
+			// Hooks receive raw engine outputs, so terraform_data's surface is
+			// adapted the same way as on the registration path: property-level
+			// lowering here, cty type restore after re-expansion.
+			outputs := lowerTerraformDataOutputs(res.Type, args.NewOutputs, opts)
+			return evaluatePostcondition(rule, hclSnapshot, outputs, res.Type, tdataEvaluated, resSchema, mapping, dryRun, index, instance.Key)
 		}
 		if err := e.resmon.RegisterResourceHook(ctx, hookName, callback, ResourceHookOptions{
 			OnDryRun: true,
@@ -4209,13 +4214,15 @@ func (e *Engine) bindPostconditionHooks(
 // evaluatePostcondition evaluates a postcondition with `self` bound to the
 // engine-supplied NewOutputs.
 func evaluatePostcondition(
-	rule *ast.CheckRule, hclCtx *hcl.EvalContext, newOutputs property.Map,
+	rule *ast.CheckRule, hclCtx *hcl.EvalContext, newOutputs property.Map, tfType string,
+	tdataEvaluated map[string]cty.Value,
 	resSchema *schema.Resource, mapping *bridge.BodyMapping, dryRun bool, index int, resourceName string,
 ) error {
 	outputObj, err := transform.ResourceOutputToCty(newOutputs, resSchema, mapping, dryRun)
 	if err != nil {
 		return fmt.Errorf("converting outputs for postcondition %d on %s: %w", index, resourceName, err)
 	}
+	restoreTerraformDataOutputTypes(tfType, outputObj, tdataEvaluated)
 	return evaluatePostconditionValue(rule, hclCtx, cty.ObjectVal(outputObj), index, resourceName)
 }
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1493,6 +1493,13 @@ func (e *Engine) registerResourceInstanceInContext(
 	}
 
 	resourceMapping := e.resolver.ResourceBodyMapping(ctx, res.Type)
+	// terraform_data's attributes are dynamically typed, so their cty types
+	// (e.g. set-ness) survive the Pulumi property round-trip only via the
+	// evaluated values captured here; see restoreTerraformDataOutputTypes.
+	var tdataEvaluated map[string]cty.Value
+	if res.Type == packages.TerraformDataType {
+		tdataEvaluated = map[string]cty.Value{}
+	}
 	resourceInputs, diags := transform.EvalResourceWithSchema(res.Config, resSchema, resourceMapping,
 		func(propKey resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
 			var val cty.Value
@@ -1506,6 +1513,10 @@ func (e *Engine) registerResourceInstanceInContext(
 			}
 			if diags.HasErrors() {
 				return val, diags
+			}
+
+			if tdataEvaluated != nil {
+				tdataEvaluated[string(propKey)] = val
 			}
 
 			if plainInputProps[string(propKey)] {
@@ -1610,6 +1621,7 @@ func (e *Engine) registerResourceInstanceInContext(
 	if err != nil {
 		return fmt.Errorf("converting resource outputs to HCL types: %w", err)
 	}
+	restoreTerraformDataOutputTypes(res.Type, outputObj, tdataEvaluated)
 	if e.dryRun && id == "" {
 		outputObj["id"] = cty.UnknownVal(cty.String)
 	} else {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1622,7 +1622,9 @@ func (e *Engine) registerResourceInstanceInContext(
 	if err != nil {
 		return fmt.Errorf("converting resource outputs to HCL types: %w", err)
 	}
-	unwrapTerraformDataOutputs(res.Type, outputObj, outputs)
+	if err := unwrapTerraformDataOutputs(res.Type, outputObj, outputs); err != nil {
+		return fmt.Errorf("converting resource outputs to HCL types: %w", err)
+	}
 	if e.dryRun && id == "" {
 		outputObj["id"] = cty.UnknownVal(cty.String)
 	} else {
@@ -4221,7 +4223,9 @@ func evaluatePostcondition(
 	if err != nil {
 		return fmt.Errorf("converting outputs for postcondition %d on %s: %w", index, resourceName, err)
 	}
-	unwrapTerraformDataOutputs(tfType, outputObj, newOutputs)
+	if err := unwrapTerraformDataOutputs(tfType, outputObj, newOutputs); err != nil {
+		return fmt.Errorf("converting outputs for postcondition %d on %s: %w", index, resourceName, err)
+	}
 	return evaluatePostconditionValue(rule, hclCtx, cty.ObjectVal(outputObj), index, resourceName)
 }
 

--- a/pkg/hcl/run/terraform_data.go
+++ b/pkg/hcl/run/terraform_data.go
@@ -17,6 +17,8 @@ package run
 import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // lowerTerraformDataInputs adapts evaluated terraform_data inputs to Stash's
@@ -64,4 +66,34 @@ func lowerTerraformDataOutputs(resType string, outputs property.Map, opts *Resou
 	}
 	outputs = outputs.Set("output", outputs.Get("input"))
 	return outputs.Set("triggers_replace", opts.ReplacementTrigger.AsArray().Get(0))
+}
+
+// restoreTerraformDataOutputTypes restores the cty types of terraform_data's
+// dynamically typed attributes after the Pulumi property round-trip, which
+// flattens a cty set to an ordered array that would otherwise re-expand as a
+// tuple. `input` and `triggers_replace` echo the program's evaluated values
+// and `output` mirrors `input`, so each re-expanded value converts back to the
+// corresponding evaluated type. A value that no longer converts, or an
+// evaluation with no known type, is left as re-expanded.
+func restoreTerraformDataOutputTypes(resType string, outputs, evaluated map[string]cty.Value) {
+	if resType != packages.TerraformDataType {
+		return
+	}
+	for outName, inName := range map[string]string{
+		"input":            "input",
+		"output":           "input",
+		"triggers_replace": "triggers_replace",
+	} {
+		src, ok := evaluated[inName]
+		if !ok || src.Type() == cty.DynamicPseudoType {
+			continue
+		}
+		v, ok := outputs[outName]
+		if !ok {
+			continue
+		}
+		if converted, err := convert.Convert(v, src.Type()); err == nil {
+			outputs[outName] = converted
+		}
+	}
 }

--- a/pkg/hcl/run/terraform_data.go
+++ b/pkg/hcl/run/terraform_data.go
@@ -120,9 +120,6 @@ func unwrapTerraformDataOutputs(resType string, outputs map[string]cty.Value, pr
 		return
 	}
 	for _, name := range []string{"input", "output", "triggers_replace"} {
-		if _, ok := outputs[name]; !ok {
-			continue
-		}
 		if v, ok := unwrapTerraformDataValue(props.Get(name)); ok {
 			outputs[name] = v
 		}

--- a/pkg/hcl/run/terraform_data.go
+++ b/pkg/hcl/run/terraform_data.go
@@ -15,10 +15,13 @@
 package run
 
 import (
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 // lowerTerraformDataInputs adapts evaluated terraform_data inputs to Stash's
@@ -68,32 +71,94 @@ func lowerTerraformDataOutputs(resType string, outputs property.Map, opts *Resou
 	return outputs.Set("triggers_replace", opts.ReplacementTrigger.AsArray().Get(0))
 }
 
-// restoreTerraformDataOutputTypes restores the cty types of terraform_data's
-// dynamically typed attributes after the Pulumi property round-trip, which
-// flattens a cty set to an ordered array that would otherwise re-expand as a
-// tuple. `input` and `triggers_replace` echo the program's evaluated values
-// and `output` mirrors `input`, so each re-expanded value converts back to the
-// corresponding evaluated type. A value that no longer converts, or an
-// evaluation with no known type, is left as re-expanded.
-func restoreTerraformDataOutputTypes(resType string, outputs, evaluated map[string]cty.Value) {
+// terraform_data's attributes are dynamically typed, and the Pulumi property
+// encoding cannot represent every cty type: a set flattens to an ordered array
+// that would re-expand as a tuple. Each evaluated input is therefore boxed as
+// a {type, value} wrapper object before registration — persisting the cty type
+// through the engine and its state alongside the value, the way OpenTofu
+// stores dynamic attributes — and unboxed wherever outputs re-expand to cty,
+// including from prior state (e.g. a destroy-time provisioner's self).
+const (
+	tdataTypeKey  = "type"
+	tdataValueKey = "value"
+)
+
+// wrapTerraformDataInputs boxes terraform_data's evaluated inputs as
+// {type, value} wrappers. It is a no-op for every other type.
+func wrapTerraformDataInputs(resType string, inputs property.Map, evaluated map[string]cty.Value) property.Map {
 	if resType != packages.TerraformDataType {
-		return
+		return inputs
 	}
-	for outName, inName := range map[string]string{
-		"input":            "input",
-		"output":           "input",
-		"triggers_replace": "triggers_replace",
-	} {
-		src, ok := evaluated[inName]
-		if !ok || src.Type() == cty.DynamicPseudoType {
-			continue
-		}
-		v, ok := outputs[outName]
+	for _, name := range []string{"input", "triggers_replace"} {
+		v, ok := inputs.GetOk(name)
 		if !ok {
 			continue
 		}
-		if converted, err := convert.Convert(v, src.Type()); err == nil {
-			outputs[outName] = converted
+		src, ok := evaluated[name]
+		if !ok {
+			continue
+		}
+		typeJSON, err := ctyjson.MarshalType(src.Type())
+		if err != nil {
+			continue
+		}
+		inputs = inputs.Set(name, property.New(map[string]property.Value{
+			tdataTypeKey:  property.New(string(typeJSON)),
+			tdataValueKey: v,
+		}))
+	}
+	return inputs
+}
+
+// unwrapTerraformDataOutputs replaces the re-expanded cty values of
+// terraform_data's dynamically typed attributes with their wrapper contents,
+// read from the pre-expansion property outputs — where the wrapper's shape is
+// exact, unlike its re-expanded form (whose cty shape depends on whether the
+// two fields' types unify). It is a no-op for every other type.
+func unwrapTerraformDataOutputs(resType string, outputs map[string]cty.Value, props property.Map) {
+	if resType != packages.TerraformDataType {
+		return
+	}
+	for _, name := range []string{"input", "output", "triggers_replace"} {
+		if _, ok := outputs[name]; !ok {
+			continue
+		}
+		if v, ok := unwrapTerraformDataValue(props.Get(name)); ok {
+			outputs[name] = v
 		}
 	}
+}
+
+// unwrapTerraformDataValue unboxes one property-encoded {type, value} wrapper
+// into the cty value of its recorded type. It reports false for the values at
+// these positions that are legitimately not wrappers — the null and unknown
+// placeholders of an absent or not-yet-known attribute — which re-expand
+// correctly without help.
+func unwrapTerraformDataValue(pv property.Value) (cty.Value, bool) {
+	secret := pv.Secret()
+	pv = pv.WithSecret(false)
+	if !pv.IsMap() {
+		return cty.Value{}, false
+	}
+	m := pv.AsMap()
+	typeJSON, ok := m.GetOk(tdataTypeKey)
+	if !ok || m.Len() != 2 || !typeJSON.IsString() {
+		return cty.Value{}, false
+	}
+	value, ok := m.GetOk(tdataValueKey)
+	if !ok {
+		return cty.Value{}, false
+	}
+	recorded, err := ctyjson.UnmarshalType([]byte(typeJSON.AsString()))
+	if err != nil {
+		return cty.Value{}, false
+	}
+	inner := transform.PropertyValueToCty(value)
+	if converted, err := convert.Convert(inner, recorded); err == nil {
+		inner = converted
+	}
+	if secret {
+		inner = inner.Mark(eval.SensitiveMark)
+	}
+	return inner, true
 }

--- a/pkg/hcl/run/terraform_data.go
+++ b/pkg/hcl/run/terraform_data.go
@@ -15,6 +15,9 @@
 package run
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/transform"
@@ -46,6 +49,19 @@ import (
 func lowerTerraformDataInputs(resType string, inputs property.Map, opts *ResourceOptions) property.Map {
 	if resType != packages.TerraformDataType {
 		return inputs
+	}
+	// An ignore_changes path into input (input["k"], input[0]) ignores the
+	// whole attribute: input is a single dynamic attribute, and its keys live
+	// under the {type, value} wrapper in the engine's encoding, where a nested
+	// glob would match nothing.
+	for i, g := range opts.IgnoreChanges {
+		text, err := g.MarshalText()
+		if err != nil {
+			continue
+		}
+		if s := string(text); strings.HasPrefix(s, "input.") || strings.HasPrefix(s, "input[") {
+			opts.IgnoreChanges[i] = property.GlobFromSegments(property.NewSegment("input"))
+		}
 	}
 	triggers := inputs.Get("triggers_replace")
 	inputs = inputs.Delete("triggers_replace")
@@ -115,47 +131,48 @@ func wrapTerraformDataInputs(resType string, inputs property.Map, evaluated map[
 // read from the pre-expansion property outputs — where the wrapper's shape is
 // exact, unlike its re-expanded form (whose cty shape depends on whether the
 // two fields' types unify). It is a no-op for every other type.
-func unwrapTerraformDataOutputs(resType string, outputs map[string]cty.Value, props property.Map) {
+func unwrapTerraformDataOutputs(resType string, outputs map[string]cty.Value, props property.Map) error {
 	if resType != packages.TerraformDataType {
-		return
+		return nil
 	}
 	for _, name := range []string{"input", "output", "triggers_replace"} {
-		if v, ok := unwrapTerraformDataValue(props.Get(name)); ok {
+		v, ok, err := unwrapTerraformDataValue(props.Get(name))
+		if err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+		if ok {
 			outputs[name] = v
 		}
 	}
+	return nil
 }
 
 // unwrapTerraformDataValue unboxes one property-encoded {type, value} wrapper
 // into the cty value of its recorded type. It reports false for the values at
 // these positions that are legitimately not wrappers — the null and unknown
 // placeholders of an absent or not-yet-known attribute — which re-expand
-// correctly without help.
-func unwrapTerraformDataValue(pv property.Value) (cty.Value, bool) {
-	secret := pv.Secret()
-	pv = pv.WithSecret(false)
+// correctly without help. Any map here is a wrapper (evaluated inputs are
+// always wrapped), so one that fails to decode is corrupt state and an error.
+func unwrapTerraformDataValue(pv property.Value) (cty.Value, bool, error) {
 	if !pv.IsMap() {
-		return cty.Value{}, false
+		return cty.Value{}, false, nil
 	}
 	m := pv.AsMap()
-	typeJSON, ok := m.GetOk(tdataTypeKey)
-	if !ok || m.Len() != 2 || !typeJSON.IsString() {
-		return cty.Value{}, false
-	}
-	value, ok := m.GetOk(tdataValueKey)
-	if !ok {
-		return cty.Value{}, false
+	typeJSON, typeOk := m.GetOk(tdataTypeKey)
+	value, valueOk := m.GetOk(tdataValueKey)
+	if !typeOk || !valueOk || m.Len() != 2 || !typeJSON.IsString() {
+		return cty.Value{}, false, fmt.Errorf("malformed {%s, %s} wrapper", tdataTypeKey, tdataValueKey)
 	}
 	recorded, err := ctyjson.UnmarshalType([]byte(typeJSON.AsString()))
 	if err != nil {
-		return cty.Value{}, false
+		return cty.Value{}, false, fmt.Errorf("invalid recorded cty type %q: %w", typeJSON.AsString(), err)
 	}
 	inner := transform.PropertyValueToCty(value)
 	if converted, err := convert.Convert(inner, recorded); err == nil {
 		inner = converted
 	}
-	if secret {
+	if pv.Secret() {
 		inner = inner.Mark(eval.SensitiveMark)
 	}
-	return inner, true
+	return inner, true, nil
 }

--- a/pkg/hcl/run/terraform_data_internal_test.go
+++ b/pkg/hcl/run/terraform_data_internal_test.go
@@ -139,91 +139,49 @@ func TestLowerTerraformDataOutputs(t *testing.T) {
 	})
 }
 
-func TestRestoreTerraformDataOutputTypes(t *testing.T) {
+func TestWrapTerraformDataInputs(t *testing.T) {
 	t.Parallel()
 
-	strTuple := cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")})
 	strSet := cty.SetVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")})
+	arr := property.New([]property.Value{property.New("a"), property.New("b")})
+	wrapped := property.New(map[string]property.Value{
+		"type":  property.New(`["set","string"]`),
+		"value": arr,
+	})
 
 	tests := []struct {
 		name      string
 		resType   string
-		outputs   map[string]cty.Value
+		inputs    property.Map
 		evaluated map[string]cty.Value
-		want      map[string]cty.Value
+		want      property.Map
 	}{
 		{
-			name:    "set types restored on input, output, and triggers_replace",
+			name:    "input and triggers_replace are wrapped",
 			resType: packages.TerraformDataType,
-			outputs: map[string]cty.Value{
-				"input":            strTuple,
-				"output":           strTuple,
-				"triggers_replace": cty.TupleVal([]cty.Value{cty.NumberIntVal(1)}),
-			},
-			evaluated: map[string]cty.Value{
-				"input":            strSet,
-				"triggers_replace": cty.SetVal([]cty.Value{cty.NumberIntVal(1)}),
-			},
-			want: map[string]cty.Value{
-				"input":            strSet,
-				"output":           strSet,
-				"triggers_replace": cty.SetVal([]cty.Value{cty.NumberIntVal(1)}),
-			},
+			inputs: property.NewMap(map[string]property.Value{
+				"input":            arr,
+				"triggers_replace": arr,
+			}),
+			evaluated: map[string]cty.Value{"input": strSet, "triggers_replace": strSet},
+			want: property.NewMap(map[string]property.Value{
+				"input":            wrapped,
+				"triggers_replace": wrapped,
+			}),
 		},
 		{
-			name:    "unknown output takes the evaluated type",
-			resType: packages.TerraformDataType,
-			outputs: map[string]cty.Value{
-				"output": cty.UnknownVal(cty.DynamicPseudoType),
-			},
-			evaluated: map[string]cty.Value{"input": strSet},
-			want: map[string]cty.Value{
-				"output": cty.UnknownVal(cty.Set(cty.String)),
-			},
-		},
-		{
-			name:    "evaluation without a known type is skipped",
-			resType: packages.TerraformDataType,
-			outputs: map[string]cty.Value{
-				"input":  strTuple,
-				"output": strTuple,
-			},
-			evaluated: map[string]cty.Value{"input": cty.DynamicVal},
-			want: map[string]cty.Value{
-				"input":  strTuple,
-				"output": strTuple,
-			},
-		},
-		{
-			name:    "unconvertible value is left as re-expanded",
-			resType: packages.TerraformDataType,
-			outputs: map[string]cty.Value{
-				"output": cty.ObjectVal(map[string]cty.Value{"k": cty.True}),
-			},
-			evaluated: map[string]cty.Value{"input": strSet},
-			want: map[string]cty.Value{
-				"output": cty.ObjectVal(map[string]cty.Value{"k": cty.True}),
-			},
-		},
-		{
-			name:    "element marks lift to the restored set",
-			resType: packages.TerraformDataType,
-			outputs: map[string]cty.Value{
-				"output": cty.TupleVal([]cty.Value{
-					cty.StringVal("a").Mark(eval.SensitiveMark), cty.StringVal("b"),
-				}),
-			},
-			evaluated: map[string]cty.Value{"input": strSet},
-			want: map[string]cty.Value{
-				"output": strSet.Mark(eval.SensitiveMark),
-			},
+			name:      "unevaluated inputs are untouched",
+			resType:   packages.TerraformDataType,
+			inputs:    property.NewMap(map[string]property.Value{"input": arr}),
+			evaluated: map[string]cty.Value{},
+			want:      property.NewMap(map[string]property.Value{"input": arr}),
 		},
 		{
 			name:      "other types are untouched",
 			resType:   "random_pet",
-			outputs:   map[string]cty.Value{"output": strTuple},
+			inputs:    property.NewMap(map[string]property.Value{"input": arr}),
 			evaluated: map[string]cty.Value{"input": strSet},
-			want:      map[string]cty.Value{"output": strTuple},
+			want:      property.NewMap(map[string]property.Value{"input": arr}),
 		},
 	}
 
@@ -231,7 +189,144 @@ func TestRestoreTerraformDataOutputTypes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			restoreTerraformDataOutputTypes(tt.resType, tt.outputs, tt.evaluated)
+			got := wrapTerraformDataInputs(tt.resType, tt.inputs, tt.evaluated)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUnwrapTerraformDataOutputs(t *testing.T) {
+	t.Parallel()
+
+	strSet := cty.SetVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")})
+	arr := property.New([]property.Value{property.New("a"), property.New("b")})
+	wrap := func(typeJSON string, v property.Value) property.Value {
+		return property.New(map[string]property.Value{
+			"type":  property.New(typeJSON),
+			"value": v,
+		})
+	}
+	// The generically re-expanded stand-in the unwrap must replace; its exact
+	// shape is irrelevant to the property-level wrapper detection.
+	reexpanded := cty.ObjectVal(map[string]cty.Value{"any": cty.True})
+
+	tests := []struct {
+		name    string
+		resType string
+		outputs map[string]cty.Value
+		props   property.Map
+		want    map[string]cty.Value
+	}{
+		{
+			name:    "wrappers unbox on input, output, and triggers_replace",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{
+				"input":            reexpanded,
+				"output":           reexpanded,
+				"triggers_replace": reexpanded,
+			},
+			props: property.NewMap(map[string]property.Value{
+				"input":            wrap(`["set","string"]`, arr),
+				"output":           wrap(`["set","string"]`, arr),
+				"triggers_replace": wrap(`["set","bool"]`, property.New([]property.Value{property.New(true)})),
+			}),
+			want: map[string]cty.Value{
+				"input":            strSet,
+				"output":           strSet,
+				"triggers_replace": cty.SetVal([]cty.Value{cty.True}),
+			},
+		},
+		{
+			name:    "wrapped scalar unboxes (its re-expanded shape is a cty map)",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{
+				"output": cty.MapVal(map[string]cty.Value{
+					"type":  cty.StringVal(`"string"`),
+					"value": cty.StringVal("hello"),
+				}),
+			},
+			props: property.NewMap(map[string]property.Value{
+				"output": wrap(`"string"`, property.New("hello")),
+			}),
+			want: map[string]cty.Value{
+				"output": cty.StringVal("hello"),
+			},
+		},
+		{
+			name:    "unknown wrapped value takes the recorded type",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{"output": cty.UnknownVal(cty.DynamicPseudoType)},
+			props: property.NewMap(map[string]property.Value{
+				"output": wrap(`["set","string"]`, property.New(property.Computed)),
+			}),
+			want: map[string]cty.Value{
+				"output": cty.UnknownVal(cty.Set(cty.String)),
+			},
+		},
+		{
+			name:    "null and unknown placeholders re-expand without help",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{
+				"input":            cty.NullVal(cty.DynamicPseudoType),
+				"output":           cty.NullVal(cty.DynamicPseudoType),
+				"triggers_replace": cty.UnknownVal(cty.DynamicPseudoType),
+			},
+			props: property.NewMap(map[string]property.Value{
+				"input":            property.New(property.Null),
+				"output":           property.New(property.Null),
+				"triggers_replace": property.New(property.Computed),
+			}),
+			want: map[string]cty.Value{
+				"input":            cty.NullVal(cty.DynamicPseudoType),
+				"output":           cty.NullVal(cty.DynamicPseudoType),
+				"triggers_replace": cty.UnknownVal(cty.DynamicPseudoType),
+			},
+		},
+		{
+			name:    "unconvertible value is kept at its own type",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{"output": reexpanded},
+			props: property.NewMap(map[string]property.Value{
+				"output": wrap(`["set","string"]`, property.New(true)),
+			}),
+			want: map[string]cty.Value{
+				"output": cty.True,
+			},
+		},
+		{
+			name:    "wrapper secrecy and element secrets mark the result",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{
+				"input":  reexpanded,
+				"output": reexpanded,
+			},
+			props: property.NewMap(map[string]property.Value{
+				"input": wrap(`["set","string"]`, arr).WithSecret(true),
+				"output": wrap(`["set","string"]`, property.New([]property.Value{
+					property.New("a").WithSecret(true), property.New("b"),
+				})),
+			}),
+			want: map[string]cty.Value{
+				"input":  strSet.Mark(eval.SensitiveMark),
+				"output": strSet.Mark(eval.SensitiveMark),
+			},
+		},
+		{
+			name:    "other types are untouched",
+			resType: "random_pet",
+			outputs: map[string]cty.Value{"output": reexpanded},
+			props: property.NewMap(map[string]property.Value{
+				"output": wrap(`["set","string"]`, arr),
+			}),
+			want: map[string]cty.Value{"output": reexpanded},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			unwrapTerraformDataOutputs(tt.resType, tt.outputs, tt.props)
 			assert.Equal(t, tt.want, tt.outputs)
 		})
 	}

--- a/pkg/hcl/run/terraform_data_internal_test.go
+++ b/pkg/hcl/run/terraform_data_internal_test.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
 
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
 )
 
@@ -135,4 +137,102 @@ func TestLowerTerraformDataOutputs(t *testing.T) {
 			"triggers_replace": null,
 		}), got)
 	})
+}
+
+func TestRestoreTerraformDataOutputTypes(t *testing.T) {
+	t.Parallel()
+
+	strTuple := cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")})
+	strSet := cty.SetVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")})
+
+	tests := []struct {
+		name      string
+		resType   string
+		outputs   map[string]cty.Value
+		evaluated map[string]cty.Value
+		want      map[string]cty.Value
+	}{
+		{
+			name:    "set types restored on input, output, and triggers_replace",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{
+				"input":            strTuple,
+				"output":           strTuple,
+				"triggers_replace": cty.TupleVal([]cty.Value{cty.NumberIntVal(1)}),
+			},
+			evaluated: map[string]cty.Value{
+				"input":            strSet,
+				"triggers_replace": cty.SetVal([]cty.Value{cty.NumberIntVal(1)}),
+			},
+			want: map[string]cty.Value{
+				"input":            strSet,
+				"output":           strSet,
+				"triggers_replace": cty.SetVal([]cty.Value{cty.NumberIntVal(1)}),
+			},
+		},
+		{
+			name:    "unknown output takes the evaluated type",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{
+				"output": cty.UnknownVal(cty.DynamicPseudoType),
+			},
+			evaluated: map[string]cty.Value{"input": strSet},
+			want: map[string]cty.Value{
+				"output": cty.UnknownVal(cty.Set(cty.String)),
+			},
+		},
+		{
+			name:    "evaluation without a known type is skipped",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{
+				"input":  strTuple,
+				"output": strTuple,
+			},
+			evaluated: map[string]cty.Value{"input": cty.DynamicVal},
+			want: map[string]cty.Value{
+				"input":  strTuple,
+				"output": strTuple,
+			},
+		},
+		{
+			name:    "unconvertible value is left as re-expanded",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{
+				"output": cty.ObjectVal(map[string]cty.Value{"k": cty.True}),
+			},
+			evaluated: map[string]cty.Value{"input": strSet},
+			want: map[string]cty.Value{
+				"output": cty.ObjectVal(map[string]cty.Value{"k": cty.True}),
+			},
+		},
+		{
+			name:    "element marks lift to the restored set",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{
+				"output": cty.TupleVal([]cty.Value{
+					cty.StringVal("a").Mark(eval.SensitiveMark), cty.StringVal("b"),
+				}),
+			},
+			evaluated: map[string]cty.Value{"input": strSet},
+			want: map[string]cty.Value{
+				"output": strSet.Mark(eval.SensitiveMark),
+			},
+		},
+		{
+			name:      "other types are untouched",
+			resType:   "random_pet",
+			outputs:   map[string]cty.Value{"output": strTuple},
+			evaluated: map[string]cty.Value{"input": strSet},
+			want:      map[string]cty.Value{"output": strTuple},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			restoreTerraformDataOutputTypes(tt.resType, tt.outputs, tt.evaluated)
+			assert.Equal(t, tt.want, tt.outputs)
+		})
+	}
 }

--- a/pkg/hcl/run/terraform_data_internal_test.go
+++ b/pkg/hcl/run/terraform_data_internal_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
@@ -102,6 +103,23 @@ func TestLowerTerraformDataInputs(t *testing.T) {
 		got := lowerTerraformDataInputs("random_pet", inputs, &opts)
 		assert.Equal(t, inputs, got)
 		assert.Equal(t, ResourceOptions{}, opts)
+	})
+
+	t.Run("ignore_changes paths into input collapse to the whole attribute", func(t *testing.T) {
+		t.Parallel()
+
+		glob := func(s string) property.Glob {
+			var g property.Glob
+			require.NoError(t, g.UnmarshalText([]byte(s)))
+			return g
+		}
+		opts := ResourceOptions{IgnoreChanges: []property.Glob{
+			glob("input.k"), glob("input[0]"), glob("input"), glob("triggers_replace.k"),
+		}}
+		lowerTerraformDataInputs(packages.TerraformDataType, property.Map{}, &opts)
+		assert.Equal(t, []property.Glob{
+			glob("input"), glob("input"), glob("input"), glob("triggers_replace.k"),
+		}, opts.IgnoreChanges)
 	})
 }
 
@@ -216,6 +234,7 @@ func TestUnwrapTerraformDataOutputs(t *testing.T) {
 		outputs map[string]cty.Value
 		props   property.Map
 		want    map[string]cty.Value
+		wantErr string
 	}{
 		{
 			name:    "wrappers unbox on input, output, and triggers_replace",
@@ -312,6 +331,26 @@ func TestUnwrapTerraformDataOutputs(t *testing.T) {
 			},
 		},
 		{
+			name:    "unparsable recorded type is rejected",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{"output": reexpanded},
+			props: property.NewMap(map[string]property.Value{
+				"output": wrap(`not a type`, arr),
+			}),
+			wantErr: `output: invalid recorded cty type "not a type": invalid character 'o' in literal null (expecting 'u')`,
+		},
+		{
+			name:    "malformed wrapper is rejected",
+			resType: packages.TerraformDataType,
+			outputs: map[string]cty.Value{"input": reexpanded},
+			props: property.NewMap(map[string]property.Value{
+				"input": property.New(map[string]property.Value{
+					"type": property.New(`"string"`),
+				}),
+			}),
+			wantErr: "input: malformed {type, value} wrapper",
+		},
+		{
 			name:    "other types are untouched",
 			resType: "random_pet",
 			outputs: map[string]cty.Value{"output": reexpanded},
@@ -326,7 +365,12 @@ func TestUnwrapTerraformDataOutputs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			unwrapTerraformDataOutputs(tt.resType, tt.outputs, tt.props)
+			err := unwrapTerraformDataOutputs(tt.resType, tt.outputs, tt.props)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, tt.outputs)
 		})
 	}

--- a/tests/tfcompat/l2_tdata_postcond_self_set_test.go
+++ b/tests/tfcompat/l2_tdata_postcond_self_set_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// A postcondition on terraform_data binds `self` from raw engine outputs, so
+// its dynamically-typed attributes need the same lowering and cty type restore
+// as the registration path: `self.output` must be the input's set, not a
+// tuple, for the set-equality condition to hold.
+func TestL2TdataPostcondSelfSet(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_postcond_self_set", tfcompat.Case{})
+}

--- a/tests/tfcompat/l2_tdata_provisioner_destroy_after_update_test.go
+++ b/tests/tfcompat/l2_tdata_provisioner_destroy_after_update_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// terraform_data is created with one set, updated in place to another, then
+// destroyed. The destroy-time provisioner's self.output must be the
+// last-applied input, still typed as a set — not the create-time value frozen
+// in the engine's builtin, and not a tuple.
+func TestL2TdataProvisionerDestroyAfterUpdate(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_provisioner_destroy_after_update", tfcompat.Case{
+		Stages: []tfcompat.Stage{
+			{},
+			{},
+			{Mode: tfcompat.StageDestroy},
+		},
+	})
+}

--- a/tests/tfcompat/l2_tdata_provisioner_destroy_self_set_test.go
+++ b/tests/tfcompat/l2_tdata_provisioner_destroy_self_set_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// A destroy-time provisioner on terraform_data binds `self` from prior state,
+// where the dynamically-typed output's set type must survive: OpenTofu stores
+// the cty type with the value, so `self.output == toset([...])` holds at
+// destroy.
+func TestL2TdataProvisionerDestroySelfSet(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_provisioner_destroy_self_set", tfcompat.Case{
+		Stages: []tfcompat.Stage{
+			{},
+			{Mode: tfcompat.StageDestroy},
+		},
+	})
+}

--- a/tests/tfcompat/l2_tdata_provisioner_self_set_test.go
+++ b/tests/tfcompat/l2_tdata_provisioner_self_set_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// A provisioner on terraform_data binds `self` from raw engine outputs, so its
+// dynamically-typed attributes need the same lowering and cty type restore as
+// the registration path: `self.output` must be the input's set, not a tuple,
+// for the set-equality in the command to hold.
+func TestL2TdataProvisionerSelfSet(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_provisioner_self_set", tfcompat.Case{})
+}

--- a/tests/tfcompat/l2_tdata_set_fidelity_test.go
+++ b/tests/tfcompat/l2_tdata_set_fidelity_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+func TestL2TdataSetFidelity(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_set_fidelity", tfcompat.Case{})
+}

--- a/tests/tfcompat/l2_tdata_wrapper_attacks_test.go
+++ b/tests/tfcompat/l2_tdata_wrapper_attacks_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// An ignore_changes traversal into terraform_data's input — a map key or a
+// numeric list index — ignores the whole attribute: input is a single dynamic
+// attribute, so the prior input (all of it, not just the ignored key) is kept
+// across an apply that changes it.
+func TestL2TdataIgnoreInputIndex(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_ignore_input_index", tfcompat.Case{})
+}
+
+func TestL2TdataIgnoreInputNum(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_ignore_input_num", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_input_index/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_input_index/0/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+resource "terraform_data" "x" {
+  input = { k = "v1", other = "keep" }
+
+  lifecycle {
+    ignore_changes = [input["k"]]
+  }
+}
+
+output "k" {
+  value = terraform_data.x.output.k
+}
+
+output "other" {
+  value = terraform_data.x.output.other
+}

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_input_index/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_input_index/1/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+resource "terraform_data" "x" {
+  input = { k = "v2", other = "changed" }
+
+  lifecycle {
+    ignore_changes = [input["k"]]
+  }
+}
+
+output "k" {
+  value = terraform_data.x.output.k
+}
+
+output "other" {
+  value = terraform_data.x.output.other
+}

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_input_num/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_input_num/0/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+}
+resource "terraform_data" "x" {
+  input = ["v1", "keep"]
+  lifecycle {
+    ignore_changes = [input[0]]
+  }
+}
+output "first" { value = terraform_data.x.output[0] }

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_input_num/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_input_num/1/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+}
+resource "terraform_data" "x" {
+  input = ["v2", "changed"]
+  lifecycle {
+    ignore_changes = [input[0]]
+  }
+}
+output "first" { value = terraform_data.x.output[0] }

--- a/tests/tfcompat/testdata/cases/l2_tdata_postcond_self_set/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_postcond_self_set/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+resource "terraform_data" "x" {
+  input = toset(["a", "b", "c"])
+
+  lifecycle {
+    postcondition {
+      condition     = self.output == toset(["a", "b", "c"])
+      error_message = "output is not a set equal to input"
+    }
+  }
+}
+
+output "ok" {
+  value = terraform_data.x.output
+}

--- a/tests/tfcompat/testdata/cases/l2_tdata_provisioner_destroy_after_update/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_provisioner_destroy_after_update/0/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+# Created with one set, updated to another (stage 1), then destroyed: the
+# destroy-time self.output must be the last-applied input as a set — not the
+# create-time value, and not a tuple.
+resource "terraform_data" "x" {
+  input = toset(["a", "b"])
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = self.output == toset(["x", "y", "z"]) ? "true" : "false"
+  }
+}
+
+output "ok" {
+  value = terraform_data.x.output
+}

--- a/tests/tfcompat/testdata/cases/l2_tdata_provisioner_destroy_after_update/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_provisioner_destroy_after_update/1/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+resource "terraform_data" "x" {
+  input = toset(["x", "y", "z"])
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = self.output == toset(["x", "y", "z"]) ? "true" : "false"
+  }
+}
+
+output "ok" {
+  value = terraform_data.x.output
+}

--- a/tests/tfcompat/testdata/cases/l2_tdata_provisioner_destroy_after_update/2/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_provisioner_destroy_after_update/2/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+resource "terraform_data" "x" {
+  input = toset(["x", "y", "z"])
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = self.output == toset(["x", "y", "z"]) ? "true" : "false"
+  }
+}
+
+output "ok" {
+  value = terraform_data.x.output
+}

--- a/tests/tfcompat/testdata/cases/l2_tdata_provisioner_destroy_self_set/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_provisioner_destroy_self_set/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+# A destroy-time provisioner's `self` comes from prior state, where OpenTofu
+# stores terraform_data's dynamically-typed output together with its cty type:
+# the command exits 0 only when the set equality holds, so a dropped set type
+# fails the destroy.
+resource "terraform_data" "x" {
+  input = toset(["a", "b", "c"])
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = self.output == toset(["a", "b", "c"]) ? "true" : "false"
+  }
+}
+
+output "ok" {
+  value = terraform_data.x.output
+}

--- a/tests/tfcompat/testdata/cases/l2_tdata_provisioner_self_set/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_provisioner_self_set/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+# A provisioner's `self` must see terraform_data's output still typed as a set:
+# the command exits 0 only when the set equality holds, so a dropped set type
+# fails the apply.
+resource "terraform_data" "x" {
+  input = toset(["a", "b", "c"])
+
+  provisioner "local-exec" {
+    command = self.output == toset(["a", "b", "c"]) ? "true" : "false"
+  }
+}
+
+output "ok" {
+  value = terraform_data.x.output
+}

--- a/tests/tfcompat/testdata/cases/l2_tdata_set_fidelity/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_set_fidelity/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+# terraform_data.input/output are dynamically typed. A set fed into input must
+# come back out of output still typed as a set, so an == comparison against a
+# set of the same members is true.
+resource "terraform_data" "set_input" {
+  input = toset(["c", "a", "b", "a"])
+}
+
+# The raw serialized value is identical on both paths (a sorted array)...
+output "set_output" {
+  value = terraform_data.set_input.output
+}
+
+# ...but only OpenTofu preserves the set *type*, so this equality holds there
+# and pulumi-hcl (which returns the output as a tuple) reports false.
+output "set_is_set" {
+  value = terraform_data.set_input.output == toset(["a", "b", "c"])
+}


### PR DESCRIPTION
## Divergence

A set fed into `terraform_data.input` (a dynamically-typed attribute) loses its cty type in pulumi-hcl:

- **OpenTofu**: `.output` is still typed as a set, so `terraform_data.x.output == toset([...])` is `true` — from resource references, postcondition/provisioner `self`, and destroy-time `self` alike.
- **pulumi-hcl**: the value re-expanded as a tuple, so those comparisons were `false` (and a set-guarded destroy provisioner failed the destroy).

The serialized value (a sorted array) is identical on both paths — only the cty **type** was dropped.

## Root cause

`terraform_data`'s `input`, `output`, and `triggers_replace` are dynamically typed, and the Pulumi property encoding cannot represent every cty type: a set flattens to an ordered array. The `TFSet` mapping from https://github.com/pulumi-labs/pulumi-hcl/pull/386 cannot reach this — there is no shim schema for `terraform_data`, and the attribute type is dynamic. OpenTofu keeps fidelity because it stores dynamic attributes together with their cty type in state.

## Fix

Persist the type the same way OpenTofu does. `terraform_data` lowers onto the engine's builtin Stash resource, whose `input` is echoed verbatim through the engine and its state, so:

- **Wrap**: each evaluated input is boxed as a `{type, value}` wrapper before registration (`wrapTerraformDataInputs`, type via `ctyjson.MarshalType`). The type rides through engine, state, and the replacement trigger.
- **Unwrap**: every surface that re-expands outputs to cty — the registration path, postcondition `self`, and provisioner `self` (create **and** destroy) — unboxes the wrapper (`unwrapTerraformDataOutputs`) and converts the value to its recorded type. Old state carries its own types, so destroy-time `self.output` is the last-applied input with its set-ness intact (not the value frozen at create in the Stash builtin, not a tuple).

The wrapper is detected in the **property encoding**, where its shape is exact: the re-expanded cty shape is ambiguous (an Any-typed property map re-expands as a cty *map* when its element types unify — e.g. a wrapped string — and an *object* otherwise), so the unboxed value overwrites the generic re-expansion wholesale and the wrapper shape can never leak into the program. Marks survive: wrapper-level secrecy and element secrets mark the result, and element marks lift to sets.

Faithful side effects: a type-only change to `input` (e.g. `toset([...])` → `[...]`) now diffs as an in-place update, and a type-only change to `triggers_replace` forces replacement — both matching OpenTofu, where a dynamic attribute's type change is a change.

Corrupt wrappers reject loudly: any map at these attribute positions is by construction a wrapper, so one that fails to decode (missing key, wrong arity, non-string or unparsable `type`) is an error through every re-expansion path rather than a silent fallback. Only the legitimate non-wrapper placeholders (null/unknown) pass through quietly.

### ignore_changes into `input`

The wrapper relocates `input`'s keys (a key that lived at `input.k` is stored at `input.value.k`), which broke `ignore_changes` traversals into `input`: `input["k"]` translated to the engine glob `input.k`, matched nothing, and ignored nothing — while OpenTofu keeps the **entire** prior input (a nested ignore into a single dynamic attribute ignores the whole attribute, including keys not named in the path). `lowerTerraformDataInputs` now collapses any `ignore_changes` glob rooted into `input` to the whole-`input` glob, matching that semantics. Found by an adversarial test pass against the wrapper design; the same pass confirmed wrapper-collision inputs (a user value literally shaped `{type, value}`), sensitivity round-trips, chained terraform_data, trigger interplay with `replace_triggered_by`, type-only changes, and preview-stage unknowns all behave.

## Test

- `TestL2TdataSetFidelity` (added failing): `set_is_set` is `true` on both paths.
- `TestL2TdataPostcondSelfSet`, `TestL2TdataProvisionerSelfSet`: `self.output` set equality in postconditions and create-time provisioners.
- `TestL2TdataProvisionerDestroySelfSet`: destroy-time `self.output` set equality (was failing 3/3 before the wrapper).
- `TestL2TdataProvisionerDestroyAfterUpdate`: create set A → in-place update to set B → destroy asserts `self.output == toset(B)` — pins that destroy `self` tracks the last-applied input.
- `TestL2TdataIgnoreInputIndex`, `TestL2TdataIgnoreInputNum` (added failing 3/3): `ignore_changes = [input["k"]]` / `[input[0]]` keep the entire prior input across an apply that changes it.
- Unit coverage pins wrap/unwrap: recorded-type conversion, unknown values taking the recorded type, null/unknown placeholders, secrecy marking, corrupt-wrapper rejection, the `ignore_changes` collapse, and the non-`terraform_data` no-op.

Full tfcompat suite (188), root module (1502 tests, 45 packages), and `./pkg/...` (1078) pass.
