### PR TITLE
Skip ignore_changes entries whose path does not resolve in the configuration

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-414.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-414.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Drop `ignore_changes` entries whose path no longer resolves in the configuration, so removing a block no longer suppresses a ForceNew replacement
+time: 2026-07-16T16:10:00Z
+custom:
+    Component: runtime
+    PR: "414"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1555,8 +1555,6 @@ func (e *Engine) registerResourceInstanceInContext(
 	if diags.HasErrors() {
 		return diags
 	}
-	resourceInputs = wrapTerraformDataInputs(res.Type, resourceInputs, tdataEvaluated)
-
 	if strings.HasPrefix(res.Type, "pulumi_providers_") && res.PluginDownloadURL != nil {
 		val, valDiags := res.PluginDownloadURL.Value(hclCtx)
 		if !valDiags.HasErrors() && val.Type() == cty.String {
@@ -1564,10 +1562,14 @@ func (e *Engine) registerResourceInstanceInContext(
 		}
 	}
 
-	opts, err := e.buildResourceOptionsInContext(ctx, res, instance, evalCtx, parentURN, node.ModuleInfo, modInst, resourceMapping, resSchema.InputProperties, resSchema.Properties)
+	opts, err := e.buildResourceOptionsInContext(ctx, res, instance, evalCtx, parentURN, node.ModuleInfo, modInst, resourceMapping, resSchema.InputProperties, resSchema.Properties, resourceInputs)
 	if err != nil {
 		return err
 	}
+	// The options are built from the unboxed inputs: terraform_data's
+	// {type, value} boxing would hide the value shapes that
+	// ignoreChangesApplies inspects.
+	resourceInputs = wrapTerraformDataInputs(res.Type, resourceInputs, tdataEvaluated)
 	opts.Custom = !resSchema.IsComponent
 	opts.Remote = resSchema.IsComponent
 	opts.PropertyDependencies = dependsOn
@@ -1709,7 +1711,7 @@ func (e *Engine) buildResourceOptionsInContext(
 	ctx context.Context, res *ast.Resource, instance *graph.ExpandedResource,
 	evalCtx *eval.Context, parentURN urn.URN,
 	modInfo *graph.ModuleInfo, modInst *moduleInstance, resourceMapping *bridge.BodyMapping,
-	inputProps, outputProps []*schema.Property,
+	inputProps, outputProps []*schema.Property, inputs property.Map,
 ) (*ResourceOptions, error) {
 	opts := &ResourceOptions{}
 	opts.Parent = parentURN
@@ -1744,6 +1746,9 @@ func (e *Engine) buildResourceOptionsInContext(
 			icStr, err := translateAttrPathTraversal(ic, resourceMapping, inputProps)
 			if err != nil {
 				return nil, fmt.Errorf("invalid property path: %w", err)
+			}
+			if !ignoreChangesApplies(ic, resourceMapping, inputProps, inputs) {
+				continue
 			}
 			opts.IgnoreChanges = append(opts.IgnoreChanges, icStr)
 		}
@@ -2812,6 +2817,79 @@ func translateAttrPathTraversal(
 	}
 
 	return property.GlobFromSegments(segments...), nil
+}
+
+// ignoreChangesApplies reports whether an ignore_changes path resolves inside
+// the evaluated inputs. OpenTofu silently skips an entry whose path does not
+// apply to the configuration — removing a whole block un-ignores the
+// attributes inside it, so e.g. a ForceNew change there is planned as a
+// replacement again. Passing such an entry to the engine anyway would keep
+// suppressing the diff, because the engine ignores by state paths too.
+//
+// Mirroring OpenTofu's check: a trailing map key is exempt (a key may be
+// ignored while being added or removed), a missing leaf attribute still
+// resolves (it decodes as null in OpenTofu's config), and an unknown value
+// cannot be disproven, so those keep the entry. OpenTofu also requires the
+// path to resolve in the prior state, which is not visible here.
+func ignoreChangesApplies(
+	traversal hcl.Traversal, mapping *bridge.BodyMapping, props []*schema.Property, inputs property.Map,
+) bool {
+	if len(traversal) > 1 {
+		if idx, ok := traversal[len(traversal)-1].(hcl.TraverseIndex); ok && idx.Key.Type() == cty.String {
+			traversal = traversal[:len(traversal)-1]
+		}
+	}
+	resolver := attrPathNameResolver{mapping: mapping, props: props}
+	v := property.New(inputs)
+	prevSingularBlock := false
+	for i, step := range traversal {
+		if v.IsComputed() {
+			return true
+		}
+		var tfName string
+		switch s := step.(type) {
+		case hcl.TraverseRoot:
+			tfName = s.Name
+		case hcl.TraverseAttr:
+			tfName = s.Name
+		case hcl.TraverseIndex:
+			if prevSingularBlock {
+				prevSingularBlock = false
+				continue
+			}
+			switch {
+			case s.Key.Type() == cty.Number && v.IsArray():
+				idx, acc := s.Key.AsBigFloat().Int64()
+				if acc != big.Exact || idx < 0 || idx >= int64(v.AsArray().Len()) {
+					return false
+				}
+				v = v.AsArray().Get(int(idx))
+			case s.Key.Type() == cty.String && v.IsMap():
+				el, ok := v.AsMap().GetOk(s.Key.AsString())
+				if !ok {
+					return false
+				}
+				v = el
+			default:
+				return false
+			}
+			continue
+		}
+		name, singularBlock, err := resolver.next(tfName)
+		if err != nil {
+			return false
+		}
+		if !v.IsMap() {
+			return false
+		}
+		el, ok := v.AsMap().GetOk(name)
+		if !ok {
+			return i == len(traversal)-1
+		}
+		v = el
+		prevSingularBlock = singularBlock
+	}
+	return true
 }
 
 // ctyPathTraversal converts a cty.Path over an evaluated inputs object into an

--- a/pkg/hcl/run/run_internal_test.go
+++ b/pkg/hcl/run/run_internal_test.go
@@ -277,14 +277,18 @@ func TestIgnoreChangesApplies(t *testing.T) {
 	mapping := &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
 		"note": {TFName: "note", PulumiName: "note"},
 		"tags": {TFName: "tags", PulumiName: "tags"},
-		"settings": {TFName: "settings", PulumiName: "settings", TFBlock: true, MaxItemsOne: true,
+		"settings": {
+			TFName: "settings", PulumiName: "settings", TFBlock: true, MaxItemsOne: true,
 			Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
 				"mode": {TFName: "mode", PulumiName: "mode"},
-			}}},
-		"rules": {TFName: "rules", PulumiName: "rules", TFBlock: true,
+			}},
+		},
+		"rules": {
+			TFName: "rules", PulumiName: "rules", TFBlock: true,
 			Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
 				"port": {TFName: "port", PulumiName: "port"},
-			}}},
+			}},
+		},
 	}}
 
 	tests := []struct {

--- a/pkg/hcl/run/run_internal_test.go
+++ b/pkg/hcl/run/run_internal_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -249,6 +250,125 @@ func TestTranslateAttrPathTraversal(t *testing.T) {
 			text, err := glob.MarshalText()
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, string(text))
+		})
+	}
+}
+
+// TestIgnoreChangesApplies covers the OpenTofu-style existence check that
+// decides whether an ignore_changes entry is forwarded to the engine: the path
+// (minus a trailing map key) must resolve inside the evaluated inputs.
+func TestIgnoreChangesApplies(t *testing.T) {
+	t.Parallel()
+
+	attr := func(names ...string) hcl.Traversal {
+		tr := make(hcl.Traversal, len(names))
+		for i, n := range names {
+			tr[i] = hcl.TraverseAttr{Name: n}
+		}
+		return tr
+	}
+	numIndex := func(base hcl.Traversal, i int) hcl.Traversal {
+		return append(base, hcl.TraverseIndex{Key: cty.NumberIntVal(int64(i))})
+	}
+	strIndex := func(base hcl.Traversal, key string) hcl.Traversal {
+		return append(base, hcl.TraverseIndex{Key: cty.StringVal(key)})
+	}
+
+	mapping := &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+		"note": {TFName: "note", PulumiName: "note"},
+		"tags": {TFName: "tags", PulumiName: "tags"},
+		"settings": {TFName: "settings", PulumiName: "settings", TFBlock: true, MaxItemsOne: true,
+			Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+				"mode": {TFName: "mode", PulumiName: "mode"},
+			}}},
+		"rules": {TFName: "rules", PulumiName: "rules", TFBlock: true,
+			Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+				"port": {TFName: "port", PulumiName: "port"},
+			}}},
+	}}
+
+	tests := []struct {
+		name      string
+		traversal hcl.Traversal
+		inputs    property.Map
+		want      bool
+	}{
+		{
+			name:      "leaf attribute present",
+			traversal: attr("note"),
+			inputs:    property.NewMap(map[string]property.Value{"note": property.New("x")}),
+			want:      true,
+		},
+		{
+			name:      "leaf attribute unset decodes as null and still applies",
+			traversal: attr("note"),
+			inputs:    property.Map{},
+			want:      true,
+		},
+		{
+			name:      "singular block removed un-ignores its attributes",
+			traversal: append(numIndex(attr("settings"), 0), hcl.TraverseAttr{Name: "mode"}),
+			inputs:    property.NewMap(map[string]property.Value{"note": property.New("y")}),
+			want:      false,
+		},
+		{
+			name:      "singular block present",
+			traversal: attr("settings", "mode"),
+			inputs: property.NewMap(map[string]property.Value{
+				"settings": property.New(map[string]property.Value{"mode": property.New("a")}),
+			}),
+			want: true,
+		},
+		{
+			name:      "list block index in range",
+			traversal: append(numIndex(attr("rules"), 0), hcl.TraverseAttr{Name: "port"}),
+			inputs: property.NewMap(map[string]property.Value{
+				"rules": property.New([]property.Value{
+					property.New(map[string]property.Value{"port": property.New(80.0)}),
+				}),
+			}),
+			want: true,
+		},
+		{
+			name:      "list block index out of range",
+			traversal: append(numIndex(attr("rules"), 1), hcl.TraverseAttr{Name: "port"}),
+			inputs: property.NewMap(map[string]property.Value{
+				"rules": property.New([]property.Value{
+					property.New(map[string]property.Value{"port": property.New(80.0)}),
+				}),
+			}),
+			want: false,
+		},
+		{
+			name:      "trailing map key may be absent",
+			traversal: strIndex(attr("tags"), "missing"),
+			inputs:    property.NewMap(map[string]property.Value{"tags": property.New(map[string]property.Value{})}),
+			want:      true,
+		},
+		{
+			name:      "trailing map key with map itself unset",
+			traversal: strIndex(attr("tags"), "k"),
+			inputs:    property.Map{},
+			want:      true,
+		},
+		{
+			name:      "non-trailing map key must exist",
+			traversal: append(strIndex(attr("tags"), "missing"), hcl.TraverseAttr{Name: "x"}),
+			inputs:    property.NewMap(map[string]property.Value{"tags": property.New(map[string]property.Value{})}),
+			want:      false,
+		},
+		{
+			name:      "unknown value cannot be disproven",
+			traversal: attr("settings", "mode"),
+			inputs:    property.NewMap(map[string]property.Value{"settings": property.New(property.Computed)}),
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ignoreChangesApplies(tt.traversal, mapping, nil, tt.inputs))
 		})
 	}
 }

--- a/tests/testutil/tfcompat/providers/fnblock.go
+++ b/tests/testutil/tfcompat/providers/fnblock.go
@@ -1,0 +1,57 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// FNBlockProvider exposes `fnblock_resource`, a resource with a MaxItems=1
+// `settings` block whose `mode` attribute is ForceNew. Changing or removing
+// `mode` forces the whole resource to be replaced. Used to observe how
+// `ignore_changes` on a ForceNew nested-block attribute interacts with the
+// replace-vs-update decision.
+func FNBlockProvider() *schema.Provider {
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"fnblock_resource": {
+				Schema: map[string]*schema.Schema{
+					"note": {Type: schema.TypeString, Optional: true},
+					"settings": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"mode":    {Type: schema.TypeString, Optional: true, ForceNew: true},
+								"verbose": {Type: schema.TypeBool, Optional: true},
+							},
+						},
+					},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("fnblock-id")
+					return nil
+				},
+				ReadContext:   func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				UpdateContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+			},
+		},
+	}
+}

--- a/tests/tfcompat/l2_ignore_changes_forcenew_block_removed_test.go
+++ b/tests/tfcompat/l2_ignore_changes_forcenew_block_removed_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2IgnoreChangesForceNewBlockRemoved covers ignore_changes on a ForceNew
+// attribute inside a MaxItems=1 block when that block is removed. `mode` is
+// ForceNew and listed in ignore_changes as settings[0].mode. When stage 1
+// removes the whole `settings` block, OpenTofu can no longer reset
+// settings[0].mode (the index no longer exists), so it observes the ForceNew
+// change and replaces the resource (destroy + create). pulumi-hcl suppresses
+// the change and updates the resource in place, so the two runtimes emit a
+// different sequence of provider operations.
+func TestL2IgnoreChangesForceNewBlockRemoved(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_ignore_changes_forcenew_block_removed", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "fnblock", Factory: providers.FNBlockProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_ignore_changes_forcenew_block_removed/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ignore_changes_forcenew_block_removed/0/main.tf
@@ -1,0 +1,12 @@
+# Stage 0: create with a `settings` block. `mode` is ForceNew, and it is listed
+# in ignore_changes. `verbose` is an ordinary in-place attribute.
+resource "fnblock_resource" "r" {
+  note = "x"
+  settings {
+    mode    = "a"
+    verbose = false
+  }
+  lifecycle { ignore_changes = [settings[0].mode] }
+}
+
+output "settings" { value = fnblock_resource.r.settings }

--- a/tests/tfcompat/testdata/cases/l2_ignore_changes_forcenew_block_removed/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ignore_changes_forcenew_block_removed/1/main.tf
@@ -1,0 +1,10 @@
+# Stage 1: remove the whole `settings` block. Because `mode` (ForceNew) is only
+# ever addressable as settings[0].mode, ignore_changes cannot reset it once the
+# block is gone, so OpenTofu sees the ForceNew attribute change and REPLACES the
+# resource (destroy + create). pulumi-hcl instead updates it in place.
+resource "fnblock_resource" "r" {
+  note = "y"
+  lifecycle { ignore_changes = [settings[0].mode] }
+}
+
+output "settings" { value = fnblock_resource.r.settings }


### PR DESCRIPTION
## Bug

With `ignore_changes = [settings[0].mode]` on a ForceNew attribute inside a `MaxItems=1` block, removing the whole `settings` block in a later stage must replace the resource: OpenTofu skips an `ignore_changes` entry whose path no longer applies to the configuration, so the ForceNew change on `mode` is planned again and fires a replacement (destroy + create). pulumi-hcl instead updated the resource in place — the ignored path suppressed the replacement.

## Root cause

OpenTofu's `processIgnoreChangesIndividual` honors an entry only when its path applies to the configuration (`icPath.Apply(config)` must succeed; a trailing map key is trimmed first, and a missing leaf attribute decodes as null, so both still apply). pulumi-hcl forwarded every entry to the engine unconditionally, and the engine matches ignored paths against the prior state as well — so an entry whose path existed only in state (the removed block) kept suppressing the diff.

## Fix

`ignoreChangesApplies` (pkg/hcl/run) re-implements the configuration-side existence check against the evaluated inputs, honoring the trailing-map-key exemption, null leaf attributes, unknown values, and MaxItems=1 index flattening. Entries that fail the check are dropped before registration. `terraform_data`'s `{type, value}` boxing is now applied after options are built so the check sees the real value shapes (covered by the existing `l2_tdata_ignore_input_num` case).

Covered by the new `TestL2IgnoreChangesForceNewBlockRemoved` tfcompat test (fails on master) and a `TestIgnoreChangesApplies` unit table; the pre-existing `ignore_changes`/`terraform_data` tfcompat cases still pass.

## Known remaining divergence (out of reach here)

OpenTofu also requires the path to resolve in the *prior state* (adding a block whose ForceNew attribute is ignored still replaces there). The language host never sees prior state; that half lives in pulumi-terraform-bridge's `computeIgnoreChanges`, which matches ignored paths against olds ∪ news instead of olds ∩ news.