### PR TITLE
Narrow instance-addressed references to the addressed instance

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-416.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-416.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Depend on only the addressed instance for instance-addressed references (`a["x"]` in `depends_on` or expressions) instead of every instance, and run count/for_each instances concurrently
+time: 2026-07-16T18:40:00Z
+custom:
+    Component: runtime
+    PR: "416"

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -424,11 +424,12 @@ resource target "test:index:Item" {
 
 		mock := testConvertedPCL(t, pclSource, rangeSchema)
 
-		// stack + 2 source items + 1 target
+		// stack + 2 source items + 1 target; registration order between the
+		// target and the source instance it does not reference is undefined.
 		require.Len(t, mock.RegisteredResources, 4, "expected stack + 2 sources + 1 target")
 		assert.Equal(t, "pulumi:pulumi:Stack", mock.RegisteredResources[0].Type)
 
-		target := mock.RegisteredResources[3]
+		target := findRegistered(t, mock.RegisteredResources, "target")
 		assert.Equal(t, "test:index:Item", target.Type)
 		assert.Equal(t, property.New("src-0-ref"), target.Inputs.Get("name"))
 	})
@@ -452,13 +453,27 @@ resource target "test:index:Item" {
 
 		mock := testConvertedPCL(t, pclSource, rangeSchema)
 
-		// stack + 2 source items + 1 target
+		// stack + 2 source items + 1 target; registration order between the
+		// target and the source instance it does not reference is undefined.
 		require.Len(t, mock.RegisteredResources, 4, "expected stack + 2 sources + 1 target")
 
-		target := mock.RegisteredResources[3]
+		target := findRegistered(t, mock.RegisteredResources, "target")
 		assert.Equal(t, "test:index:Item", target.Type)
 		assert.Equal(t, property.New("alpha-ref"), target.Inputs.Get("name"))
 	})
+}
+
+// findRegistered returns the registered resource with the given name; sibling
+// instances register concurrently, so positional indexing is not stable.
+func findRegistered(t *testing.T, resources []hclrun.RegisterResourceRequest, name string) hclrun.RegisterResourceRequest {
+	t.Helper()
+	for _, r := range resources {
+		if r.Name == name {
+			return r
+		}
+	}
+	t.Fatalf("no registered resource named %q", name)
+	return hclrun.RegisterResourceRequest{}
 }
 
 // TestStdLookupInlinedInForEachResource checks that a `std:index:*` function (which has a

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"testing"
 

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1543,7 +1544,7 @@ func TestInvokeInRangeOption(t *testing.T) {
 			sinkNames = append(sinkNames, r.Name)
 		}
 	}
-	assert.Equal(t, []string{"targets-0", "targets-1"}, sinkNames)
+	assert.ElementsMatch(t, []string{"targets-0", "targets-1"}, sinkNames)
 }
 
 // TestInvokeReturnType covers the case where a function declares its outputs via

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"maps"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 
@@ -434,12 +433,20 @@ func (c *Context) HCLContext() *hcl.EvalContext {
 			resourcesByType[typeName] = make(map[string]cty.Value)
 		}
 		if len(instances) > 0 && instances[0].isCount {
-			sort.Slice(instances, func(i, j int) bool {
-				return instances[i].index < instances[j].index
-			})
-			vals := make([]cty.Value, len(instances))
-			for i, inst := range instances {
-				vals[i] = inst.value
+			// Instances register concurrently, so lower indexes may not be in
+			// yet when a dependent narrowed to one index evaluates. Keep every
+			// index at its true position, holding unregistered gaps unknown —
+			// a correctly scheduled dependent never reads a gap.
+			maxIndex := 0
+			for _, inst := range instances {
+				maxIndex = max(maxIndex, inst.index)
+			}
+			vals := make([]cty.Value, maxIndex+1)
+			for i := range vals {
+				vals[i] = cty.DynamicVal
+			}
+			for _, inst := range instances {
+				vals[inst.index] = inst.value
 			}
 			resourcesByType[typeName][resName] = cty.TupleVal(vals)
 		} else {

--- a/pkg/hcl/eval/iteration_test.go
+++ b/pkg/hcl/eval/iteration_test.go
@@ -111,3 +111,24 @@ func TestWithIterationIsolatesConcurrentForEach(t *testing.T) {
 	require.Equal(t, "a", aKey, "A observed B's each.key — the iteration binding is shared, not per-view")
 	require.Equal(t, "b", bKey)
 }
+
+// TestPartialCountAssemblySparse pins the property that lets a dependent
+// narrowed to one count index evaluate while sibling instances are still
+// registering: each registered index sits at its true tuple position, with
+// unregistered gaps held unknown.
+func TestPartialCountAssemblySparse(t *testing.T) {
+	t.Parallel()
+	c, err := NewContext("/tmp", "/tmp", "/tmp", "", "", "")
+	require.NoError(t, err)
+
+	c.SetCountResource("simple_resource.a", 1, "urn:a1", cty.ObjectVal(map[string]cty.Value{
+		"result": cty.StringVal("one"),
+	}))
+
+	tuple := c.HCLContext().Variables["simple_resource"].GetAttr("a")
+	require.Equal(t, 2, tuple.LengthInt())
+	require.False(t, tuple.Index(cty.NumberIntVal(0)).IsKnown())
+	one := tuple.Index(cty.NumberIntVal(1))
+	one, _ = one.Unmark()
+	require.Equal(t, cty.StringVal("one"), one.GetAttr("result"))
+}

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -207,10 +207,21 @@ type Graph struct {
 	// instanceDeps maps a dependent node's key to the keys of dependencies it
 	// narrows to specific instances: dependency node key → full instance keys
 	// (in ExpandedResource.Key form, e.g. `type.name["x"]`). An entry exists
-	// only when every reference from the dependent to that dependency is an
-	// instance-addressed depends_on; any whole-resource reference widens the
-	// dependency and no entry is recorded.
+	// only when every reference from the dependent to that dependency is
+	// instance-addressed; any whole-resource reference widens the dependency
+	// and no entry is recorded.
 	instanceDeps map[string]map[string][]string
+
+	// modulePlans holds, per module path, the plan for spawning one walk unit
+	// per member node for each module instance (see SpawnModuleInstanceUnits).
+	// Computed at the end of BuildFromConfig.
+	modulePlans map[modulepath.Path][]*memberPlan
+
+	// initInputEdges are deferred (from, to-init) edges ordering a module
+	// call's init after its input expressions' references. Applied
+	// best-effort once the whole graph exists, where a cyclic edge (mutual
+	// module-input references) can be detected and skipped.
+	initInputEdges [][2]pdag.Node
 
 	// moved holds the moved blocks of each module keyed by that module's path.
 	// A moved block's from/to addresses are relative to the module it is written
@@ -249,6 +260,7 @@ func NewGraph() *Graph {
 		dependents:   make(map[string]int),
 		successors:   make(map[string][]pdag.Node),
 		instanceDeps: make(map[string]map[string][]string),
+		modulePlans:  make(map[modulepath.Path][]*memberPlan),
 		moved:        make(map[modulepath.Path][]*ast.Moved),
 		scopes:       make(map[string]*moduleScope),
 
@@ -519,6 +531,18 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 		}
 	}
 
+	// Apply the deferred init-input edges (see initInputEdges), skipping any
+	// that the finished graph shows to be cyclic.
+	for _, edge := range g.initInputEdges {
+		if err := g.dag.NewEdge(edge[0], edge[1]); err != nil {
+			var cyc pdag.ErrorCycle[dagNode]
+			if errors.As(err, &cyc) {
+				continue
+			}
+			return nil, err
+		}
+	}
+
 	// Snapshot every resource node's successors for SpawnInstances (see the
 	// successors field).
 	for key, n := range g.seen {
@@ -526,6 +550,8 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 			g.successors[key] = slices.Collect(g.dag.Successors(n.i))
 		}
 	}
+
+	g.buildModulePlans()
 
 	return g, nil
 }
@@ -1169,6 +1195,16 @@ type InstanceExec struct {
 	Exec func(context.Context) error
 }
 
+// SpawnTarget is a walk node that must be re-gated on a resource's expanded
+// instances: a successor of the resource's own node (at root), or a member
+// unit and template inside a module clone. Key is the dependent's node key,
+// consulted for instance narrowing; an empty Key never narrows (the target
+// waits for every instance).
+type SpawnTarget struct {
+	Key string
+	N   pdag.Node
+}
+
 // SpawnInstances schedules the expanded instances of resource node nodeKey as
 // their own concurrent walk units. It must be called during a Walk from within
 // nodeKey's own exec, before it returns: each successor of nodeKey is re-gated
@@ -1178,17 +1214,31 @@ type InstanceExec struct {
 func (g *Graph) SpawnInstances(nodeKey string, instances []InstanceExec) error {
 	succs, ok := g.successors[nodeKey]
 	contract.Assertf(ok, "SpawnInstances is only valid for resource nodes, not %q", nodeKey)
+	targets := make([]SpawnTarget, len(succs))
+	for i, succ := range succs {
+		targets[i] = SpawnTarget{Key: g.keyByDagNode[succ], N: succ}
+	}
+	return g.SpawnInstancesTo(nodeKey, instances, targets)
+}
+
+// SpawnInstancesTo is SpawnInstances with an explicit target set, for
+// resources whose work runs inside a module-instance unit: the targets are
+// that instance's aligned successor units plus the resource's own template.
+func (g *Graph) SpawnInstancesTo(nodeKey string, instances []InstanceExec, targets []SpawnTarget) error {
 	nodes := make([]pdag.Node, len(instances))
 	ready := make([]pdag.Done, len(instances))
 	for i, inst := range instances {
 		nodes[i], ready[i] = g.dag.NewNode(dagNode{key: inst.Key, exec: inst.Exec})
 	}
-	for _, succ := range succs {
-		// nil means the successor depends on the whole resource. A narrow key
+	for _, t := range targets {
+		// nil means the target depends on the whole resource. A narrow key
 		// that names no actual instance (a nonexistent instance, or a count
 		// index against for_each string keys) also falls back to the whole
 		// resource, as OpenTofu's reference resolution does.
-		narrow := g.instanceDeps[g.keyByDagNode[succ]][nodeKey]
+		var narrow []string
+		if t.Key != "" {
+			narrow = g.instanceDeps[t.Key][nodeKey]
+		}
 		for _, key := range narrow {
 			if !slices.ContainsFunc(instances, func(inst InstanceExec) bool { return inst.Key == key }) {
 				narrow = nil
@@ -1199,10 +1249,141 @@ func (g *Graph) SpawnInstances(nodeKey string, instances []InstanceExec) error {
 			if narrow != nil && !slices.Contains(narrow, inst.Key) {
 				continue
 			}
-			if err := g.dag.NewEdge(nodes[i], succ); err != nil {
+			if err := g.dag.NewEdge(nodes[i], t.N); err != nil {
 				return err
 			}
 		}
+	}
+	for _, done := range ready {
+		done()
+	}
+	return nil
+}
+
+// memberPlan is the spawning plan for one member node of a module: the
+// classification of its static edges into intra-module (instance-aligned in
+// each clone) and external (node-level, unchanged).
+type memberPlan struct {
+	node *Node
+	tmpl pdag.Node
+	// sameModulePreds / sameModuleSuccs are member keys of the same module
+	// that are static predecessors / successors of this member.
+	sameModulePreds []string
+	sameModuleSuccs []string
+	// externalPreds are the walk nodes of static predecessors owned outside
+	// the module: root nodes, or other modules' templates (whose completion
+	// implies their units completed).
+	externalPreds []pdag.Node
+}
+
+// OwnerPath returns the module path whose instances execute this node's work.
+// A module's init and completion nodes run per instance of the *enclosing*
+// module (they evaluate the call in the parent's scope); every other
+// module-inlined node runs per instance of its own module. Root-owned nodes
+// run their work synchronously in their exec.
+func (n *Node) OwnerPath() modulepath.Path {
+	if n.ModuleInfo == nil {
+		return modulepath.Root()
+	}
+	switch n.Type {
+	case NodeTypeModuleInit, NodeTypeModule:
+		return n.ModuleInfo.ParentPath()
+	default:
+		return n.ModuleInfo.Path
+	}
+}
+
+// buildModulePlans classifies every non-root-owned node's static edges for
+// SpawnModuleInstanceUnits. Called once at the end of BuildFromConfig.
+func (g *Graph) buildModulePlans() {
+	// Call nodes execute at root against the root config, and pass-through
+	// provider shadows are inert stand-ins with no init edge; neither does
+	// per-instance work, so both they and their consumers connect at node
+	// level (external).
+	planned := func(n *Node) bool {
+		return !n.OwnerPath().IsRoot() && n.Type != NodeTypeCall && n.Type != NodeTypeBuiltin
+	}
+
+	plans := make(map[string]*memberPlan)
+	for key, in := range g.seen {
+		if !planned(in.n) {
+			continue
+		}
+		owner := in.n.OwnerPath()
+		plan := &memberPlan{node: in.n, tmpl: in.i}
+		for pred := range g.dag.Predecessors(in.i) {
+			pk := g.keyByDagNode[pred]
+			pn, ok := g.seen[pk]
+			if ok && planned(pn.n) && pn.n.OwnerPath() == owner {
+				if !slices.Contains(plan.sameModulePreds, pk) {
+					plan.sameModulePreds = append(plan.sameModulePreds, pk)
+				}
+			} else if !slices.Contains(plan.externalPreds, pred) {
+				plan.externalPreds = append(plan.externalPreds, pred)
+			}
+		}
+		plans[key] = plan
+		g.modulePlans[owner] = append(g.modulePlans[owner], plan)
+	}
+	for key, plan := range plans {
+		for _, pk := range plan.sameModulePreds {
+			pred := plans[pk]
+			pred.sameModuleSuccs = append(pred.sameModuleSuccs, key)
+		}
+	}
+}
+
+// MemberUnit hands a member's walk unit to the exec builder passed to
+// SpawnModuleInstanceUnits. Targets is filled in before the unit can run: the
+// instance's units of the members that statically depend on this member, plus
+// this member's own template — the set a resource unit re-gates when spawning
+// its count/for_each instances.
+type MemberUnit struct {
+	Node    *Node
+	Targets []SpawnTarget
+	n       pdag.Node
+}
+
+// SpawnModuleInstanceUnits creates one concurrent walk unit per member of the
+// module at path, for a single module instance. Units carry the module's
+// static topology instance-aligned: intra-module edges connect this
+// instance's units only, external predecessors attach at node level, and each
+// unit becomes a prerequisite of its member's template — so a template
+// completes only when every instance's unit has, preserving node-level
+// semantics for everything outside the module. Must be called during a Walk
+// from within the exec (or unit) of the module's init node.
+func (g *Graph) SpawnModuleInstanceUnits(
+	path modulepath.Path, label string, exec func(u *MemberUnit) func(context.Context) error,
+) error {
+	units := make(map[string]*MemberUnit)
+	var ready []pdag.Done
+	for _, plan := range g.modulePlans[path] {
+		u := &MemberUnit{Node: plan.node}
+		fn := exec(u)
+		var done pdag.Done
+		u.n, done = g.dag.NewNode(dagNode{key: plan.node.Key + label, exec: fn})
+		units[plan.node.Key] = u
+		ready = append(ready, done)
+	}
+	for _, plan := range g.modulePlans[path] {
+		u := units[plan.node.Key]
+		for _, pk := range plan.sameModulePreds {
+			if err := g.dag.NewEdge(units[pk].n, u.n); err != nil {
+				return err
+			}
+		}
+		for _, ext := range plan.externalPreds {
+			if err := g.dag.NewEdge(ext, u.n); err != nil {
+				return err
+			}
+		}
+		if err := g.dag.NewEdge(u.n, plan.tmpl); err != nil {
+			return err
+		}
+		for _, sk := range plan.sameModuleSuccs {
+			u.Targets = append(u.Targets, SpawnTarget{Key: sk, N: units[sk].n})
+		}
+		u.Targets = append(u.Targets, SpawnTarget{N: plan.tmpl})
 	}
 	for _, done := range ready {
 		done()
@@ -1382,6 +1563,17 @@ func (g *Graph) inlineModule(
 	}
 
 	_, initIdx := g.newNode(initKey)
+
+	// Init eagerly evaluates the call's input expressions in the parent scope
+	// (they become the component resource's registered inputs), so it should
+	// order after everything they reference. The edges are deferred to the
+	// end of BuildFromConfig and added best-effort there: module inputs may
+	// legally reference each other's outputs mutually (acyclic at variable
+	// granularity), and those eager component inputs then degrade instead of
+	// the graph failing.
+	for _, dep := range g.bodyDeps(mod.Config, parentPrefix, nil, nil) {
+		g.initInputEdges = append(g.initInputEdges, [2]pdag.Node{dep, initIdx})
+	}
 
 	// Variables: each depends on init + the corresponding input expression from the module block.
 	moduleInputAttrs, _ := mod.Config.JustAttributes()

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
 	"github.com/pulumi/pulumi/pkg/v3/util/pdag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // ModuleInfo holds metadata for nodes that are part of an inlined module.
@@ -196,6 +197,20 @@ type Graph struct {
 	// dependency list. Read by HasDependents at Walk time.
 	dependents map[string]int
 
+	// successors holds, for each resource node, the nodes that depend on it.
+	// Snapshotted from dag.Successors at the end of BuildFromConfig —
+	// SpawnInstances needs the set during a Walk, when the dag is being
+	// mutated and dag.Successors is not safe to call.
+	successors map[string][]pdag.Node
+
+	// instanceDeps maps a dependent node's key to the keys of dependencies it
+	// narrows to specific instances: dependency node key → full instance keys
+	// (in ExpandedResource.Key form, e.g. `type.name["x"]`). An entry exists
+	// only when every reference from the dependent to that dependency is an
+	// instance-addressed depends_on; any whole-resource reference widens the
+	// dependency and no entry is recorded.
+	instanceDeps map[string]map[string][]string
+
 	// moved holds the moved blocks of each module keyed by that module's path.
 	// A moved block's from/to addresses are relative to the module it is written
 	// in, so resolving a rename needs the blocks scoped to the resource's own
@@ -231,6 +246,8 @@ func NewGraph() *Graph {
 		references:   make(map[string][]hcl.Range),
 		keyByDagNode: make(map[pdag.Node]string),
 		dependents:   make(map[string]int),
+		successors:   make(map[string][]pdag.Node),
+		instanceDeps: make(map[string]map[string][]string),
 		moved:        make(map[modulepath.Path][]*ast.Moved),
 		scopes:       make(map[string]*moduleScope),
 
@@ -451,7 +468,7 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 
 	// Add resource nodes
 	for key, resource := range config.Resources {
-		deps := g.resourceDeps(resource, "")
+		deps := g.resourceDeps(resource, "", key)
 		deps = append(deps, g.defaultProviderDeps(resource, config, "")...)
 		err := g.AddNode(&Node{
 			Key:      key,
@@ -465,7 +482,7 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 
 	// Add data source nodes
 	for key, dataSource := range config.DataSources {
-		deps := g.resourceDeps(dataSource, "")
+		deps := g.resourceDeps(dataSource, "", "data."+key)
 		deps = append(deps, g.defaultProviderDeps(dataSource, config, "")...)
 		err := g.AddNode(&Node{
 			Key:      "data." + key,
@@ -498,6 +515,14 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 		}, deps)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	// Snapshot every resource node's successors for SpawnInstances (see the
+	// successors field).
+	for key, n := range g.seen {
+		if n.n.Type == NodeTypeResource {
+			g.successors[key] = slices.Collect(g.dag.Successors(n.i))
 		}
 	}
 
@@ -718,20 +743,55 @@ func packageNameFromResourceType(token string) string {
 	return strings.SplitN(token, "_", 2)[0]
 }
 
-// resourceDeps extracts all dependencies from a resource, applying prefix to resolved keys.
-func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node {
-	seen := make(map[pdag.Node]bool)
+// instanceRefs classifies a dependent's resource/data references by instance
+// addressing: narrow collects the instance keys of literal-indexed references
+// (`a["x"]`, in ExpandedResource.Key form with prefix applied); whole marks
+// dependencies referenced as a whole object. A dependency stays narrow only if
+// nothing references it as a whole.
+type instanceRefs struct {
+	whole  map[string]bool
+	narrow map[string][]string
+}
 
-	for _, dep := range g.exprDeps(resource.Count, prefix) {
-		seen[dep] = true
+// record classifies one reference traversal and returns the prefixed
+// dependency key ("" for non-reference traversals). A nil receiver only
+// resolves the key (for dependents that never narrow).
+func (r *instanceRefs) record(traversal hcl.Traversal, prefix string) string {
+	dep, instance := InstanceTarget(traversal)
+	if dep == "" {
+		return ""
 	}
-	for _, dep := range g.exprDeps(resource.ForEach, prefix) {
-		seen[dep] = true
+	if r == nil {
+		return prefix + dep
 	}
+	if instance == "" {
+		r.whole[prefix+dep] = true
+	} else {
+		r.narrow[prefix+dep] = append(r.narrow[prefix+dep], prefix+instance)
+	}
+	return prefix + dep
+}
+
+// resourceDeps extracts all dependencies from a resource, applying prefix to
+// resolved keys. nodeKey is the key the resource's own node is registered
+// under; body and depends_on references that address a single count/for_each
+// instance are recorded against it in g.instanceDeps.
+func (g *Graph) resourceDeps(resource *ast.Resource, prefix, nodeKey string) []pdag.Node {
+	seen := make(map[pdag.Node]bool)
+	refs := &instanceRefs{whole: make(map[string]bool), narrow: make(map[string][]string)}
+	markWhole := func(deps ...pdag.Node) {
+		for _, dep := range deps {
+			seen[dep] = true
+			refs.whole[g.keyByDagNode[dep]] = true
+		}
+	}
+
+	markWhole(g.exprDeps(resource.Count, prefix)...)
+	markWhole(g.exprDeps(resource.ForEach, prefix)...)
 	for _, traversal := range resource.DependsOn {
-		if dep := formatTraversal(traversal); dep != "" {
-			g.recordRef(prefix+dep, traversal.SourceRange())
-			_, idx := g.newNode(prefix + dep)
+		if dep := refs.record(traversal, prefix); dep != "" {
+			g.recordRef(dep, traversal.SourceRange())
+			_, idx := g.newNode(dep)
 			seen[idx] = true
 		}
 	}
@@ -739,12 +799,10 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node 
 		if dep := formatTraversal(resource.ResourceParent); dep != "" {
 			g.recordRef(prefix+dep, resource.ResourceParent.SourceRange())
 			_, idx := g.newNode(prefix + dep)
-			seen[idx] = true
+			markWhole(idx)
 		}
 	}
-	for _, dep := range g.exprDeps(resource.Provider, prefix) {
-		seen[dep] = true
-	}
+	markWhole(g.exprDeps(resource.Provider, prefix)...)
 	// A bare `provider = name` reference (no alias) is a single-segment
 	// traversal, which exprDeps drops because it carries no attribute after the
 	// root. It names the default configuration, which resolves through
@@ -754,20 +812,21 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node 
 	// resolved by exprDeps above.
 	if resource.Provider != nil {
 		if vars := resource.Provider.Variables(); len(vars) == 1 && len(vars[0]) == 1 {
-			for _, dep := range g.defaultProviderNode(vars[0].RootName(), g.scopes[prefix]) {
-				seen[dep] = true
-			}
+			markWhole(g.defaultProviderNode(vars[0].RootName(), g.scopes[prefix])...)
 		}
 	}
 	for _, traversal := range resource.Providers {
 		if dep := formatTraversal(traversal); dep != "" {
 			g.recordRef(prefix+dep, traversal.SourceRange())
 			_, idx := g.newNode(prefix + dep)
-			seen[idx] = true
+			markWhole(idx)
 		}
 	}
+	// Body references are classified through refs rather than markWhole, so a
+	// literal-indexed reference narrows just like an instance-addressed
+	// depends_on.
 	if resource.Config != nil {
-		for _, dep := range g.bodyDeps(resource.Config, prefix, nil) {
+		for _, dep := range g.bodyDeps(resource.Config, prefix, nil, refs) {
 			seen[dep] = true
 		}
 	}
@@ -775,25 +834,31 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node 
 		if dep := formatTraversal(resource.DeletedWith); dep != "" {
 			g.recordRef(prefix+dep, resource.DeletedWith.SourceRange())
 			_, idx := g.newNode(prefix + dep)
-			seen[idx] = true
+			markWhole(idx)
 		}
 	}
 	for _, traversal := range resource.ReplaceWith {
 		if dep := formatTraversal(traversal); dep != "" {
 			g.recordRef(prefix+dep, traversal.SourceRange())
 			_, idx := g.newNode(prefix + dep)
-			seen[idx] = true
+			markWhole(idx)
 		}
 	}
 	if resource.Lifecycle != nil {
 		for _, expr := range resource.Lifecycle.ReplaceTriggeredBy {
-			for _, dep := range g.exprDeps(expr, prefix) {
-				seen[dep] = true
-			}
+			markWhole(g.exprDeps(expr, prefix)...)
 		}
 	}
-	for _, dep := range g.exprDeps(resource.Aliases, prefix) {
-		seen[dep] = true
+	markWhole(g.exprDeps(resource.Aliases, prefix)...)
+
+	for dep, instances := range refs.narrow {
+		if refs.whole[dep] {
+			continue
+		}
+		if g.instanceDeps[nodeKey] == nil {
+			g.instanceDeps[nodeKey] = make(map[string][]string)
+		}
+		g.instanceDeps[nodeKey][dep] = instances
 	}
 
 	return slices.Collect(maps.Keys(seen))
@@ -808,7 +873,7 @@ func (g *Graph) providerDeps(provider *ast.Provider, key, prefix string) []pdag.
 		seen[dep] = true
 	}
 	if provider.Config != nil {
-		for _, dep := range g.bodyDeps(provider.Config, prefix, nil) {
+		for _, dep := range g.bodyDeps(provider.Config, prefix, nil, nil) {
 			seen[dep] = true
 		}
 	}
@@ -817,19 +882,21 @@ func (g *Graph) providerDeps(provider *ast.Provider, key, prefix string) []pdag.
 	return slices.Collect(maps.Keys(seen))
 }
 
-// bodyDeps extracts dependencies from an HCL body, applying prefix to resolved keys.
-func (g *Graph) bodyDeps(body hcl.Body, prefix string, exclude map[string]bool) []pdag.Node {
+// bodyDeps extracts dependencies from an HCL body, applying prefix to resolved
+// keys. A non-nil refs classifies each resource/data reference for instance
+// narrowing.
+func (g *Graph) bodyDeps(body hcl.Body, prefix string, exclude map[string]bool, refs *instanceRefs) []pdag.Node {
 	if eb, ok := body.(*ast.EscapedBody); ok {
 		// Scan the underlying bodies so the native-syntax walk below still
 		// sees dynamic and lifecycle blocks; the merged body hides them.
-		return append(g.bodyDeps(eb.Base, prefix, exclude), g.bodyDeps(eb.Escape, prefix, exclude)...)
+		return append(g.bodyDeps(eb.Base, prefix, exclude, refs), g.bodyDeps(eb.Escape, prefix, exclude, refs)...)
 	}
 
 	seen := make(map[pdag.Node]bool)
 
 	attrs, _ := body.JustAttributes()
 	for _, attr := range attrs {
-		for _, dep := range g.exprDepsExcluding(attr.Expr, prefix, exclude) {
+		for _, dep := range g.exprDepsExcluding(attr.Expr, prefix, exclude, refs) {
 			seen[dep] = true
 		}
 	}
@@ -846,7 +913,7 @@ func (g *Graph) bodyDeps(body hcl.Body, prefix string, exclude map[string]bool) 
 				childExclude := make(map[string]bool, len(exclude)+1)
 				maps.Copy(childExclude, exclude)
 				childExclude[iterName] = true
-				for _, dep := range g.bodyDeps(block.Body, prefix, childExclude) {
+				for _, dep := range g.bodyDeps(block.Body, prefix, childExclude, refs) {
 					seen[dep] = true
 				}
 			} else if block.Type == "lifecycle" {
@@ -857,18 +924,18 @@ func (g *Graph) bodyDeps(body hcl.Body, prefix string, exclude map[string]bool) 
 					if attrName == "ignore_changes" {
 						continue
 					}
-					for _, dep := range g.exprDepsExcluding(attr.Expr, prefix, exclude) {
+					for _, dep := range g.exprDepsExcluding(attr.Expr, prefix, exclude, refs) {
 						seen[dep] = true
 					}
 				}
 				// Still recurse into nested blocks (precondition, postcondition).
 				for _, nested := range block.Body.Blocks {
-					for _, dep := range g.bodyDeps(nested.Body, prefix, exclude) {
+					for _, dep := range g.bodyDeps(nested.Body, prefix, exclude, refs) {
 						seen[dep] = true
 					}
 				}
 			} else {
-				for _, dep := range g.bodyDeps(block.Body, prefix, exclude) {
+				for _, dep := range g.bodyDeps(block.Body, prefix, exclude, refs) {
 					seen[dep] = true
 				}
 			}
@@ -955,10 +1022,10 @@ func (g *Graph) addVariableNodes(key string, v *ast.Variable, modInfo *ModuleInf
 
 // exprDeps extracts all dependencies from an expression, applying prefix to resolved keys.
 func (g *Graph) exprDeps(expr hcl.Expression, prefix string) []pdag.Node {
-	return g.exprDepsExcluding(expr, prefix, nil)
+	return g.exprDepsExcluding(expr, prefix, nil, nil)
 }
 
-func (g *Graph) exprDepsExcluding(expr hcl.Expression, prefix string, exclude map[string]bool) []pdag.Node {
+func (g *Graph) exprDepsExcluding(expr hcl.Expression, prefix string, exclude map[string]bool, refs *instanceRefs) []pdag.Node {
 	if expr == nil {
 		return nil
 	}
@@ -985,9 +1052,7 @@ func (g *Graph) exprDepsExcluding(expr hcl.Expression, prefix string, exclude ma
 		case "path", "terraform", "count", "each", "self", "pulumi":
 			continue
 		case "data":
-			if len(parts) >= 2 {
-				dep = fmt.Sprintf("%sdata.%s.%s", prefix, parts[0], parts[1])
-			}
+			dep = refs.record(traversal, prefix)
 		case "module":
 			if len(parts) >= 1 {
 				if out := moduleOutputName(traversal); out != "" {
@@ -1001,9 +1066,7 @@ func (g *Graph) exprDepsExcluding(expr hcl.Expression, prefix string, exclude ma
 				dep = fmt.Sprintf("%scall.%s.%s", prefix, parts[0], parts[1])
 			}
 		default:
-			if len(parts) >= 1 {
-				dep = fmt.Sprintf("%s%s.%s", prefix, namespace, parts[0])
-			}
+			dep = refs.record(traversal, prefix)
 		}
 
 		if dep != "" {
@@ -1056,6 +1119,84 @@ func (g *Graph) providerFunctionDep(prefix, providerName string) (string, bool) 
 // This is exported for use by other packages.
 func FormatTraversal(traversal hcl.Traversal) string {
 	return formatTraversal(traversal)
+}
+
+// InstanceTarget splits a reference traversal into its node-level dependency
+// key and, when the traversal addresses a single count/for_each instance
+// through a literal index (a dynamic index like `a[each.key]` never survives
+// into a traversal), the full instance key in ExpandedResource.Key form
+// (`type.name[0]`, `type.name["x"]`). instance is empty for whole-resource
+// references and for non-resource targets.
+func InstanceTarget(traversal hcl.Traversal) (dep, instance string) {
+	dep = formatTraversal(traversal)
+	if dep == "" {
+		return "", ""
+	}
+	// The instance index sits right after the resource address: TYPE.NAME[KEY]
+	// for managed resources, data.TYPE.NAME[KEY] for data sources. Other
+	// namespaces (module, var, ...) have no resource instances.
+	i := 2
+	switch traversal.RootName() {
+	case "data":
+		i = 3
+	case "var", "local", "path", "terraform", "count", "each", "self", "pulumi", "module", "call":
+		return dep, ""
+	}
+	if i >= len(traversal) {
+		return dep, ""
+	}
+	idx, ok := traversal[i].(hcl.TraverseIndex)
+	if !ok {
+		return dep, ""
+	}
+	switch idx.Key.Type() {
+	case cty.String:
+		return dep, fmt.Sprintf("%s[%q]", dep, idx.Key.AsString())
+	case cty.Number:
+		n, _ := idx.Key.AsBigFloat().Int64()
+		return dep, fmt.Sprintf("%s[%d]", dep, n)
+	}
+	return dep, ""
+}
+
+// InstanceExec is one expanded instance of a resource node, scheduled as its
+// own walk unit by SpawnInstances.
+type InstanceExec struct {
+	// Key is the instance key in ExpandedResource.Key form.
+	Key  string
+	Exec func(context.Context) error
+}
+
+// SpawnInstances schedules the expanded instances of resource node nodeKey as
+// their own concurrent walk units. It must be called during a Walk from within
+// nodeKey's own exec, before it returns: each successor of nodeKey is re-gated
+// on the instances it depends on — all of them, unless the successor narrowed
+// its references to specific instances — because the node's own completion
+// stops implying that its instances have registered.
+func (g *Graph) SpawnInstances(nodeKey string, instances []InstanceExec) error {
+	succs, ok := g.successors[nodeKey]
+	contract.Assertf(ok, "SpawnInstances is only valid for resource nodes, not %q", nodeKey)
+	nodes := make([]pdag.Node, len(instances))
+	ready := make([]pdag.Done, len(instances))
+	for i, inst := range instances {
+		nodes[i], ready[i] = g.dag.NewNode(dagNode{key: inst.Key, exec: inst.Exec})
+	}
+	for _, succ := range succs {
+		// nil means the successor depends on the whole resource.
+		narrow := g.instanceDeps[g.keyByDagNode[succ]][nodeKey]
+		for i, inst := range instances {
+			if narrow != nil && !slices.Contains(narrow, inst.Key) {
+				continue
+			}
+			if err := g.dag.NewEdge(nodes[i], succ); err != nil {
+				return err
+			}
+		}
+	}
+	for _, done := range ready {
+		done()
+	}
+	return nil
 }
 
 // formatTraversal converts a traversal to a dependency string.
@@ -1298,7 +1439,7 @@ func (g *Graph) inlineModule(
 
 	// Resources
 	for key, resource := range loaded.Config.Resources {
-		deps := g.resourceDeps(resource, prefix)
+		deps := g.resourceDeps(resource, prefix, prefix+key)
 		deps = append(deps, initIdx)
 		ownDeps := g.defaultProviderDeps(resource, loaded.Config, prefix)
 		passDeps := g.passThroughProviderDeps(resource, scope)
@@ -1319,7 +1460,7 @@ func (g *Graph) inlineModule(
 
 	// Data sources
 	for key, ds := range loaded.Config.DataSources {
-		deps := g.resourceDeps(ds, prefix)
+		deps := g.resourceDeps(ds, prefix, prefix+"data."+key)
 		deps = append(deps, initIdx)
 		ownDeps := g.defaultProviderDeps(ds, loaded.Config, prefix)
 		passDeps := g.passThroughProviderDeps(ds, scope)
@@ -1418,7 +1559,7 @@ func (g *Graph) addCallNodes(config *ast.Config, prefix string, modInfo *ModuleI
 			deps = append(deps, idx)
 		}
 		if call.Config != nil {
-			deps = append(deps, g.bodyDeps(call.Config, prefix, nil)...)
+			deps = append(deps, g.bodyDeps(call.Config, prefix, nil, nil)...)
 		}
 		if err := g.AddNode(&Node{
 			Key:        callKey,

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math/big"
 	"slices"
 	"strings"
 
@@ -1153,8 +1154,9 @@ func InstanceTarget(traversal hcl.Traversal) (dep, instance string) {
 	case cty.String:
 		return dep, fmt.Sprintf("%s[%q]", dep, idx.Key.AsString())
 	case cty.Number:
-		n, _ := idx.Key.AsBigFloat().Int64()
-		return dep, fmt.Sprintf("%s[%d]", dep, n)
+		if n, acc := idx.Key.AsBigFloat().Int64(); acc == big.Exact {
+			return dep, fmt.Sprintf("%s[%d]", dep, n)
+		}
 	}
 	return dep, ""
 }
@@ -1182,8 +1184,17 @@ func (g *Graph) SpawnInstances(nodeKey string, instances []InstanceExec) error {
 		nodes[i], ready[i] = g.dag.NewNode(dagNode{key: inst.Key, exec: inst.Exec})
 	}
 	for _, succ := range succs {
-		// nil means the successor depends on the whole resource.
+		// nil means the successor depends on the whole resource. A narrow key
+		// that names no actual instance (a nonexistent instance, or a count
+		// index against for_each string keys) also falls back to the whole
+		// resource, as OpenTofu's reference resolution does.
 		narrow := g.instanceDeps[g.keyByDagNode[succ]][nodeKey]
+		for _, key := range narrow {
+			if !slices.ContainsFunc(instances, func(inst InstanceExec) bool { return inst.Key == key }) {
+				narrow = nil
+				break
+			}
+		}
 		for i, inst := range instances {
 			if narrow != nil && !slices.Contains(narrow, inst.Key) {
 				continue

--- a/pkg/hcl/graph/graph_test.go
+++ b/pkg/hcl/graph/graph_test.go
@@ -16,9 +16,11 @@ package graph
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi/pulumi/pkg/v3/util/pdag"
 	"github.com/stretchr/testify/assert"
@@ -381,4 +383,109 @@ func TestResourceExpander(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestInstanceTarget(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		expr     string
+		dep      string
+		instance string
+	}{
+		{`aws_instance.web`, "aws_instance.web", ""},
+		{`aws_instance.web["x"]`, "aws_instance.web", `aws_instance.web["x"]`},
+		{`aws_instance.web[0]`, "aws_instance.web", "aws_instance.web[0]"},
+		{`data.aws_ami.ubuntu`, "data.aws_ami.ubuntu", ""},
+		{`data.aws_ami.ubuntu["x"]`, "data.aws_ami.ubuntu", `data.aws_ami.ubuntu["x"]`},
+		{`module.m`, "module.m", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.expr, func(t *testing.T) {
+			t.Parallel()
+			traversal, diags := hclsyntax.ParseTraversalAbs([]byte(c.expr), "test.hcl", hcl.InitialPos)
+			require.False(t, diags.HasErrors(), diags.Error())
+			dep, instance := InstanceTarget(traversal)
+			assert.Equal(t, c.dep, dep)
+			assert.Equal(t, c.instance, instance)
+		})
+	}
+}
+
+func TestInstanceDeps(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+resource "aws_instance" "a" {
+  for_each = toset(["x", "y"])
+}
+
+# Instance-addressed depends_on and a literal-indexed body reference both
+# narrow, and their instance keys accumulate.
+resource "aws_instance" "b" {
+  depends_on = [aws_instance.a["x"]]
+  ami        = aws_instance.a["y"].id
+}
+
+# A whole-resource reference (dynamic index) widens the instance addresses.
+resource "aws_instance" "c" {
+  for_each   = toset(["x", "y"])
+  depends_on = [aws_instance.a["x"]]
+  ami        = aws_instance.a[each.key].id
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.Empty(t, diags)
+
+	g, err := BuildFromConfig(config, nil, "")
+	require.NoError(t, err)
+
+	slices.Sort(g.instanceDeps["aws_instance.b"]["aws_instance.a"])
+	assert.Equal(t, map[string]map[string][]string{
+		"aws_instance.b": {"aws_instance.a": {`aws_instance.a["x"]`, `aws_instance.a["y"]`}},
+	}, g.instanceDeps)
+}
+
+func TestSpawnInstances(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+resource "aws_instance" "a" {
+  for_each = toset(["x", "y"])
+}
+
+resource "aws_instance" "b" {
+  depends_on = [aws_instance.a["x"]]
+}
+
+resource "aws_instance" "c" {
+  depends_on = [aws_instance.a]
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.Empty(t, diags)
+
+	g, err := BuildFromConfig(config, nil, "")
+	require.NoError(t, err)
+
+	preds := func(key string) int {
+		n := 0
+		for range g.dag.Predecessors(g.seen[key].i) {
+			n++
+		}
+		return n
+	}
+	bBefore, cBefore := preds("aws_instance.b"), preds("aws_instance.c")
+
+	noop := func(context.Context) error { return nil }
+	require.NoError(t, g.SpawnInstances("aws_instance.a", []InstanceExec{
+		{Key: `aws_instance.a["x"]`, Exec: noop},
+		{Key: `aws_instance.a["y"]`, Exec: noop},
+	}))
+
+	// b narrows to a["x"]: one new edge. c depends on the whole resource:
+	// edges from both instances.
+	assert.Equal(t, bBefore+1, preds("aws_instance.b"))
+	assert.Equal(t, cBefore+2, preds("aws_instance.c"))
 }

--- a/pkg/hcl/graph/graph_test.go
+++ b/pkg/hcl/graph/graph_test.go
@@ -395,6 +395,7 @@ func TestInstanceTarget(t *testing.T) {
 		{`aws_instance.web`, "aws_instance.web", ""},
 		{`aws_instance.web["x"]`, "aws_instance.web", `aws_instance.web["x"]`},
 		{`aws_instance.web[0]`, "aws_instance.web", "aws_instance.web[0]"},
+		{`aws_instance.web[1.5]`, "aws_instance.web", ""},
 		{`data.aws_ami.ubuntu`, "data.aws_ami.ubuntu", ""},
 		{`data.aws_ami.ubuntu["x"]`, "data.aws_ami.ubuntu", `data.aws_ami.ubuntu["x"]`},
 		{`module.m`, "module.m", ""},

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -429,6 +429,9 @@ type Engine struct {
 
 	// moduleInstances maps module path → list of instances for inlined modules.
 	moduleInstances *util.SyncMap[modulepath.Path, []*moduleInstance]
+	// moduleInstancesMu serializes read-modify-write appends to
+	// moduleInstances (see appendModuleInstances).
+	moduleInstancesMu sync.Mutex
 
 	parallel int
 
@@ -698,6 +701,14 @@ func (e *Engine) registerStackOutputs(ctx context.Context) error {
 
 // processNode processes a single node based on its type.
 func (e *Engine) processNode(ctx context.Context, node *graph.Node) error {
+	// Module-owned work runs in per-module-instance walk units created by the
+	// enclosing init (see SpawnModuleInstanceUnits); the node itself is a
+	// template whose completion (gated on its units) anchors node-level
+	// ordering for everything outside the module. Call nodes are exempt: they
+	// resolve against the root config.
+	if node.Type != graph.NodeTypeCall && !node.OwnerPath().IsRoot() {
+		return nil
+	}
 	switch node.Type {
 	case graph.NodeTypeVariable:
 		return e.processVariable(ctx, node)
@@ -716,9 +727,6 @@ func (e *Engine) processNode(ctx context.Context, node *graph.Node) error {
 	case graph.NodeTypeCall:
 		return e.processCall(ctx, node)
 	case graph.NodeTypeOutput:
-		if node.ModuleInfo != nil {
-			return e.processModuleOutput(ctx, node)
-		}
 		return nil
 	case graph.NodeTypeProvider:
 		return e.processProvider(ctx, node)
@@ -745,11 +753,6 @@ func (e *Engine) processVariable(ctx context.Context, node *graph.Node) error {
 	v := node.Variable
 	if v == nil {
 		return fmt.Errorf("variable node missing Variable field")
-	}
-
-	// Module variable: evaluate input expression in parent context, store in each instance context.
-	if node.ModuleInfo != nil {
-		return e.processModuleVariable(node)
 	}
 
 	varName := v.Name
@@ -872,11 +875,6 @@ func (e *Engine) processVariableValidation(node *graph.Node) error {
 	if v == nil {
 		return fmt.Errorf("variable validation node missing Variable field")
 	}
-	if node.ModuleInfo != nil {
-		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-			return runVariableValidations(eval.NewEvaluator(inst.EvalCtx), v.Name, v.Validations)
-		})
-	}
 	return runVariableValidations(e.evaluator, v.Name, v.Validations)
 }
 
@@ -947,18 +945,6 @@ func (e *Engine) processLocal(ctx context.Context, node *graph.Node) error {
 		return fmt.Errorf("local node missing Local field")
 	}
 
-	if node.ModuleInfo != nil {
-		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-			localName := strings.TrimPrefix(node.Key, node.ModuleInfo.Prefix()+"local.")
-			val, diags := local.Value.Value(inst.EvalCtx.HCLContext())
-			if diags.HasErrors() {
-				return fmt.Errorf("evaluating local value %s: %s", localName, diags.Error())
-			}
-			inst.EvalCtx.SetLocal(localName, val)
-			return nil
-		})
-	}
-
 	val, diags := e.evaluator.EvaluateExpression(local.Value)
 	if diags.HasErrors() {
 		return fmt.Errorf("evaluating local value: %s", diags.Error())
@@ -986,12 +972,6 @@ func (e *Engine) processProvider(ctx context.Context, node *graph.Node) error {
 	// see explicitly-declared providers in the snapshot.
 	if !e.alwaysRegisterProviders && e.graph != nil && !e.graph.HasDependents(node.Key) {
 		return nil
-	}
-
-	if node.ModuleInfo != nil {
-		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-			return e.registerProvider(ctx, node, provider, inst.EvalCtx, inst.URN, inst)
-		})
 	}
 
 	return e.registerProvider(ctx, node, provider, e.evaluator.Context(), e.stackURN, nil)
@@ -1377,18 +1357,13 @@ func (e *Engine) processResource(ctx context.Context, node *graph.Node) error {
 		return fmt.Errorf("resource node missing Resource field")
 	}
 
-	if node.ModuleInfo != nil {
-		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-			return e.processResourceInContext(ctx, node, res, inst.EvalCtx, inst.URN, inst)
-		})
-	}
-
-	return e.processResourceInContext(ctx, node, res, e.evaluator.Context(), e.stackURN, nil)
+	return e.processResourceInContext(ctx, node, res, e.evaluator.Context(), e.stackURN, nil, nil)
 }
 
 func (e *Engine) processResourceInContext(
 	ctx context.Context, node *graph.Node, res *ast.Resource,
 	evalCtx *eval.Context, parentURN urn.URN, modInst *moduleInstance,
+	targets []graph.SpawnTarget,
 ) error {
 	resSchema, err := e.resolver.ResolveResource(ctx, res.Type)
 	if err != nil {
@@ -1468,10 +1443,12 @@ func (e *Engine) processResourceInContext(
 	}
 
 	// Expanded instances run as their own concurrent walk units, and this
-	// node's successors are re-gated on the instances they depend on: all of
+	// node's dependents are re-gated on the instances they depend on: all of
 	// them, or — for a dependent that references a single instance
 	// (`type.name["x"]`) — only that instance, so it does not wait for the
-	// delayed siblings.
+	// delayed siblings. At root the dependents are the node's static
+	// successors; inside a module clone they are the instance's aligned
+	// member units plus this node's template.
 	if !result.IsSingle && e.graph != nil {
 		insts := make([]graph.InstanceExec, len(result.Instances))
 		for i, instance := range result.Instances {
@@ -1480,7 +1457,13 @@ func (e *Engine) processResourceInContext(
 				Exec: func(ctx context.Context) error { return registerInstance(ctx, instance) },
 			}
 		}
-		if err := e.graph.SpawnInstances(node.Key, insts); err != nil {
+		var err error
+		if targets != nil {
+			err = e.graph.SpawnInstancesTo(node.Key, insts, targets)
+		} else {
+			err = e.graph.SpawnInstances(node.Key, insts)
+		}
+		if err != nil {
 			return fmt.Errorf("scheduling instances of %s: %w", node.Key, err)
 		}
 	} else {
@@ -3216,12 +3199,6 @@ func (e *Engine) processDataSource(ctx context.Context, node *graph.Node) error 
 		return fmt.Errorf("data source node missing Resource field")
 	}
 
-	if node.ModuleInfo != nil {
-		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-			return e.processDataSourceInContext(ctx, node, ds, inst.EvalCtx)
-		})
-	}
-
 	return e.processDataSourceInContext(ctx, node, ds, e.evaluator.Context())
 }
 
@@ -3877,23 +3854,59 @@ func (a *moduleLoaderAdapter) LoadModule(source, version, workDir string) (*grap
 	}, nil
 }
 
-// forEachModuleInstance iterates over all instances of the module identified by node.ModuleInfo.Prefix().
-func (e *Engine) forEachModuleInstance(node *graph.Node, fn func(inst *moduleInstance) error) error {
-	instances, ok := e.moduleInstances.Get(node.ModuleInfo.Path)
-	if !ok {
-		return fmt.Errorf("no module instances for prefix %q", node.ModuleInfo.Prefix())
-	}
-	for _, inst := range instances {
-		if err := fn(inst); err != nil {
-			return err
-		}
-	}
-	return nil
+// appendModuleInstances records newly created instances of a module call,
+// creating the entry when absent so consumers can distinguish "initialized,
+// zero instances" from "not yet initialized". Nested calls append once per
+// enclosing-module instance, concurrently.
+func (e *Engine) appendModuleInstances(path modulepath.Path, insts []*moduleInstance) {
+	e.moduleInstancesMu.Lock()
+	defer e.moduleInstancesMu.Unlock()
+	cur, _ := e.moduleInstances.Get(path)
+	e.moduleInstances.Set(path, append(slices.Clip(cur), insts...))
 }
 
-// processModuleVariable evaluates a module variable's input expression in the parent context
-// and stores the result in each module instance's eval context.
-func (e *Engine) processModuleVariable(node *graph.Node) error {
+// processMemberUnit runs one module member's work for one instance of its
+// module — the body of a walk unit created by SpawnModuleInstanceUnits.
+func (e *Engine) processMemberUnit(ctx context.Context, u *graph.MemberUnit, inst *moduleInstance) error {
+	node := u.Node
+	switch node.Type {
+	case graph.NodeTypeVariable:
+		return e.processModuleVariableInstance(node, inst)
+	case graph.NodeTypeVariableValidation:
+		return runVariableValidations(eval.NewEvaluator(inst.EvalCtx), node.Variable.Name, node.Variable.Validations)
+	case graph.NodeTypeLocal:
+		localName := strings.TrimPrefix(node.Key, node.ModuleInfo.Prefix()+"local.")
+		val, diags := node.Local.Value.Value(inst.EvalCtx.HCLContext())
+		if diags.HasErrors() {
+			return fmt.Errorf("evaluating local value %s: %s", localName, diags.Error())
+		}
+		inst.EvalCtx.SetLocal(localName, val)
+		return nil
+	case graph.NodeTypeProvider:
+		// See processProvider: unused provider blocks are never configured.
+		if !e.alwaysRegisterProviders && e.graph != nil && !e.graph.HasDependents(node.Key) {
+			return nil
+		}
+		return e.registerProvider(ctx, node, node.Provider, inst.EvalCtx, inst.URN, inst)
+	case graph.NodeTypeResource:
+		return e.processResourceInContext(ctx, node, node.Resource, inst.EvalCtx, inst.URN, inst, u.Targets)
+	case graph.NodeTypeDataSource:
+		return e.processDataSourceInContext(ctx, node, node.Resource, inst.EvalCtx)
+	case graph.NodeTypeOutput:
+		return e.processModuleOutputInstance(node, inst)
+	case graph.NodeTypeModuleInit:
+		return e.initModuleCall(ctx, node, inst)
+	case graph.NodeTypeModule:
+		return e.completeModuleFor(ctx, node, inst)
+	default:
+		return nil
+	}
+}
+
+// processModuleVariableInstance evaluates a module variable's input expression
+// in the parent context and stores the result in one module instance's eval
+// context.
+func (e *Engine) processModuleVariableInstance(node *graph.Node, inst *moduleInstance) error {
 	v := node.Variable
 	modInfo := node.ModuleInfo
 	varName := v.Name
@@ -3901,101 +3914,94 @@ func (e *Engine) processModuleVariable(node *graph.Node) error {
 	moduleInputAttrs, _ := modInfo.Module.Config.JustAttributes()
 	inputAttr, hasInput := moduleInputAttrs[varName]
 
-	return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-		var val cty.Value
+	var val cty.Value
 
-		if hasInput {
-			// The input expression lives in the enclosing module instance's
-			// scope so that expressions like var.name resolve correctly; for
-			// root-level calls that is the root evaluator context.
-			parentEvalCtx := e.evaluator.Context()
-			if inst.Parent != nil {
-				parentEvalCtx = inst.Parent.EvalCtx
-			}
-			var diags hcl.Diagnostics
-			hclCtx := parentEvalCtx.HCLContextWithIteration(inst.Index, inst.EachKey, inst.EachVal)
-			val, diags = inputAttr.Expr.Value(hclCtx)
-			if diags.HasErrors() {
-				return fmt.Errorf("evaluating module input %s: %s", varName, diags.Error())
-			}
-		} else {
-			// No input: fall through to default/env/config
-			envVarName := "TF_VAR_" + varName
-			if envVal := os.Getenv(envVarName); envVal != "" {
-				val = cty.StringVal(envVal)
-			} else if v.Default != nil {
-				var diags hcl.Diagnostics
-				val, diags = v.Default.Value(inst.EvalCtx.HCLContext())
-				if diags.HasErrors() {
-					return fmt.Errorf("evaluating variable default for %s: %s", varName, diags.Error())
-				}
-			} else {
-				return fmt.Errorf("variable %q is required but no value was provided", varName)
-			}
+	if hasInput {
+		// The input expression lives in the enclosing module instance's
+		// scope so that expressions like var.name resolve correctly; for
+		// root-level calls that is the root evaluator context.
+		parentEvalCtx := e.evaluator.Context()
+		if inst.Parent != nil {
+			parentEvalCtx = inst.Parent.EvalCtx
 		}
-
-		// A `nullable = false` variable rejects an explicit null argument: the
-		// default is substituted when one is declared, otherwise it is an
-		// error. Matches Terraform/OpenTofu.
-		if val.IsNull() && !v.Nullable {
-			if v.Default == nil {
-				return fmt.Errorf("variable %q must not be set to null: it is declared with nullable = false and has no default", varName)
-			}
+		var diags hcl.Diagnostics
+		hclCtx := parentEvalCtx.HCLContextWithIteration(inst.Index, inst.EachKey, inst.EachVal)
+		val, diags = inputAttr.Expr.Value(hclCtx)
+		if diags.HasErrors() {
+			return fmt.Errorf("evaluating module input %s: %s", varName, diags.Error())
+		}
+	} else {
+		// No input: fall through to default/env/config
+		envVarName := "TF_VAR_" + varName
+		if envVal := os.Getenv(envVarName); envVal != "" {
+			val = cty.StringVal(envVal)
+		} else if v.Default != nil {
 			var diags hcl.Diagnostics
 			val, diags = v.Default.Value(inst.EvalCtx.HCLContext())
 			if diags.HasErrors() {
 				return fmt.Errorf("evaluating variable default for %s: %s", varName, diags.Error())
 			}
+		} else {
+			return fmt.Errorf("variable %q is required but no value was provided", varName)
 		}
+	}
 
-		// Fill in optional()-attribute defaults before type conversion so
-		// the result satisfies the declared object shape.
-		if v.TypeDefaults != nil && !val.IsNull() {
-			val = v.TypeDefaults.Apply(val)
+	// A `nullable = false` variable rejects an explicit null argument: the
+	// default is substituted when one is declared, otherwise it is an
+	// error. Matches Terraform/OpenTofu.
+	if val.IsNull() && !v.Nullable {
+		if v.Default == nil {
+			return fmt.Errorf("variable %q must not be set to null: it is declared with nullable = false and has no default", varName)
 		}
-
-		// Coerce the value to match the variable's type constraint.
-		if v.TypeConstraint != cty.NilType {
-			if converted, err := ctyconvert.Convert(val, v.TypeConstraint); err == nil {
-				val = converted
-			}
+		var diags hcl.Diagnostics
+		val, diags = v.Default.Value(inst.EvalCtx.HCLContext())
+		if diags.HasErrors() {
+			return fmt.Errorf("evaluating variable default for %s: %s", varName, diags.Error())
 		}
+	}
 
-		if v.Sensitive {
-			val = val.Mark(eval.SensitiveMark)
+	// Fill in optional()-attribute defaults before type conversion so
+	// the result satisfies the declared object shape.
+	if v.TypeDefaults != nil && !val.IsNull() {
+		val = v.TypeDefaults.Apply(val)
+	}
+
+	// Coerce the value to match the variable's type constraint.
+	if v.TypeConstraint != cty.NilType {
+		if converted, err := ctyconvert.Convert(val, v.TypeConstraint); err == nil {
+			val = converted
 		}
-		if v.Ephemeral {
-			val = val.Mark(eval.EphemeralMark)
-		}
+	}
 
-		inst.EvalCtx.SetVariable(varName, val)
+	if v.Sensitive {
+		val = val.Mark(eval.SensitiveMark)
+	}
+	if v.Ephemeral {
+		val = val.Mark(eval.EphemeralMark)
+	}
 
-		return runVariableValidations(eval.NewEvaluator(inst.EvalCtx), varName, v.Validations)
-	})
+	inst.EvalCtx.SetVariable(varName, val)
+
+	return runVariableValidations(eval.NewEvaluator(inst.EvalCtx), varName, v.Validations)
 }
 
-// processModuleInit processes a module init node: registers component resources and creates instances.
+// processModuleInit handles a root-level module call's init node. A nested
+// call's init runs as a per-parent-instance unit instead (see
+// processMemberUnit), so its work naturally happens once per instance of the
+// enclosing module — and never when the enclosing module has no instances.
 func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error {
+	return e.initModuleCall(ctx, node, nil)
+}
+
+// initModuleCall evaluates one module call within a single instance of the
+// enclosing module (nil parent = the root config), registers the resulting
+// module instances, and spawns the per-instance walk units that run the
+// module's contents.
+func (e *Engine) initModuleCall(ctx context.Context, node *graph.Node, parent *moduleInstance) error {
 	modInfo := node.ModuleInfo
 	mod := modInfo.Module
 
 	componentType := fmt.Sprintf("components:index:%s", componentTypeName(modInfo.SourcePath))
-
-	// A nested module call runs once per instance of the enclosing module; a
-	// root-level call runs in the single root scope (a nil parent instance).
-	// When the parent has zero instances (count=0 / for_each empty) the
-	// entire inner subtree must be skipped — registering an empty instances
-	// slice lets downstream per-instance work (vars, locals, nested modules,
-	// resources) loop zero times instead of falling back to the root context.
-	parents := []*moduleInstance{nil}
-	if modInfo.ParentPrefix() != "" {
-		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPath())
-		if !ok || len(parentInstances) == 0 {
-			e.moduleInstances.Set(modInfo.Path, nil)
-			return nil
-		}
-		parents = parentInstances
-	}
 
 	// Load the child module to get variable type constraints for input coercion.
 	loaderWorkDir := modInfo.ParentSourcePath
@@ -4014,15 +4020,23 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 		return fmt.Errorf("module %s: %w", mod.Source, err)
 	}
 
-	var instances []*moduleInstance
-	for _, parent := range parents {
-		insts, err := e.initModuleCallIn(ctx, node, childMod, moduleFunctions, componentType, parent)
-		if err != nil {
-			return err
-		}
-		instances = append(instances, insts...)
+	instances, err := e.initModuleCallIn(ctx, node, childMod, moduleFunctions, componentType, parent)
+	if err != nil {
+		return err
 	}
-	e.moduleInstances.Set(modInfo.Path, instances)
+	e.appendModuleInstances(modInfo.Path, instances)
+
+	for _, inst := range instances {
+		err := e.graph.SpawnModuleInstanceUnits(modInfo.Path, "@"+inst.Path.String(),
+			func(u *graph.MemberUnit) func(context.Context) error {
+				return func(ctx context.Context) error {
+					return e.processMemberUnit(ctx, u, inst)
+				}
+			})
+		if err != nil {
+			return fmt.Errorf("scheduling module instance %s: %w", inst.Path.String(), err)
+		}
+	}
 	return nil
 }
 
@@ -4153,61 +4167,45 @@ func (e *Engine) initModuleCallIn(
 	return instances, nil
 }
 
-// processModuleOutput evaluates a module output in each instance and stores it in the parent context.
-func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error {
+// processModuleOutputInstance evaluates a module output in one instance and
+// stores it in the enclosing scope's context.
+func (e *Engine) processModuleOutputInstance(node *graph.Node, inst *moduleInstance) error {
 	output := node.Output
 	modInfo := node.ModuleInfo
 	outputName := strings.TrimPrefix(node.Key, modInfo.Prefix()+"output.")
 
-	err := e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-		if err := runOutputPreconditions(output, inst.EvalCtx.HCLContext(), outputName); err != nil {
-			return err
-		}
-		val, diags := output.Value.Value(inst.EvalCtx.HCLContext())
-		if diags.HasErrors() {
-			return fmt.Errorf("evaluating module output %s: %s", outputName, diags.Error())
-		}
-		// A `sensitive = true` output carries the mark into the calling module,
-		// so a reference to it stays sensitive; likewise for `ephemeral = true`.
-		if output.Sensitive {
-			val = val.Mark(eval.SensitiveMark)
-		}
-		if output.Ephemeral {
-			val = val.Mark(eval.EphemeralMark)
-		}
-		inst.mu.Lock()
-		inst.Outputs[outputName] = val
-		inst.mu.Unlock()
-		return nil
-	})
-	if err != nil {
+	if err := runOutputPreconditions(output, inst.EvalCtx.HCLContext(), outputName); err != nil {
 		return err
 	}
-
-	// Eagerly publish outputs to the parent contexts so other module variables
-	// can reference them before the completion node runs.
-	instances, ok := e.moduleInstances.Get(modInfo.Path)
-	if !ok {
-		return nil
+	val, diags := output.Value.Value(inst.EvalCtx.HCLContext())
+	if diags.HasErrors() {
+		return fmt.Errorf("evaluating module output %s: %s", outputName, diags.Error())
 	}
-	e.publishModuleValue(modInfo, instances)
+	// A `sensitive = true` output carries the mark into the calling module,
+	// so a reference to it stays sensitive; likewise for `ephemeral = true`.
+	if output.Sensitive {
+		val = val.Mark(eval.SensitiveMark)
+	}
+	if output.Ephemeral {
+		val = val.Mark(eval.EphemeralMark)
+	}
+	inst.mu.Lock()
+	inst.Outputs[outputName] = val
+	inst.mu.Unlock()
+
+	// Eagerly publish outputs to the enclosing scope so other module
+	// variables can reference them before the completion node runs.
+	if instances, ok := e.moduleInstances.Get(modInfo.Path); ok {
+		e.publishModuleValue(modInfo, instances, []*moduleInstance{inst.Parent})
+	}
 	return nil
 }
 
 // publishModuleValue assembles the value of `module.<name>` from the
-// instances' collected outputs and publishes it into each enclosing module
-// instance's eval context (or the root context for a top-level call). Each
-// enclosing instance sees only its own instances of the call.
-func (e *Engine) publishModuleValue(modInfo *graph.ModuleInfo, instances []*moduleInstance) {
-	parents := []*moduleInstance{nil}
-	if modInfo.ParentPrefix() != "" {
-		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPath())
-		if !ok {
-			return
-		}
-		parents = parentInstances
-	}
-
+// instances' collected outputs and publishes it into each given enclosing
+// module instance's eval context (nil = the root context). Each enclosing
+// instance sees only its own instances of the call.
+func (e *Engine) publishModuleValue(modInfo *graph.ModuleInfo, instances, parents []*moduleInstance) {
 	mod := modInfo.Module
 	name := modInfo.ModuleName()
 	for _, parent := range parents {
@@ -4263,36 +4261,46 @@ func (e *Engine) publishModuleValue(modInfo *graph.ModuleInfo, instances []*modu
 	}
 }
 
-// processModuleComplete handles the module completion node: registers component outputs
-// and assembles the full module value in the parent context.
+// processModuleComplete handles a root-level module call's completion node.
+// A nested call's completion runs as a per-parent-instance unit (see
+// processMemberUnit).
 func (e *Engine) processModuleComplete(ctx context.Context, node *graph.Node) error {
+	return e.completeModuleFor(ctx, node, nil)
+}
+
+// completeModuleFor registers component outputs for the call's instances
+// under one enclosing-module instance (nil = the root scope) and assembles
+// the full module value in that scope's context.
+func (e *Engine) completeModuleFor(ctx context.Context, node *graph.Node, parent *moduleInstance) error {
 	modInfo := node.ModuleInfo
 	if modInfo == nil {
 		return fmt.Errorf("module completion node missing ModuleInfo")
 	}
 
-	instances, ok := e.moduleInstances.Get(modInfo.Path)
-	if !ok {
-		return fmt.Errorf("no module instances for prefix %q", modInfo.Prefix())
-	}
+	instances, _ := e.moduleInstances.Get(modInfo.Path)
 
 	// Register component outputs and collect per-instance output objects.
 	for _, inst := range instances {
+		if inst.Parent != parent {
+			continue
+		}
 		if e.resmon != nil {
 			outputProps := make(map[string]property.Value)
+			inst.mu.Lock()
 			for k, v := range inst.Outputs {
 				pv, err := transform.CtyToPropertyValue(v)
 				if err == nil {
 					outputProps[k] = pv
 				}
 			}
+			inst.mu.Unlock()
 			if err := e.resmon.RegisterResourceOutputs(ctx, inst.URN, property.NewMap(outputProps)); err != nil {
 				return fmt.Errorf("registering module outputs: %w", err)
 			}
 		}
 	}
 
-	e.publishModuleValue(modInfo, instances)
+	e.publishModuleValue(modInfo, instances, []*moduleInstance{parent})
 	return nil
 }
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1735,28 +1735,30 @@ func (e *Engine) registerResourceInstanceInContext(
 // dependsOnURNs resolves a depends_on traversal to the URNs it gates on: the
 // addressed instance's URN when the traversal names one, the whole resource's
 // URN otherwise — which for a count/for_each resource (no whole-resource
-// outputs entry) means every registered instance's URN.
+// outputs entry) means every registered instance's URN. An instance address
+// that names no registered instance falls back to the whole resource.
 func (e *Engine) dependsOnURNs(traversal hcl.Traversal, resPrefix string) []string {
 	depKey, instKey := graph.InstanceTarget(traversal)
 	if depKey == "" {
 		return nil
 	}
-	lookup := resPrefix + depKey
 	if instKey != "" {
-		lookup = resPrefix + instKey
+		if outputs, ok := e.resourceOutputs.Get(resPrefix + instKey); ok {
+			if urn := ctyAsString(outputs.GetAttr("urn")); urn != "" {
+				return []string{urn}
+			}
+			return nil
+		}
 	}
-	if outputs, ok := e.resourceOutputs.Get(lookup); ok {
+	if outputs, ok := e.resourceOutputs.Get(resPrefix + depKey); ok {
 		if urn := ctyAsString(outputs.GetAttr("urn")); urn != "" {
 			return []string{urn}
 		}
 		return nil
 	}
-	if instKey != "" {
-		return nil
-	}
 	var urns []string
 	for key, outputs := range e.resourceOutputs.All() {
-		if !strings.HasPrefix(key, lookup+"[") {
+		if !strings.HasPrefix(key, resPrefix+depKey+"[") {
 			continue
 		}
 		if urn := ctyAsString(outputs.GetAttr("urn")); urn != "" {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -53,6 +53,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 	ctyconvert "github.com/zclconf/go-cty/cty/convert"
 	"github.com/zclconf/go-cty/cty/function"
+	"golang.org/x/sync/errgroup"
 )
 
 // PackageRef is an opaque reference returned by RegisterPackage that routes
@@ -1453,15 +1454,40 @@ func (e *Engine) processResourceInContext(
 
 	result := expander.Expand(node)
 
-	for _, instance := range result.Instances {
+	registerInstance := func(ctx context.Context, instance *graph.ExpandedResource) error {
 		if e.hasFailedDependency(res) {
 			e.failedNodes.Set(instance.Key, fmt.Errorf("skipped: dependency failed"))
-			continue
+			return nil
 		}
 		if err := e.registerResourceInstanceInContext(
 			ctx, node, res, resSchema, instance, evalCtx, parentURN, modInst, metaArgDeps,
 		); err != nil {
 			return fmt.Errorf("registering %s: %w", instance.Key, err)
+		}
+		return nil
+	}
+
+	// Expanded instances run as their own concurrent walk units, and this
+	// node's successors are re-gated on the instances they depend on: all of
+	// them, or — for a dependent that references a single instance
+	// (`type.name["x"]`) — only that instance, so it does not wait for the
+	// delayed siblings.
+	if !result.IsSingle && e.graph != nil {
+		insts := make([]graph.InstanceExec, len(result.Instances))
+		for i, instance := range result.Instances {
+			insts[i] = graph.InstanceExec{
+				Key:  instance.Key,
+				Exec: func(ctx context.Context) error { return registerInstance(ctx, instance) },
+			}
+		}
+		if err := e.graph.SpawnInstances(node.Key, insts); err != nil {
+			return fmt.Errorf("scheduling instances of %s: %w", node.Key, err)
+		}
+	} else {
+		for _, instance := range result.Instances {
+			if err := registerInstance(ctx, instance); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1706,6 +1732,41 @@ func (e *Engine) registerResourceInstanceInContext(
 	return nil
 }
 
+// dependsOnURNs resolves a depends_on traversal to the URNs it gates on: the
+// addressed instance's URN when the traversal names one, the whole resource's
+// URN otherwise — which for a count/for_each resource (no whole-resource
+// outputs entry) means every registered instance's URN.
+func (e *Engine) dependsOnURNs(traversal hcl.Traversal, resPrefix string) []string {
+	depKey, instKey := graph.InstanceTarget(traversal)
+	if depKey == "" {
+		return nil
+	}
+	lookup := resPrefix + depKey
+	if instKey != "" {
+		lookup = resPrefix + instKey
+	}
+	if outputs, ok := e.resourceOutputs.Get(lookup); ok {
+		if urn := ctyAsString(outputs.GetAttr("urn")); urn != "" {
+			return []string{urn}
+		}
+		return nil
+	}
+	if instKey != "" {
+		return nil
+	}
+	var urns []string
+	for key, outputs := range e.resourceOutputs.All() {
+		if !strings.HasPrefix(key, lookup+"[") {
+			continue
+		}
+		if urn := ctyAsString(outputs.GetAttr("urn")); urn != "" {
+			urns = append(urns, urn)
+		}
+	}
+	slices.Sort(urns)
+	return urns
+}
+
 // buildResourceOptionsInContext builds resource options using the provided eval context and parent URN.
 func (e *Engine) buildResourceOptionsInContext(
 	ctx context.Context, res *ast.Resource, instance *graph.ExpandedResource,
@@ -1722,15 +1783,7 @@ func (e *Engine) buildResourceOptionsInContext(
 	}
 
 	for _, dep := range res.DependsOn {
-		depKey := graph.FormatTraversal(dep)
-		if depKey == "" {
-			continue
-		}
-		if outputs, ok := e.resourceOutputs.Get(resPrefix + depKey); ok {
-			if urn := ctyAsString(outputs.GetAttr("urn")); urn != "" {
-				opts.DependsOn = append(opts.DependsOn, urn)
-			}
-		}
+		opts.DependsOn = append(opts.DependsOn, e.dependsOnURNs(dep, resPrefix)...)
 	}
 
 	// Handle lifecycle options
@@ -2654,11 +2707,25 @@ func knownProviders(tfBlock *ast.Terraform) []string {
 // When true, the resource should be skipped so that only genuinely independent
 // resources are registered with the engine.
 func (e *Engine) hasFailedDependency(res *ast.Resource) bool {
-	// Check explicit depends_on traversals.
+	// Check explicit depends_on traversals. failedNodes is keyed by instance
+	// key, so a whole-resource dependency on an expanded resource has to match
+	// any of its instances.
 	for _, dep := range res.DependsOn {
-		depKey := graph.FormatTraversal(dep)
-		if depKey != "" {
-			if _, failed := e.failedNodes.Get(depKey); failed {
+		depKey, instKey := graph.InstanceTarget(dep)
+		if depKey == "" {
+			continue
+		}
+		if instKey != "" {
+			if _, failed := e.failedNodes.Get(instKey); failed {
+				return true
+			}
+			continue
+		}
+		if _, failed := e.failedNodes.Get(depKey); failed {
+			return true
+		}
+		for key := range e.failedNodes.All() {
+			if strings.HasPrefix(key, depKey+"[") {
 				return true
 			}
 		}
@@ -3236,37 +3303,38 @@ func (e *Engine) processRangedDataSource(
 
 	result := expander.Expand(node)
 
-	var tupleOutputs []cty.Value
-	eachOutputs := make(map[string]cty.Value)
-	isForEach := ds.ForEach != nil
-
-	for _, instance := range result.Instances {
-		instCtx := evalCtx.WithIteration(instance.Index, instance.EachKey, instance.EachValue)
-
-		ctyOut, invokeErr := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, instCtx)
-
-		if invokeErr != nil {
+	// Instance reads run concurrently, matching how the graph walk runs the
+	// instances of an expanded resource.
+	outputs := make([]cty.Value, len(result.Instances))
+	grp, grpCtx := errgroup.WithContext(ctx)
+	for i, instance := range result.Instances {
+		grp.Go(func() error {
+			instCtx := evalCtx.WithIteration(instance.Index, instance.EachKey, instance.EachValue)
+			ctyOut, invokeErr := e.invokeDataSourceOnce(grpCtx, node, ds, funcSchema, instCtx)
+			outputs[i] = ctyOut
 			return invokeErr
-		}
-		if isForEach {
-			eachOutputs[instance.EachKey.AsString()] = ctyOut
-		} else {
-			tupleOutputs = append(tupleOutputs, ctyOut)
-		}
+		})
+	}
+	if err := grp.Wait(); err != nil {
+		return err
 	}
 
 	var aggregated cty.Value
-	if isForEach {
-		if len(eachOutputs) == 0 {
+	if ds.ForEach != nil {
+		if len(result.Instances) == 0 {
 			aggregated = cty.EmptyObjectVal
 		} else {
+			eachOutputs := make(map[string]cty.Value, len(result.Instances))
+			for i, instance := range result.Instances {
+				eachOutputs[instance.EachKey.AsString()] = outputs[i]
+			}
 			aggregated = cty.ObjectVal(eachOutputs)
 		}
 	} else {
-		if len(tupleOutputs) == 0 {
+		if len(result.Instances) == 0 {
 			aggregated = cty.EmptyTupleVal
 		} else {
-			aggregated = cty.TupleVal(tupleOutputs)
+			aggregated = cty.TupleVal(outputs)
 		}
 	}
 
@@ -3375,17 +3443,13 @@ func (e *Engine) invokeDataSourceOnce(
 		}
 	}
 
+	dsPrefix := ""
+	if node.ModuleInfo != nil {
+		dsPrefix = node.ModuleInfo.Prefix()
+	}
 	for _, dep := range ds.DependsOn {
-		depKey := graph.FormatTraversal(dep)
-		if depKey == "" {
-			continue
-		}
-		fullDepKey := depKey
-		if node.ModuleInfo != nil {
-			fullDepKey = node.ModuleInfo.Prefix() + depKey
-		}
-		if outputs, ok := e.resourceOutputs.Get(fullDepKey); ok {
-			addURN(ctyAsString(outputs.GetAttr("urn")))
+		for _, urn := range e.dependsOnURNs(dep, dsPrefix) {
+			addURN(urn)
 		}
 	}
 

--- a/pkg/util/syncmap.go
+++ b/pkg/util/syncmap.go
@@ -50,6 +50,13 @@ func (s *SyncMap[K, V]) Get(key K) (V, bool) {
 	return v, ok
 }
 
+// All returns a point-in-time snapshot iterator over the map's entries.
+func (s *SyncMap[K, V]) All() iter.Seq2[K, V] {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return maps.All(maps.Clone(s.m))
+}
+
 func (s *SyncMap[K, V]) Values() iter.Seq[V] {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/tests/testutil/tfcompat/providers/ordering.go
+++ b/tests/testutil/tfcompat/providers/ordering.go
@@ -22,21 +22,39 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// OrderProvider exposes `order_resource`, a minimal resource for
-// Case.OrderDeterministic ordering tests: the recorded op sequence itself
-// asserts ordering, so the resource carries no assertion logic of its own.
+// OrderProvider exposes `order_resource` and the `order_data` data source,
+// minimal objects for Case.OrderDeterministic ordering tests: the recorded op
+// sequence itself asserts ordering, so they carry no assertion logic of their
+// own.
 //
-// `delay_create`/`delay_delete` hold that operation open briefly. Set the
-// delay on the op that must complete *first* in the correct order. When the
-// dependency edge under test is honored the delay only stretches the already
-// serialized sequence; when the edge is missing the two ops run concurrently
-// and the undelayed op reliably records ahead of the delayed one, so the
-// regression flips the recorded order deterministically instead of leaving
-// the comparison to a race.
+// `delay_create`/`delay_delete`/`delay_read` hold that operation open briefly.
+// Set the delay on the op that must complete *first* in the correct order.
+// When the dependency edge under test is honored the delay only stretches the
+// already serialized sequence; when the edge is missing the two ops run
+// concurrently and the undelayed op reliably records ahead of the delayed one,
+// so the regression flips the recorded order deterministically instead of
+// leaving the comparison to a race.
 func OrderProvider() *schema.Provider {
 	const delay = 1 * time.Second
 	noop := func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil }
 	return &schema.Provider{
+		DataSourcesMap: map[string]*schema.Resource{
+			"order_data": {
+				Schema: map[string]*schema.Schema{
+					"name":       {Type: schema.TypeString, Required: true},
+					"delay_read": {Type: schema.TypeBool, Optional: true},
+					"result":     {Type: schema.TypeString, Computed: true},
+				},
+				ReadContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					if b, _ := d.Get("delay_read").(bool); b {
+						time.Sleep(delay)
+					}
+					name, _ := d.Get("name").(string)
+					d.SetId(name)
+					return diag.FromErr(d.Set("result", name))
+				},
+			},
+		},
 		ResourcesMap: map[string]*schema.Resource{
 			"order_resource": {
 				Schema: map[string]*schema.Schema{

--- a/tests/tfcompat/l2_data_for_each_set_flow_test.go
+++ b/tests/tfcompat/l2_data_for_each_set_flow_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A for_each resource feeding a for_each data source through a dynamic index
+// (`a[each.key].result`). The dynamic index references the whole resource, so
+// values must flow and every read must wait for every instance; the recorded
+// op order pins the scheduling either way.
+func TestL2DataForEachSetFlow(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_for_each_set_flow", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_depends_on_count_chain_test.go
+++ b/tests/tfcompat/l2_depends_on_count_chain_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A chain of instance-addressed depends_on across count resources — each
+// resource waits on the next one's instance [0], the last on nothing — must
+// create in reverse declaration order, and the narrow edges must let the chain
+// finish ahead of the last resource's delayed sibling instance.
+func TestL2DependsOnCountChain(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_depends_on_count_chain", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_depends_on_for_each_instance_test.go
+++ b/tests/tfcompat/l2_depends_on_for_each_instance_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// depends_on referencing a single for_each instance (`a["x"]`) must create a
+// dependency on only that instance, not the whole resource. OpenTofu honors
+// the instance address; the recorded op order proves whether the runtime keeps
+// the edge narrow or widens it to every instance of `a`.
+func TestL2DependsOnForEachInstance(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_depends_on_for_each_instance", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_module_for_each_instance_flow_test.go
+++ b/tests/tfcompat/l2_module_for_each_instance_flow_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A reference inside a for_each module resolves within the same module
+// instance: m["x"].b waits only for m["x"].a, never for the delayed
+// m["y"].a. The recorded op order proves whether the runtime keeps
+// module-internal edges per module instance or widens them across all
+// instances of the module.
+func TestL2ModuleForEachInstanceFlow(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_for_each_instance_flow", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_ref_count_index_test.go
+++ b/tests/tfcompat/l2_ref_count_index_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A body reference to a single count instance (`a[0].result`) must create a
+// dependency on only that instance, like a for_each key reference does. The
+// recorded op order proves whether the runtime keeps the edge narrow or widens
+// it to every instance of `a`.
+func TestL2RefCountIndex(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_ref_count_index", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_ref_for_each_instance_test.go
+++ b/tests/tfcompat/l2_ref_for_each_instance_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A body reference to a single for_each instance (`a["x"].result`) must, like
+// an instance-addressed depends_on, create a dependency on only that instance.
+// The recorded op order proves whether the runtime keeps the edge narrow or
+// widens it to every instance of `a`.
+func TestL2RefForEachInstance(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_ref_for_each_instance", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_data_for_each_set_flow/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_for_each_set_flow/main.tf
@@ -1,0 +1,20 @@
+# A resource over a set feeding a data source over the same set through a
+# dynamic index (`a[each.key]`). The dynamic index means the reference is to
+# the whole resource, so every `d` read waits for every `a` instance
+# (including the delayed `a["y"]`): [a["x"], a["y"], d["x"], d["y"]], with
+# `d["y"]`'s read delayed to keep the two reads totally ordered.
+resource "order_resource" "a" {
+  for_each     = toset(["x", "y"])
+  name         = each.key
+  delay_create = each.key == "y"
+}
+
+data "order_data" "d" {
+  for_each   = toset(["x", "y"])
+  name       = order_resource.a[each.key].result
+  delay_read = each.key == "y"
+}
+
+output "d_results" {
+  value = join(",", [for k in sort(keys(data.order_data.d)) : data.order_data.d[k].result])
+}

--- a/tests/tfcompat/testdata/cases/l2_depends_on_count_chain/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_depends_on_count_chain/main.tf
@@ -1,0 +1,33 @@
+# A reverse chain across count resources: r0 depends on r1[0], r1 on r2[0],
+# r2 on r3[0], and r3 depends on nothing, so creates run in reverse
+# declaration order. r3's second instance is delayed: the instance-addressed
+# edges let the whole chain complete before r3[1], recording
+# [r3-0, r2, r1, r0, r3-1]. A runtime that widens any hop to the whole
+# resource waits for the delayed r3[1] mid-chain — a deterministic flip.
+resource "order_resource" "r0" {
+  count      = 1
+  name       = "r0"
+  depends_on = [order_resource.r1[0]]
+}
+
+resource "order_resource" "r1" {
+  count      = 1
+  name       = "r1"
+  depends_on = [order_resource.r2[0]]
+}
+
+resource "order_resource" "r2" {
+  count      = 1
+  name       = "r2"
+  depends_on = [order_resource.r3[0]]
+}
+
+resource "order_resource" "r3" {
+  count        = 2
+  name         = "r3-${count.index}"
+  delay_create = count.index == 1
+}
+
+output "r0_result" {
+  value = order_resource.r0[0].result
+}

--- a/tests/tfcompat/testdata/cases/l2_depends_on_for_each_instance/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_depends_on_for_each_instance/main.tf
@@ -1,0 +1,22 @@
+# `b` depends_on a single for_each instance `a["x"]`. OpenTofu honors the
+# instance address: `b` waits only for `a["x"]`, not for the delayed `a["y"]`,
+# so the recorded create order is [a["x"], b, a["y"]].
+#
+# The `a["y"]` create is delayed. With the correct narrow edge, `b` (which does
+# not depend on `a["y"]`) records ahead of the delayed `a["y"]`. A runtime that
+# widens the edge to the whole resource `a` makes `b` wait for `a["y"]`, so
+# `a["y"]` records ahead of `b` — a deterministic order flip.
+resource "order_resource" "a" {
+  for_each     = toset(["x", "y"])
+  name         = each.key
+  delay_create = each.key == "y"
+}
+
+resource "order_resource" "b" {
+  depends_on = [order_resource.a["x"]]
+  name       = "b"
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_for_each_instance_flow/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_for_each_instance_flow/child/main.tf
@@ -1,0 +1,16 @@
+variable "key" {
+  type = string
+}
+
+resource "order_resource" "a" {
+  name         = "a-${var.key}"
+  delay_create = var.key == "y"
+}
+
+resource "order_resource" "b" {
+  name = "b-${order_resource.a.result}"
+}
+
+output "result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_for_each_instance_flow/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_for_each_instance_flow/main.tf
@@ -1,0 +1,14 @@
+# Each module instance's `b` depends only on its own instance's `a`. OpenTofu
+# expands modules per instance, so m["x"].b creates as soon as m["x"].a is
+# done, ahead of the delayed m["y"].a: [a-x, b-x, a-y, b-y]. A runtime that
+# widens module-internal edges across module instances makes both `b`s wait
+# for the delayed a-y — a deterministic order flip.
+module "m" {
+  source   = "./child"
+  for_each = toset(["x", "y"])
+  key      = each.key
+}
+
+output "results" {
+  value = join(",", [for k in sort(keys(module.m)) : module.m[k].result])
+}

--- a/tests/tfcompat/testdata/cases/l2_ref_count_index/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ref_count_index/main.tf
@@ -1,0 +1,16 @@
+# `b` references a single count instance `a[0]` in its body. OpenTofu resolves
+# a literal-indexed reference to the exact instance: `b` waits only for `a[0]`,
+# not for the delayed `a[1]`, so the recorded create order is [a[0], b, a[1]].
+resource "order_resource" "a" {
+  count        = 2
+  name         = "a-${count.index}"
+  delay_create = count.index == 1
+}
+
+resource "order_resource" "b" {
+  name = "b-${order_resource.a[0].result}"
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_ref_for_each_instance/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ref_for_each_instance/main.tf
@@ -1,0 +1,18 @@
+# `b` references a single for_each instance `a["x"]` in its body. OpenTofu
+# resolves a literal-indexed reference to the exact instance: `b` waits only
+# for `a["x"]`, not for the delayed `a["y"]`, so the recorded create order is
+# [a["x"], b, a["y"]]. A runtime that widens the reference to the whole
+# resource `a` makes `b` wait for `a["y"]` too — a deterministic order flip.
+resource "order_resource" "a" {
+  for_each     = toset(["x", "y"])
+  name         = each.key
+  delay_create = each.key == "y"
+}
+
+resource "order_resource" "b" {
+  name = "b-${order_resource.a["x"].result}"
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}


### PR DESCRIPTION
## Bug

An instance-addressed reference — `a["x"]` in `depends_on` or in an expression — widened to the whole resource: the dependency graph is node-level, so the dependent waited for **every** instance of the target, including ones the reference never named. OpenTofu resolves a literal-indexed reference to exactly that instance:

```
tofu ops:   0. a["x"]   1. b               2. a["y"](delay_create)
pulumi ops: 0. a["x"]   1. a["y"](delay)   2. b
```

## Fix

**Graph** (`pkg/hcl/graph`):
- Each resource/data reference of a dependent is classified as instance-narrowed (`a["x"]`, `a[0]` — literal index right after the resource address) or whole. A dependency stays narrow only if *every* reference to it is instance-addressed; any whole reference widens it. Dynamic indexes (`a[each.key]`) never survive into a traversal, so they keep whole-resource semantics — same as OpenTofu, verified empirically (`l2_data_for_each_set_flow`).
- A narrow key that names no actual instance — a nonexistent index/key, or a number index against for_each string keys (conformance program `l3-range-list-ref`) — falls back to edges from **all** instances, matching tofu's containing-resource fallback: the dependent waits for every instance to fill and the reference then errors (or converts) at evaluation.
- An expanded (count/for_each) resource now runs its instances as their own concurrent walk units (`SpawnInstances`, using pdag's mid-walk node insertion). The node's successors are re-gated on the instances they depend on — all of them, or only the addressed one for a narrowed dependent. Concurrent instances also match OpenTofu's scheduling; previously instances registered sequentially in random map order, which is inherently flaky against OpenTofu in ordered-op comparisons.

**Eval** (`pkg/hcl/eval`): count instances assemble sparsely into their tuple — each registered index at its true position, unregistered gaps held unknown — so a dependent narrowed to `a[1]` evaluates correctly while `a[0]` is still creating. A correctly scheduled dependent never reads a gap.

**Runtime** (`pkg/hcl/run`):
- Data-source instance reads run concurrently within the node, for the same scheduling parity.
- Engine-level `depends_on` resolution is instance-aware: an instance address resolves to that instance's URN, and a whole-resource `depends_on` on an expanded resource records every instance URN — previously it silently recorded **none** (the whole-resource key has no outputs entry), so state had no dependency at all. The failed-dependency check matches instance keys the same way.

Data sources as narrowed *producers* (`data.d["x"]` as a dependency) stay conservatively whole: their instance outputs publish as one aggregate, and nothing observable requires narrowing them yet.

**Modules** (`pkg/hcl/graph` + `pkg/hcl/run`): references inside a for_each/count module resolve within the same module instance, as in tofu — `m["x"].b` waits only for `m["x"].a`, never a delayed `m["y"].a`. Module-inlined nodes become *templates*; the call's init spawns one walk unit per (member × module instance) (`SpawnModuleInstanceUnits`). Intra-module static edges become instance-aligned unit edges, external predecessors attach at node level, and each unit is a prerequisite of its own template, so *template done ⟺ all units done* — everything outside the module keeps node-level semantics through the unchanged static graph. Init/completion run per enclosing-module instance (`Node.OwnerPath`), so nested modules cascade; resource expansion composes inside units (`SpawnInstancesTo`). This deletes the sequential `forEachModuleInstance` iteration that hard-coded the widening. Two latent bugs surfaced and fixed: pass-through provider shadows / call nodes connect at node level (no init edge, no per-instance work), and init — which eagerly evaluates call inputs for the component registration — now orders after their references, added best-effort post-build so mutually-referencing module inputs (`l3-deferred-outputs`) keep their historical eager-input behavior instead of failing the build.

## Tests

- `TestL2DependsOnForEachInstance` — `depends_on = [a["x"]]` narrows (the original failing test).
- `TestL2RefForEachInstance` — a body reference `a["x"].result` narrows (failed before the fix: tofu `[x, b, y]`, pulumi `[x, y, b]`).
- `TestL2RefCountIndex` — a body reference `a[0].result` on a count resource narrows the same way.
- `TestL2DataForEachSetFlow` — for_each resource → for_each data source through `a[each.key]`: whole-resource semantics, values flow, reads ordered as in tofu (needed the concurrent-instance scheduling to be deterministic).
- `TestL2ModuleForEachInstanceFlow` — for_each module: `m["x"].b` creates ahead of the delayed `m["y"].a` (failed before the module-clone work: tofu `[a-x, b-x, a-y, b-y]`, pulumi widened).
- `TestL2DependsOnCountChain` — a `depends_on` chain across count resources creates in reverse declaration order ahead of a delayed sibling instance.
- Unit tests for the traversal splitting (`InstanceTarget`), narrow/widen classification (`instanceDeps`), and successor re-gating (`SpawnInstances`).

Ordering tests stressed at `-count=3` (and the order/destroy/depends family at `-count=2`) with no flakes; pkg tests pass under `-race`.
