### PR TITLE
Bump pulumi-terraform to v6.1.0 to preserve null-valued remote-state outputs

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-407.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-407.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Preserve null-valued `terraform_remote_state` outputs
+time: 2026-07-21T10:05:00Z
+custom:
+    Component: runtime
+    PR: "407"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: opentofu/setup-opentofu@v2
       # terraform_remote_state lowers to the pulumi-terraform getLocalReference
       # invoke; the tfcompat harness disables plugin acquisition, so pre-install it.
-      - run: pulumi plugin install resource terraform 6.0.2
+      - run: pulumi plugin install resource terraform 6.1.0
       - run: pulumi plugin install resource terraform-provider 1.2.1
       - run: pulumi plugin install resource local 0.1.6
       - run: make bin/pulumi-language-hcl bin/pulumi-converter-hcl bin/pulumi-resource-hcl

--- a/pkg/hcl/run/terraform_remote_state.go
+++ b/pkg/hcl/run/terraform_remote_state.go
@@ -29,7 +29,7 @@ const (
 	// TerraformStatePackage / TerraformStatePackageVersion is the external
 	// pulumi-terraform package that provides the state-reference invokes.
 	TerraformStatePackage        = "terraform"
-	TerraformStatePackageVersion = "6.0.2"
+	TerraformStatePackageVersion = "6.1.0"
 )
 
 // lowerRemoteStateInvoke rewrites a terraform_remote_state invoke into the matching

--- a/tests/tfcompat/l2_remote_state_null_output_test.go
+++ b/tests/tfcompat/l2_remote_state_null_output_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL2RemoteStateNullOutput reads a terraform_remote_state whose state stores
+// a null-valued output (typed string). OpenTofu preserves the null output, so
+// the outputs object keeps the `nullstr` key with a null value. Both paths must
+// agree on the rendered outputs object.
+func TestL2RemoteStateNullOutput(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_remote_state_null_output", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_remote_state_null_output/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_remote_state_null_output/main.tf
@@ -1,0 +1,15 @@
+# The referenced state stores an output whose value is null (typed string).
+# OpenTofu preserves null outputs: referencing the outputs object keeps the
+# `nullstr` key with a null value, so jsonencode renders it as `"nullstr":null`.
+data "terraform_remote_state" "rs" {
+  backend = "local"
+  config = {
+    path = "remote.tfstate"
+  }
+}
+
+# jsonencode the whole outputs object so the presence of the null-valued output
+# is observable without referencing (and erroring on) a possibly-absent key.
+output "outputs_json" {
+  value = jsonencode(data.terraform_remote_state.rs.outputs)
+}

--- a/tests/tfcompat/testdata/cases/l2_remote_state_null_output/remote.tfstate
+++ b/tests/tfcompat/testdata/cases/l2_remote_state_null_output/remote.tfstate
@@ -1,0 +1,12 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 1,
+  "lineage": "3d6f6d7b-4429-46cb-d10f-10ab291859f7",
+  "outputs": {
+    "greeting": { "value": "hello", "type": "string" },
+    "nullstr":  { "value": null, "type": "string" }
+  },
+  "resources": [],
+  "check_results": null
+}


### PR DESCRIPTION
## Problem

A `terraform_remote_state` (local backend) whose stored state contains a
null-valued output diverged between the runtimes:

- **OpenTofu** preserves the null output — the `outputs` object keeps the key with a null value.
- **pulumi-hcl** dropped it entirely — a direct reference errored with `This object does not have an attribute named "nullstr"`, and `jsonencode(outputs)` omitted the key.

```
OpenTofu:   {"greeting":"hello","nullstr":null}
pulumi-hcl: {"greeting":"hello"}
```

The drop happened in `pulumi-terraform`'s state-reference invokes, not in this
repo. It is fixed upstream in
[pulumi/pulumi-terraform v6.1.0](https://github.com/pulumi/pulumi-terraform/releases/tag/v6.1.0).

## Change

- Bump `TerraformStatePackageVersion` from `6.0.2` to `6.1.0` (and the matching
  `pulumi plugin install` pin in `.github/workflows/ci.yml`).
- Add `TestL2RemoteStateNullOutput` (`tests/tfcompat/l2_remote_state_null_output_test.go`
  plus a checked-in `remote.tfstate` fixture) to lock the behaviour in.

The test fails deterministically on the `6.0.2` pin and passes on `6.1.0`.