### PR TITLE
Evaluate an import block's id expression

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-401.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-401.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Evaluate an `import` block's `id` expression at plan time instead of requiring a constant
+time: 2026-07-16T07:33:49Z
+custom:
+    Component: runtime
+    PR: "401"

--- a/pkg/hcl/ast/import.go
+++ b/pkg/hcl/ast/import.go
@@ -32,8 +32,10 @@ type Import struct {
 	// To is the target resource address.
 	To hcl.Traversal
 
-	// Id is the external resource ID to import.
-	Id string
+	// Id is the expression for the external resource ID to import. It is
+	// evaluated at runtime and must produce a known, non-null, non-sensitive
+	// string.
+	Id hcl.Expression
 
 	// Provider is the raw expression from the optional `provider` attribute.
 	// It is evaluated at runtime; the resulting value supplies the provider URN/ID.

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -1433,11 +1433,7 @@ func (p *Parser) parseImportBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	}
 
 	if attr, ok := content.Attributes["id"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.String {
-			imp.Id = val.AsString()
-		}
+		imp.Id = attr.Expr
 	}
 
 	if attr, ok := content.Attributes["provider"]; ok {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1830,7 +1830,11 @@ func (e *Engine) buildResourceOptionsInContext(
 	}
 
 	// Handle import blocks - resolve import ID from import blocks that target this resource
-	opts.ImportId = e.resolveImportId(res, instance.Index, instance.EachKeyString(), modInst)
+	importId, err := e.resolveImportId(res, instance.Index, instance.EachKeyString(), modInst)
+	if err != nil {
+		return nil, err
+	}
+	opts.ImportId = importId
 
 	hclCtx := evalCtx.HCLContext()
 
@@ -2358,7 +2362,7 @@ func instanceKeysEqual(aIdx *int, aEach *string, bIdx *int, bEach *string) bool 
 // keyed with its own instance key.
 func (e *Engine) resolveImportId(
 	res *ast.Resource, index *int, eachKey *string, modInst *moduleInstance,
-) string {
+) (string, error) {
 	resPath := modulepath.Root()
 	if modInst != nil {
 		resPath = modInst.Path
@@ -2377,10 +2381,53 @@ func (e *Engine) resolveImportId(
 				continue
 			}
 		}
-		return imp.Id
+		return e.evaluateImportId(imp)
 	}
 
-	return ""
+	return "", nil
+}
+
+// evaluateImportId evaluates an import block's id expression, which must
+// produce a known, non-null, non-sensitive string at plan time.
+func (e *Engine) evaluateImportId(imp *ast.Import) (string, error) {
+	errf := func(detail string) error {
+		var subject *hcl.Range
+		if imp.Id != nil {
+			subject = imp.Id.Range().Ptr()
+		} else {
+			subject = imp.DeclRange.Ptr()
+		}
+		return hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid import id argument",
+			Detail:   detail,
+			Subject:  subject,
+		}}
+	}
+
+	if imp.Id == nil {
+		return "", errf("The import ID cannot be null.")
+	}
+	val, diags := e.evaluator.EvaluateExpression(imp.Id)
+	if diags.HasErrors() {
+		return "", diags
+	}
+	sensitive := val.HasMark(eval.SensitiveMark)
+	val, _ = val.Unmark()
+	if val.IsNull() {
+		return "", errf("The import ID cannot be null.")
+	}
+	if !val.IsKnown() {
+		return "", errf(`The import block "id" argument depends on resource attributes that cannot be determined until apply.`)
+	}
+	if sensitive {
+		return "", errf("The import ID cannot be sensitive.")
+	}
+	converted, err := ctyconvert.Convert(val, cty.String)
+	if err != nil {
+		return "", errf(fmt.Sprintf("The import ID value is unsuitable: %s.", err))
+	}
+	return converted.AsString(), nil
 }
 
 // evaluateAliases evaluates the aliases expression and returns a list of Alias values.

--- a/tests/tfcompat/l2_import_local_id_test.go
+++ b/tests/tfcompat/l2_import_local_id_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+func TestL2ImportLocalID(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_import_local_id", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "importable", Factory: providers.ImportableProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_import_local_id/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_import_local_id/main.tf
@@ -1,0 +1,14 @@
+locals {
+  the_id = "id-from-local"
+}
+
+import {
+  to = importable_resource.target
+  id = local.the_id
+}
+
+resource "importable_resource" "target" {}
+
+output "target_name" {
+  value = importable_resource.target.name
+}


### PR DESCRIPTION
## Bug

An `import {}` block whose `id` references a value known at plan time (a `local` or `var`):

```hcl
locals { the_id = "id-from-local" }
import { to = importable_resource.target, id = local.the_id }
resource "importable_resource" "target" {}
```

- **OpenTofu**: accepts it and imports with the resolved id.
- **pulumi-hcl**: the parser evaluated the `id` attribute with a nil EvalContext, so any variable reference failed with `Variables not allowed; Variables may not be used here`.

Distinct from [#389](https://github.com/pulumi-labs/pulumi-hcl/pull/389) (for_each instance-key matching).

## Fix

Store `ast.Import.Id` as an `hcl.Expression` and evaluate it in `resolveImportId` once the import is matched to a resource instance, mirroring OpenTofu's `evaluateImportIdExpression`: null, unknown ("cannot be determined until apply"), and sensitive values are rejected, and the result is converted to a string.

The other parse-time constant evaluations in the parser (provider `alias`, `required_providers` source/version, variable metadata) are attributes OpenTofu also requires to be constant, so the import `id` was the only expression evaluated too early.

## Test

`TestL2ImportLocalID` — reuses `ImportableProvider`; failed on master, passes with the fix. Existing `TestL2Import` still passes.