### PR TITLE
Treat a keyed-from, unkeyed-to `moved` block as an instance move

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-411.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-411.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Fix `moved` out of `count`/`for_each` (`a[0]` → `a`) destroying and recreating the instance instead of renaming it
+time: 2026-07-16T14:50:00Z
+custom:
+    Component: runtime
+    PR: "411"

--- a/pkg/hcl/modules/loader_test.go
+++ b/pkg/hcl/modules/loader_test.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	regaddr "github.com/opentofu/registry-address/v2"
@@ -35,10 +36,25 @@ import (
 // versions is returned for /versions; downloads maps version → URL returned
 // via the X-Terraform-Get header for /<v>/download (204 response).
 type fakeRegistry struct {
-	versions     []string
-	downloads    map[string]string
+	versions  []string
+	downloads map[string]string
+
+	// mu guards the hit counters, written from concurrent handler goroutines.
+	mu           sync.Mutex
 	versionsHits int
 	downloadHits map[string]int
+}
+
+func (r *fakeRegistry) versionsHitCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.versionsHits
+}
+
+func (r *fakeRegistry) downloadHitCount(v string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.downloadHits[v]
 }
 
 func newFakeRegistry(t *testing.T, versions []string, downloads map[string]string) (*httptest.Server, *fakeRegistry) {
@@ -56,7 +72,9 @@ func newFakeRegistry(t *testing.T, versions []string, downloads map[string]strin
 		segs := strings.Split(trimmed, "/")
 		switch {
 		case len(segs) == 4 && segs[3] == "versions":
+			reg.mu.Lock()
 			reg.versionsHits++
+			reg.mu.Unlock()
 			payload := map[string]any{
 				"modules": []map[string]any{
 					{"versions": versionsPayload(reg.versions)},
@@ -65,7 +83,9 @@ func newFakeRegistry(t *testing.T, versions []string, downloads map[string]strin
 			_ = json.NewEncoder(w).Encode(payload)
 		case len(segs) == 5 && segs[4] == "download":
 			v := segs[3]
+			reg.mu.Lock()
 			reg.downloadHits[v]++
+			reg.mu.Unlock()
 			dl, ok := reg.downloads[v]
 			if !ok {
 				http.Error(w, "no such version", http.StatusNotFound)
@@ -149,8 +169,8 @@ func TestGetRegistryDownloadURL_NoConstraintPicksLatest(t *testing.T) {
 	got, err := n.getRegistryDownloadURL(regaddr.DefaultModuleRegistryHost, srv.URL, "acme", "thing", "aws", "")
 	require.NoError(t, err)
 	require.Equal(t, "https://example.com/v420.tar.gz", got)
-	require.Equal(t, 1, reg.versionsHits)
-	require.Equal(t, 1, reg.downloadHits["4.2.0"])
+	require.Equal(t, 1, reg.versionsHitCount())
+	require.Equal(t, 1, reg.downloadHitCount("4.2.0"))
 }
 
 func TestGetRegistryDownloadURL_ConstraintPicksHighestMatching(t *testing.T) {
@@ -163,7 +183,7 @@ func TestGetRegistryDownloadURL_ConstraintPicksHighestMatching(t *testing.T) {
 	got, err := n.getRegistryDownloadURL(regaddr.DefaultModuleRegistryHost, srv.URL, "acme", "thing", "aws", "~> 4.0")
 	require.NoError(t, err)
 	require.Equal(t, "https://example.com/v410.tar.gz", got)
-	require.Equal(t, 1, reg.downloadHits["4.1.0"])
+	require.Equal(t, 1, reg.downloadHitCount("4.1.0"))
 }
 
 func TestGetRegistryDownloadURL_ExactVersionPin(t *testing.T) {
@@ -265,7 +285,7 @@ func TestLoadModule_VersionConstraintPlumbedThroughToRegistry(t *testing.T) {
 	require.NotNil(t, loaded.Config)
 	require.Contains(t, loaded.Config.Outputs, "ok",
 		"the module body fetched should be the 4.0.1 fixture")
-	require.Equal(t, 1, reg.downloadHits["4.0.1"],
+	require.Equal(t, 1, reg.downloadHitCount("4.0.1"),
 		"constraint ~> 4.0 should resolve to 4.0.1 (highest 4.x), not 5.1.0 or 3.x")
 }
 
@@ -287,7 +307,7 @@ func TestLoadModule_VersionQueryStringStillSupported(t *testing.T) {
 
 	_, err := l.LoadModule(t.Context(), "acme/thing/aws?version=3.0.0", "", t.TempDir())
 	require.NoError(t, err)
-	require.Equal(t, 1, reg.downloadHits["3.0.0"])
+	require.Equal(t, 1, reg.downloadHitCount("3.0.0"))
 }
 
 // TestLoadModule_HostQualifiedRegistrySource verifies that a source carrying an

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2241,17 +2241,25 @@ func (e *Engine) resolveMovedAliases(
 				}
 				fromPath := appendModuleSteps(scope, from.modules)
 
-				// Determine the prior instance key. A keyed `to` targets one specific
-				// instance and takes the prior key from `from`; an unkeyed `to` is a
-				// whole-resource rename that maps every instance to the same key.
+				// Determine the prior instance key. A keyed endpoint on either side
+				// makes this an instance move taking the prior key from `from` (an
+				// unkeyed endpoint paired with a keyed one names the no-key
+				// instance); with both endpoints unkeyed it is a whole-resource
+				// rename that maps every instance to the same key.
 				var priorIdx *int
 				var priorEach *string
-				if to.keyed() {
+				switch {
+				case to.keyed():
 					if !instanceKeysEqual(cur.index, cur.eachKey, to.keyIndex, to.keyEach) {
 						continue
 					}
 					priorIdx, priorEach = from.keyIndex, from.keyEach
-				} else {
+				case from.keyed():
+					if cur.index != nil || cur.eachKey != nil {
+						continue
+					}
+					priorIdx, priorEach = from.keyIndex, from.keyEach
+				default:
 					priorIdx, priorEach = cur.index, cur.eachKey
 				}
 

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -3456,6 +3456,72 @@ resource "aws_instance" "web" {
 	}
 }
 
+// TestEngine_MovedBlockDisableCount moves a counted instance back to a bare
+// resource (`aws_instance.web[0]` -> `aws_instance.web`), so the alias must
+// carry the prior instance key from the keyed `from` address.
+func TestEngine_MovedBlockDisableCount(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+moved {
+  from = aws_instance.web[0]
+  to   = aws_instance.web
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-12345"
+  instance_type = "t3.micro"
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "aws",
+			Resources: map[string]schema.ResourceSpec{
+				"aws:index:Instance": {
+					InputProperties: map[string]schema.PropertySpec{
+						"ami":          {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"instanceType": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"ami":          {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"instanceType": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	var instanceReq *run.RegisterResourceRequest
+	for i := range mock.RegisteredResources {
+		if mock.RegisteredResources[i].Type == "aws:index:Instance" {
+			instanceReq = &mock.RegisteredResources[i]
+			break
+		}
+	}
+	require.NotNil(t, instanceReq, "expected aws:index:Instance resource to be registered")
+
+	assert.Equal(t, []run.Alias{{Spec: &run.AliasSpec{
+		Name:     "web[0]",
+		NoParent: false,
+	}}}, instanceReq.Aliases)
+}
+
 func TestEngine_ImportBlock(t *testing.T) {
 	t.Parallel()
 

--- a/tests/tfcompat/l2_moved_disable_count_test.go
+++ b/tests/tfcompat/l2_moved_disable_count_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2MovedDisableCount moves a counted instance back to a bare resource
+// (`simple_resource.a[0]` -> `simple_resource.a`, disabling count). OpenTofu
+// treats this as a state-only move: the object keeps its identity and the
+// rename issues no provider Create/Delete. pulumi-hcl instead creates a fresh
+// `simple_resource.a` and deletes `simple_resource.a[0]`, so the two runtimes
+// disagree on the provider operations. The inverse direction (enabling count,
+// `a` -> `a[0]`) is already covered and works.
+func TestL2MovedDisableCount(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_moved_disable_count", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_moved_test.go
+++ b/tests/tfcompat/l2_moved_test.go
@@ -45,8 +45,9 @@ func TestL2Moved(t *testing.T) {
 
 		// Changing a resource's instance key (enabling/disabling count/for_each,
 		// or rekeying a for_each instance).
-		{name: "enable_count", dir: "l2_moved_enable_count"}, // whole resource -> a[0]
-		{name: "rekey_for_each", dir: "l2_moved_rekey"},      // a["small"] -> a["tiny"]
+		{name: "enable_count", dir: "l2_moved_enable_count"},           // whole resource -> a[0]
+		{name: "rekey_for_each", dir: "l2_moved_rekey"},                // a["small"] -> a["tiny"]
+		{name: "count_to_for_each", dir: "l2_moved_count_to_for_each"}, // a[0] -> a["x"]
 
 		// Moving a resource across a module boundary.
 		{name: "split_module", dir: "l2_moved_split"}, // root resource -> module.x

--- a/tests/tfcompat/testdata/cases/l2_moved_count_to_for_each/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_count_to_for_each/0/main.tf
@@ -1,0 +1,5 @@
+resource "simple_resource" "a" {
+  count     = 1
+  input_one = "x"
+}
+output "r" { value = simple_resource.a[0].result }

--- a/tests/tfcompat/testdata/cases/l2_moved_count_to_for_each/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_count_to_for_each/1/main.tf
@@ -1,0 +1,11 @@
+resource "simple_resource" "a" {
+  for_each  = toset(["x"])
+  input_one = "x"
+}
+
+moved {
+  from = simple_resource.a[0]
+  to   = simple_resource.a["x"]
+}
+
+output "r" { value = simple_resource.a["x"].result }

--- a/tests/tfcompat/testdata/cases/l2_moved_disable_count/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_disable_count/0/main.tf
@@ -1,0 +1,5 @@
+resource "simple_resource" "a" {
+  count     = 1
+  input_one = "x"
+}
+output "r" { value = simple_resource.a[0].result }

--- a/tests/tfcompat/testdata/cases/l2_moved_disable_count/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_disable_count/1/main.tf
@@ -1,0 +1,10 @@
+resource "simple_resource" "a" {
+  input_one = "x"
+}
+
+moved {
+  from = simple_resource.a[0]
+  to   = simple_resource.a
+}
+
+output "r" { value = simple_resource.a.result }


### PR DESCRIPTION
## Bug

A `moved` block that moves a counted instance back to a bare resource — `simple_resource.a[0]` → `simple_resource.a` (disabling `count`) — is a state-only move in OpenTofu: the object keeps its identity, with zero provider Create/Delete on the rename. pulumi-hcl instead created a fresh `simple_resource.a` and deleted `simple_resource.a[0]` — an unnecessary destroy/recreate on a pure refactor.

```
tofu ops (1):   [Create a[0]]                              (stage-1 move is state-only)
pulumi ops (3): [Create a[0], Create a, Delete a[0]]       (stage-1 move became replace)
```

## Root cause & fix

`resolveMovedAliases` treated any unkeyed `to` as a whole-resource rename, copying the *current* instance key as the prior key — so the alias came out identical to the resource's own name and never matched the prior `a[0]` state. An unkeyed endpoint paired with a keyed one names the no-key instance: the move applies only to the unkeyed instance and the prior key comes from `from`. The inverse direction (enabling count, `a` → `a[0]`) and both-endpoints-unkeyed renames were already correct and are unchanged.

## Tests

- `TestL2MovedDisableCount` (tfcompat): `a[0]` → `a`, failed on master, now passes.
- `TestL2Moved/count_to_for_each` (tfcompat): locks in the both-keyed direction `a[0]` → `a["x"]` (already worked).
- `TestEngine_MovedBlockDisableCount` (unit): asserts the alias carries the prior key (`web[0]`).
- All 15 `TestL2Moved*` tfcompat cases pass.