### PR TITLE
Remove dead code and fold duplicated helpers

### DIFF
--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -852,26 +852,8 @@ func (g *generator) extractCallArgs(call *model.FunctionCallExpression) (resourc
 		resourceName = scopeTraversal.Traversal.RootName()
 	}
 	// Second arg: method name string literal
-	methodName, ok = extractStringLiteralFromCallArg(call.Args[1])
+	methodName, ok = extractStringLiteral(call.Args[1])
 	return resourceName, methodName, ok
-}
-
-// extractStringLiteralFromCallArg extracts a string value from a method name argument,
-// which can be a TemplateExpression or a LiteralValueExpression.
-func extractStringLiteralFromCallArg(expr model.Expression) (string, bool) {
-	switch e := expr.(type) {
-	case *model.LiteralValueExpression:
-		if e.Value.Type() == cty.String {
-			return e.Value.AsString(), true
-		}
-	case *model.TemplateExpression:
-		if len(e.Parts) == 1 {
-			if lit, ok := e.Parts[0].(*model.LiteralValueExpression); ok && lit.Value.Type() == cty.String {
-				return lit.Value.AsString(), true
-			}
-		}
-	}
-	return "", false
 }
 
 // genCallBlock generates a call block for a method invocation.

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -436,31 +436,28 @@ func (ft *fileTransformer) scanProviderFunctions(ctx context.Context, body *hcls
 	return diags
 }
 
+// blockLogicalName returns the referenceable name label of a resource,
+// variable, output, or module block, or "" for other block types.
+func blockLogicalName(block *hclsyntax.Block) string {
+	switch block.Type {
+	case "resource":
+		if len(block.Labels) >= 2 {
+			return block.Labels[1]
+		}
+	case "variable", "output", "module":
+		if len(block.Labels) >= 1 {
+			return block.Labels[0]
+		}
+	}
+	return ""
+}
+
 func (ft *fileTransformer) computeNameRewrites(bodies []*hclsyntax.Body) {
 	usedNames := make(map[string]bool)
 	// First pass: collect all names that are already valid identifiers.
 	for _, body := range bodies {
 		for _, block := range body.Blocks {
-			var name string
-			switch block.Type {
-			case "resource":
-				if len(block.Labels) >= 2 {
-					name = block.Labels[1]
-				}
-			case "variable":
-				if len(block.Labels) >= 1 {
-					name = block.Labels[0]
-				}
-			case "output":
-				if len(block.Labels) >= 1 {
-					name = block.Labels[0]
-				}
-			case "module":
-				if len(block.Labels) >= 1 {
-					name = block.Labels[0]
-				}
-			}
-			if name != "" && hclsyntax.ValidIdentifier(name) {
+			if name := blockLogicalName(block); name != "" && hclsyntax.ValidIdentifier(name) {
 				usedNames[name] = true
 			}
 		}
@@ -468,26 +465,11 @@ func (ft *fileTransformer) computeNameRewrites(bodies []*hclsyntax.Body) {
 	// Second pass: generate sanitized names for invalid identifiers.
 	for _, body := range bodies {
 		for _, block := range body.Blocks {
-			var name string
-			switch block.Type {
-			case "resource":
-				if len(block.Labels) >= 2 {
-					name = block.Labels[1]
-				}
-			case "variable":
-				if len(block.Labels) >= 1 {
-					name = block.Labels[0]
-				}
-			case "output":
-				// Outputs are never referenced in expressions, so they don't need rewriting.
-				continue
-			case "module":
-				if len(block.Labels) >= 1 {
-					name = block.Labels[0]
-				}
-			default:
+			// Outputs are never referenced in expressions, so they don't need rewriting.
+			if block.Type == "output" {
 				continue
 			}
+			name := blockLogicalName(block)
 			if name == "" || hclsyntax.ValidIdentifier(name) {
 				continue
 			}
@@ -592,7 +574,7 @@ func (ft *fileTransformer) emitFile(
 
 	var resultDiags hcl.Diagnostics
 
-	for _, alias := range sortedKeys(paramInfos) {
+	for _, alias := range slices.Sorted(maps.Keys(paramInfos)) {
 		emitPackageBlock(out, alias, paramInfos[alias])
 	}
 
@@ -2277,16 +2259,6 @@ func invertTokens(tokens hclwrite.Tokens) hclwrite.Tokens {
 		return rest
 	}
 	return append(hclwrite.Tokens{{Type: hclsyntax.TokenBang, Bytes: []byte("!")}}, tokens...)
-}
-
-// sortedKeys returns the keys of a map in sorted order.
-func sortedKeys[V any](m map[string]V) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }
 
 // emitPackageBlock writes a PCL "package" block from a workspace.PackageDescriptor.

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -71,9 +71,6 @@ type Context struct {
 	// moduleOutputs stores incremental per-output values: moduleName → outputName → value
 	moduleOutputs map[string]map[string]cty.Value
 
-	// providers contains provider references (provider.name)
-	providers map[string]cty.Value
-
 	// calls contains call results keyed as "resourceName.methodName"
 	calls map[string]cty.Value
 
@@ -88,9 +85,6 @@ type Context struct {
 
 	// each contains each context for for_each iteration
 	each *EachContext
-
-	// self contains the current resource for self references
-	self cty.Value
 
 	// typeInference makes HCLContext serve type-preserving function variants
 	// (see TypeInferenceFunctions). It is set only when the context is used to
@@ -230,7 +224,6 @@ func newContext(path PathContext, rootModuleDir, stack, project, organization st
 		dataSources:     make(map[string]cty.Value),
 		modules:         make(map[string]cty.Value),
 		moduleOutputs:   make(map[string]map[string]cty.Value),
-		providers:       make(map[string]cty.Value),
 		calls:           make(map[string]cty.Value),
 		path:            path,
 		pulumi: PulumiContext{
@@ -350,13 +343,6 @@ func (c *Context) SetCall(key string, value cty.Value) {
 	c.calls[key] = value
 }
 
-// SetProvider sets a provider reference.
-func (c *Context) SetProvider(name string, value cty.Value) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.providers[name] = value
-}
-
 // WithIteration returns a view of c that shares its evaluation state and lock
 // but carries its own count.index / each.key / each.value, so concurrent
 // registrations bind the iteration goroutine-locally instead of racing on the
@@ -381,25 +367,11 @@ func (c *Context) SetCount(index int) {
 	c.count = &CountContext{Index: index}
 }
 
-// ClearCount clears the count context.
-func (c *Context) ClearCount() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.count = nil
-}
-
 // SetEach sets the each context for for_each iteration.
 func (c *Context) SetEach(key, value cty.Value) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.each = &EachContext{Key: key, Value: value}
-}
-
-// ClearEach clears the each context.
-func (c *Context) ClearEach() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.each = nil
 }
 
 // SetModuleName records the resolved Pulumi logical name of the module
@@ -408,20 +380,6 @@ func (c *Context) SetModuleName(name string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.pulumi.ModuleName = &name
-}
-
-// SetSelf sets the self reference (for provisioner expressions).
-func (c *Context) SetSelf(value cty.Value) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.self = value
-}
-
-// ClearSelf clears the self reference.
-func (c *Context) ClearSelf() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.self = cty.NilVal
 }
 
 // HCLContext returns an hcl.EvalContext for evaluating expressions.
@@ -604,11 +562,6 @@ func (c *Context) HCLContext() *hcl.EvalContext {
 		})
 	}
 
-	// Add self if set (for provisioners)
-	if c.self != cty.NilVal {
-		vars["self"] = c.self
-	}
-
 	functions := Functions(c.rootModuleDir)
 	if c.typeInference {
 		functions = TypeInferenceFunctions(c.rootModuleDir)
@@ -688,11 +641,9 @@ func (c *Context) Clone() *Context {
 		dataSources:       maps.Clone(c.dataSources),
 		modules:           maps.Clone(c.modules),
 		moduleOutputs:     clonedModuleOutputs,
-		providers:         maps.Clone(c.providers),
 		calls:             maps.Clone(c.calls),
 		path:              c.path,
 		pulumi:            c.pulumi,
-		self:              c.self,
 	}
 
 	if c.count != nil {

--- a/pkg/hcl/eval/evaluator.go
+++ b/pkg/hcl/eval/evaluator.go
@@ -269,11 +269,6 @@ func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (result map[string]cty.
 	return result, false, deps, diags
 }
 
-// GetReferencedVariables returns all variables referenced by an expression.
-func (e *Evaluator) GetReferencedVariables(expr hcl.Expression) []hcl.Traversal {
-	return expr.Variables()
-}
-
 // ParseTraversal parses a traversal into its components.
 func ParseTraversal(traversal hcl.Traversal) (namespace string, parts []string) {
 	if len(traversal) == 0 {
@@ -404,10 +399,4 @@ func IsKnown(val cty.Value) bool {
 // EvaluateExpression evaluates an HCL expression.
 func (e *Evaluator) EvaluateExpression(expr hcl.Expression) (cty.Value, hcl.Diagnostics) {
 	return expr.Value(e.ctx.HCLContext())
-}
-
-// UnknownValue creates an unknown value of the given type.
-// This is used during planning when values are not yet known.
-func UnknownValue(ty cty.Type) cty.Value {
-	return cty.UnknownVal(ty)
 }

--- a/pkg/hcl/modulepath/modulepath.go
+++ b/pkg/hcl/modulepath/modulepath.go
@@ -81,15 +81,6 @@ func NewKeyedStep(name string, key string) Step {
 // Name returns the block label of this step (e.g. "vpc", "vpc.primary").
 func (s Step) Name() string { return s.name }
 
-// Index returns the count index of this step. ok is false if the step is
-// not from a count expansion.
-func (s Step) Index() (index int, ok bool) {
-	if s.kind != stepKindIndex {
-		return 0, false
-	}
-	return int(s.idx), true //nolint:gosec // constructed via NewIndexedStep, fits int
-}
-
 // Key returns the for_each key of this step. ok is false if the step is not
 // from a for_each expansion.
 func (s Step) Key() (key string, ok bool) {
@@ -283,21 +274,6 @@ func (p Path) PrefixString() string {
 		}
 		b.WriteByte('.')
 	}
-	return b.String()
-}
-
-// NodeKey returns an opaque, collision-free string formed by combining p
-// with localID. It is suitable as a unique identifier for an element
-// (resource, local, output, ...) inside the module instance described by p.
-//
-// The returned bytes are not human-readable and not stable across process
-// boundaries. Use this only as an in-memory map key.
-func (p Path) NodeKey(localID string) string {
-	var b strings.Builder
-	b.Grow(len(p.repr) + 2 + len(localID))
-	b.WriteString(p.repr)
-	writeUint16(&b, len(localID))
-	b.WriteString(localID)
 	return b.String()
 }
 

--- a/pkg/hcl/modulepath/modulepath_test.go
+++ b/pkg/hcl/modulepath/modulepath_test.go
@@ -63,15 +63,8 @@ func TestStep_Accessors(t *testing.T) {
 
 	bare := modulepath.NewStep("a")
 	assert.Equal(t, "a", bare.Name())
-	_, ok := bare.Index()
+	_, ok := bare.Key()
 	assert.False(t, ok)
-	_, ok = bare.Key()
-	assert.False(t, ok)
-
-	idx := modulepath.NewIndexedStep("a", 3)
-	got, ok := idx.Index()
-	assert.True(t, ok)
-	assert.Equal(t, 3, got)
 
 	key := modulepath.NewKeyedStep("a", "k")
 	gotKey, ok := key.Key()
@@ -140,9 +133,7 @@ func TestPath_Parent(t *testing.T) {
 	parent, last, ok = ab.Parent()
 	assert.True(t, ok)
 	assert.Equal(t, "a", parent.LogicalName())
-	idx, hasIdx := last.Index()
-	assert.True(t, hasIdx)
-	assert.Equal(t, 5, idx)
+	assert.Equal(t, "b[5]", last.LogicalName())
 }
 
 func TestPath_Steps(t *testing.T) {
@@ -236,32 +227,6 @@ func TestPath_LogicalName_NoCollisionAcrossDashedKeys(t *testing.T) {
 	assert.Equal(t, `m-a["b"]`, byLabel.LogicalName())
 }
 
-func TestPath_NodeKey_DistinguishesPaths(t *testing.T) {
-	t.Parallel()
-
-	p1 := modulepath.Root().Append(modulepath.NewStep("a"))
-	p2 := modulepath.Root().Append(modulepath.NewStep("b"))
-	assert.NotEqual(t, p1.NodeKey("res"), p2.NodeKey("res"))
-}
-
-func TestPath_NodeKey_DistinguishesLocalIDs(t *testing.T) {
-	t.Parallel()
-
-	p := modulepath.Root().Append(modulepath.NewStep("a"))
-	assert.NotEqual(t, p.NodeKey("res1"), p.NodeKey("res2"))
-}
-
-func TestPath_NodeKey_NoBoundaryCollision(t *testing.T) {
-	t.Parallel()
-
-	// Without length prefixing, a label "ax" + local "b" would collide with
-	// label "a" + local "xb". With the length-prefixed encoding we use, they
-	// must differ.
-	p1 := modulepath.Root().Append(modulepath.NewStep("ax"))
-	p2 := modulepath.Root().Append(modulepath.NewStep("a"))
-	assert.NotEqual(t, p1.NodeKey("b"), p2.NodeKey("xb"))
-}
-
 func TestPath_PrefixString(t *testing.T) {
 	t.Parallel()
 
@@ -309,9 +274,7 @@ func TestPath_LargeIndex(t *testing.T) {
 
 	// Indices may exceed 64; the encoding allocates a full uint64 so this is fine.
 	p := modulepath.Root().Append(modulepath.NewIndexedStep("a", 1<<20))
-	idx, ok := first(p.Steps).Index()
-	assert.True(t, ok)
-	assert.Equal(t, 1<<20, idx)
+	assert.Equal(t, "a[1048576]", first(p.Steps).LogicalName())
 }
 
 // first returns the first value yielded by an iter.Seq[T]-like function.

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -131,12 +132,11 @@ func (p *Parser) parseBlock(config *ast.Config, block *hcl.Block) hcl.Diagnostic
 	case "call":
 		return p.parseCallBlock(config, block)
 	default:
-		return hcl.Diagnostics{{
-			Severity: hcl.DiagError,
-			Summary:  "Unknown block type",
-			Detail:   fmt.Sprintf("Block type %q is not supported.", block.Type),
-			Subject:  &block.DefRange,
-		}}
+		// Body.Content(rootSchema) already rejected anything not listed in
+		// rootSchema, so reaching here means a type was added to rootSchema
+		// without a case in this switch.
+		contract.Failf("block type %q allowed by rootSchema but not handled", block.Type)
+		return nil
 	}
 }
 

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -500,6 +500,19 @@ terraform {
 	})
 }
 
+func TestParseUnknownBlockType(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+widget "x" {
+}
+`)
+	p := NewParser()
+	_, diags := p.ParseSource("test.hcl", src)
+	require.True(t, diags.HasErrors())
+	require.Equal(t, "Unsupported block type", diags[0].Summary)
+	require.Equal(t, `Blocks of type "widget" are not expected here.`, diags[0].Detail)
+}
+
 func TestParseProvisionerInvalidWhen(t *testing.T) {
 	t.Parallel()
 	src := []byte(`

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -1912,16 +1912,6 @@ func CtyToPropertyMap(val cty.Value) (property.Map, error) {
 	return property.NewMap(pm), nil
 }
 
-// MakeSecret wraps a PropertyValue as a secret.
-func MakeSecret(pv resource.PropertyValue) resource.PropertyValue {
-	return resource.MakeSecret(pv)
-}
-
-// MakeComputed wraps a PropertyValue as computed/unknown.
-func MakeComputed(pv resource.PropertyValue) resource.PropertyValue {
-	return resource.MakeComputed(pv)
-}
-
 // missingDiscriminatorError: the value lacks the discriminator property.
 type missingDiscriminatorError struct {
 	Discriminator string   // snake_case name for HCL display

--- a/pkg/provisioner/runtime/local_exec.go
+++ b/pkg/provisioner/runtime/local_exec.go
@@ -54,7 +54,7 @@ func runLocalExec(ctx context.Context, spec *Spec, hclCtx *hcl.EvalContext) erro
 		return fmt.Errorf("local-exec: command must be non-empty")
 	}
 
-	workingDir, err := evalOptionalString(content, "working_dir", hclCtx)
+	workingDir, err := evalString(content, "working_dir", hclCtx)
 	if err != nil {
 		return err
 	}
@@ -167,10 +167,6 @@ func evalString(content *hcl.BodyContent, name string, hclCtx *hcl.EvalContext) 
 		return "", err
 	}
 	return val.AsString(), nil
-}
-
-func evalOptionalString(content *hcl.BodyContent, name string, hclCtx *hcl.EvalContext) (string, error) {
-	return evalString(content, name, hclCtx)
 }
 
 func evalOptionalBool(content *hcl.BodyContent, name string, hclCtx *hcl.EvalContext) (bool, error) {

--- a/pkg/server/module_resource.go
+++ b/pkg/server/module_resource.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"time"
 
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
@@ -506,15 +505,9 @@ func customTimeoutsToProto(ct *resource.CustomTimeouts) *pulumirpc.ConstructRequ
 	if ct == nil {
 		return nil
 	}
-	dur := func(seconds float64) string {
-		if seconds == 0 {
-			return ""
-		}
-		return (time.Duration(seconds) * time.Second).String()
-	}
 	return &pulumirpc.ConstructRequest_CustomTimeouts{
-		Create: dur(ct.Create),
-		Update: dur(ct.Update),
-		Delete: dur(ct.Delete),
+		Create: formatTimeoutSeconds(ct.Create),
+		Update: formatTimeoutSeconds(ct.Update),
+		Delete: formatTimeoutSeconds(ct.Delete),
 	}
 }

--- a/pkg/server/parameterize.go
+++ b/pkg/server/parameterize.go
@@ -17,6 +17,7 @@ package server
 import (
 	"archive/tar"
 	"bytes"
+	"cmp"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -26,7 +27,6 @@ import (
 	"path"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -412,18 +412,13 @@ func dedupeEdges(edges []resolvedEdge) []resolvedEdge {
 		seen[e] = struct{}{}
 		out = append(out, e)
 	}
-	sort.Slice(out, func(i, j int) bool {
-		a, b := out[i], out[j]
-		if a.Caller != b.Caller {
-			return a.Caller < b.Caller
-		}
-		if a.Source != b.Source {
-			return a.Source < b.Source
-		}
-		if a.Version != b.Version {
-			return a.Version < b.Version
-		}
-		return a.Target < b.Target
+	slices.SortFunc(out, func(a, b resolvedEdge) int {
+		return cmp.Or(
+			cmp.Compare(a.Caller, b.Caller),
+			cmp.Compare(a.Source, b.Source),
+			cmp.Compare(a.Version, b.Version),
+			cmp.Compare(a.Target, b.Target),
+		)
 	})
 	return out
 }
@@ -533,9 +528,8 @@ func excludedFromBundle(rel string) (skip, skipDeep bool) {
 func packArchive(dirs map[string]string) ([]byte, error) {
 	type entry struct {
 		name    string
-		absPath string      // set for files copied from disk
-		data    []byte      // set for in-memory files
-		info    os.FileInfo // nil for in-memory files
+		absPath string
+		info    os.FileInfo
 	}
 	var files []entry
 	for relPath, absDir := range dirs {
@@ -560,7 +554,7 @@ func packArchive(dirs map[string]string) ([]byte, error) {
 			return nil, err
 		}
 	}
-	sort.Slice(files, func(i, j int) bool { return files[i].name < files[j].name })
+	slices.SortFunc(files, func(a, b entry) int { return cmp.Compare(a.name, b.name) })
 
 	var buf bytes.Buffer
 	gz := gzip.NewWriter(&buf)
@@ -569,23 +563,20 @@ func packArchive(dirs map[string]string) ([]byte, error) {
 		hdr := &tar.Header{Name: f.name, ModTime: bundleEpoch}
 		var data []byte
 		switch {
-		case f.info != nil && f.info.IsDir():
+		case f.info.IsDir():
 			hdr.Typeflag = tar.TypeDir
 			hdr.Mode = 0o755
 			hdr.Name += "/"
-		case f.info != nil && !f.info.Mode().IsRegular():
+		case !f.info.Mode().IsRegular():
 			continue // skip symlinks, devices, and other irregular entries
 		default:
 			hdr.Typeflag = tar.TypeReg
 			hdr.Mode = 0o644
-			data = f.data
-			if f.absPath != "" {
-				b, err := os.ReadFile(f.absPath)
-				if err != nil {
-					return nil, err
-				}
-				data = b
+			b, err := os.ReadFile(f.absPath)
+			if err != nil {
+				return nil, err
 			}
+			data = b
 			hdr.Size = int64(len(data))
 		}
 		if err := tw.WriteHeader(hdr); err != nil {

--- a/pkg/util/syncmap.go
+++ b/pkg/util/syncmap.go
@@ -50,28 +50,6 @@ func (s *SyncMap[K, V]) Get(key K) (V, bool) {
 	return v, ok
 }
 
-// Delete removes a value from the map.
-func (s *SyncMap[K, V]) Delete(key K) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	delete(s.m, key)
-}
-
-// Len returns the number of items in the map.
-func (s *SyncMap[K, V]) Len() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return len(s.m)
-}
-
-func (s *SyncMap[K, V]) Keys() iter.Seq[K] {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	// Copy the iterator so the iter is thread safe.
-	return slices.Values(slices.Collect(maps.Keys(s.m)))
-}
-
 func (s *SyncMap[K, V]) Values() iter.Seq[V] {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/tests/testutil/monitor.go
+++ b/tests/testutil/monitor.go
@@ -177,8 +177,11 @@ func (m *MockResourceMonitor) CheckPulumiVersion(ctx context.Context, versionRan
 	return nil
 }
 
+// LogWarning panics: nothing asserts on warnings through this mock, so a
+// warning reaching it means a test exercises a path it doesn't expect. Record
+// the message in a field instead if a test needs to assert on warnings.
 func (m *MockResourceMonitor) LogWarning(ctx context.Context, message string) error {
-	return nil
+	panic("MockResourceMonitor.LogWarning: unexpected warning: " + message)
 }
 
 func (m *MockResourceMonitor) RegisterPackage(ctx context.Context, pkg workspace.PackageDescriptor) (run.PackageRef, error) {

--- a/tests/testutil/monitor.go
+++ b/tests/testutil/monitor.go
@@ -31,7 +31,6 @@ type MockResourceMonitor struct {
 	RegisteredResources []run.RegisterResourceRequest
 	ReadResources       []run.ReadResourceRequest
 	InvokedFunctions    []run.InvokeRequest
-	Warnings            []string
 	StackOutputs        property.Map
 	stackURN            urn.URN
 	hooks               map[string]registeredHook
@@ -44,9 +43,6 @@ type MockResourceMonitor struct {
 
 	// RegisterResourceHandler, if  set, is  called for each  RegisterResource instead of the default behavior.
 	RegisterResourceHandler func(ctx context.Context, req run.RegisterResourceRequest) (*run.RegisterResourceResponse, error)
-
-	// ReadResourceHandler, if set, is called for each ReadResource instead of the default behavior.
-	ReadResourceHandler func(ctx context.Context, req run.ReadResourceRequest) (*run.ReadResourceResponse, error)
 }
 
 type registeredHook struct {
@@ -109,12 +105,7 @@ func (m *MockResourceMonitor) RegisterResource(ctx context.Context, req run.Regi
 func (m *MockResourceMonitor) ReadResource(ctx context.Context, req run.ReadResourceRequest) (*run.ReadResourceResponse, error) {
 	m.mu.Lock()
 	m.ReadResources = append(m.ReadResources, req)
-	handler := m.ReadResourceHandler
 	m.mu.Unlock()
-
-	if handler != nil {
-		return handler(ctx, req)
-	}
 
 	resURN := urn.URN("urn:pulumi:test::project::" + req.Type + "::" + req.Name)
 	return &run.ReadResourceResponse{
@@ -186,11 +177,7 @@ func (m *MockResourceMonitor) CheckPulumiVersion(ctx context.Context, versionRan
 	return nil
 }
 
-// LogWarning records emitted warning diagnostics for assertion in tests.
 func (m *MockResourceMonitor) LogWarning(ctx context.Context, message string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.Warnings = append(m.Warnings, message)
 	return nil
 }
 

--- a/tests/testutil/pulexec/run.go
+++ b/tests/testutil/pulexec/run.go
@@ -162,42 +162,10 @@ backend:
 	return &Driver{pt: pt, dir: dir, providers: provNames}
 }
 
-// Apply writes programFiles into the project dir (replacing any prior .tf
-// program files) and runs `pulumi up`. Returns stack outputs and resource
-// state from the resulting deployment.
 // Dir returns the program directory where pulumi runs and program files are
 // written. Tests use this to scrub the temp path out of values that bake it
 // in (e.g. path.cwd) before cross-driver comparison.
 func (d *Driver) Dir() string { return d.dir }
-
-func (d *Driver) Apply(t *testing.T, programFiles map[string]string) Result {
-	t.Helper()
-
-	d.writeFiles(t, programFiles)
-
-	upResult := d.pt.Up(t)
-
-	outputs := make(map[string]string, len(upResult.Outputs))
-	for k, v := range upResult.Outputs {
-		if s, ok := v.Value.(string); ok {
-			outputs[k] = s
-		} else {
-			raw, err := json.Marshal(v.Value)
-			require.NoError(t, err)
-			outputs[k] = string(raw)
-		}
-	}
-
-	exported := d.pt.ExportStack(t)
-	var deployment apitype.DeploymentV3
-	require.NoError(t, json.Unmarshal(exported.Deployment, &deployment))
-
-	return Result{
-		Outputs:   outputs,
-		Resources: deployment.Resources,
-		Output:    upResult.StdOut + "\n" + upResult.StdErr,
-	}
-}
 
 // TryApply runs `pulumi up` and returns the error instead of fataling. State
 // is exported regardless of error so callers can inspect post-failure state.

--- a/tests/testutil/tfexec/driver.go
+++ b/tests/testutil/tfexec/driver.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
@@ -82,9 +83,6 @@ func PFProvider(name string, factory func() provider.Provider, rec *Recorder) Pr
 type Driver struct {
 	cwd             string
 	reattachConfigs map[string]*plugin.ReattachConfig
-	// Env is passed through to the terraform subprocess (and therefore to any
-	// provisioner shell commands) on top of os.Environ().
-	Env map[string]string
 }
 
 func init() {
@@ -160,25 +158,17 @@ func NewDriver(t *testing.T, providers []Provider) *Driver {
 // in (e.g. path.cwd) before cross-driver comparison.
 func (d *Driver) Dir() string { return d.cwd }
 
-// Apply writes the input files, runs terraform init + apply, and returns all outputs.
-// Config values are passed as -var flags to terraform apply.
+// TryApply writes the input files, runs terraform init + apply, and returns
+// all outputs, the apply's combined output (so callers can assert on
+// diagnostics, e.g. check-block warnings), and the error from `tofu apply`.
+// Config values are passed as -var flags to terraform apply. The outputs map
+// is still parsed from terraform.tfstate when the file exists, so callers can
+// inspect post-failure state.
 //
-// Apply may be called multiple times against the same Driver to drive a stack
-// across stages; previous program files are removed before the new ones are
-// written so a stage that drops a file doesn't leave the old one behind. State
-// files (terraform.tfstate*, .terraform*) are kept across applies.
-func (d *Driver) Apply(t *testing.T, input map[string]string, config map[string]string) map[string]string {
-	t.Helper()
-	outputs, _, err := d.TryApply(t, input, config)
-	require.NoError(t, err)
-	return outputs
-}
-
-// TryApply is like Apply but returns the error from `tofu apply` instead of
-// failing the test. It also returns the apply's combined output so callers can
-// assert on diagnostics (e.g. check-block warnings). The outputs map is still
-// parsed from terraform.tfstate when the file exists, so callers can inspect
-// post-failure state.
+// TryApply may be called multiple times against the same Driver to drive a
+// stack across stages; previous program files are removed before the new ones
+// are written so a stage that drops a file doesn't leave the old one behind.
+// State files (terraform.tfstate*, .terraform*) are kept across applies.
 func (d *Driver) TryApply(
 	t *testing.T, input map[string]string, config map[string]string,
 ) (map[string]string, string, error) {
@@ -250,13 +240,11 @@ func (d *Driver) Plan(t *testing.T, input map[string]string, config map[string]s
 	return err
 }
 
-// tryParseOutputs reads terraform.tfstate if it exists and returns its outputs.
-// Returns an empty map when the file is missing, so callers can use it on
-// failure paths without panicking.
-func (d *Driver) tryParseOutputs() map[string]string {
+// readStateOutputs reads terraform.tfstate and returns its outputs.
+func (d *Driver) readStateOutputs() (map[string]string, error) {
 	raw, err := os.ReadFile(filepath.Join(d.cwd, "terraform.tfstate"))
 	if err != nil {
-		return map[string]string{}
+		return nil, err
 	}
 	var state struct {
 		Outputs map[string]struct {
@@ -264,58 +252,31 @@ func (d *Driver) tryParseOutputs() map[string]string {
 		} `json:"outputs"`
 	}
 	if err := json.Unmarshal(raw, &state); err != nil {
-		return map[string]string{}
+		return nil, err
 	}
 	result := make(map[string]string, len(state.Outputs))
 	for k, v := range state.Outputs {
 		result[k] = normalizeStateOutput(v.Value)
 	}
-	return result
+	return result, nil
 }
 
-// StateResources reads terraform.tfstate and returns the list of resource
-// addresses present (e.g. "simple_resource.example"). Empty when the state
-// file is missing.
-func (d *Driver) StateResources(t *testing.T) []string {
-	t.Helper()
-	raw, err := os.ReadFile(filepath.Join(d.cwd, "terraform.tfstate"))
+// tryParseOutputs returns the state outputs, or an empty map when the state
+// file is missing or unreadable, so callers can use it on failure paths
+// without panicking.
+func (d *Driver) tryParseOutputs() map[string]string {
+	outputs, err := d.readStateOutputs()
 	if err != nil {
-		return nil
+		return map[string]string{}
 	}
-	var state struct {
-		Resources []struct {
-			Mode string `json:"mode"`
-			Type string `json:"type"`
-			Name string `json:"name"`
-		} `json:"resources"`
-	}
-	require.NoError(t, json.Unmarshal(raw, &state))
-	addrs := make([]string, 0, len(state.Resources))
-	for _, r := range state.Resources {
-		if r.Mode == "managed" {
-			addrs = append(addrs, r.Type+"."+r.Name)
-		}
-	}
-	return addrs
+	return outputs
 }
 
 func (d *Driver) parseOutputs(t *testing.T) map[string]string {
 	t.Helper()
-	raw, err := os.ReadFile(filepath.Join(d.cwd, "terraform.tfstate"))
+	outputs, err := d.readStateOutputs()
 	require.NoError(t, err)
-
-	var state struct {
-		Outputs map[string]struct {
-			Value json.RawMessage `json:"value"`
-		} `json:"outputs"`
-	}
-	require.NoError(t, json.Unmarshal(raw, &state))
-
-	result := make(map[string]string, len(state.Outputs))
-	for k, v := range state.Outputs {
-		result[k] = normalizeStateOutput(v.Value)
-	}
-	return result
+	return outputs
 }
 
 // normalizeStateOutput converts a value from terraform.tfstate to the same
@@ -396,7 +357,7 @@ func removeProgramFiles(dir string) error {
 		name := e.Name()
 		switch {
 		case name == ".terraform", name == ".terraform.lock.hcl":
-		case len(name) >= len("terraform.tfstate") && name[:len("terraform.tfstate")] == "terraform.tfstate":
+		case strings.HasPrefix(name, "terraform.tfstate"):
 		default:
 			if err := os.RemoveAll(filepath.Join(dir, name)); err != nil {
 				return err

--- a/tests/testutil/tfexec/exec.go
+++ b/tests/testutil/tfexec/exec.go
@@ -34,9 +34,6 @@ func (d *Driver) execTf(t *testing.T, args ...string) (string, error) {
 	if reattach := d.formatReattachEnvVar(); reattach != "" {
 		cmd.Env = append(cmd.Env, reattach)
 	}
-	for k, v := range d.Env {
-		cmd.Env = append(cmd.Env, k+"="+v)
-	}
 	t.Logf("%s", cmd.String())
 	err := cmd.Run()
 	if err != nil {

--- a/tests/testutil/tfexec/recorder.go
+++ b/tests/testutil/tfexec/recorder.go
@@ -74,8 +74,7 @@ func (r *Recorder) OrderedOps() []Op {
 func (r *Recorder) Ops() []Op {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	out := make([]Op, len(r.ops))
-	copy(out, r.ops)
+	out := slices.Clone(r.ops)
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Kind != out[j].Kind {
 			return out[i].Kind < out[j].Kind


### PR DESCRIPTION
A repo-wide audit for dead code and duplicated logic. Net −307 lines with no behavior change.

## Deletions (no callers, verified with `deadcode`, `golangci-lint unused`, and whole-repo greps)

- **eval.Context**: the `self` and `providers` plumbing (`SetSelf`/`ClearSelf`/`SetProvider`, both fields, and their `HCLContext`/`Clone` handling) was unreachable — provisioners bind `self` via `child.Variables`, and the `providers` map was written by nothing and never read into HCL variables. `ClearCount`/`ClearEach` were orphaned by the `WithIteration` goroutine-local refactor.
- **eval**: `UnknownValue` and `Evaluator.GetReferencedVariables` one-line wrappers.
- **transform**: `MakeSecret`/`MakeComputed` one-line wrappers over `resource.*`.
- **modulepath**: `Path.NodeKey` and `Step.Index` had no production callers; their tests now assert through `LogicalName()`, which still exercises the encode/decode roundtrip (including the >2^16 index case).
- **util**: `SyncMap.Keys`/`Delete`/`Len`.
- **testutil**: both drivers' unused `Apply` (everything drives `TryApply`), `tfexec.Driver.StateResources`, the never-assigned `tfexec.Driver.Env` field, and the never-read `ReadResourceHandler`/`Warnings` fields on `MockResourceMonitor`.

## Consolidations

- **codegen**: `extractStringLiteralFromCallArg` duplicated the more general `extractStringLiteral`.
- **converter**: both `computeNameRewrites` passes share a new `blockLogicalName` helper; `sortedKeys` is now `slices.Sorted(maps.Keys(m))`.
- **server**: `customTimeoutsToProto` reuses `formatTimeoutSeconds` — the duplicate closure truncated fractional seconds (`time.Duration(seconds) * time.Second`), the shared helper doesn't; `dedupeEdges` sorts via `slices.SortFunc` + `cmp.Or`; `packArchive` drops its never-used in-memory-file support.
- **tfexec**: `parseOutputs`/`tryParseOutputs` share a single `readStateOutputs`; the hand-rolled `terraform.tfstate` prefix check is `strings.HasPrefix`.

Kept: `SkipRequiredProvidersVersion` in `pkg/codegen` — it has an external consumer.

No changelog fragment: internal-only, nothing user-visible changes.