### PR TITLE
Carry passed-in providers through a second module hop

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-400.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-400.yaml
@@ -1,0 +1,7 @@
+kind: bug-fixes
+body: Carry a provider passed via `providers` through a second module hop, both
+    re-passed explicitly and inherited as the module default
+time: 2026-07-16T00:00:00Z
+custom:
+    Component: runtime
+    PR: "400"

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -537,13 +537,10 @@ type moduleScope struct {
 	parentPrefix string
 }
 
-// inheritedProviderDeps returns an edge to the nearest ancestor module's
-// default `<pkg>` configuration — its own un-aliased `provider "<pkg>" {}`
-// block or the pass-through entry of its module call (whose shadow node
-// stands in) — for an in-module resource/data source with no `provider`, no
-// own-module block, and no pass-through. parent is the enclosing module's
-// scope; the walk runs from there toward the root. The edge forces that
-// configuration to register and orders it before the resource.
+// inheritedProviderDeps returns an edge to the nearest ancestor's default
+// `<pkg>` configuration (see defaultProviderNode) for an in-module
+// resource/data source with no `provider`, no own-module block, and no
+// pass-through, forcing that configuration to register before the resource.
 func (g *Graph) inheritedProviderDeps(resource *ast.Resource, parent *moduleScope) []pdag.Node {
 	if resource.Provider != nil {
 		return nil

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -538,10 +538,12 @@ type moduleScope struct {
 }
 
 // inheritedProviderDeps returns an edge to the nearest ancestor module's
-// un-aliased `provider "<pkg>" {}` block, for an in-module resource/data source
-// with no `provider`, no own-module block, and no pass-through. parent is the
-// enclosing module's scope; the walk runs from there toward the root. The edge
-// forces that block to register and orders it before the resource.
+// default `<pkg>` configuration — its own un-aliased `provider "<pkg>" {}`
+// block or the pass-through entry of its module call (whose shadow node
+// stands in) — for an in-module resource/data source with no `provider`, no
+// own-module block, and no pass-through. parent is the enclosing module's
+// scope; the walk runs from there toward the root. The edge forces that
+// configuration to register and orders it before the resource.
 func (g *Graph) inheritedProviderDeps(resource *ast.Resource, parent *moduleScope) []pdag.Node {
 	if resource.Provider != nil {
 		return nil
@@ -550,13 +552,7 @@ func (g *Graph) inheritedProviderDeps(resource *ast.Resource, parent *moduleScop
 	if pkgName == "" {
 		return nil
 	}
-	for s := parent; s != nil; s = s.parent {
-		if _, ok := s.config.Providers[pkgName]; ok {
-			_, idx := g.newNode(s.prefix + pkgName)
-			return []pdag.Node{idx}
-		}
-	}
-	return nil
+	return g.defaultProviderNode(pkgName, parent)
 }
 
 // passThroughProviderDeps returns an edge from an in-module resource to the

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -251,6 +251,9 @@ type moduleInstance struct {
 	// leaf [modulepath.Step] carries the count index or for_each key, if
 	// any.
 	Path modulepath.Path
+	// ModuleInfo describes the module call this instance belongs to,
+	// shared by every instance of the call.
+	ModuleInfo *graph.ModuleInfo
 	// Name is the resolved Pulumi logical name of this instance's component:
 	// a `pulumi { name = ... }` override when present, else the parent
 	// instance's Name joined to this instance's step with ".". It prefixes
@@ -1043,7 +1046,10 @@ func (e *Engine) registerProvider(
 // resolvePassThroughProvider looks up a provider passed into a module via
 // `providers = { <localKey> = <parentExpr> }` and returns the resolved
 // URN::ID, or "" when the resource isn't in a module, there's no entry for
-// localKey, or the parent expression doesn't yield a provider reference.
+// localKey, or the parent expression doesn't yield a provider reference. A
+// parent expression with no binding in the parent's own scope may name a
+// configuration the parent itself received through its own module call, so
+// the reference chases the parent's pass-through entries recursively.
 func (e *Engine) resolvePassThroughProvider(modInfo *graph.ModuleInfo, localKey string) string {
 	if modInfo == nil || modInfo.Module == nil || localKey == "" {
 		return ""
@@ -1052,19 +1058,28 @@ func (e *Engine) resolvePassThroughProvider(modInfo *graph.ModuleInfo, localKey 
 	if !ok {
 		return ""
 	}
-	parentCtx := e.parentEvalContext(modInfo)
-	if parentCtx == nil {
-		return ""
+	if parentCtx := e.parentEvalContext(modInfo); parentCtx != nil {
+		val, diags := eval.NewEvaluator(parentCtx).EvaluateExpression(passExpr)
+		if !diags.HasErrors() {
+			if ref, err := providerRefFromCty(val); err == nil {
+				return ref
+			}
+		}
 	}
-	val, diags := eval.NewEvaluator(parentCtx).EvaluateExpression(passExpr)
-	if diags.HasErrors() {
-		return ""
+	return e.resolvePassThroughProvider(e.parentModuleInfo(modInfo), providerExprKey(passExpr))
+}
+
+// parentModuleInfo returns the ModuleInfo of the module call enclosing
+// modInfo, or nil when the parent is the root config (or has no instances).
+func (e *Engine) parentModuleInfo(modInfo *graph.ModuleInfo) *graph.ModuleInfo {
+	if modInfo.ParentPrefix() == "" {
+		return nil
 	}
-	ref, err := providerRefFromCty(val)
-	if err != nil {
-		return ""
+	insts, ok := e.moduleInstances.Get(modInfo.ParentPath())
+	if !ok || len(insts) == 0 {
+		return nil
 	}
-	return ref
+	return insts[0].ModuleInfo
 }
 
 // resolveExplicitProvider resolves a resource/data source `provider = ...`
@@ -1101,9 +1116,11 @@ func (e *Engine) resolveExplicitProvider(
 	return "", nil
 }
 
-// inheritedDefaultProvider walks up the module tree from modInfo, returning the
-// nearest ancestor's registered un-aliased default provider config for pkg
-// (URN::ID), or "" if none. The graph adds a matching edge so that block is
+// inheritedDefaultProvider walks up the module tree from modInfo, returning
+// the nearest ancestor's un-aliased default provider config for pkg
+// (URN::ID), or "" if none. An ancestor's default is its own registered
+// `provider "<pkg>"` block or a configuration passed to it through its module
+// call's providers argument. The graph adds a matching edge so that block is
 // registered before this resolves.
 func (e *Engine) inheritedDefaultProvider(modInfo *graph.ModuleInfo, pkg string) string {
 	for path := modInfo.Path; ; {
@@ -1113,6 +1130,11 @@ func (e *Engine) inheritedDefaultProvider(modInfo *graph.ModuleInfo, pkg string)
 		}
 		if outputs, ok := e.resourceOutputs.Get(parent.PrefixString() + pkg); ok {
 			if ref, err := providerRefFromCty(outputs); err == nil {
+				return ref
+			}
+		}
+		if insts, ok := e.moduleInstances.Get(parent); ok && len(insts) > 0 {
+			if ref := e.resolvePassThroughProvider(insts[0].ModuleInfo, pkg); ref != "" {
 				return ref
 			}
 		}
@@ -3744,15 +3766,16 @@ func (e *Engine) initModuleCallIn(
 		instCtx.SetProviderFunctions(moduleFunctions)
 		instCtx.SetModuleName(instName)
 		return &moduleInstance{
-			Path:    instPath,
-			Name:    instName,
-			EvalCtx: instCtx,
-			URN:     componentURN,
-			Parent:  parent,
-			Index:   index,
-			EachKey: eachKey,
-			EachVal: eachVal,
-			Outputs: make(map[string]cty.Value),
+			Path:       instPath,
+			ModuleInfo: modInfo,
+			Name:       instName,
+			EvalCtx:    instCtx,
+			URN:        componentURN,
+			Parent:     parent,
+			Index:      index,
+			EachKey:    eachKey,
+			EachVal:    eachVal,
+			Outputs:    make(map[string]cty.Value),
 		}, nil
 	}
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1046,10 +1046,9 @@ func (e *Engine) registerProvider(
 // resolvePassThroughProvider looks up a provider passed into a module via
 // `providers = { <localKey> = <parentExpr> }` and returns the resolved
 // URN::ID, or "" when the resource isn't in a module, there's no entry for
-// localKey, or the parent expression doesn't yield a provider reference. A
-// parent expression with no binding in the parent's own scope may name a
-// configuration the parent itself received through its own module call, so
-// the reference chases the parent's pass-through entries recursively.
+// localKey, or the parent expression doesn't yield a provider reference. An
+// expression the parent's scope doesn't bind is chased recursively through
+// the parent's own pass-through entries.
 func (e *Engine) resolvePassThroughProvider(modInfo *graph.ModuleInfo, localKey string) string {
 	if modInfo == nil || modInfo.Module == nil || localKey == "" {
 		return ""
@@ -1118,10 +1117,9 @@ func (e *Engine) resolveExplicitProvider(
 
 // inheritedDefaultProvider walks up the module tree from modInfo, returning
 // the nearest ancestor's un-aliased default provider config for pkg
-// (URN::ID), or "" if none. An ancestor's default is its own registered
-// `provider "<pkg>"` block or a configuration passed to it through its module
-// call's providers argument. The graph adds a matching edge so that block is
-// registered before this resolves.
+// (URN::ID), or "" if none. An ancestor's default is its own registered block
+// or one passed to it through its module call. The graph adds a matching edge
+// so that block is registered before this resolves.
 func (e *Engine) inheritedDefaultProvider(modInfo *graph.ModuleInfo, pkg string) string {
 	for path := modInfo.Path; ; {
 		parent, _, ok := path.Parent()

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -4657,6 +4657,150 @@ resource "simple_resource" "r" {
 		"the resource must bind to the provider instance selected by its key")
 }
 
+// An aliased provider passed into a module via `providers = { simple =
+// simple.special }` must survive a second hop into a nested module, whether
+// the middle module re-passes it explicitly (`providers = { simple = simple }`)
+// or the nested call inherits the middle module's default implicitly.
+func TestEngine_ProviderResolution_AliasedPassThroughSecondHop(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	explicitInnerDir := tmpDir + "/modules/outer/inner"
+	implicitInnerDir := tmpDir + "/modules/outer_implicit/inner"
+	require.NoError(t, os.MkdirAll(explicitInnerDir, 0o755))
+	require.NoError(t, os.MkdirAll(implicitInnerDir, 0o755))
+
+	require.NoError(t, os.WriteFile(tmpDir+"/main.tf", []byte(`
+provider "simple" {
+  prefix = "default"
+}
+
+provider "simple" {
+  alias  = "special"
+  prefix = "special"
+}
+
+module "outer" {
+  source = "./modules/outer"
+  providers = {
+    simple = simple.special
+  }
+}
+
+module "outer_implicit" {
+  source = "./modules/outer_implicit"
+  providers = {
+    simple = simple.special
+  }
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(tmpDir+"/modules/outer/main.tf", []byte(`
+module "inner" {
+  source = "./inner"
+  providers = {
+    simple = simple
+  }
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(explicitInnerDir+"/main.tf", []byte(`
+resource "simple_resource" "r" {
+  input = "explicit"
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(tmpDir+"/modules/outer_implicit/main.tf", []byte(`
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+module "inner" {
+  source = "./inner"
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(implicitInnerDir+"/main.tf", []byte(`
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+resource "simple_resource" "r" {
+  input = "implicit"
+}
+`), 0o644))
+
+	p := parser.NewParser()
+	config, diags := p.ParseDirectory(tmpDir)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testLiveModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         tmpDir,
+		RootDir:         tmpDir,
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "simple",
+			Provider: &schema.ResourceSpec{
+				InputProperties: map[string]schema.PropertySpec{
+					"prefix": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+			Resources: map[string]schema.ResourceSpec{
+				"simple:index:Resource": {
+					InputProperties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	var specialProvider *run.RegisterResourceRequest
+	resources := map[string]*run.RegisterResourceRequest{}
+	for i := range mock.RegisteredResources {
+		r := &mock.RegisteredResources[i]
+		switch r.Type {
+		case "pulumi:providers:simple":
+			if v, ok := r.Inputs.GetOk("prefix"); ok && v.IsString() && v.AsString() == "special" {
+				specialProvider = r
+			}
+		case "simple:index:Resource":
+			if v, ok := r.Inputs.GetOk("input"); ok && v.IsString() {
+				resources[v.AsString()] = r
+			}
+		}
+	}
+	require.NotNil(t, specialProvider, "the aliased provider block should register")
+	require.NotNil(t, resources["explicit"], "the explicitly re-passed resource should register")
+	require.NotNil(t, resources["implicit"], "the implicitly inheriting resource should register")
+
+	specialRef := "urn:pulumi:test::project::" + specialProvider.Type + "::" + specialProvider.Name +
+		"::" + specialProvider.Name + "-id"
+	assert.Equal(t, specialRef, resources["explicit"].Provider,
+		"an explicit `providers = { simple = simple }` re-pass must carry the aliased config")
+	assert.Equal(t, specialRef, resources["implicit"].Provider,
+		"an implicit nested call must inherit the middle module's passed-in default")
+}
+
 func TestEngine_ProviderResolution_ChildModuleBlockWins(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -4657,10 +4657,9 @@ resource "simple_resource" "r" {
 		"the resource must bind to the provider instance selected by its key")
 }
 
-// An aliased provider passed into a module via `providers = { simple =
-// simple.special }` must survive a second hop into a nested module, whether
-// the middle module re-passes it explicitly (`providers = { simple = simple }`)
-// or the nested call inherits the middle module's default implicitly.
+// An aliased provider passed into a module via `providers` must survive a
+// second hop into a nested module, whether re-passed explicitly or inherited
+// implicitly as the nested call's default.
 func TestEngine_ProviderResolution_AliasedPassThroughSecondHop(t *testing.T) {
 	t.Parallel()
 

--- a/tests/tfcompat/l2_nested_module_aliased_provider_passthrough_test.go
+++ b/tests/tfcompat/l2_nested_module_aliased_provider_passthrough_test.go
@@ -21,12 +21,12 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-// Root passes an aliased provider (simple.special, prefix "special") into
-// module "outer" via a providers map. "outer" re-passes its inherited simple
-// provider down to nested module "inner", whose resource reads the provider's
-// prefix. OpenTofu carries the aliased configuration through both hops, so the
-// resource sees prefix "special"; pulumi drops the aliased config on the second
-// hop and configures the nested resource with an empty provider.
+// Root passes an aliased provider (simple.special, prefix "special") into a
+// middle module via a providers map, and the configuration must survive the
+// second hop into a nested module: "outer" re-passes its inherited simple
+// explicitly (providers = { simple = simple }), while "outer_implicit"'s
+// nested call inherits the passed-in default implicitly. Both nested
+// resources must see prefix "special".
 func TestL2NestedModuleAliasedProviderPassthrough(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_nested_module_aliased_provider_passthrough", tfcompat.Case{

--- a/tests/tfcompat/l2_nested_module_aliased_provider_passthrough_test.go
+++ b/tests/tfcompat/l2_nested_module_aliased_provider_passthrough_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// Root passes an aliased provider (simple.special, prefix "special") into
+// module "outer" via a providers map. "outer" re-passes its inherited simple
+// provider down to nested module "inner", whose resource reads the provider's
+// prefix. OpenTofu carries the aliased configuration through both hops, so the
+// resource sees prefix "special"; pulumi drops the aliased config on the second
+// hop and configures the nested resource with an empty provider.
+func TestL2NestedModuleAliasedProviderPassthrough(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_nested_module_aliased_provider_passthrough", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_nested_module_aliased_provider_passthrough_test.go
+++ b/tests/tfcompat/l2_nested_module_aliased_provider_passthrough_test.go
@@ -21,12 +21,10 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-// Root passes an aliased provider (simple.special, prefix "special") into a
-// middle module via a providers map, and the configuration must survive the
-// second hop into a nested module: "outer" re-passes its inherited simple
-// explicitly (providers = { simple = simple }), while "outer_implicit"'s
-// nested call inherits the passed-in default implicitly. Both nested
-// resources must see prefix "special".
+// An aliased provider (prefix "special") passed into a middle module must
+// survive the second hop into a nested module: "outer" re-passes it
+// explicitly, "outer_implicit"'s nested call inherits it implicitly. Both
+// nested resources must see prefix "special".
 func TestL2NestedModuleAliasedProviderPassthrough(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_nested_module_aliased_provider_passthrough", tfcompat.Case{

--- a/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/main.tf
@@ -1,0 +1,20 @@
+provider "simple" {
+  prefix = "default"
+}
+
+provider "simple" {
+  alias  = "special"
+  prefix = "special"
+}
+
+module "outer" {
+  source = "./outer"
+  tag    = "a"
+  providers = {
+    simple = simple.special
+  }
+}
+
+output "result" {
+  value = module.outer.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/main.tf
@@ -15,6 +15,21 @@ module "outer" {
   }
 }
 
+# Same aliased pass into the middle module, but the innermost module inherits
+# the middle module's default `simple` implicitly (no `providers` block on the
+# inner call).
+module "outer_implicit" {
+  source = "./outer_implicit"
+  tag    = "b"
+  providers = {
+    simple = simple.special
+  }
+}
+
 output "result" {
   value = module.outer.prefix_result
+}
+
+output "result_implicit" {
+  value = module.outer_implicit.prefix_result
 }

--- a/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/main.tf
@@ -15,9 +15,7 @@ module "outer" {
   }
 }
 
-# Same aliased pass into the middle module, but the innermost module inherits
-# the middle module's default `simple` implicitly (no `providers` block on the
-# inner call).
+# Like `outer`, but the nested call inherits the passed-in default implicitly.
 module "outer_implicit" {
   source = "./outer_implicit"
   tag    = "b"

--- a/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/outer/inner/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/outer/inner/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+variable "tag" {
+  type = string
+}
+
+resource "simple_resource" "r" {
+  input_one = var.tag
+}
+
+output "prefix_result" {
+  value = simple_resource.r.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/outer/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/outer/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+variable "tag" {
+  type = string
+}
+
+module "inner" {
+  source = "./inner"
+  tag    = var.tag
+  providers = {
+    simple = simple
+  }
+}
+
+output "prefix_result" {
+  value = module.inner.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/outer_implicit/inner/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/outer_implicit/inner/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+variable "tag" {
+  type = string
+}
+
+resource "simple_resource" "r" {
+  input_one = var.tag
+}
+
+output "prefix_result" {
+  value = simple_resource.r.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/outer_implicit/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/outer_implicit/main.tf
@@ -10,8 +10,7 @@ variable "tag" {
   type = string
 }
 
-# No `providers` block: `inner` inherits this module's default `simple`, which
-# was itself passed in from the parent.
+# No `providers` block: `inner` inherits this module's default `simple`.
 module "inner" {
   source = "./inner"
   tag    = var.tag

--- a/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/outer_implicit/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_nested_module_aliased_provider_passthrough/outer_implicit/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+variable "tag" {
+  type = string
+}
+
+# No `providers` block: `inner` inherits this module's default `simple`, which
+# was itself passed in from the parent.
+module "inner" {
+  source = "./inner"
+  tag    = var.tag
+}
+
+output "prefix_result" {
+  value = module.inner.prefix_result
+}


### PR DESCRIPTION
## Divergence

A module receives an aliased, non-default provider via `providers = { simple = simple.special }`, and that configuration must make a **second hop** into a nested module. OpenTofu carries it through both hops; pulumi-hcl lost it in both forms:

- **Explicit re-pass** (`providers = { simple = simple }` on the nested call): the runtime evaluated the entry only in the middle module's eval context, where a passed-in configuration has no binding (the graph registers only a no-op shadow node), so the reference was silently dropped and the nested resource bound to the empty engine default (`"-a"` instead of `"special-a"`).
- **Implicit inheritance** (no `providers` block on the nested call): `inheritedProviderDeps` only ordered the resource after an ancestor's own `provider` block, never after a configuration the ancestor received through its module call. Resolution raced the aliased block's registration and bound the root default instead (`"default-b"` instead of `"special-b"`).

One-level passthrough worked; only the second hop lost the configuration.

## Fix

- `resolvePassThroughProvider` chases a `providers` entry recursively through the enclosing calls' entries when the expression has no binding in the parent's own scope (`moduleInstance` now carries its call's `ModuleInfo` to walk the chain).
- `inheritedDefaultProvider` consults each ancestor's pass-through entry during its walk, so an implicitly inheriting resource picks up a passed-in default.
- `inheritedProviderDeps` delegates to `defaultProviderNode`, giving implicitly inheriting resources a graph edge through the shadow node to the originating provider block instead of racing it.

## Testing

- `TestL2NestedModuleAliasedProviderPassthrough` (added failing in the first commit, extended with the implicit sibling): fails on master with `{"result":"-a","result_implicit":"default-b"}`, passes with the fix (`special-a` / `special-b`), verified over repeated runs.
- New engine unit test `TestEngine_ProviderResolution_AliasedPassThroughSecondHop` covers both hops against the mock monitor.
- All `pkg/hcl/graph` + `pkg/hcl/run` unit tests and all provider/module tfcompat tests pass; lint clean.