### PR TITLE
Report every failing precondition and postcondition, not just the first

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-409.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-409.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Report every failing `precondition` and `postcondition`, not just the first
+time: 2026-07-18T00:00:00Z
+custom:
+    Component: runtime
+    PR: "409"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -3183,10 +3183,8 @@ func (e *Engine) invokeDataSourceOnce(
 	hclCtx := evalCtx.HCLContext()
 
 	// Failed preconditions prevent the read; unknown conditions defer.
-	for i, rule := range ds.Preconditions {
-		if err := evaluatePrecondition(rule, hclCtx, i+1, node.Key); err != nil {
-			return cty.NilVal, err
-		}
+	if err := evaluatePreconditions(ds.Preconditions, hclCtx, node.Key); err != nil {
+		return cty.NilVal, err
 	}
 
 	depMarks := cty.ValueMarks{}
@@ -3303,10 +3301,8 @@ func (e *Engine) invokeDataSourceOnce(
 		return cty.NilVal, fmt.Errorf("converting function outputs to HCL types: %w", err)
 	}
 
-	for i, rule := range ds.Postconditions {
-		if err := evaluatePostconditionValue(rule, hclCtx, ctyOutputs, i+1, node.Key); err != nil {
-			return cty.NilVal, err
-		}
+	if err := evaluatePostconditionValues(ds.Postconditions, hclCtx, ctyOutputs, node.Key); err != nil {
+		return cty.NilVal, err
 	}
 
 	return ctyOutputs.WithMarks(depMarks), nil
@@ -4336,8 +4332,10 @@ func provisionerDeps(res *ast.Resource, hclCtx *hcl.EvalContext) []string {
 	return deps
 }
 
-// bindPreconditionHooks registers a hook per precondition and binds it to
-// BeforeCreate/BeforeUpdate so a false condition blocks the operation.
+// bindPreconditionHooks registers a single hook that evaluates every
+// precondition and binds it to BeforeCreate/BeforeUpdate so a false condition
+// blocks the operation. All rules are evaluated in one hook because the engine
+// stops at the first failing hook, while every failing rule must be reported.
 //
 // The HCL eval context is snapshotted at registration so the async callback
 // sees the per-instance count/each/self that was in scope here — by the time
@@ -4353,32 +4351,34 @@ func (e *Engine) bindPreconditionHooks(
 	opts *ResourceOptions,
 	resourceName string,
 ) error {
+	if len(res.Preconditions) == 0 {
+		return nil
+	}
 	if opts.Hooks == nil {
 		opts.Hooks = &ResourceHookBinding{}
 	}
 	hclSnapshot := evalCtx.HCLContext()
-	for i, rule := range res.Preconditions {
-		rule, index := rule, i+1
-		hookName := fmt.Sprintf("%s.%s:precondition:%d", res.Type, resourceName, i)
-		callback := func(_ context.Context, _ *ResourceHookArgs) error {
-			return evaluatePrecondition(rule, hclSnapshot, index, instance.Key)
-		}
-		if err := e.resmon.RegisterResourceHook(ctx, hookName, callback, ResourceHookOptions{
-			OnDryRun: true,
-		}); err != nil {
-			return fmt.Errorf("registering precondition hook: %w", err)
-		}
-		opts.Hooks.BeforeCreate = append(opts.Hooks.BeforeCreate, hookName)
-		opts.Hooks.BeforeUpdate = append(opts.Hooks.BeforeUpdate, hookName)
+	hookName := fmt.Sprintf("%s.%s:precondition", res.Type, resourceName)
+	callback := func(_ context.Context, _ *ResourceHookArgs) error {
+		return evaluatePreconditions(res.Preconditions, hclSnapshot, instance.Key)
 	}
+	if err := e.resmon.RegisterResourceHook(ctx, hookName, callback, ResourceHookOptions{
+		OnDryRun: true,
+	}); err != nil {
+		return fmt.Errorf("registering precondition hook: %w", err)
+	}
+	opts.Hooks.BeforeCreate = append(opts.Hooks.BeforeCreate, hookName)
+	opts.Hooks.BeforeUpdate = append(opts.Hooks.BeforeUpdate, hookName)
 	return nil
 }
 
-// bindPostconditionHooks registers a hook per postcondition and binds it to
-// AfterCreate/AfterUpdate. The hook fires after the resource is created or
-// updated; the engine supplies the resource's new outputs as `self` in the
-// callback. Failed postconditions surface as deployment errors but do not
-// unwind the resource registration — same as TF.
+// bindPostconditionHooks registers a single hook that evaluates every
+// postcondition and binds it to AfterCreate/AfterUpdate. The hook fires after
+// the resource is created or updated; the engine supplies the resource's new
+// outputs as `self` in the callback. All rules are evaluated in one hook
+// because the engine stops at the first failing hook, while every failing rule
+// must be reported. Failed postconditions surface as deployment errors but do
+// not unwind the resource registration — same as TF.
 func (e *Engine) bindPostconditionHooks(
 	ctx context.Context,
 	res *ast.Resource,
@@ -4389,46 +4389,59 @@ func (e *Engine) bindPostconditionHooks(
 	opts *ResourceOptions,
 	resourceName string,
 ) error {
+	if len(res.Postconditions) == 0 {
+		return nil
+	}
 	if opts.Hooks == nil {
 		opts.Hooks = &ResourceHookBinding{}
 	}
 	hclSnapshot := evalCtx.HCLContext()
 	dryRun := e.dryRun
-	for i, rule := range res.Postconditions {
-		rule, index := rule, i+1
-		hookName := fmt.Sprintf("%s.%s:postcondition:%d", res.Type, resourceName, i)
-		callback := func(_ context.Context, args *ResourceHookArgs) error {
-			// Hooks receive raw engine outputs, so terraform_data's surface is
-			// adapted the same way as on the registration path: property-level
-			// lowering here, wrapper unboxing after re-expansion.
-			outputs := lowerTerraformDataOutputs(res.Type, args.NewOutputs, opts)
-			return evaluatePostcondition(rule, hclSnapshot, outputs, res.Type, resSchema, mapping, dryRun, index, instance.Key)
-		}
-		if err := e.resmon.RegisterResourceHook(ctx, hookName, callback, ResourceHookOptions{
-			OnDryRun: true,
-		}); err != nil {
-			return fmt.Errorf("registering postcondition hook: %w", err)
-		}
-		opts.Hooks.AfterCreate = append(opts.Hooks.AfterCreate, hookName)
-		opts.Hooks.AfterUpdate = append(opts.Hooks.AfterUpdate, hookName)
+	hookName := fmt.Sprintf("%s.%s:postcondition", res.Type, resourceName)
+	callback := func(_ context.Context, args *ResourceHookArgs) error {
+		// Hooks receive raw engine outputs, so terraform_data's surface is
+		// adapted the same way as on the registration path: property-level
+		// lowering here, wrapper unboxing after re-expansion.
+		outputs := lowerTerraformDataOutputs(res.Type, args.NewOutputs, opts)
+		return evaluatePostconditions(res.Postconditions, hclSnapshot, outputs, res.Type, resSchema, mapping, dryRun, instance.Key)
 	}
+	if err := e.resmon.RegisterResourceHook(ctx, hookName, callback, ResourceHookOptions{
+		OnDryRun: true,
+	}); err != nil {
+		return fmt.Errorf("registering postcondition hook: %w", err)
+	}
+	opts.Hooks.AfterCreate = append(opts.Hooks.AfterCreate, hookName)
+	opts.Hooks.AfterUpdate = append(opts.Hooks.AfterUpdate, hookName)
 	return nil
 }
 
-// evaluatePostcondition evaluates a postcondition with `self` bound to the
-// engine-supplied NewOutputs.
-func evaluatePostcondition(
-	rule *ast.CheckRule, hclCtx *hcl.EvalContext, newOutputs property.Map, tfType string,
-	resSchema *schema.Resource, mapping *bridge.BodyMapping, dryRun bool, index int, resourceName string,
+// evaluatePostconditions evaluates every postcondition with `self` bound to
+// the engine-supplied NewOutputs, joining the failures so every failing rule
+// is reported.
+func evaluatePostconditions(
+	rules []*ast.CheckRule, hclCtx *hcl.EvalContext, newOutputs property.Map, tfType string,
+	resSchema *schema.Resource, mapping *bridge.BodyMapping, dryRun bool, resourceName string,
 ) error {
 	outputObj, err := transform.ResourceOutputToCty(newOutputs, resSchema, mapping, dryRun)
 	if err != nil {
-		return fmt.Errorf("converting outputs for postcondition %d on %s: %w", index, resourceName, err)
+		return fmt.Errorf("converting outputs for postconditions on %s: %w", resourceName, err)
 	}
 	if err := unwrapTerraformDataOutputs(tfType, outputObj, newOutputs); err != nil {
-		return fmt.Errorf("converting outputs for postcondition %d on %s: %w", index, resourceName, err)
+		return fmt.Errorf("converting outputs for postconditions on %s: %w", resourceName, err)
 	}
-	return evaluatePostconditionValue(rule, hclCtx, cty.ObjectVal(outputObj), index, resourceName)
+	return evaluatePostconditionValues(rules, hclCtx, cty.ObjectVal(outputObj), resourceName)
+}
+
+// evaluatePostconditionValues evaluates every postcondition with `self` bound
+// to the given value, joining the failures so every failing rule is reported.
+func evaluatePostconditionValues(
+	rules []*ast.CheckRule, hclCtx *hcl.EvalContext, self cty.Value, resourceName string,
+) error {
+	var errs []error
+	for i, rule := range rules {
+		errs = append(errs, evaluatePostconditionValue(rule, hclCtx, self, i+1, resourceName))
+	}
+	return errors.Join(errs...)
 }
 
 // evaluatePostconditionValue evaluates a postcondition with `self` bound to
@@ -4482,15 +4495,20 @@ func conditionResultToBool(v cty.Value) (bool, error) {
 }
 
 // runOutputPreconditions evaluates an output's `precondition` rules against
-// hclCtx and returns an error for the first rule whose condition is known and
-// false; unknown conditions are deferred.
+// hclCtx, reporting every rule whose condition is known and false; unknown
+// conditions are deferred.
 func runOutputPreconditions(output *ast.Output, hclCtx *hcl.EvalContext, name string) error {
-	for i, rule := range output.Preconditions {
-		if err := evaluatePrecondition(rule, hclCtx, i+1, fmt.Sprintf("output %q", name)); err != nil {
-			return err
-		}
+	return evaluatePreconditions(output.Preconditions, hclCtx, fmt.Sprintf("output %q", name))
+}
+
+// evaluatePreconditions evaluates every rule and joins the failures so every
+// failing rule is reported, not just the first.
+func evaluatePreconditions(rules []*ast.CheckRule, hclCtx *hcl.EvalContext, resourceName string) error {
+	var errs []error
+	for i, rule := range rules {
+		errs = append(errs, evaluatePrecondition(rule, hclCtx, i+1, resourceName))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // evaluatePrecondition returns nil when the rule holds or its condition is

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -2036,6 +2036,94 @@ resource "test_resource" "res" {
 	})
 }
 
+func TestEngine_Precondition_MultipleFailures(t *testing.T) {
+	t.Parallel()
+
+	// When several check rules fail, every failing rule's message is reported,
+	// not just the first.
+	runProgram := func(t *testing.T, src string) error {
+		t.Helper()
+		p := parser.NewParser()
+		config, diags := p.ParseSource("test.hcl", []byte(src))
+		require.False(t, diags.HasErrors(), diags.Error())
+
+		engine := newTestEngine(t, config, &run.EngineOptions{
+			ModuleLoader:    testModuleLoader(t),
+			ProjectName:     "test-project",
+			StackName:       "dev",
+			ResourceMonitor: &testutil.MockResourceMonitor{},
+			WorkDir:         t.TempDir(),
+			RootDir:         t.TempDir(),
+			SchemaLoader:    schemaloader.New(t, testSchema()),
+		})
+		return engine.Run(t.Context())
+	}
+
+	t.Run("preconditions", func(t *testing.T) {
+		t.Parallel()
+		err := runProgram(t, `
+resource "test_resource" "res" {
+  field = "x"
+
+  lifecycle {
+    precondition {
+      condition     = 1 > 5
+      error_message = "FIRST_RULE_FAILED"
+    }
+    precondition {
+      condition     = 1 > 10
+      error_message = "SECOND_RULE_FAILED"
+    }
+  }
+}
+`)
+		require.ErrorContains(t, err, "FIRST_RULE_FAILED")
+		require.ErrorContains(t, err, "SECOND_RULE_FAILED")
+	})
+
+	t.Run("postconditions", func(t *testing.T) {
+		t.Parallel()
+		err := runProgram(t, `
+resource "test_resource" "res" {
+  field = "x"
+
+  lifecycle {
+    postcondition {
+      condition     = self.field == "a"
+      error_message = "FIRST_RULE_FAILED"
+    }
+    postcondition {
+      condition     = self.field == "b"
+      error_message = "SECOND_RULE_FAILED"
+    }
+  }
+}
+`)
+		require.ErrorContains(t, err, "FIRST_RULE_FAILED")
+		require.ErrorContains(t, err, "SECOND_RULE_FAILED")
+	})
+
+	t.Run("output preconditions", func(t *testing.T) {
+		t.Parallel()
+		err := runProgram(t, `
+output "result" {
+  value = "x"
+
+  precondition {
+    condition     = 1 > 5
+    error_message = "FIRST_RULE_FAILED"
+  }
+  precondition {
+    condition     = 1 > 10
+    error_message = "SECOND_RULE_FAILED"
+  }
+}
+`)
+		require.ErrorContains(t, err, "FIRST_RULE_FAILED")
+		require.ErrorContains(t, err, "SECOND_RULE_FAILED")
+	})
+}
+
 func TestEngine_Precondition_SensitiveErrorMessage(t *testing.T) {
 	t.Parallel()
 

--- a/tests/tfcompat/l2_precondition_multiple_fail_test.go
+++ b/tests/tfcompat/l2_precondition_multiple_fail_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2Precondition_MultipleFail asserts that when a resource has several
+// preconditions and more than one fails, both runtimes report every failing
+// rule. OpenTofu evaluates all precondition rules and aggregates their
+// diagnostics; pulumi-hcl registers each rule as an independent resource hook
+// and aborts on the first failure, so it only surfaces the first message.
+func TestL2Precondition_MultipleFail(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_precondition_multiple_fail", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{
+			ExpectErr: "PRECOND_TWO_FAILS",
+		}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_precondition_multiple_fail/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_precondition_multiple_fail/main.tf
@@ -1,0 +1,19 @@
+variable "x" {
+  type    = number
+  default = 1
+}
+
+resource "simple_resource" "guarded" {
+  input_one = "hi"
+
+  lifecycle {
+    precondition {
+      condition     = var.x > 5
+      error_message = "PRECOND_ONE_FAILS"
+    }
+    precondition {
+      condition     = var.x > 10
+      error_message = "PRECOND_TWO_FAILS"
+    }
+  }
+}


### PR DESCRIPTION
## Divergence

When a resource has multiple `precondition` rules and more than one fails:

- **OpenTofu** evaluates every rule and reports all failing `error_message`s.
- **pulumi-hcl** registered each rule as its own Pulumi resource hook; the engine stops at the first failing hook, so only the first message surfaced.

## Fix

`bindPreconditionHooks` and `bindPostconditionHooks` now register a single hook per resource whose callback evaluates every rule and joins the failures with `errors.Join`, so all failing rules are reported.

The same first-error pattern existed at the sibling sites and is fixed the same way:

- data-source preconditions and postconditions (`invokeDataSourceOnce`)
- output preconditions (`runOutputPreconditions`)

## Tests

- `TestL2Precondition_MultipleFail` (tfcompat, added on this branch) — fails on master, passes with the fix.
- `TestEngine_Precondition_MultipleFailures` (unit) — resource preconditions, resource postconditions, and output preconditions each report every failing rule.
- All existing condition-related unit and tfcompat tests pass.