### PR TITLE
Accept `ephemeral` on variable and output blocks, treating ephemeral values as secrets

### DIFF
--- a/.changes/unreleased/runtime-Improvements-402.yaml
+++ b/.changes/unreleased/runtime-Improvements-402.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Add `ephemeralasnull`; hide diffs of resource properties that ephemeral values flow into
+time: 2026-07-16T09:20:00Z
+custom:
+    Component: runtime
+    PR: "402"

--- a/.changes/unreleased/runtime-bug-fixes-402.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-402.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Accept `ephemeral` on `variable` and `output` blocks, treating ephemeral values as secrets
+time: 2026-07-16T08:57:00Z
+custom:
+    Component: runtime
+    PR: "402"

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -2802,3 +2802,159 @@ func TestHideDiffsPathTranslated(t *testing.T) {
 	assert.Equal(t, []property.Glob{property.GlobFromSegments(property.NewSegment("inputOne"))},
 		mock.RegisteredResources[1].HideDiffs)
 }
+
+// TestEphemeralVariableHidesDiffs verifies the Pulumi-side behavior of
+// `ephemeral = true`, which has no OpenTofu mirror: an ephemeral value may
+// differ on every run, so a resource property it flows into is registered
+// with its diff hidden, and the value itself is persisted as a secret.
+func TestEphemeralVariableHidesDiffs(t *testing.T) {
+	t.Parallel()
+
+	src := `variable "session_token" {
+  type      = string
+  default   = "ephemeral-default"
+  ephemeral = true
+}
+
+resource "test_resource" "r" {
+  input_one = var.session_token
+  input_two = "plain"
+}`
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Resource": {
+				InputProperties: map[string]schema.PropertySpec{
+					"inputOne": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"inputTwo": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"inputOne": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"inputTwo": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+	loader := schemaloader.New(t, testSchema)
+
+	hclParser := parser.NewParser()
+	config, hclDiags := hclParser.ParseSource("main.tf", []byte(src))
+	require.False(t, hclDiags.HasErrors(), hclDiags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &hclrun.EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		ModuleLoader:    modules.NewLoader(modules.LiveResolver(t.Context())),
+		SchemaLoader:    loader,
+	})
+	require.NoError(t, engine.Run(t.Context()))
+
+	require.Len(t, mock.RegisteredResources, 2)
+	r := mock.RegisteredResources[1]
+	assert.Equal(t, "test:index:Resource", r.Type)
+	assert.Equal(t, []property.Glob{property.GlobFromSegments(property.NewSegment("inputOne"))},
+		r.HideDiffs)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"inputOne": property.New("ephemeral-default").WithSecret(true),
+		"inputTwo": property.New("plain"),
+	}), r.Inputs)
+}
+
+// TestEphemeralNestedBlockHidesDiffFineGrained verifies that an ephemeral
+// value reaching an attribute inside a repeated block hides the diff of that
+// attribute only — settings[0].token, not the whole settings property or the
+// sibling block.
+func TestEphemeralNestedBlockHidesDiffFineGrained(t *testing.T) {
+	t.Parallel()
+
+	src := `variable "session_token" {
+  type      = string
+  default   = "ephemeral-default"
+  ephemeral = true
+}
+
+resource "test_resource" "r" {
+  input_one = "plain"
+
+  settings {
+    name  = "a"
+    token = var.session_token
+  }
+
+  settings {
+    name = "b"
+  }
+}`
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Resource": {
+				InputProperties: map[string]schema.PropertySpec{
+					"inputOne": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"settings": {
+						TypeSpec: schema.TypeSpec{
+							Type:  "array",
+							Items: &schema.TypeSpec{Ref: "#/types/test:index:Settings"},
+						},
+					},
+				},
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"inputOne": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"settings": {
+							TypeSpec: schema.TypeSpec{
+								Type:  "array",
+								Items: &schema.TypeSpec{Ref: "#/types/test:index:Settings"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Types: map[string]schema.ComplexTypeSpec{
+			"test:index:Settings": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]schema.PropertySpec{
+						"name":  {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"token": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+	loader := schemaloader.New(t, testSchema)
+
+	hclParser := parser.NewParser()
+	config, hclDiags := hclParser.ParseSource("main.tf", []byte(src))
+	require.False(t, hclDiags.HasErrors(), hclDiags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &hclrun.EngineOptions{
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		ModuleLoader:    modules.NewLoader(modules.LiveResolver(t.Context())),
+		SchemaLoader:    loader,
+	})
+	require.NoError(t, engine.Run(t.Context()))
+
+	require.Len(t, mock.RegisteredResources, 2)
+	r := mock.RegisteredResources[1]
+	assert.Equal(t, "test:index:Resource", r.Type)
+	assert.Equal(t, []property.Glob{property.GlobFromSegments(
+		property.NewSegment("settings"), property.NewSegment(0), property.NewSegment("token"),
+	)}, r.HideDiffs)
+}

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -92,6 +92,7 @@ variable "name" {
 | `default`     | expression | No       | Default value when not configured                                                                  |
 | `description` | string     | No       | Human-readable description                                                                         |
 | `sensitive`   | bool       | No       | When `true`, the value becomes a Pulumi secret                                                     |
+| `ephemeral`   | bool       | No       | Ephemeral value; see [Ephemeral Values](#ephemeral-values)                                         |
 | `nullable`    | bool       | No       | When `false`, rejects null values (default: `true`)                                                |
 | `validation`  | block      | No       | One or more validation rules (see below)                                                           |
 
@@ -479,6 +480,7 @@ output "vpc_id" {
 | `value`        | expression | Yes      | The value to export                             |
 | `description`  | string     | No       | Human-readable description                      |
 | `sensitive`    | bool       | No       | When `true`, the output becomes a Pulumi secret |
+| `ephemeral`    | bool       | No       | Ephemeral value; see [Ephemeral Values](#ephemeral-values)  |
 | `depends_on`   | list       | No       | Explicit dependencies                           |
 | `precondition` | block      | No       | Validation checks before export                 |
 
@@ -802,7 +804,7 @@ Pulumi HCL supports nearly all Terraform built-in functions. Functions are group
 
 ### Type Conversion
 
-`can`, `issensitive`, `nonsensitive`, `sensitive`, `tobool`, `tolist`, `tomap`, `tonumber`, `toset`, `tostring`, `try`, `type`
+`can`, `ephemeralasnull`, `issensitive`, `nonsensitive`, `sensitive`, `tobool`, `tolist`, `tomap`, `tonumber`, `toset`, `tostring`, `try`, `type`
 
 ### Pulumi-Specific Functions
 
@@ -879,7 +881,33 @@ few unsupported features. If you find a case where `tofu` works and `pulumi` doe
 
 **Sensitive values** — Variables and outputs marked `sensitive = true` become Pulumi secrets, encrypted at rest in state.
 
+**Ephemeral values** — see [Ephemeral Values](#ephemeral-values).
+
 **Property names** — HCL uses `snake_case`. The plugin automatically converts to Pulumi's `camelCase` for the engine. Map keys are not translated.
+
+### Ephemeral Values
+
+Terraform's ephemeral values exist to keep a value out of state and plan files entirely. Pulumi's state model already
+encrypts secrets at rest, so Pulumi HCL interprets `ephemeral = true` through that lens instead of reproducing
+Terraform's persistence rules:
+
+- **Persisted as secrets.** A value from an ephemeral variable or output is stored in state, but encrypted, exactly
+  like `sensitive = true`. It is masked in CLI output and in the Pulumi Console.
+- **Diffs are hidden.** An ephemeral value is free to differ on every run, so the resource property it flows into is
+  registered with its diff hidden (the `hideDiffs` resource option), down to the exact property path — an ephemeral
+  value inside one block of a repeated block hides only that block's attribute.
+- **Not sensitive.** Ephemerality and sensitivity are tracked separately: `issensitive` returns `false` for a purely
+  ephemeral value, matching Terraform.
+- **`ephemeralasnull` is supported** and behaves as in Terraform: it replaces the ephemeral parts of a value with
+  typed nulls (preserving sensitivity marks), making the result usable anywhere.
+
+Differences from Terraform to be aware of:
+
+- Terraform rejects an ephemeral value used in a non-ephemeral context (a regular resource argument, a non-ephemeral
+  output). Pulumi HCL accepts it and persists the value encrypted; there is no flow validation.
+- Terraform re-prompts for a required ephemeral variable on every run. Pulumi HCL reads it from stack configuration
+  like any other variable, so set it once with `pulumi config set --secret`.
+- A root-level ephemeral output becomes a secret stack output rather than being omitted.
 
 ### Feature Mappings
 

--- a/pkg/hcl/ast/output.go
+++ b/pkg/hcl/ast/output.go
@@ -47,6 +47,10 @@ type Output struct {
 	// In Pulumi, this maps to marking the output as a secret.
 	Sensitive bool
 
+	// Ephemeral indicates whether the output value is ephemeral. Ephemeral
+	// values are persisted as Pulumi secrets.
+	Ephemeral bool
+
 	// DependsOn contains explicit dependencies for the output.
 	DependsOn []hcl.Traversal
 

--- a/pkg/hcl/ast/variable.go
+++ b/pkg/hcl/ast/variable.go
@@ -61,6 +61,11 @@ type Variable struct {
 	// Sensitive indicates whether the variable value should be hidden in logs.
 	Sensitive bool
 
+	// Ephemeral indicates whether the variable value is ephemeral. Ephemeral
+	// values are persisted as Pulumi secrets and their diffs are hidden on
+	// resources they flow into.
+	Ephemeral bool
+
 	// Nullable indicates whether the variable can be null (default true).
 	Nullable bool
 

--- a/pkg/hcl/eval/evaluator.go
+++ b/pkg/hcl/eval/evaluator.go
@@ -48,6 +48,9 @@ func (e *Evaluator) Evaluate(expr hcl.Expression) (cty.Value, hcl.Diagnostics) {
 // SensitiveMark is the cty value mark applied to sensitive values.
 const SensitiveMark = "sensitive"
 
+// EphemeralMark is the cty value mark applied to ephemeral values.
+const EphemeralMark = "ephemeral"
+
 // SyntheticMark is the cty value mark applied to attributes that pulumi-hcl
 // injects onto a resource-reference object but that have no OpenTofu
 // equivalent.

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -207,19 +207,20 @@ func Functions(baseDir string) map[string]function.Function {
 		"cidrsubnets":  cidrSubnetsFunc,
 
 		// Type conversion functions
-		"can":          canFunc,
-		"recover":      recoverFunc,
-		"issensitive":  issensitiveFunc,
-		"nonsensitive": nonsensitiveFunc,
-		"sensitive":    sensitiveFunc,
-		"tobool":       makeToFunc(cty.Bool),
-		"tolist":       makeToFunc(cty.List(cty.DynamicPseudoType)),
-		"tomap":        makeToFunc(cty.Map(cty.DynamicPseudoType)),
-		"tonumber":     makeToFunc(cty.Number),
-		"toset":        makeToFunc(cty.Set(cty.DynamicPseudoType)),
-		"tostring":     toStringFunc,
-		"try":          tryfunc.TryFunc,
-		"type":         typeFunc,
+		"can":             canFunc,
+		"recover":         recoverFunc,
+		"ephemeralasnull": ephemeralasnullFunc,
+		"issensitive":     issensitiveFunc,
+		"nonsensitive":    nonsensitiveFunc,
+		"sensitive":       sensitiveFunc,
+		"tobool":          makeToFunc(cty.Bool),
+		"tolist":          makeToFunc(cty.List(cty.DynamicPseudoType)),
+		"tomap":           makeToFunc(cty.Map(cty.DynamicPseudoType)),
+		"tonumber":        makeToFunc(cty.Number),
+		"toset":           makeToFunc(cty.Set(cty.DynamicPseudoType)),
+		"tostring":        toStringFunc,
+		"try":             tryfunc.TryFunc,
+		"type":            typeFunc,
 
 		// Pulumi-specific functions
 		"pulumiResourceName": pulumiResourceNameFunc,
@@ -2131,6 +2132,41 @@ var sensitiveFunc = function.New(&function.Spec{
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 		return args[0].Mark(SensitiveMark), nil
+	},
+})
+
+var ephemeralasnullFunc = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name:             "value",
+			Type:             cty.DynamicPseudoType,
+			AllowUnknown:     true,
+			AllowNull:        true,
+			AllowMarked:      true,
+			AllowDynamicType: true,
+		},
+	},
+	Type: func(args []cty.Value) (cty.Type, error) {
+		return args[0].Type(), nil
+	},
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		return cty.Transform(args[0], func(_ cty.Path, val cty.Value) (cty.Value, error) {
+			nonEphemeralMarks := val.Marks()
+			delete(nonEphemeralMarks, EphemeralMark)
+			switch {
+			case val.IsNull():
+				return cty.NullVal(val.Type()).WithMarks(nonEphemeralMarks), nil
+			case !val.IsKnown():
+				// An unknown value's ephemerality is not yet finalized: an
+				// expression like `var.cond ? var.ephemeral : "b"` only
+				// resolves its mark once var.cond is known.
+				return cty.UnknownVal(val.Type()).WithMarks(nonEphemeralMarks), nil
+			case val.HasMark(EphemeralMark):
+				return cty.NullVal(val.Type()).WithMarks(nonEphemeralMarks), nil
+			default:
+				return val, nil
+			}
+		})
 	},
 })
 

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -836,6 +836,37 @@ func TestIsSensitiveUnknown(t *testing.T) {
 	assert.Equal(t, cty.UnknownVal(cty.Bool), is)
 }
 
+// TestEphemeralAsNull is called directly because no HCL function constructs
+// ephemeral values; only variable/output declarations apply the mark.
+func TestEphemeralAsNull(t *testing.T) {
+	t.Parallel()
+
+	got, err := ephemeralasnullFunc.Call([]cty.Value{cty.StringVal("hunter2").Mark(EphemeralMark)})
+	require.NoError(t, err)
+	assert.Equal(t, cty.NullVal(cty.String), got)
+
+	// Nested ephemeral parts null out individually; non-ephemeral marks survive.
+	got, err = ephemeralasnullFunc.Call([]cty.Value{cty.ObjectVal(map[string]cty.Value{
+		"open":   cty.StringVal("visible"),
+		"secret": cty.StringVal("hunter2").Mark(EphemeralMark).Mark(SensitiveMark),
+	})})
+	require.NoError(t, err)
+	assert.Equal(t, cty.ObjectVal(map[string]cty.Value{
+		"open":   cty.StringVal("visible"),
+		"secret": cty.NullVal(cty.String).Mark(SensitiveMark),
+	}), got)
+
+	// An unknown value's ephemerality is not yet finalized, so it stays
+	// unknown rather than becoming null.
+	got, err = ephemeralasnullFunc.Call([]cty.Value{cty.UnknownVal(cty.String).Mark(EphemeralMark)})
+	require.NoError(t, err)
+	assert.Equal(t, cty.UnknownVal(cty.String), got)
+
+	got, err = ephemeralasnullFunc.Call([]cty.Value{cty.StringVal("plain")})
+	require.NoError(t, err)
+	assert.Equal(t, cty.StringVal("plain"), got)
+}
+
 // TestToNumber pins that `tonumber` parses the whole string as a decimal
 // number rather than truncating at the first non-digit character. A `%d`-style
 // parse would stop at the '.' in "3.14" or the 'e' in "1e2" and silently return

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -554,6 +554,16 @@ func (p *Parser) parseVariableBlock(config *ast.Config, block *hcl.Block) hcl.Di
 		}
 	}
 
+	// Ephemeral values are treated as secrets: encrypted state addresses the
+	// persistence concern that ephemerality exists to solve.
+	if attr, ok := content.Attributes["ephemeral"]; ok {
+		val, valDiags := attr.Expr.Value(nil)
+		diags = append(diags, valDiags...)
+		if val.Type() == cty.Bool && val.True() {
+			variable.Sensitive = true
+		}
+	}
+
 	if attr, ok := content.Attributes["nullable"]; ok {
 		val, valDiags := attr.Expr.Value(nil)
 		diags = append(diags, valDiags...)
@@ -1113,6 +1123,15 @@ func (p *Parser) parseOutputBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 		diags = append(diags, valDiags...)
 		if val.Type() == cty.Bool {
 			output.Sensitive = val.True()
+		}
+	}
+
+	// Ephemeral outputs are treated as secrets, mirroring ephemeral variables.
+	if attr, ok := content.Attributes["ephemeral"]; ok {
+		val, valDiags := attr.Expr.Value(nil)
+		diags = append(diags, valDiags...)
+		if val.Type() == cty.Bool && val.True() {
+			output.Sensitive = true
 		}
 	}
 

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -554,14 +555,8 @@ func (p *Parser) parseVariableBlock(config *ast.Config, block *hcl.Block) hcl.Di
 		}
 	}
 
-	// Ephemeral values are treated as secrets: encrypted state addresses the
-	// persistence concern that ephemerality exists to solve.
 	if attr, ok := content.Attributes["ephemeral"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.Bool && val.True() {
-			variable.Sensitive = true
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &variable.Ephemeral)...)
 	}
 
 	if attr, ok := content.Attributes["nullable"]; ok {
@@ -1126,13 +1121,8 @@ func (p *Parser) parseOutputBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 		}
 	}
 
-	// Ephemeral outputs are treated as secrets, mirroring ephemeral variables.
 	if attr, ok := content.Attributes["ephemeral"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.Bool && val.True() {
-			output.Sensitive = true
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &output.Ephemeral)...)
 	}
 
 	if attr, ok := content.Attributes["depends_on"]; ok {

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -785,6 +785,31 @@ variable "subnets" {
 	}
 }
 
+func TestParseEphemeralAsSensitive(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+variable "token" {
+  type      = string
+  ephemeral = true
+}
+
+variable "plain" {
+  type      = string
+  ephemeral = false
+}
+
+output "token_out" {
+  value     = var.token
+  ephemeral = true
+}
+`)
+	config, diags := NewParser().ParseSource("test.tf", src)
+	require.False(t, diags.HasErrors(), "unexpected errors: %v", diags.Errs())
+	assert.True(t, config.Variables["token"].Sensitive)
+	assert.False(t, config.Variables["plain"].Sensitive)
+	assert.True(t, config.Outputs["token_out"].Sensitive)
+}
+
 func TestParseProviderForEach(t *testing.T) {
 	t.Parallel()
 	src := []byte(`

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -785,7 +785,7 @@ variable "subnets" {
 	}
 }
 
-func TestParseEphemeralAsSensitive(t *testing.T) {
+func TestParseEphemeral(t *testing.T) {
 	t.Parallel()
 	src := []byte(`
 variable "token" {
@@ -805,9 +805,44 @@ output "token_out" {
 `)
 	config, diags := NewParser().ParseSource("test.tf", src)
 	require.False(t, diags.HasErrors(), "unexpected errors: %v", diags.Errs())
-	assert.True(t, config.Variables["token"].Sensitive)
-	assert.False(t, config.Variables["plain"].Sensitive)
-	assert.True(t, config.Outputs["token_out"].Sensitive)
+	assert.True(t, config.Variables["token"].Ephemeral)
+	assert.False(t, config.Variables["token"].Sensitive)
+	assert.False(t, config.Variables["plain"].Ephemeral)
+	assert.True(t, config.Outputs["token_out"].Ephemeral)
+	assert.False(t, config.Outputs["token_out"].Sensitive)
+}
+
+// A non-bool ephemeral value is a hard error; a string that converts to bool
+// ("true") is accepted. Both mirror OpenTofu's bool decoding.
+func TestParseEphemeralNonBool(t *testing.T) {
+	t.Parallel()
+
+	_, diags := NewParser().ParseSource("test.tf", []byte(`
+variable "token" {
+  type      = string
+  ephemeral = "yes"
+}
+`))
+	require.True(t, diags.HasErrors())
+	assert.Equal(t, "Unsuitable value type", diags[0].Summary)
+
+	_, diags = NewParser().ParseSource("test.tf", []byte(`
+output "token_out" {
+  value     = "v"
+  ephemeral = 1
+}
+`))
+	require.True(t, diags.HasErrors())
+	assert.Equal(t, "Unsuitable value type", diags[0].Summary)
+
+	config, diags := NewParser().ParseSource("test.tf", []byte(`
+variable "token" {
+  type      = string
+  ephemeral = "true"
+}
+`))
+	require.False(t, diags.HasErrors(), "unexpected errors: %v", diags.Errs())
+	assert.True(t, config.Variables["token"].Ephemeral)
 }
 
 func TestParseProviderForEach(t *testing.T) {

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -113,6 +113,7 @@ var variableSchema = &hcl.BodySchema{
 		{Name: "description"},
 		{Name: "sensitive"},
 		{Name: "nullable"},
+		{Name: "ephemeral"},
 	},
 	Blocks: []hcl.BlockHeaderSchema{
 		{Type: "validation"},
@@ -133,6 +134,7 @@ var outputSchema = &hcl.BodySchema{
 		{Name: "value", Required: true},
 		{Name: "description"},
 		{Name: "sensitive"},
+		{Name: "ephemeral"},
 		{Name: "depends_on"},
 	},
 	Blocks: []hcl.BlockHeaderSchema{

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -852,6 +852,9 @@ func (e *Engine) processVariable(ctx context.Context, node *graph.Node) error {
 	if v.Sensitive || isSecret {
 		val = val.Mark(eval.SensitiveMark)
 	}
+	if v.Ephemeral {
+		val = val.Mark(eval.EphemeralMark)
+	}
 
 	// Store in eval context (needed for validation which may reference var.<name>)
 	e.evaluator.Context().SetVariable(varName, val)
@@ -1204,7 +1207,7 @@ func (e *Engine) registerProviderInContext(
 	}
 
 	providerMapping := e.resolver.ProviderConfigBodyMapping(ctx, provider.Name)
-	inputsMap, diags := transform.EvalResourceWithSchema(provider.Config, resSchema, providerMapping,
+	inputsMap, _, diags := transform.EvalResourceWithSchema(provider.Config, resSchema, providerMapping,
 		func(_ resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
 			c := hclCtx
 			if len(extraVars) > 0 {
@@ -1520,7 +1523,7 @@ func (e *Engine) registerResourceInstanceInContext(
 	if res.Type == packages.TerraformDataType {
 		tdataEvaluated = map[string]cty.Value{}
 	}
-	resourceInputs, diags := transform.EvalResourceWithSchema(res.Config, resSchema, resourceMapping,
+	resourceInputs, ephemeralPaths, diags := transform.EvalResourceWithSchema(res.Config, resSchema, resourceMapping,
 		func(propKey resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
 			var val cty.Value
 			var diags hcl.Diagnostics
@@ -1568,6 +1571,25 @@ func (e *Engine) registerResourceInstanceInContext(
 	opts.Custom = !resSchema.IsComponent
 	opts.Remote = resSchema.IsComponent
 	opts.PropertyDependencies = dependsOn
+
+	// An ephemeral value is free to differ on every run, so a property it
+	// flows into should not display a diff. The path arrives in the assembled
+	// inputs' namespace (snake-cased Pulumi names, MaxItemsOne blocks already
+	// flattened), which translateAttrPathTraversal maps to engine form; a name
+	// it cannot resolve (a bridge rename) widens to the whole top-level
+	// property rather than leaking the diff.
+	for _, p := range ephemeralPaths {
+		glob, err := translateAttrPathTraversal(ctyPathTraversal(p), resourceMapping, resSchema.InputProperties)
+		if err != nil {
+			glob, err = translateAttrPathTraversal(ctyPathTraversal(p[:1]), resourceMapping, resSchema.InputProperties)
+			if err != nil {
+				return fmt.Errorf("translating ephemeral property path on %q: %w", res.Type+"."+res.Name, err)
+			}
+		}
+		if !slices.Contains(opts.HideDiffs, glob) {
+			opts.HideDiffs = append(opts.HideDiffs, glob)
+		}
+	}
 	for _, deps := range dependsOn {
 		for _, dep := range deps {
 			if !slices.Contains(opts.DependsOn, dep) {
@@ -2772,6 +2794,22 @@ func translateAttrPathTraversal(
 	return property.GlobFromSegments(segments...), nil
 }
 
+// ctyPathTraversal converts a cty.Path over an evaluated inputs object into an
+// attribute-path traversal, so it can be translated to engine form by
+// translateAttrPathTraversal like a hide_diffs entry.
+func ctyPathTraversal(p cty.Path) hcl.Traversal {
+	t := make(hcl.Traversal, 0, len(p))
+	for _, step := range p {
+		switch s := step.(type) {
+		case cty.GetAttrStep:
+			t = append(t, hcl.TraverseAttr{Name: s.Name})
+		case cty.IndexStep:
+			t = append(t, hcl.TraverseIndex{Key: s.Key})
+		}
+	}
+	return t
+}
+
 // translateSecretOutputName translates a single additional_secret_outputs entry
 // from its TF (snake_case) name to its Pulumi name. Unlike hide_diffs and
 // replace_on_changes, an additional_secret_outputs entry names a single
@@ -3760,7 +3798,10 @@ func (e *Engine) processModuleVariable(node *graph.Node) error {
 		}
 
 		if v.Sensitive {
-			val = val.Mark("sensitive")
+			val = val.Mark(eval.SensitiveMark)
+		}
+		if v.Ephemeral {
+			val = val.Mark(eval.EphemeralMark)
 		}
 
 		inst.EvalCtx.SetVariable(varName, val)
@@ -3963,9 +4004,12 @@ func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error 
 			return fmt.Errorf("evaluating module output %s: %s", outputName, diags.Error())
 		}
 		// A `sensitive = true` output carries the mark into the calling module,
-		// so a reference to it stays sensitive.
+		// so a reference to it stays sensitive; likewise for `ephemeral = true`.
 		if output.Sensitive {
 			val = val.Mark(eval.SensitiveMark)
+		}
+		if output.Ephemeral {
+			val = val.Mark(eval.EphemeralMark)
 		}
 		inst.mu.Lock()
 		inst.Outputs[outputName] = val
@@ -4158,8 +4202,8 @@ func (e *Engine) processOutput(_ context.Context, name string, output *ast.Outpu
 		return fmt.Errorf("converting output value: %w", err)
 	}
 
-	// Mark as secret if sensitive
-	if output.Sensitive {
+	// Sensitive and ephemeral outputs are both persisted as secrets.
+	if output.Sensitive || output.Ephemeral {
 		pv = pv.WithSecret(true)
 	}
 
@@ -4647,7 +4691,7 @@ const sensitiveErrorMessageRef = "Error message refers to sensitive values"
 // carry. A null / unknown / non-string value yields "" so the caller can fall
 // back to its own default message.
 func renderErrorMessage(v cty.Value) string {
-	if v.HasMark(eval.SensitiveMark) {
+	if v.HasMark(eval.SensitiveMark) || v.HasMark(eval.EphemeralMark) {
 		return sensitiveErrorMessageRef
 	}
 	return ctyAsString(v)

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1575,16 +1575,11 @@ func (e *Engine) registerResourceInstanceInContext(
 	// An ephemeral value is free to differ on every run, so a property it
 	// flows into should not display a diff. The path arrives in the assembled
 	// inputs' namespace (snake-cased Pulumi names, MaxItemsOne blocks already
-	// flattened), which translateAttrPathTraversal maps to engine form; a name
-	// it cannot resolve (a bridge rename) widens to the whole top-level
-	// property rather than leaking the diff.
+	// flattened), which translateAttrPathTraversal maps to engine form.
 	for _, p := range ephemeralPaths {
 		glob, err := translateAttrPathTraversal(ctyPathTraversal(p), resourceMapping, resSchema.InputProperties)
 		if err != nil {
-			glob, err = translateAttrPathTraversal(ctyPathTraversal(p[:1]), resourceMapping, resSchema.InputProperties)
-			if err != nil {
-				return fmt.Errorf("translating ephemeral property path on %q: %w", res.Type+"."+res.Name, err)
-			}
+			return fmt.Errorf("translating ephemeral property path on %q: %w", res.Type+"."+res.Name, err)
 		}
 		if !slices.Contains(opts.HideDiffs, glob) {
 			opts.HideDiffs = append(opts.HideDiffs, glob)

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -452,7 +452,7 @@ func inferOutputType(evaluator *eval.Evaluator, o *ast.Output) (cty.Value, error
 func variableToPropertySpec(v *ast.Variable) (*PropertySpec, error) {
 	prop := &PropertySpec{
 		Description: v.Description,
-		Secret:      v.Sensitive,
+		Secret:      v.Sensitive || v.Ephemeral,
 	}
 
 	// Convert type constraint to schema type
@@ -518,7 +518,7 @@ func outputToPropertySpec(o *ast.Output, val cty.Value) (*PropertySpec, error) {
 		return nil, err
 	}
 	prop.Description = o.Description
-	prop.Secret = o.Sensitive
+	prop.Secret = o.Sensitive || o.Ephemeral
 	return prop, nil
 }
 

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -71,19 +71,56 @@ func EvalFunctionWithSchema(config hcl.Body, r *schema.Function, mapping *bridge
 }
 
 // EvalResourceWithSchema evaluates a resource body against the Pulumi resource
-// schema. See EvalFunctionWithSchema for the role of mapping.
-func EvalResourceWithSchema(config hcl.Body, r *schema.Resource, mapping *bridge.BodyMapping, eval EvalFunc) (property.Map, hcl.Diagnostics) {
+// schema. See EvalFunctionWithSchema for the role of mapping. The second
+// result lists the paths within the evaluated inputs that carry an ephemeral
+// mark. Paths are in the assembled inputs' namespace — snake-cased Pulumi
+// names with MaxItemsOne blocks already flattened — and sorted.
+func EvalResourceWithSchema(config hcl.Body, r *schema.Resource, mapping *bridge.BodyMapping, eval EvalFunc) (property.Map, []cty.Path, hcl.Diagnostics) {
 	resourceInputs, attrExprs, diags := evalBlockWithSchema(config, r.InputProperties, mapping, eval)
 	if diags.HasErrors() {
-		return property.Map{}, diags
+		return property.Map{}, nil, diags
 	}
 
 	m, err := ctyToResourceInputs(resourceInputs, r, attrExprs)
 	if err != nil {
-		return property.Map{}, append(diags,
+		return property.Map{}, nil, append(diags,
 			conversionDiagnostic(err, "failed to convert HCL resource inputs to Pulumi inputs"))
 	}
-	return m, diags
+	return m, ephemeralInputPaths(resourceInputs), diags
+}
+
+// ephemeralInputPaths returns the paths within inputs whose value carries
+// eval.EphemeralMark, sorted for determinism.
+func ephemeralInputPaths(inputs cty.Value) []cty.Path {
+	if inputs == cty.NilVal || inputs.IsNull() {
+		return nil
+	}
+	_, pathMarks := inputs.UnmarkDeepWithPaths()
+	var out []cty.Path
+	for _, pm := range pathMarks {
+		if _, ok := pm.Marks[eval.EphemeralMark]; ok {
+			out = append(out, pm.Path)
+		}
+	}
+	slices.SortFunc(out, func(a, b cty.Path) int {
+		return strings.Compare(pathSortKey(a), pathSortKey(b))
+	})
+	return out
+}
+
+// pathSortKey renders a cty.Path as a string usable as a deterministic sort key.
+func pathSortKey(p cty.Path) string {
+	var b strings.Builder
+	for _, step := range p {
+		switch s := step.(type) {
+		case cty.GetAttrStep:
+			b.WriteByte('.')
+			b.WriteString(s.Name)
+		case cty.IndexStep:
+			fmt.Fprintf(&b, "[%v]", s.Key)
+		}
+	}
+	return b.String()
 }
 
 func conversionDiagnostic(err error, fallbackSummary string) *hcl.Diagnostic {
@@ -742,7 +779,11 @@ func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, expr hc
 	if val.IsMarked() {
 		var marks cty.ValueMarks
 		val, marks = val.Unmark()
-		if _, isSensitive := marks[eval.SensitiveMark]; isSensitive && !alreadyInSecret {
+		_, isSensitive := marks[eval.SensitiveMark]
+		// Ephemeral values are persisted as secrets: encrypted state addresses
+		// the persistence concern that ephemerality exists to solve.
+		_, isEphemeral := marks[eval.EphemeralMark]
+		if (isSensitive || isEphemeral) && !alreadyInSecret {
 			v, err := ctyToResourceProperty(path, val, prop, expr, true)
 			return v.WithSecret(true), err
 		}
@@ -976,12 +1017,14 @@ func CtyToPropertyValue(val cty.Value) (property.Value, error) {
 }
 
 func ctyToPropertyValue(val cty.Value) (property.Value, error) {
-	// Handle sensitive-marked values by unwrapping, converting, and wrapping as secret.
+	// Handle sensitive- and ephemeral-marked values by unwrapping, converting,
+	// and wrapping as secret.
 	if val.IsMarked() {
 		unmarked, marks := val.Unmark()
 		_, isSensitive := marks[eval.SensitiveMark]
+		_, isEphemeral := marks[eval.EphemeralMark]
 		pv, err := ctyToPropertyValue(unmarked)
-		return pv.WithSecret(isSensitive), err
+		return pv.WithSecret(isSensitive || isEphemeral), err
 	}
 
 	if val.IsNull() {

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -92,9 +92,6 @@ func EvalResourceWithSchema(config hcl.Body, r *schema.Resource, mapping *bridge
 // ephemeralInputPaths returns the paths within inputs whose value carries
 // eval.EphemeralMark, sorted for determinism.
 func ephemeralInputPaths(inputs cty.Value) []cty.Path {
-	if inputs == cty.NilVal || inputs.IsNull() {
-		return nil
-	}
 	_, pathMarks := inputs.UnmarkDeepWithPaths()
 	var out []cty.Path
 	for _, pm := range pathMarks {
@@ -103,24 +100,9 @@ func ephemeralInputPaths(inputs cty.Value) []cty.Path {
 		}
 	}
 	slices.SortFunc(out, func(a, b cty.Path) int {
-		return strings.Compare(pathSortKey(a), pathSortKey(b))
+		return strings.Compare(fmt.Sprintf("%v", a), fmt.Sprintf("%v", b))
 	})
 	return out
-}
-
-// pathSortKey renders a cty.Path as a string usable as a deterministic sort key.
-func pathSortKey(p cty.Path) string {
-	var b strings.Builder
-	for _, step := range p {
-		switch s := step.(type) {
-		case cty.GetAttrStep:
-			b.WriteByte('.')
-			b.WriteString(s.Name)
-		case cty.IndexStep:
-			fmt.Fprintf(&b, "[%v]", s.Key)
-		}
-	}
-	return b.String()
 }
 
 func conversionDiagnostic(err error, fallbackSummary string) *hcl.Diagnostic {

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -446,7 +446,7 @@ resource "fake" "f" {
 		return expr.Value(&hcl.EvalContext{Variables: extraVars})
 	}
 
-	_, diags = EvalResourceWithSchema(resourceBody, r, nil, evalFn)
+	_, _, diags = EvalResourceWithSchema(resourceBody, r, nil, evalFn)
 	require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
 }
 
@@ -500,7 +500,7 @@ resource "fake" "f" {
 		return expr.Value(&hcl.EvalContext{Variables: extraVars})
 	}
 
-	out, diags := EvalResourceWithSchema(resourceBody, r, nil, evalFn)
+	out, _, diags := EvalResourceWithSchema(resourceBody, r, nil, evalFn)
 	require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
 
 	expected := property.NewMap(map[string]property.Value{
@@ -1901,7 +1901,7 @@ resource "fake" "f" {
 				return expr.Value(&hcl.EvalContext{Variables: extraVars})
 			}
 
-			out, diags := EvalResourceWithSchema(resourceBody, r, nil, evalFn)
+			out, _, diags := EvalResourceWithSchema(resourceBody, r, nil, evalFn)
 			require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
 			assert.Equal(t, property.NewMap(map[string]property.Value{
 				"settings": tt.expected,
@@ -1942,7 +1942,7 @@ resource "fake" "f" {
 		return expr.Value(&hcl.EvalContext{Variables: extraVars})
 	}
 
-	out, diags := EvalResourceWithSchema(resourceBody, r, nil, evalFn)
+	out, _, diags := EvalResourceWithSchema(resourceBody, r, nil, evalFn)
 	require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
 	assert.Equal(t, property.NewMap(map[string]property.Value{
 		"settings": property.New(property.Computed),
@@ -1990,7 +1990,7 @@ resource "fake" "f" {
 				return expr.Value(&hcl.EvalContext{Variables: extraVars})
 			}
 
-			_, diags := EvalResourceWithSchema(resourceBody, r, nil, evalFn)
+			_, _, diags := EvalResourceWithSchema(resourceBody, r, nil, evalFn)
 			require.True(t, diags.HasErrors())
 			assert.Equal(t, "Invalid dynamic for_each value", diags[0].Summary)
 			assert.Equal(t, tt.detail, diags[0].Detail)

--- a/tests/tfcompat/l1_ephemeral_variable_test.go
+++ b/tests/tfcompat/l1_ephemeral_variable_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// A root variable declared `ephemeral = true` (OpenTofu 1.11+) is accepted by
+// `tofu apply`, which proceeds normally. pulumi-hcl's variable schema does not
+// list `ephemeral`, so its strict block decode rejects the config with an
+// "Unsupported argument" error before anything runs.
+func TestL1EphemeralVariable(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_ephemeral_variable", tfcompat.Case{})
+}

--- a/tests/tfcompat/l1_ephemeralasnull_test.go
+++ b/tests/tfcompat/l1_ephemeralasnull_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// ephemeralasnull replaces the ephemeral parts of a value with typed nulls,
+// making the result usable in persisted contexts like a non-ephemeral output.
+// The deep case (object with one ephemeral attribute), the scalar case, and
+// the negative case (values with no ephemeral parts pass through unchanged)
+// are all exercised.
+func TestL1EphemeralAsNull(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_ephemeralasnull", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_ephemeral_variable/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_ephemeral_variable/main.tf
@@ -1,0 +1,9 @@
+variable "session_token" {
+  type      = string
+  default   = "ephemeral-default"
+  ephemeral = true
+}
+
+output "result" {
+  value = "ok"
+}

--- a/tests/tfcompat/testdata/cases/l1_ephemeralasnull/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_ephemeralasnull/main.tf
@@ -1,0 +1,36 @@
+variable "session_token" {
+  type      = string
+  default   = "ephemeral-default"
+  ephemeral = true
+}
+
+locals {
+  mixed = {
+    open  = "visible"
+    token = var.session_token
+  }
+}
+
+output "result" {
+  value = ephemeralasnull(local.mixed)
+}
+
+output "scalar" {
+  value = ephemeralasnull(var.session_token)
+}
+
+variable "plain" {
+  type    = string
+  default = "not-ephemeral"
+}
+
+output "passthrough" {
+  value = ephemeralasnull(var.plain)
+}
+
+output "passthrough_object" {
+  value = ephemeralasnull({
+    name  = var.plain
+    count = 2
+  })
+}


### PR DESCRIPTION
## What

Terraform 1.10+ / OpenTofu 1.11+ `ephemeral` support. Previously a root `variable` (or `output`) declared `ephemeral = true` was rejected at parse time with `An argument named "ephemeral" is not expected here`.

Ephemerality is now tracked as its own cty mark (`eval.EphemeralMark`), distinct from `sensitive`:

- **Persisted as secrets.** Boundary conversions (resource inputs, stack outputs, module component outputs, generated schemas) treat ephemeral-marked values as Pulumi secrets. Pulumi's encrypted state addresses the persistence concern ephemerality exists to solve.
- **Diffs are hidden.** An ephemeral value may differ on every run, so the resource property it flows into is registered with the `hideDiffs` resource option — down to the exact property path (`settings[0].token`, not all of `settings`), translated through the same resolver `hide_diffs`/`replace_on_changes` use (MaxItemsOne flattening, bridge renames). An untranslatable path widens to the whole top-level property rather than leaking a diff.
- **Ephemeral ≠ sensitive.** `issensitive` returns `false` for purely ephemeral values, matching OpenTofu.
- **`ephemeralasnull`** is implemented with OpenTofu's exact semantics: deep transform, ephemeral parts become typed nulls preserving other marks (a sensitive-and-ephemeral value becomes a sensitive null), unknowns stay unknown.
- **Strict decoding.** A non-bool `ephemeral` argument is a hard error (`gohcl.DecodeExpression`, the same decode OpenTofu uses), including the string-conversion behavior (`"true"` is accepted).

Documented in `docs/language-reference.md` ("Ephemeral Values"), including the deliberate differences from OpenTofu below.

## Deliberate differences from OpenTofu

- OpenTofu hard-errors when an ephemeral value reaches a persisted context (regular resource argument, non-ephemeral output). We accept it and persist the value encrypted; there is no flow validation.
- OpenTofu re-prompts for a required ephemeral variable every run; we read it from stack config like any other variable.
- A root-level ephemeral output becomes a secret stack output rather than being omitted.

Related: https://github.com/pulumi-labs/pulumi-hcl/issues/169 covers ephemeral *blocks* (`ephemeral "type" "name" {}`), a separate construct.

## Tests

- `TestL1EphemeralVariable` (tfcompat) — the original failing test; passes.
- `TestL1EphemeralAsNull` (tfcompat) — deep object, scalar, and negative pass-through cases against real OpenTofu.
- `TestEphemeralVariableHidesDiffs`, `TestEphemeralNestedBlockHidesDiffFineGrained` — Pulumi-side behavior with no OpenTofu mirror: mock monitor asserts `hideDiffs` paths (including the fine-grained `settings[0].token`) and secret inputs.
- `TestEphemeralAsNull` (eval), `TestParseEphemeral` / `TestParseEphemeralNonBool` (parser) unit coverage.

## Follow-up

The other constant-value attributes (`sensitive`, `nullable`, `description`, lifecycle bools, provider `alias`/`version`, …) still silently ignore wrongly-typed values where OpenTofu errors; a follow-up PR will convert them all to the same strict decode.