### PR TITLE
Retype null and unknown variable values to their declared type

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-412.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-412.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Convert unknown variable values to their declared type, so declared `optional()` attributes resolve at preview
+time: 2026-07-16T12:58:55Z
+custom:
+    Component: runtime
+    PR: "412"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -823,13 +823,12 @@ func (e *Engine) processVariable(ctx context.Context, node *graph.Node) error {
 	}
 
 	// Fill in optional()-attribute defaults before sensitive marking.
-	if v.TypeDefaults != nil && !val.IsNull() && val.IsKnown() {
+	if v.TypeDefaults != nil && !val.IsNull() {
 		val = v.TypeDefaults.Apply(val)
 	}
 
 	if valueSource != "environment" && valueSource != "config" &&
-		v.TypeConstraint != cty.NilType && v.TypeConstraint != cty.DynamicPseudoType &&
-		!val.IsNull() && val.IsKnown() {
+		v.TypeConstraint != cty.NilType && v.TypeConstraint != cty.DynamicPseudoType {
 		if converted, err := ctyconvert.Convert(val, v.TypeConstraint); err == nil {
 			val = converted
 		}
@@ -3781,12 +3780,12 @@ func (e *Engine) processModuleVariable(node *graph.Node) error {
 
 		// Fill in optional()-attribute defaults before type conversion so
 		// the result satisfies the declared object shape.
-		if v.TypeDefaults != nil && !val.IsNull() && val.IsKnown() {
+		if v.TypeDefaults != nil && !val.IsNull() {
 			val = v.TypeDefaults.Apply(val)
 		}
 
 		// Coerce the value to match the variable's type constraint.
-		if v.TypeConstraint != cty.NilType && !val.IsNull() && val.IsKnown() {
+		if v.TypeConstraint != cty.NilType {
 			if converted, err := ctyconvert.Convert(val, v.TypeConstraint); err == nil {
 				val = converted
 			}

--- a/tests/tfcompat/l2_module_unknown_input_optional_attr_test.go
+++ b/tests/tfcompat/l2_module_unknown_input_optional_attr_test.go
@@ -23,13 +23,9 @@ import (
 
 // TestL2ModuleUnknownInputOptionalAttr drives a module input that is unknown at
 // preview and whose declared type adds an optional attribute the source object
-// lacks. OpenTofu always retypes a module argument to the variable's declared
-// type — even when the value is unknown — so the module body sees the declared
-// object type (with the optional `c`) and `var.cfg.c` is valid. pulumi-hcl
-// skips the type conversion for an unknown value, so the module body sees the
-// source object type (without `c`) and evaluating `var.cfg.c` fails preview
-// with "This object does not have an attribute named c". OpenTofu's plan
-// succeeds, so this is a real migration-breaking divergence.
+// lacks. A module argument must be retyped to the variable's declared type even
+// when the value is unknown, so the module body sees the declared object type
+// (with the optional `c`) and `var.cfg.c` is valid at preview.
 func TestL2ModuleUnknownInputOptionalAttr(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_module_unknown_input_optional_attr", tfcompat.Case{

--- a/tests/tfcompat/l2_module_unknown_input_optional_attr_test.go
+++ b/tests/tfcompat/l2_module_unknown_input_optional_attr_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ModuleUnknownInputOptionalAttr drives a module input that is unknown at
+// preview and whose declared type adds an optional attribute the source object
+// lacks. OpenTofu always retypes a module argument to the variable's declared
+// type — even when the value is unknown — so the module body sees the declared
+// object type (with the optional `c`) and `var.cfg.c` is valid. pulumi-hcl
+// skips the type conversion for an unknown value, so the module body sees the
+// source object type (without `c`) and evaluating `var.cfg.c` fails preview
+// with "This object does not have an attribute named c". OpenTofu's plan
+// succeeds, so this is a real migration-breaking divergence.
+func TestL2ModuleUnknownInputOptionalAttr(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_unknown_input_optional_attr", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{Mode: tfcompat.StagePreview}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_module_unknown_input_optional_attr/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_unknown_input_optional_attr/main.tf
@@ -1,0 +1,16 @@
+resource "simple_resource" "r" {
+  input_one = "hello"
+  input_two = true
+}
+locals {
+  # Unknown predicate at preview -> a wholly-unknown object({a=string}) that
+  # lacks `c`. OpenTofu converts it to the declared object type (adding `c`),
+  # so var.cfg.c is valid. If pulumi skips the conversion for the unknown
+  # value, var.cfg stays object({a}) and var.cfg.c errors at preview.
+  uo = simple_resource.r.result == "hello-true" ? { a = "one" } : { a = "two" }
+}
+module "m" {
+  source = "./modules/m"
+  cfg    = local.uo
+}
+output "c" { value = module.m.c }

--- a/tests/tfcompat/testdata/cases/l2_module_unknown_input_optional_attr/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_unknown_input_optional_attr/main.tf
@@ -4,9 +4,7 @@ resource "simple_resource" "r" {
 }
 locals {
   # Unknown predicate at preview -> a wholly-unknown object({a=string}) that
-  # lacks `c`. OpenTofu converts it to the declared object type (adding `c`),
-  # so var.cfg.c is valid. If pulumi skips the conversion for the unknown
-  # value, var.cfg stays object({a}) and var.cfg.c errors at preview.
+  # lacks `c`; the module must retype it to the declared object type.
   uo = simple_resource.r.result == "hello-true" ? { a = "one" } : { a = "two" }
 }
 module "m" {

--- a/tests/tfcompat/testdata/cases/l2_module_unknown_input_optional_attr/modules/m/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_unknown_input_optional_attr/modules/m/main.tf
@@ -1,0 +1,9 @@
+# Declared type adds an optional attribute `c` that the source object lacks.
+variable "cfg" {
+  type = object({
+    a = string
+    c = optional(string, "def")
+  })
+}
+# `.c` is valid only if the value carries the declared object type (with `c`).
+output "c" { value = var.cfg.c }


### PR DESCRIPTION
When a module argument is unknown at preview, OpenTofu still converts it to the variable's declared type, so declared optional attributes are present and a module output referencing them plans cleanly. pulumi-hcl gated both the `optional()`-attribute default-fill and the type conversion on `!val.IsNull() && val.IsKnown()`, so a wholly-unknown value kept its source type and accessing a declared-but-absent attribute failed preview:

```
tofu plan:      succeeds (var.cfg retyped to object({a, c=optional}), so var.cfg.c is valid)
pulumi preview: evaluating module output c: This object does not have an attribute named "c".
```

## Fix

Match OpenTofu's `prepareFinalInputVariableValue`: gate `TypeDefaults.Apply` only on `!val.IsNull()` (`Apply` is internally unknown-safe) and run the conversion to the declared type constraint unconditionally, in both the module-input path and the sibling root-variable path in `pkg/hcl/run/run.go`. Unknown values now convert to unknown-of-declared-type, so declared attributes resolve at preview.

## Test

`TestL2ModuleUnknownInputOptionalAttr` (StagePreview) passes a wholly-unknown `object({a})` (a conditional over an unknown computed attribute) into a module whose variable is declared `object({ a = string, c = optional(string, "def") })` and which outputs `var.cfg.c`. Failed on master, passes with the fix. Only wholly-unknown values (`IsKnown()==false`) hit the old guard; partially-unknown objects report `IsKnown()==true`, and at apply the value is known — hence preview-only.