### PR TITLE
Failing test: create_before_destroy leaks to a dependent

### DIFF
--- a/tests/tfcompat/l2_cbd_dependent_replace_order_test.go
+++ b/tests/tfcompat/l2_cbd_dependent_replace_order_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2CbdDependentReplaceOrder proves that create_before_destroy must not
+// propagate to a resource's dependents. `a` declares create_before_destroy and
+// is replaced by a ForceNew change; `b` depends on `a` and is replaced too but
+// declares no lifecycle. OpenTofu propagates create_before_destroy only to
+// dependencies, so `b` keeps delete-before-create ordering and its old instance
+// is destroyed before the replacement is created (witness_b = 3). pulumi-hcl
+// instead creates every replacement before any delete, so `b` is created before
+// its old instance is destroyed (witness_b = 2), a create-before-destroy
+// ordering `b` never asked for.
+func TestL2CbdDependentReplaceOrder(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_cbd_dependent_replace_order", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "cascade", Factory: providers.CascadeProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_cbd_dependent_replace_order/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_cbd_dependent_replace_order/0/main.tf
@@ -1,0 +1,26 @@
+# `a` declares create_before_destroy and is replaced across the two stages by a
+# ForceNew change to `parent`. `b` depends on `a` (through a's computed
+# `witness`, which is a ForceNew input on b), so b is replaced too, but b does
+# NOT declare create_before_destroy.
+#
+# OpenTofu propagates create_before_destroy only to a resource's DEPENDENCIES,
+# never to its dependents. b is a dependent of a, so b keeps the default
+# delete-before-create ordering: b's old instance is destroyed before its
+# replacement is created. Only a is created-before-destroyed.
+#
+# CascadeProvider bumps a shared counter on every create and delete and records
+# the counter at each child's create in `witness`, making the interleaving of
+# creates and deletes observable as a value.
+resource "cascade_child" "a" {
+  parent = "L1"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cascade_child" "b" {
+  parent = cascade_child.a.witness
+}
+
+output "witness_a" { value = cascade_child.a.witness }
+output "witness_b" { value = cascade_child.b.witness }

--- a/tests/tfcompat/testdata/cases/l2_cbd_dependent_replace_order/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_cbd_dependent_replace_order/1/main.tf
@@ -1,0 +1,26 @@
+# `a` declares create_before_destroy and is replaced across the two stages by a
+# ForceNew change to `parent`. `b` depends on `a` (through a's computed
+# `witness`, which is a ForceNew input on b), so b is replaced too, but b does
+# NOT declare create_before_destroy.
+#
+# OpenTofu propagates create_before_destroy only to a resource's DEPENDENCIES,
+# never to its dependents. b is a dependent of a, so b keeps the default
+# delete-before-create ordering: b's old instance is destroyed before its
+# replacement is created. Only a is created-before-destroyed.
+#
+# CascadeProvider bumps a shared counter on every create and delete and records
+# the counter at each child's create in `witness`, making the interleaving of
+# creates and deletes observable as a value.
+resource "cascade_child" "a" {
+  parent = "L2"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cascade_child" "b" {
+  parent = cascade_child.a.witness
+}
+
+output "witness_a" { value = cascade_child.a.witness }
+output "witness_b" { value = cascade_child.b.witness }


### PR DESCRIPTION
## Divergence

`create_before_destroy` must propagate only to a resource's **dependencies**, never its **dependents**.

Fixture: `a` (`cascade_child`) declares `create_before_destroy` and is replaced by a ForceNew `parent` change L1→L2. `b` depends on `a` (through `a`'s computed `witness`, a ForceNew input on `b`), so `b` is replaced too, but `b` declares no lifecycle. `CascadeProvider` bumps a shared counter on every create/delete and records it at each child's create, making the create/delete interleaving observable.

```
expected (tofu):  witness_a=2, witness_b=3
actual   (pulumi): witness_a=1, witness_b=2
```

- **tofu** order: delete old-`b` (1), create new-`a` (2), create new-`b` (3), delete old-`a` (4). `b` is delete-before-create.
- **pulumi** order: create new-`a` (1), create new-`b` (2), then the deletes. `b` is created before its old instance is destroyed — a create-before-destroy ordering it never declared.

Both applies succeed; the stack outputs differ, with pulumi-hcl the one diverging from OpenTofu.

## Relationship to #375

This is the **inverse** of #375. #375 propagates CBD *to dependencies* (verified working here); this case is CBD leaking *to a dependent* — a different, uncovered corner. The existing CBD cases (`l2_cbd_propagation`, `_transitive`, `_cross_module`) all test propagation to dependencies only. If you consider it part of the #375 work, it can be folded in; filing separately since the direction and code path differ.

## Test

`TestL2CbdDependentReplaceOrder` in `tests/tfcompat/l2_cbd_dependent_replace_order_test.go` (numbered stage dirs, `CascadeProvider`). Deterministic — fails 3/3 on master.

**This PR contains only the failing test and is expected to fail CI.**