### PR TITLE
Decode constant block attributes strictly

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-405.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-405.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Error on wrongly-typed constant attributes (`sensitive`, `nullable`, `description`, `alias`, `source`, `version`, lifecycle flags) instead of silently ignoring them
+time: 2026-07-16T13:30:00Z
+custom:
+    Component: runtime
+    PR: "405"

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -254,34 +254,28 @@ func (p *Parser) parseTerraformComponentBlock(block *hcl.Block) (*ast.ComponentB
 	}
 
 	if attr, ok := content.Attributes["name"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &comp.Name)
 		diags = append(diags, valDiags...)
-		if val.Type() == cty.String {
-			comp.Name = val.AsString()
-			if !tokens.IsName(comp.Name) {
-				diags = append(diags, &hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Invalid component name",
-					Detail:   fmt.Sprintf("%q is not a valid Pulumi name.", comp.Name),
-					Subject:  attr.Expr.Range().Ptr(),
-				})
-			}
+		if !valDiags.HasErrors() && !tokens.IsName(comp.Name) {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid component name",
+				Detail:   fmt.Sprintf("%q is not a valid Pulumi name.", comp.Name),
+				Subject:  attr.Expr.Range().Ptr(),
+			})
 		}
 	}
 
 	if attr, ok := content.Attributes["module"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &comp.Module)
 		diags = append(diags, valDiags...)
-		if val.Type() == cty.String {
-			comp.Module = val.AsString()
-			if !tokens.IsName(comp.Module) {
-				diags = append(diags, &hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Invalid component module",
-					Detail:   fmt.Sprintf("%q is not a valid Pulumi name.", comp.Module),
-					Subject:  attr.Expr.Range().Ptr(),
-				})
-			}
+		if !valDiags.HasErrors() && !tokens.IsName(comp.Module) {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid component module",
+				Detail:   fmt.Sprintf("%q is not a valid Pulumi name.", comp.Module),
+				Subject:  attr.Expr.Range().Ptr(),
+			})
 		}
 	}
 
@@ -298,26 +292,22 @@ func (p *Parser) parseTerraformPackageBlock(block *hcl.Block) (*ast.PackageBlock
 	}
 
 	if attr, ok := content.Attributes["name"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &pkg.Name)
 		diags = append(diags, valDiags...)
-		if val.Type() == cty.String {
-			pkg.Name = val.AsString()
-			if !tokens.IsName(pkg.Name) {
-				diags = append(diags, &hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Invalid package name",
-					Detail:   fmt.Sprintf("%q is not a valid Pulumi name.", pkg.Name),
-					Subject:  attr.Expr.Range().Ptr(),
-				})
-			}
+		if !valDiags.HasErrors() && !tokens.IsName(pkg.Name) {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid package name",
+				Detail:   fmt.Sprintf("%q is not a valid Pulumi name.", pkg.Name),
+				Subject:  attr.Expr.Range().Ptr(),
+			})
 		}
 	}
 
 	if attr, ok := content.Attributes["version"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &pkg.Version)
 		diags = append(diags, valDiags...)
-		if val.Type() == cty.String {
-			pkg.Version = val.AsString()
+		if !valDiags.HasErrors() {
 			if _, err := semver.Parse(pkg.Version); err != nil {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
@@ -370,27 +360,15 @@ func (p *Parser) parseRequiredProviders(tf *ast.Terraform, block *hcl.Block) hcl
 				kw := hcl.ExprAsKeyword(pair.Key)
 				switch kw {
 				case "source":
-					v, vd := pair.Value.Value(nil)
-					diags = append(diags, vd...)
-					if v.Type() == cty.String && !v.IsNull() {
-						provider.Source = v.AsString()
-					}
+					diags = append(diags, gohcl.DecodeExpression(pair.Value, nil, &provider.Source)...)
 				case "version":
-					v, vd := pair.Value.Value(nil)
-					diags = append(diags, vd...)
-					if v.Type() == cty.String && !v.IsNull() {
-						provider.Version = v.AsString()
-					}
+					diags = append(diags, gohcl.DecodeExpression(pair.Value, nil, &provider.Version)...)
 				case "configuration_aliases":
 					// Accept and ignore — see comment above.
 				}
 			}
 		} else {
-			val, valDiags := attr.Expr.Value(nil)
-			diags = append(diags, valDiags...)
-			if val.Type() == cty.String {
-				provider.Version = val.AsString()
-			}
+			diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &provider.Version)...)
 		}
 
 		// Pulumi providers don't go through TF-style constraint resolution, so
@@ -440,11 +418,7 @@ func (p *Parser) parseProviderBlock(config *ast.Config, block *hcl.Block) hcl.Di
 	}
 
 	if attr, ok := content.Attributes["alias"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.String {
-			provider.Alias = val.AsString()
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &provider.Alias)...)
 	}
 	if attr, ok := content.Attributes["for_each"]; ok {
 		provider.ForEach = attr.Expr
@@ -540,19 +514,11 @@ func (p *Parser) parseVariableBlock(config *ast.Config, block *hcl.Block) hcl.Di
 	}
 
 	if attr, ok := content.Attributes["description"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.String {
-			variable.Description = val.AsString()
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &variable.Description)...)
 	}
 
 	if attr, ok := content.Attributes["sensitive"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.Bool {
-			variable.Sensitive = val.True()
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &variable.Sensitive)...)
 	}
 
 	if attr, ok := content.Attributes["ephemeral"]; ok {
@@ -560,11 +526,7 @@ func (p *Parser) parseVariableBlock(config *ast.Config, block *hcl.Block) hcl.Di
 	}
 
 	if attr, ok := content.Attributes["nullable"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.Bool {
-			variable.Nullable = val.True()
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &variable.Nullable)...)
 	}
 
 	for _, subBlock := range content.Blocks {
@@ -844,11 +806,7 @@ func (p *Parser) parsePulumiResourceOptions(block *hcl.Block, resource *ast.Reso
 	}
 
 	if attr, ok := content.Attributes["import_id"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.String {
-			resource.ImportID = val.AsString()
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &resource.ImportID)...)
 	}
 
 	if attr, ok := content.Attributes["env_var_mappings"]; ok {
@@ -886,19 +844,20 @@ func (p *Parser) parseLifecycleBlock(block *hcl.Block) (*lifecycleResult, hcl.Di
 	}
 
 	if attr, ok := content.Attributes["create_before_destroy"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
+		var b bool
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &b)
 		diags = append(diags, valDiags...)
-		if val.Type() == cty.Bool {
-			b := val.True()
+		if !valDiags.HasErrors() {
 			lifecycle.CreateBeforeDestroy = &b
 		}
 	}
 
 	if attr, ok := content.Attributes["prevent_destroy"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
+		var b bool
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &b)
 		diags = append(diags, valDiags...)
-		if val.Type() == cty.Bool {
-			lifecycle.PreventDestroy = ptr(val.True())
+		if !valDiags.HasErrors() {
+			lifecycle.PreventDestroy = &b
 		}
 	}
 
@@ -966,11 +925,7 @@ func (p *Parser) parseConnectionBlock(block *hcl.Block) (*ast.Connection, hcl.Di
 	}
 
 	if attr, ok := content.Attributes["type"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.String {
-			conn.Type = val.AsString()
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &conn.Type)...)
 	}
 
 	if conn.Type == "" {
@@ -1106,19 +1061,11 @@ func (p *Parser) parseOutputBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	}
 
 	if attr, ok := content.Attributes["description"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.String {
-			output.Description = val.AsString()
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &output.Description)...)
 	}
 
 	if attr, ok := content.Attributes["sensitive"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.Bool {
-			output.Sensitive = val.True()
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &output.Sensitive)...)
 	}
 
 	if attr, ok := content.Attributes["ephemeral"]; ok {
@@ -1262,19 +1209,11 @@ func (p *Parser) parseModuleBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	}
 
 	if attr, ok := content.Attributes["source"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.String {
-			module.Source = val.AsString()
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &module.Source)...)
 	}
 
 	if attr, ok := content.Attributes["version"]; ok {
-		val, valDiags := attr.Expr.Value(nil)
-		diags = append(diags, valDiags...)
-		if val.Type() == cty.String {
-			module.Version = val.AsString()
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &module.Version)...)
 	}
 
 	if attr, ok := content.Attributes["count"]; ok {
@@ -1453,4 +1392,3 @@ func (p *Parser) parseImportBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	return diags
 }
 
-func ptr[T any](v T) *T { return &v }

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -1381,4 +1381,3 @@ func (p *Parser) parseImportBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	config.Imports = append(config.Imports, imp)
 	return diags
 }
-

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -844,21 +844,11 @@ func (p *Parser) parseLifecycleBlock(block *hcl.Block) (*lifecycleResult, hcl.Di
 	}
 
 	if attr, ok := content.Attributes["create_before_destroy"]; ok {
-		var b bool
-		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &b)
-		diags = append(diags, valDiags...)
-		if !valDiags.HasErrors() {
-			lifecycle.CreateBeforeDestroy = &b
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &lifecycle.CreateBeforeDestroy)...)
 	}
 
 	if attr, ok := content.Attributes["prevent_destroy"]; ok {
-		var b bool
-		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &b)
-		diags = append(diags, valDiags...)
-		if !valDiags.HasErrors() {
-			lifecycle.PreventDestroy = &b
-		}
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &lifecycle.PreventDestroy)...)
 	}
 
 	if attr, ok := content.Attributes["ignore_changes"]; ok {

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -845,6 +845,61 @@ variable "token" {
 	assert.True(t, config.Variables["token"].Ephemeral)
 }
 
+// TestParseConstantAttributeTypes pins that constant-valued block attributes
+// are decoded strictly: a value of the wrong type is a hard error rather than
+// being silently ignored, and a value convertible to the target type (e.g.
+// "true" for a bool) is accepted.
+func TestParseConstantAttributeTypes(t *testing.T) {
+	t.Parallel()
+
+	errCases := map[string]string{
+		"variable sensitive":       `variable "v" { sensitive = "yes" }`,
+		"variable nullable":        `variable "v" { nullable = "yes" }`,
+		"variable description":     `variable "v" { description = ["x"] }`,
+		"output sensitive":         `output "o" { value = "v", sensitive = 3 }`,
+		"output description":       `output "o" { value = "v", description = {} }`,
+		"lifecycle cbd":            `resource "r" "r" { lifecycle { create_before_destroy = "x" } }`,
+		"lifecycle prevent":        `resource "r" "r" { lifecycle { prevent_destroy = [true] } }`,
+		"provider alias":           `provider "p" { alias = ["a"] }`,
+		"module source":            `module "m" { source = ["./m"] }`,
+		"required_providers src":   `terraform { required_providers { p = { source = ["x"] } } }`,
+		"connection type":          `resource "r" "r" { connection { type = ["ssh"] } }`,
+		"component name":           `terraform { component { name = ["C"] } }`,
+		"package version non-str":  `terraform { package { name = "p", version = ["1"] } }`,
+		"resource pulumi importId": `resource "r" "r" { pulumi { import_id = ["i"] } }`,
+	}
+	for name, src := range errCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, diags := NewParser().ParseSource("test.tf", []byte(src))
+			require.True(t, diags.HasErrors(), "expected a type error for: %s", src)
+		})
+	}
+
+	// Values convertible to the target type are accepted, and site-specific
+	// validation still runs on the decoded value.
+	config, diags := NewParser().ParseSource("test.tf", []byte(`
+variable "v" {
+  sensitive = "true"
+  nullable  = "false"
+}
+`))
+	require.False(t, diags.HasErrors(), "unexpected errors: %v", diags.Errs())
+	assert.True(t, config.Variables["v"].Sensitive)
+	assert.False(t, config.Variables["v"].Nullable)
+
+	_, diags = NewParser().ParseSource("test.tf", []byte(`
+terraform {
+  package {
+    name    = "pkg"
+    version = "not-semver"
+  }
+}
+`))
+	require.True(t, diags.HasErrors())
+	assert.Equal(t, "Invalid package version", diags[0].Summary)
+}
+
 func TestParseProviderForEach(t *testing.T) {
 	t.Parallel()
 	src := []byte(`


### PR DESCRIPTION
## What

Constant-valued block attributes were parsed with a silent type guard: a wrongly-typed value was ignored and the attribute dropped, no diagnostic. The worst case inverts intent — `sensitive = "yes"` silently produced a **non-secret** value, and a failed `nullable` decode silently left the default `true`.

All of these sites now decode with `gohcl.DecodeExpression` — the same decoding OpenTofu uses — so a wrongly-typed value is a hard error and a convertible one is accepted (`sensitive = "true"` works, matching OpenTofu):

- `variable`: `sensitive`, `nullable`, `description`
- `output`: `sensitive`, `description`
- `lifecycle`: `create_before_destroy`, `prevent_destroy`
- `provider`: `alias`; `required_providers` `source`/`version` (both object and bare-string forms)
- `module`: `source`, `version`
- `connection`: `type`
- Pulumi-specific: `component`/`package` `name`/`module`/`version`, `import_id`

Site-specific validation is preserved and now runs on the decoded value: Pulumi name checks (`component`/`package`), semver checks (`package version`, Pulumi provider versions), and the `connection` `ssh` default.

Follow-up promised in https://github.com/pulumi-labs/pulumi-hcl/pull/402, which converted `ephemeral` to this decoding.

## Tests

`TestParseConstantAttributeTypes` — table of wrong-type error cases across every converted site, plus conversion acceptance (`sensitive = "true"`, `nullable = "false"`) and decoded-value validation (`package version` semver error).