### PR TITLE
Support the `_` meta-argument escaping block

### DIFF
--- a/.changes/unreleased/runtime-Improvements-410.yaml
+++ b/.changes/unreleased/runtime-Improvements-410.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Support the `_` meta-argument escaping block in `resource`, `data`, `provider`, `module`, and `provisioner` blocks
+time: 2026-07-16T15:30:00Z
+custom:
+    Component: runtime
+    PR: "410"

--- a/pkg/hcl/ast/escape.go
+++ b/pkg/hcl/ast/escape.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import "github.com/hashicorp/hcl/v2"
+
+// EscapedBody is a block body merged with the contents of its `_` escaping
+// block, whose arguments are always interpreted as block-type-specific even
+// when their names collide with meta-arguments. The embedded Body carries the
+// merge (hcl.MergeBodies), which hides the native syntax tree; Base and
+// Escape keep the underlying bodies reachable for callers that walk
+// *hclsyntax.Body directly (dependency scanning).
+type EscapedBody struct {
+	hcl.Body
+
+	Base   hcl.Body // the block's own body, minus recognized meta-arguments
+	Escape hcl.Body // the `_` block's body
+}

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -819,6 +819,12 @@ func (g *Graph) providerDeps(provider *ast.Provider, key, prefix string) []pdag.
 
 // bodyDeps extracts dependencies from an HCL body, applying prefix to resolved keys.
 func (g *Graph) bodyDeps(body hcl.Body, prefix string, exclude map[string]bool) []pdag.Node {
+	if eb, ok := body.(*ast.EscapedBody); ok {
+		// Scan the underlying bodies so the native-syntax walk below still
+		// sees dynamic and lifecycle blocks; the merged body hides them.
+		return append(g.bodyDeps(eb.Base, prefix, exclude), g.bodyDeps(eb.Escape, prefix, exclude)...)
+	}
+
 	seen := make(map[pdag.Node]bool)
 
 	attrs, _ := body.JustAttributes()

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -411,9 +411,12 @@ func (p *Parser) parseProviderBlock(config *ast.Config, block *hcl.Block) hcl.Di
 	content, remain, contentDiags := block.Body.PartialContent(providerSchema)
 	diags = append(diags, contentDiags...)
 
+	providerConfig, escDiags := mergeEscapeBlock(remain, content.Blocks, "provider-specific", "provider")
+	diags = append(diags, escDiags...)
+
 	provider := &ast.Provider{
 		Name:      block.Labels[0],
-		Config:    remain,
+		Config:    providerConfig,
 		DeclRange: block.DefRange,
 	}
 
@@ -646,10 +649,17 @@ func (p *Parser) decodeResourceBlock(block *hcl.Block, isDataSource bool) (*ast.
 	content, remain, contentDiags := block.Body.PartialContent(resourceSchema)
 	diags = append(diags, contentDiags...)
 
+	blockKind := "resource"
+	if isDataSource {
+		blockKind = "data"
+	}
+	config, escDiags := mergeEscapeBlock(remain, content.Blocks, "resource-type-specific", blockKind)
+	diags = append(diags, escDiags...)
+
 	resource := &ast.Resource{
 		Type:         resourceType,
 		Name:         name,
-		Config:       remain,
+		Config:       config,
 		DeclRange:    block.DefRange,
 		TypeRange:    block.LabelRanges[0],
 		IsDataSource: isDataSource,
@@ -942,13 +952,50 @@ func exprAsKeywordOrString(expr hcl.Expression) string {
 	return val.AsString()
 }
 
+// mergeEscapeBlock merges the special `_` escaping block (if any in blocks)
+// into config, so arguments whose names collide with meta-arguments can still
+// be written unambiguously. what and blockKind fill the duplicate-block error
+// message: arguments in the escaping block are interpreted as <what>, and each
+// <blockKind> block allows only one escaping block.
+func mergeEscapeBlock(config hcl.Body, blocks hcl.Blocks, what, blockKind string) (hcl.Body, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	var seen *hcl.Block
+	for _, block := range blocks {
+		if block.Type != "_" {
+			continue
+		}
+		if seen != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Duplicate escaping block",
+				Detail: fmt.Sprintf(
+					"The special block type \"_\" can be used to force particular arguments to be interpreted as %s rather than as meta-arguments, but each %s block can have only one such block. The first escaping block was at %s.",
+					what, blockKind, seen.DefRange,
+				),
+				Subject: &block.DefRange,
+			})
+			continue
+		}
+		seen = block
+		config = &ast.EscapedBody{
+			Body:   hcl.MergeBodies([]hcl.Body{config, block.Body}),
+			Base:   config,
+			Escape: block.Body,
+		}
+	}
+	return config, diags
+}
+
 // parseProvisionerBlock parses a provisioner block.
 func (p *Parser) parseProvisionerBlock(block *hcl.Block) (*ast.Provisioner, hcl.Diagnostics) {
 	content, remain, diags := block.Body.PartialContent(provisionerSchema)
 
+	config, escDiags := mergeEscapeBlock(remain, content.Blocks, "provisioner-type-specific", "provisioner")
+	diags = append(diags, escDiags...)
+
 	provisioner := &ast.Provisioner{
 		Type:      block.Labels[0],
-		Config:    remain,
+		Config:    config,
 		When:      "create", // Default
 		OnFailure: "fail",   // Default
 		DeclRange: block.DefRange,
@@ -1191,9 +1238,12 @@ func (p *Parser) parseModuleBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	content, remain, contentDiags := block.Body.PartialContent(moduleSchema)
 	diags = append(diags, contentDiags...)
 
+	moduleConfig, escDiags := mergeEscapeBlock(remain, content.Blocks, "module input variables", "module")
+	diags = append(diags, escDiags...)
+
 	module := &ast.Module{
 		Name:      name,
-		Config:    remain,
+		Config:    moduleConfig,
 		Providers: make(map[string]hcl.Expression),
 		DeclRange: block.DefRange,
 	}

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -15,12 +15,15 @@
 package parser
 
 import (
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestParseBasicConfig(t *testing.T) {
@@ -543,6 +546,131 @@ resource "aws_instance" "web" {
 	_, diags := p.ParseSource("test.hcl", src)
 	require.True(t, diags.HasErrors())
 	require.Equal(t, "Invalid \"on_failure\" value", diags[0].Summary)
+}
+
+// justAttrNames returns the sorted attribute names visible via JustAttributes.
+func justAttrNames(t *testing.T, body hcl.Body) []string {
+	t.Helper()
+	attrs, _ := body.JustAttributes()
+	return slices.Sorted(maps.Keys(attrs))
+}
+
+func TestParseEscapingBlocks(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+provider "aws" {
+  region = "us-west-2"
+  _ {
+    alias = "not-an-alias"
+  }
+}
+
+resource "aws_instance" "web" {
+  count = 2
+  ami   = "ami-123"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  _ {
+    # Set both as a meta-argument above and as a resource-type-specific
+    # argument here; both must be populated.
+    count = "not-a-count"
+
+    # A literal block, not the lifecycle meta-argument block.
+    lifecycle {
+      prevent_destroy = "not-a-bool"
+    }
+  }
+
+  provisioner "local-exec" {
+    when = destroy
+    _ {
+      command = "true"
+      when    = "not-a-when"
+    }
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  _ {
+    provider = "not-a-provider"
+  }
+}
+
+module "vpc" {
+  source = "./modules/vpc"
+  _ {
+    version = "not-a-version"
+  }
+}
+`)
+	p := NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), "%v", diags)
+
+	provider := config.Providers["aws"]
+	require.NotNil(t, provider)
+	assert.Equal(t, "", provider.Alias)
+	assert.Equal(t, []string{"alias", "region"}, justAttrNames(t, provider.Config))
+
+	res := config.Resources["aws_instance.web"]
+	require.NotNil(t, res)
+	// The meta-argument and the escaped argument of the same name are both
+	// populated: count = 2 drives expansion, the escaped count is config.
+	require.NotNil(t, res.Count)
+	countVal, valDiags := res.Count.Value(nil)
+	require.False(t, valDiags.HasErrors())
+	assert.True(t, cty.NumberIntVal(2).RawEquals(countVal))
+	require.NotNil(t, res.Lifecycle)
+	require.NotNil(t, res.Lifecycle.PreventDestroy)
+	assert.True(t, *res.Lifecycle.PreventDestroy)
+
+	content, _, contentDiags := res.Config.PartialContent(&hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{{Name: "ami"}, {Name: "count"}},
+		Blocks:     []hcl.BlockHeaderSchema{{Type: "lifecycle"}},
+	})
+	require.False(t, contentDiags.HasErrors(), "%v", contentDiags)
+	escapedCount, valDiags := content.Attributes["count"].Expr.Value(nil)
+	require.False(t, valDiags.HasErrors())
+	assert.Equal(t, cty.StringVal("not-a-count"), escapedCount)
+	// The lifecycle block written inside `_` is literal resource config, not
+	// the meta-argument block.
+	require.Len(t, content.Blocks, 1)
+
+	require.Len(t, res.Provisioners, 1)
+	prov := res.Provisioners[0]
+	assert.Equal(t, "destroy", prov.When)
+	assert.Equal(t, []string{"command", "when"}, justAttrNames(t, prov.Config))
+
+	ds := config.DataSources["aws_ami.ubuntu"]
+	require.NotNil(t, ds)
+	assert.Nil(t, ds.Provider)
+	assert.Equal(t, []string{"provider"}, justAttrNames(t, ds.Config))
+
+	mod := config.Modules["vpc"]
+	require.NotNil(t, mod)
+	assert.Equal(t, "", mod.Version)
+	assert.Equal(t, []string{"version"}, justAttrNames(t, mod.Config))
+}
+
+func TestParseDuplicateEscapingBlock(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+resource "aws_instance" "web" {
+  _ {
+    count = "a"
+  }
+  _ {
+    provider = "b"
+  }
+}
+`)
+	p := NewParser()
+	_, diags := p.ParseSource("test.hcl", src)
+	require.True(t, diags.HasErrors())
+	require.Equal(t, "Duplicate escaping block", diags[0].Summary)
 }
 
 func TestParseMetaArguments(t *testing.T) {

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -91,6 +91,7 @@ var providerSchema = &hcl.BodySchema{
 	},
 	Blocks: []hcl.BlockHeaderSchema{
 		{Type: "pulumi"},
+		{Type: "_"}, // meta-argument escaping block
 	},
 }
 
@@ -163,6 +164,7 @@ var resourceSchema = &hcl.BodySchema{
 		{Type: "connection"},
 		{Type: "provisioner", LabelNames: []string{"type"}},
 		{Type: "timeouts"},
+		{Type: "_"}, // meta-argument escaping block
 	},
 }
 
@@ -240,6 +242,7 @@ var provisionerSchema = &hcl.BodySchema{
 	},
 	Blocks: []hcl.BlockHeaderSchema{
 		{Type: "connection"},
+		{Type: "_"}, // meta-argument escaping block
 	},
 }
 
@@ -257,6 +260,7 @@ var moduleSchema = &hcl.BodySchema{
 	},
 	Blocks: []hcl.BlockHeaderSchema{
 		{Type: "pulumi"},
+		{Type: "_"}, // meta-argument escaping block
 	},
 }
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -4305,6 +4305,11 @@ func provisionerDeps(res *ast.Resource, hclCtx *hcl.EvalContext) []string {
 		if body == nil {
 			return
 		}
+		if eb, ok := body.(*ast.EscapedBody); ok {
+			collect(eb.Base)
+			collect(eb.Escape)
+			return
+		}
 		attrs, _ := body.JustAttributes()
 		for _, attr := range attrs {
 			for _, traversal := range attr.Expr.Variables() {

--- a/tests/testutil/tfcompat/providers/simple.go
+++ b/tests/testutil/tfcompat/providers/simple.go
@@ -64,7 +64,11 @@ func SimpleProvider() *schema.Provider {
 					// Kept here so tests can assert it survives the
 					// HCL→Pulumi translation and isn't stripped by any
 					// meta-attribute reservation.
-					"version":       {Type: schema.TypeString, Optional: true},
+					"version": {Type: schema.TypeString, Optional: true},
+					// Collides with the `for_each` meta-argument (one of the
+					// few meta-argument names SDKv2 does not reserve), so HCL
+					// can only set it through the `_` escaping block.
+					"for_each":      {Type: schema.TypeString, Optional: true},
 					"result":        {Type: schema.TypeString, Computed: true},
 					"prefix_result": {Type: schema.TypeString, Computed: true},
 				},

--- a/tests/tfcompat/l2_provisioner_escape_block_test.go
+++ b/tests/tfcompat/l2_provisioner_escape_block_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// OpenTofu merges a provisioner's `_` escaping block into its configuration, so
+// a `command` written inside `_ { ... }` runs and the apply succeeds.
+// pulumi-hcl's provisioner parser only recognizes `connection` sub-blocks and
+// leaves the `_` block in the config body, where the local-exec decoder rejects
+// it (and finds no command), so the apply errors.
+func TestL2ProvisionerEscapeBlock(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_provisioner_escape_block", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_escape_block/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_escape_block/main.tf
@@ -13,3 +13,18 @@ resource "simple_resource" "target" {
     }
   }
 }
+
+# Resource (and data/provider/module) blocks accept the same escaping block.
+# `input_one` written inside `_` must land in the resource's configuration, and
+# `for_each` — a resource attribute whose name collides with the meta-argument
+# — can only be set through the escaping block.
+resource "simple_resource" "escaped" {
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  _ {
+    input_one = simple_resource.target.result
+    for_each  = "not-the-meta-argument"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_escape_block/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_escape_block/main.tf
@@ -1,0 +1,15 @@
+# OpenTofu supports the special `_` escaping block inside a provisioner, whose
+# attributes are merged into the provisioner's configuration (it exists to let
+# provisioner arguments that collide with meta-argument names be written
+# unambiguously). Here `command` is supplied through the escaping block; on
+# OpenTofu the merge makes it the provisioner's command, so `true` runs and the
+# apply succeeds.
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  provisioner "local-exec" {
+    _ {
+      command = "true"
+    }
+  }
+}


### PR DESCRIPTION
## Divergence

OpenTofu supports the special `_` meta-argument escaping block inside `resource`, `data`, `provider`, `module`, and `provisioner` blocks: its contents merge into the block's configuration (`hcl.MergeBodies`), so arguments whose names collide with meta-argument names (`count`, `for_each`, `when`, ...) can still be written unambiguously. pulumi-hcl's parsers did not recognize `_` at all — the block stayed in the config body, where schema decoding rejected it:

```
tofu:   runs `true`, apply succeeds
pulumi: local-exec: Missing required argument; The argument "command" is required, but no definition was found.
```

Direction: OpenTofu succeeds; pulumi-hcl errors.

## Fix

All five block kinds OpenTofu escapes are fixed (same root cause at every parse site):

- `provisionerSchema`, `resourceSchema`, `providerSchema`, and `moduleSchema` now declare the `_` block.
- A shared `mergeEscapeBlock` helper in `pkg/hcl/parser/parser.go` merges the escaping block's body into the config at each parse site, and reports OpenTofu's "Duplicate escaping block" error when `_` appears twice.
- The merge is wrapped in `ast.EscapedBody`, which behaves like `hcl.MergeBodies` but keeps the underlying bodies reachable. This matters because `graph.bodyDeps` and `run.provisionerDeps` walk `*hclsyntax.Body` natively (dynamic/lifecycle blocks, provisioner sub-bodies); a bare merged body would have silently hidden those from dependency scanning. Both scanners unwrap `EscapedBody` and scan the base and escape bodies.

## Test

`TestL2ProvisionerEscapeBlock` (fails 3/3 on master, passes with the fix) covers:

- a provisioner `command` supplied via `_ { ... }`, and
- a resource-level escape setting `input_one` (via a cross-resource reference, exercising the dependency-edge path through the escape body) and `for_each` — a `simple_resource` attribute that collides with the meta-argument. `for_each` is used because it is one of the few meta-argument names SDKv2's `InternalValidate` does not reserve, so it is the realistic collision a real provider could ship.

Parser unit tests (`TestParseEscapingBlocks`, `TestParseDuplicateEscapingBlock`) cover all five block kinds, the meta/escaped same-name split (`count = 2` meta alongside escaped `count`, mirroring OpenTofu's own `escaping_blocks_test.go` fixture), a literal `lifecycle` block inside `_` staying resource config, and the duplicate-block diagnostic.

Verification: full `pkg/...` unit suite (1100 tests) and full tfcompat suite (200 tests) pass; lint clean.
