### PR TITLE
Evaluate a whole reference to an output-less module as an empty object

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-403.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-403.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Evaluate a whole reference to a module with no outputs as `{}`
+time: 2026-07-16T00:45:00Z
+custom:
+    Component: runtime
+    PR: "403"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -3907,6 +3907,9 @@ func (e *Engine) publishModuleValue(modInfo *graph.ModuleInfo, instances []*modu
 				inst.mu.Lock()
 				outs := maps.Clone(inst.Outputs)
 				inst.mu.Unlock()
+				if len(outs) == 0 {
+					parentCtx.SetModule(name, cty.EmptyObjectVal)
+				}
 				for k, v := range outs {
 					parentCtx.SetModuleOutput(name, k, v)
 				}

--- a/tests/tfcompat/l2_whole_module_no_outputs_test.go
+++ b/tests/tfcompat/l2_whole_module_no_outputs_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// Referencing a whole module that declares no outputs yields an empty object.
+// OpenTofu produces {} (keys() is []); pulumi-hcl must match.
+func TestL2WholeModuleNoOutputs(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_whole_module_no_outputs", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_whole_module_no_outputs/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_whole_module_no_outputs/child/main.tf
@@ -1,0 +1,4 @@
+resource "simple_resource" "noop" {
+  input_one = "x"
+  input_two = true
+}

--- a/tests/tfcompat/testdata/cases/l2_whole_module_no_outputs/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_whole_module_no_outputs/main.tf
@@ -1,0 +1,13 @@
+# Referencing a whole module that declares no outputs yields an empty object.
+# OpenTofu produces {} (and keys() is []); pulumi-hcl must match.
+module "child" {
+  source = "./child"
+}
+
+output "whole_empty" {
+  value = module.child
+}
+
+output "empty_keys" {
+  value = keys(module.child)
+}


### PR DESCRIPTION
## Divergence

Referencing a whole module that declares **no outputs** — `module.child`, where `child` creates resources but has no `output` blocks:

- **OpenTofu**: evaluates `module.child` to an empty object `{}` (so `keys(module.child)` is `[]`).
- **pulumi-hcl** (before this PR): errored `Unsupported attribute; This object does not have an attribute named "child"`.

## Fix

The single-instance branch of `publishModuleValue` only registered `module.<name>` via per-output `SetModuleOutput` calls, so a module with zero outputs never got a key in the `module` namespace. It now registers `cty.EmptyObjectVal` when the instance has no outputs — safe because the module completion node depends on every output node, so an empty output map at publish time means the module truly declares none.

The `count` and `for_each` branches already handled this case by calling `SetModule` unconditionally (with `outputObject()` returning `{}` per instance), and the schema generator registers every module call unconditionally, so the single-instance runtime path was the only gap.

## Test

`TestL2WholeModuleNoOutputs` — two-file module fixture; `child` creates one `simple_resource` and declares no `output`. Asserts `whole_empty = {}` and `empty_keys = []`, matching OpenTofu.