### PR TITLE
Resolve provider SDKs and packages by package name, not local name

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-415.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-415.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Resolve a provider's SDK and package by its source's package name when its `required_providers` local name is renamed
+time: 2026-07-16T16:10:00Z
+custom:
+    Component: runtime
+    PR: "415"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1111,7 +1111,7 @@ func (e *Engine) resolveExplicitProvider(
 		}
 		return "", nil
 	}
-	if ref, ok := e.defaultProviders.Get(name); ok {
+	if ref, ok := e.defaultProviders.Get(e.providerPackageName(name)); ok {
 		return ref, nil
 	}
 	return "", nil
@@ -1186,7 +1186,8 @@ func (e *Engine) registerProviderInContext(
 	evalCtx *eval.Context, parentURN urn.URN, modInst *moduleInstance,
 	inst *providerInstance,
 ) error {
-	typeToken := "pulumi:providers:" + provider.Name
+	pkgName := e.providerPackageName(provider.Name)
+	typeToken := "pulumi:providers:" + pkgName
 
 	if inst != nil {
 		key := cty.StringVal(inst.key)
@@ -1196,7 +1197,7 @@ func (e *Engine) registerProviderInContext(
 	hclCtx := evalCtx.HCLContext()
 
 	// Schema-aware eval is needed so schema.Property.Secret marks survive.
-	pkg, perr := packages.ResolvePackage(ctx, e.pkgLoader, knownProviders(e.config.Terraform), "pulumi_providers_"+provider.Name)
+	pkg, perr := packages.ResolvePackage(ctx, e.pkgLoader, knownProviders(e.config.Terraform), "pulumi_providers_"+pkgName)
 	if perr != nil {
 		return fmt.Errorf("resolving provider package %s: %w", provider.Name, perr)
 	}
@@ -1205,7 +1206,7 @@ func (e *Engine) registerProviderInContext(
 		return fmt.Errorf("resolving provider schema for %s: %w", provider.Name, perr)
 	}
 
-	providerMapping := e.resolver.ProviderConfigBodyMapping(ctx, provider.Name)
+	providerMapping := e.resolver.ProviderConfigBodyMapping(ctx, pkgName)
 	inputsMap, _, diags := transform.EvalResourceWithSchema(provider.Config, resSchema, providerMapping,
 		func(_ resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
 			c := hclCtx
@@ -1259,7 +1260,7 @@ func (e *Engine) registerProviderInContext(
 		Custom:     true,
 		Parent:     parentURN,
 		Version:    version,
-		PackageRef: e.packageRefs[provider.Name],
+		PackageRef: e.packageRefs[pkgName],
 	}
 	if resSchema.PackageReference != nil {
 		req.PluginDownloadURL = resSchema.PackageReference.PluginDownloadURL()
@@ -1348,7 +1349,7 @@ func (e *Engine) registerProviderInContext(
 	// Top-level un-aliased provider blocks become the default provider for
 	// resources of the same package that don't set `provider` explicitly.
 	if provider.Alias == "" && node.ModuleInfo == nil && providerID != "" {
-		e.defaultProviders.Set(provider.Name, string(resp.URN)+"::"+providerID)
+		e.defaultProviders.Set(pkgName, string(resp.URN)+"::"+providerID)
 	}
 
 	markedProviderOutputs := cty.ObjectVal(outputObj).Mark(eval.DepMark(resp.URN))
@@ -2616,6 +2617,23 @@ func (e *Engine) packageRefForResource(hclToken string, resSchema *schema.Resour
 	return e.packageRefForType(hclToken)
 }
 
+// providerPackageName maps a provider's required_providers local name to its
+// Pulumi package name: the basename of the entry's source ("hashicorp/simple"
+// → "simple"), or the local name itself when no entry renames it.
+func providerPackageName(tfBlock *ast.Terraform, local string) string {
+	if tfBlock != nil {
+		if req, ok := tfBlock.RequiredProviders[local]; ok && req.Source != "" {
+			parts := strings.Split(req.Source, "/")
+			return parts[len(parts)-1]
+		}
+	}
+	return local
+}
+
+func (e *Engine) providerPackageName(local string) string {
+	return providerPackageName(e.config.Terraform, local)
+}
+
 func knownProviders(tfBlock *ast.Terraform) []string {
 	if tfBlock == nil {
 		return nil
@@ -3361,7 +3379,7 @@ func (e *Engine) processCall(ctx context.Context, node *graph.Node) error {
 		}
 		if matched != nil {
 			resKey = matched.Key()
-			providerToken := "pulumi_providers_" + matched.Name
+			providerToken := "pulumi_providers_" + e.providerPackageName(matched.Name)
 			resType = providerToken
 			pkg, err := packages.ResolvePackage(ctx, e.pkgLoader, knownProviders(e.config.Terraform), providerToken)
 			if err != nil {
@@ -3523,7 +3541,7 @@ func (e *Engine) providerFunctionTable(
 
 	table := map[string]function.Function{}
 	for providerName := range referenced {
-		fns, err := e.resolver.ProviderFunctions(ctx, providerName)
+		fns, err := e.resolver.ProviderFunctions(ctx, providerPackageName(config.Terraform, providerName))
 		if err != nil {
 			if lenient {
 				logging.V(5).Infof("provider functions for %q unavailable: %v", providerName, err)
@@ -3560,7 +3578,7 @@ func (e *Engine) providerFunctionImpl(
 		req := InvokeRequest{
 			Token:      fnSchema.Token,
 			Args:       args,
-			PackageRef: e.packageRefs[providerName],
+			PackageRef: e.packageRefs[e.providerPackageName(providerName)],
 		}
 		if modInfo != nil {
 			if ref := e.resolvePassThroughProvider(modInfo, providerName); ref != "" {
@@ -3572,7 +3590,7 @@ func (e *Engine) providerFunctionImpl(
 			} else if ref := e.inheritedDefaultProvider(modInfo, providerName); ref != "" {
 				req.Provider = ref
 			}
-		} else if ref, ok := e.defaultProviders.Get(providerName); ok {
+		} else if ref, ok := e.defaultProviders.Get(e.providerPackageName(providerName)); ok {
 			req.Provider = ref
 		}
 

--- a/pkg/server/module_resource.go
+++ b/pkg/server/module_resource.go
@@ -402,7 +402,7 @@ func (m *moduleProvider) requirementSpecs(
 		}
 		req := aliases[alias]
 		if req.IsPulumi() {
-			name := pulumiPackageName(alias, req.Source)
+			name := packageName(alias, req.Source)
 			reqs = append(reqs, resolve.Request{
 				Alias: alias,
 				Spec:  &pulumirpc.PackageSpec{Source: name, Version: pulumi[name]},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -190,6 +190,7 @@ func (host *LanguageHost) GetRequiredPackages(
 	tfSpecs, pulumiPkgs, aliases := collectRequirements(ctx, modules.NewLoader(modules.LiveResolver(ctx)),
 		config, req.Info.ProgramDirectory)
 
+	emitted := map[string]bool{}
 	for _, alias := range sortedKeys(aliases) {
 		// A local SDK descriptor (written by `pulumi package add`) is the most
 		// specific source of truth: it carries the base provider name and the
@@ -198,30 +199,44 @@ func (host *LanguageHost) GetRequiredPackages(
 		// to a base provider plus parameter rather than a plain dependency. The
 		// raw source it shadows must not also be installed. An extension package
 		// reports its base provider with the parameter in the extension slot.
-		info, ok := paramInfos[alias]
+
+		// The descriptor directory is named after the resolved package, which
+		// differs from the alias when required_providers renames the provider
+		// locally; the alias and the package-name aliases then share one
+		// descriptor, reported once.
+		req := aliases[alias]
+		key := alias
+		info, ok := paramInfos[key]
+		if !ok {
+			key = packageName(alias, tfProviderSource(alias, req))
+			info, ok = paramInfos[key]
+		}
 		if !ok {
 			continue
 		}
-		pkgs = append(pkgs, &pulumirpc.PackageDependency{
-			Name:             info.Name,
-			Version:          versionString(info.Version),
-			Kind:             "resource",
-			Parameterization: parameterizationProto(info.Parameterization),
-			Extension:        parameterizationProto(info.ExtensionParameterization),
-		})
-		req := aliases[alias]
+		if !emitted[key] {
+			emitted[key] = true
+			pkgs = append(pkgs, &pulumirpc.PackageDependency{
+				Name:             info.Name,
+				Version:          versionString(info.Version),
+				Kind:             "resource",
+				Parameterization: parameterizationProto(info.Parameterization),
+				Extension:        parameterizationProto(info.ExtensionParameterization),
+			})
+			// An extension's resource tokens live in the base provider's
+			// namespace, so a program that uses only extension resources infers
+			// a bare terraform-provider requirement for the base. That base is
+			// served by the extension reported above, so drop the inferred
+			// spec. A base that is separately declared in required_providers
+			// (used directly by a base resource) stays in pulumiPkgs and is
+			// still reported.
+			if info.ExtensionParameterization != nil {
+				delete(tfSpecs, tfProviderSource(info.Name, aliases[info.Name]))
+			}
+		}
 		delete(tfSpecs, tfProviderSource(alias, req))
 		if req.IsPulumi() {
-			delete(pulumiPkgs, pulumiPackageName(alias, req.Source))
-		}
-		// An extension's resource tokens live in the base provider's namespace,
-		// so a program that uses only extension resources infers a bare
-		// terraform-provider requirement for the base. That base is served by
-		// the extension reported above, so drop the inferred spec. A base that
-		// is separately declared in required_providers (used directly by a base
-		// resource) stays in pulumiPkgs and is still reported.
-		if info.ExtensionParameterization != nil {
-			delete(tfSpecs, tfProviderSource(info.Name, aliases[info.Name]))
+			delete(pulumiPkgs, packageName(alias, req.Source))
 		}
 	}
 
@@ -257,10 +272,10 @@ func tfProviderSource(alias string, req *ast.RequiredProvider) string {
 	return "hashicorp/" + alias
 }
 
-// pulumiPackageName returns the package name for a pulumi/-sourced
-// required_providers entry: the last segment of the source ("pulumi/aws" →
-// "aws"), or the alias when source is unset.
-func pulumiPackageName(alias, source string) string {
+// packageName returns the Pulumi package name for a required_providers
+// entry: the last segment of the source ("pulumi/aws" → "aws",
+// "hashicorp/simple" → "simple"), or the alias when source is unset.
+func packageName(alias, source string) string {
 	if source == "" {
 		return alias
 	}
@@ -327,10 +342,17 @@ func missingNonPulumiSDKs(
 	_, _, aliases := collectRequirements(ctx, modules.NewLoader(modules.LiveResolver(ctx)), config, workDir)
 	var missing []string
 	for _, alias := range sortedKeys(aliases) {
-		if isBuiltinProvider(alias) || aliases[alias].IsPulumi() {
+		req := aliases[alias]
+		if isBuiltinProvider(alias) || req.IsPulumi() {
 			continue
 		}
 		if _, ok := sdks[alias]; ok {
+			continue
+		}
+		// The SDK directory is named after the resolved package (the source
+		// basename), which differs from the alias when required_providers
+		// renames the provider locally.
+		if _, ok := sdks[packageName(alias, tfProviderSource(alias, req))]; ok {
 			continue
 		}
 		// An extension resource's type namespace is its base provider name; the
@@ -431,7 +453,7 @@ func collectRequirementsRec(
 			return
 		}
 		if req.IsPulumi() {
-			pulumi[pulumiPackageName(alias, req.Source)] = req.Version
+			pulumi[packageName(alias, req.Source)] = req.Version
 			return
 		}
 		source := tfProviderSource(alias, req)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -339,6 +339,101 @@ terraform {
 	assert.Empty(t, resp.Specs)
 }
 
+// A provider whose required_providers local name differs from its package
+// name (the source basename) still resolves against the SDK directory
+// `pulumi install` wrote under the package name, and the alias plus the
+// resource-type-prefix alias share that one descriptor.
+func TestGetRequiredPackages_RenamedLocalName(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+terraform {
+  required_providers {
+    myp = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+provider "myp" {}
+
+resource "simple_resource" "r" {
+  provider = myp
+}
+`), 0o600))
+
+	host := &LanguageHost{}
+	sdkDir := filepath.Join(dir, "sdks", "simple")
+	require.NoError(t, os.MkdirAll(sdkDir, 0o755))
+	_, err := host.GeneratePackage(t.Context(), &pulumirpc.GeneratePackageRequest{
+		Directory: sdkDir,
+		Schema: `{
+			"name": "simple",
+			"version": "1.0.0",
+			"parameterization": {
+				"baseProvider": {"name": "terraform-provider", "version": "0.0.1"},
+				"parameter": "aGVsbG8="
+			}
+		}`,
+	})
+	require.NoError(t, err)
+
+	resp, err := host.GetRequiredPackages(t.Context(), &pulumirpc.GetRequiredPackagesRequest{
+		Info: &pulumirpc.ProgramInfo{
+			ProgramDirectory: dir,
+			RootDirectory:    dir,
+			EntryPoint:       ".",
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []*pulumirpc.PackageDependency{{
+		Name:    "terraform-provider",
+		Version: "0.0.1",
+		Kind:    "resource",
+		Parameterization: &pulumirpc.PackageParameterization{
+			Name:    "simple",
+			Version: "1.0.0",
+			Value:   []byte("hello"),
+		},
+	}}, resp.Packages)
+	assert.Empty(t, resp.Specs)
+}
+
+// missingNonPulumiSDKs must find the SDK directory under the resolved package
+// name when the required_providers local name renames the provider.
+func TestMissingNonPulumiSDKs_RenamedLocalName(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+terraform {
+  required_providers {
+    myp = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+provider "myp" {}
+
+resource "simple_resource" "r" {
+  provider = myp
+}
+`), 0o600))
+
+	config, diags := parser.NewParser().ParseDirectory(dir)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	sdks := map[string]workspace.PackageDescriptor{
+		"simple": {PluginDescriptor: workspace.PluginDescriptor{Name: "simple"}},
+	}
+	assert.Empty(t, missingNonPulumiSDKs(t.Context(), config, sdks, dir))
+	assert.Equal(t, []string{"myp", "simple"},
+		missingNonPulumiSDKs(t.Context(), config, nil, dir))
+}
+
 // TestGetRequiredPackages_SameSourceVersionIntersection mirrors tofu: two
 // modules requiring the same provider source are installed once, with their
 // version constraints unioned into one ", "-joined constraint. The

--- a/tests/tfcompat/l2_provider_renamed_local_name_test.go
+++ b/tests/tfcompat/l2_provider_renamed_local_name_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ProviderRenamedLocalName pins that a provider whose required_providers
+// local name differs from its package name (source basename) runs: OpenTofu
+// resolves the local name to the source, configures it, and the resource that
+// selects it via `provider = myp` sees the config.
+func TestL2ProviderRenamedLocalName(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_provider_renamed_local_name", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_provider_renamed_local_name/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provider_renamed_local_name/main.tf
@@ -1,0 +1,25 @@
+# The provider's local name ("myp") differs from its package name ("simple",
+# the basename of the source). OpenTofu resolves the local name to the source
+# and runs the program. The resource is tied to the "myp" configuration via
+# the `provider` meta-argument.
+terraform {
+  required_providers {
+    myp = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+provider "myp" {
+  prefix = "hello"
+}
+
+resource "simple_resource" "r" {
+  provider  = myp
+  input_one = "world"
+  input_two = true
+}
+
+output "prefix_result" {
+  value = simple_resource.r.prefix_result
+}


### PR DESCRIPTION
## Bug

A provider whose `required_providers` local name differs from its package name (the source basename) — e.g. `myp = { source = "hashicorp/simple" }` — runs fine under OpenTofu: it resolves the local name to the source, configures the provider, and the resource selecting it via `provider = myp` gets its result. pulumi-hcl aborted with:

```
error: an unhandled error occurred: missing local SDK for non-Pulumi provider(s) [myp]; run `pulumi install` to fetch them
```

and, past that gate, failed provider registration with `resolving provider package myp: … no resource plugin 'pulumi-resource-myp'`.

## Root cause

`pulumi install`/GenSDK writes the SDK directory under the resolved **package** name (`sdks/simple/` for a `hashicorp/simple` source), while the runtime keyed its SDK and package lookups by the **local** name (`myp`). This is a distinct path from resource-type token resolution, which already handles renamed local names.

## Fix

Map the local name to the source's package name wherever package identity matters:

- `pkg/server`: the missing-SDK gate (`missingNonPulumiSDKs`) also checks the SDK map under the resolved package name; `GetRequiredPackages` falls back to the package-name descriptor, with dedup since the renamed alias and the resource-type-prefix alias now share one descriptor; `pulumiPackageName` generalized to `packageName`.
- `pkg/hcl/run`: new `providerPackageName` (local name → source basename) applied in provider block registration (type token, schema load, body mapping, package ref); the default-provider map is now keyed by package name on set and get — matching how provider configurations attach to the provider itself rather than its local name — and the call-block and provider-function paths map the name before package resolution.

## Testing

- `TestL2ProviderRenamedLocalName` (tfcompat, added here) fails on master and passes with the fix.
- New unit tests: `TestGetRequiredPackages_RenamedLocalName`, `TestMissingNonPulumiSDKs_RenamedLocalName`.

Out of scope: the converter (eject) provider-block path resolves `pulumi_providers_<local name>` the same way and likely mishandles renamed local names too; that surface needs its own failing test first.