### PR TITLE
Resolve bridged renames for fields nested in object-typed attributes

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-417.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-417.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Accept list fields nested in object-typed attributes whose bridged names are pluralized (e.g. `azapi_resource`'s `retry.error_message_regex`)
+time: 2026-07-16T12:55:28Z
+custom:
+    Component: runtime
+    PR: "417"

--- a/pkg/hcl/transform/provider_functions.go
+++ b/pkg/hcl/transform/provider_functions.go
@@ -118,7 +118,7 @@ func ProviderFunction(fn *schema.Function, variadic bool, dryRun bool, impl Prov
 			}
 			inputs := make(map[string]property.Value, len(positional)+1)
 			for i, p := range positional {
-				v, err := ctyToResourceProperty(params[i].Name, args[i], p.Type, nil, p.Secret)
+				v, err := ctyToResourceProperty(params[i].Name, args[i], p.Type, nil, p.Secret, nil)
 				if err != nil {
 					return cty.NilVal, err
 				}
@@ -132,7 +132,7 @@ func ProviderFunction(fn *schema.Function, variadic bool, dryRun bool, impl Prov
 				elems := make([]property.Value, len(rest))
 				for i, arg := range rest {
 					v, err := ctyToResourceProperty(
-						fmt.Sprintf("%s[%d]", varParam.Name, i), arg, variadicElem, nil, variadicProp.Secret)
+						fmt.Sprintf("%s[%d]", varParam.Name, i), arg, variadicElem, nil, variadicProp.Secret, nil)
 					if err != nil {
 						return cty.NilVal, err
 					}

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -62,7 +62,7 @@ func EvalFunctionWithSchema(config hcl.Body, r *schema.Function, mapping *bridge
 		return property.Map{}, diags
 	}
 
-	m, err := ctyToFunctionInputs(functionInputs, r, attrExprs)
+	m, err := ctyToFunctionInputs(functionInputs, r, attrExprs, mapping)
 	if err != nil {
 		return property.Map{}, append(diags,
 			conversionDiagnostic(err, "failed to convert HCL function inputs to Pulumi inputs"))
@@ -81,7 +81,7 @@ func EvalResourceWithSchema(config hcl.Body, r *schema.Resource, mapping *bridge
 		return property.Map{}, nil, diags
 	}
 
-	m, err := ctyToResourceInputs(resourceInputs, r, attrExprs)
+	m, err := ctyToResourceInputs(resourceInputs, r, attrExprs, mapping)
 	if err != nil {
 		return property.Map{}, nil, append(diags,
 			conversionDiagnostic(err, "failed to convert HCL resource inputs to Pulumi inputs"))
@@ -167,22 +167,6 @@ func evalBlockWithSchema(config hcl.Body, props []*schema.Property, mapping *bri
 		return cty.EmptyObjectVal, nil, diags
 	}
 
-	// resolveProp picks the Pulumi property for a TF (snake_case) name, going
-	// through the mapping when available (for explicit renames), falling back
-	// to the snake↔camel convention otherwise.
-	resolveProp := func(tfName string) (string, *schema.Property) {
-		if mapping != nil {
-			if fm := mapping.Lookup(tfName); fm != nil {
-				for _, p := range props {
-					if p.Name == fm.PulumiName {
-						return p.Name, p
-					}
-				}
-			}
-		}
-		return camelCaseFromSnakeCase(tfName, props)
-	}
-
 	// storageKey is the cty/attrExprs key for a TF attribute; using the
 	// snake-form of the Pulumi name lets the downstream ctyToObject pipeline
 	// match the property via its existing camelCaseFromSnakeCase lookup, even
@@ -197,7 +181,7 @@ func evalBlockWithSchema(config hcl.Body, props []*schema.Property, mapping *bri
 	attrExprs := make(map[string]hcl.Expression, len(body.Attributes))
 	resourceInputs := make(map[string]cty.Value, len(body.Attributes)+len(body.Blocks))
 	for name, attr := range body.Attributes {
-		_, prop := resolveProp(name)
+		_, prop := resolvePulumiProperty(name, props, mapping)
 		contract.Assertf(prop != nil, "unable to find schema for validated property")
 
 		out, attrDiag := eval(resource.PropertyKey(prop.Name), attr.Expr, nil)
@@ -220,7 +204,7 @@ func evalBlockWithSchema(config hcl.Body, props []*schema.Property, mapping *bri
 			continue
 		}
 
-		_, prop := resolveProp(name)
+		_, prop := resolvePulumiProperty(name, props, mapping)
 		contract.Assertf(prop != nil, "unable to find schema for validated property")
 
 		blockProps, isList := blockPropertiesOf(prop.Type)
@@ -644,28 +628,43 @@ func inputBodyFromProperties(r []*schema.Property, mapping *bridge.BodyMapping) 
 	return body
 }
 
-func ctyToResourceInputs(val cty.Value, r *schema.Resource, attrExprs map[string]hcl.Expression) (property.Map, error) {
-	return ctyToObject(r.Token, val, r.InputProperties, attrExprs, false /* already in a secret */)
+func ctyToResourceInputs(val cty.Value, r *schema.Resource, attrExprs map[string]hcl.Expression, mapping *bridge.BodyMapping) (property.Map, error) {
+	return ctyToObject(r.Token, val, r.InputProperties, attrExprs, false /* already in a secret */, mapping)
 }
 
-func ctyToFunctionInputs(val cty.Value, r *schema.Function, attrExprs map[string]hcl.Expression) (property.Map, error) {
+func ctyToFunctionInputs(val cty.Value, r *schema.Function, attrExprs map[string]hcl.Expression, mapping *bridge.BodyMapping) (property.Map, error) {
 	var inputs []*schema.Property
 	if r.Inputs != nil {
 		inputs = r.Inputs.Properties
 	}
-	return ctyToObject(r.Token, val, inputs, attrExprs, false /* already in a secret */)
+	return ctyToObject(r.Token, val, inputs, attrExprs, false /* already in a secret */, mapping)
+}
+
+// resolvePulumiProperty picks the Pulumi property for a TF (snake_case) name,
+// going through the mapping when available (for renames the snake↔camel
+// convention cannot recover, e.g. pluralized list fields), falling back to
+// the convention otherwise.
+func resolvePulumiProperty(tfName string, props []*schema.Property, mapping *bridge.BodyMapping) (string, *schema.Property) {
+	if fm := mapping.Lookup(tfName); fm != nil {
+		for _, p := range props {
+			if p.Name == fm.PulumiName {
+				return p.Name, p
+			}
+		}
+	}
+	return camelCaseFromSnakeCase(tfName, props)
 }
 
 // ctyToObject's attrExprs maps each attribute's HCL (snake_case) name to
 // its source expression; passing nil disables source-range error
 // reporting for this object's children.
-func ctyToObject(path string, val cty.Value, properties []*schema.Property, attrExprs map[string]hcl.Expression, alreadyInSecret bool) (property.Map, error) {
+func ctyToObject(path string, val cty.Value, properties []*schema.Property, attrExprs map[string]hcl.Expression, alreadyInSecret bool, mapping *bridge.BodyMapping) (property.Map, error) {
 	seen := make(map[string]struct{})
 	result := map[string]property.Value{}
 	for it := val.ElementIterator(); it.Next(); {
 		k, v := it.Element()
 		keyStr := k.AsString()
-		puField, prop := camelCaseFromSnakeCase(keyStr, properties)
+		puField, prop := resolvePulumiProperty(keyStr, properties, mapping)
 		if prop == nil {
 			// We have not found the correct field in the property list, so we should put together an error
 			// message.
@@ -678,7 +677,8 @@ func ctyToObject(path string, val cty.Value, properties []*schema.Property, attr
 		}
 		seen[puField] = struct{}{}
 		var err error
-		result[puField], err = ctyToResourceProperty(keyStr, v, prop.Type, attrExprs[keyStr], prop.Secret || alreadyInSecret)
+		result[puField], err = ctyToResourceProperty(keyStr, v, prop.Type, attrExprs[keyStr],
+			prop.Secret || alreadyInSecret, nestedMappingFor(prop.Name, mapping))
 		if err != nil {
 			return property.Map{}, err
 		}
@@ -752,7 +752,7 @@ func getDefault(path string, d *schema.DefaultValue, typ schema.Type) (property.
 
 // ctyToResourceProperty's expr, when non-nil, lets union-discrimination
 // failures attach an HCL source range to the returned error.
-func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, expr hcl.Expression, alreadyInSecret bool) (property.Value, error) {
+func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, expr hcl.Expression, alreadyInSecret bool, mapping *bridge.BodyMapping) (property.Value, error) {
 	// A whole-resource reference (e.g. `handler = aws_lambda_function.fn`) is
 	// identified by its resourceMark; capture the URN before the unmark below
 	// strips it, so the *schema.ResourceType case can build a reference from it.
@@ -766,7 +766,7 @@ func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, expr hc
 		// the persistence concern that ephemerality exists to solve.
 		_, isEphemeral := marks[eval.EphemeralMark]
 		if (isSensitive || isEphemeral) && !alreadyInSecret {
-			v, err := ctyToResourceProperty(path, val, prop, expr, true)
+			v, err := ctyToResourceProperty(path, val, prop, expr, true, mapping)
 			return v.WithSecret(true), err
 		}
 	}
@@ -839,7 +839,7 @@ func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, expr hc
 		if !val.Type().IsObjectType() {
 			return property.Value{}, fmt.Errorf("expected object at %q, found %#v", path, val.Type())
 		}
-		m, err := ctyToObject(path, val, prop.Properties, attrExprsByKey(expr), alreadyInSecret)
+		m, err := ctyToObject(path, val, prop.Properties, attrExprsByKey(expr), alreadyInSecret, mapping)
 		return property.New(m), err
 	case *schema.ArrayType:
 		if !val.Type().IsListType() && !val.Type().IsSetType() && !val.Type().IsTupleType() {
@@ -854,7 +854,7 @@ func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, expr hc
 			if i < len(elemExprs) {
 				sub = elemExprs[i]
 			}
-			convertedElem, err := ctyToResourceProperty(fmt.Sprintf("%s[%d]", path, i), elem, prop.ElementType, sub, alreadyInSecret)
+			convertedElem, err := ctyToResourceProperty(fmt.Sprintf("%s[%d]", path, i), elem, prop.ElementType, sub, alreadyInSecret, mapping)
 			if err != nil {
 				return property.Value{}, err
 			}
@@ -870,7 +870,7 @@ func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, expr hc
 		for it := val.ElementIterator(); it.Next(); {
 			k, elem := it.Element()
 			key := k.AsString()
-			convertedElem, err := ctyToResourceProperty(fmt.Sprintf("%s[%q]", path, key), elem, prop.ElementType, elemExprs[key], alreadyInSecret)
+			convertedElem, err := ctyToResourceProperty(fmt.Sprintf("%s[%q]", path, key), elem, prop.ElementType, elemExprs[key], alreadyInSecret, mapping)
 			if err != nil {
 				return property.Value{}, err
 			}
@@ -889,7 +889,7 @@ func ctyToResourceProperty(path string, val cty.Value, prop schema.Type, expr hc
 			}
 			return property.Value{}, fmt.Errorf("%s: %w", summary, err)
 		} else if chosen != nil {
-			return ctyToResourceProperty(path, val, chosen, expr, alreadyInSecret)
+			return ctyToResourceProperty(path, val, chosen, expr, alreadyInSecret, mapping)
 		}
 		return ctyToPropertyValue(val)
 	default:

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -389,7 +389,7 @@ func TestCtyToResourceInputs(t *testing.T) {
 			result, err := ctyToResourceInputs(tt.input, &schema.Resource{
 				Token:           "pkg:mod:Name",
 				InputProperties: tt.properties,
-			}, nil)
+			}, nil, nil)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/tests/testutil/tfcompat/providers/pf.go
+++ b/tests/testutil/tfcompat/providers/pf.go
@@ -70,6 +70,7 @@ func (p *pfxProvider) Resources(context.Context) []func() resource.Resource {
 func (p *pfxProvider) DataSources(context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		func() datasource.DataSource { return &pfxLookup{} },
+		func() datasource.DataSource { return &pfxObjLookup{} },
 	}
 }
 
@@ -407,6 +408,53 @@ func (r *pfxObj) Update(ctx context.Context, req resource.UpdateRequest, resp *r
 }
 
 func (r *pfxObj) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {}
+
+// pfxObjLookup is the data-source counterpart of pfxObj: an object-typed
+// input attribute whose `item` field is a list of strings (bridged as
+// `items`), echoed back through the computed `value`.
+type pfxObjLookup struct{}
+
+var _ datasource.DataSource = (*pfxObjLookup)(nil)
+
+type pfxObjLookupModel struct {
+	ObjAttr types.Object `tfsdk:"obj_attr"`
+	Value   types.String `tfsdk:"value"`
+}
+
+func (d *pfxObjLookup) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_obj_lookup"
+}
+
+func (d *pfxObjLookup) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = dschema.Schema{
+		Attributes: map[string]dschema.Attribute{
+			"obj_attr": dschema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]dschema.Attribute{
+					"item": dschema.ListAttribute{ElementType: types.StringType, Optional: true},
+				},
+			},
+			"value": dschema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *pfxObjLookup) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state pfxObjLookupModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var items []string
+	if !state.ObjAttr.IsNull() {
+		resp.Diagnostics.Append(state.ObjAttr.Attributes()["item"].(types.List).ElementsAs(ctx, &items, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+	state.Value = types.StringValue(strings.Join(items, ","))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
 
 type pfxLookup struct{}
 

--- a/tests/testutil/tfcompat/providers/pf.go
+++ b/tests/testutil/tfcompat/providers/pf.go
@@ -63,6 +63,7 @@ func (p *pfxProvider) Resources(context.Context) []func() resource.Resource {
 		func() resource.Resource { return &pfxThing{} },
 		func() resource.Resource { return &pfxWidget{} },
 		func() resource.Resource { return &pfxRes{} },
+		func() resource.Resource { return &pfxObj{} },
 	}
 }
 
@@ -351,6 +352,61 @@ func (r *pfxRes) Update(ctx context.Context, req resource.UpdateRequest, resp *r
 
 func (r *pfxRes) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {
 }
+
+// pfxObj carries an optional object-typed attribute whose `item` field is a
+// list of strings — the bridge pluralizes the nested name to `items`.
+type pfxObj struct{}
+
+var _ resource.Resource = (*pfxObj)(nil)
+
+type pfxObjModel struct {
+	ID      types.String `tfsdk:"id"`
+	ObjAttr types.Object `tfsdk:"obj_attr"`
+}
+
+func (r *pfxObj) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_obj"
+}
+
+func (r *pfxObj) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"id": rschema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"obj_attr": rschema.SingleNestedAttribute{
+				Optional: true,
+				Attributes: map[string]rschema.Attribute{
+					"item": rschema.ListAttribute{ElementType: types.StringType, Optional: true},
+				},
+			},
+		},
+	}
+}
+
+func (r *pfxObj) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan pfxObjModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ID = types.StringValue("pfx-obj-id")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *pfxObj) Read(_ context.Context, _ resource.ReadRequest, _ *resource.ReadResponse) {}
+
+func (r *pfxObj) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan pfxObjModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *pfxObj) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {}
 
 type pfxLookup struct{}
 

--- a/tests/tfcompat/l2_data_object_attr_list_field_test.go
+++ b/tests/tfcompat/l2_data_object_attr_list_field_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2DataObjectAttrListField is the data-source counterpart of
+// TestL2ObjectAttrListField: a list-of-strings field nested inside an
+// object-typed attribute, whose bridged name is pluralized
+// (`item` -> `items`), on the invoke input-conversion path.
+func TestL2DataObjectAttrListField(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_object_attr_list_field", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "pfx", PFFactory: providers.PFXProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_object_attr_list_field_test.go
+++ b/tests/tfcompat/l2_object_attr_list_field_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ObjectAttrListField sets a list-of-strings field nested inside an
+// object-typed attribute. The bridge pluralizes the nested name
+// (`item` -> `items`), and the input conversion must apply the same rule
+// instead of a plain camelCase translation.
+func TestL2ObjectAttrListField(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_object_attr_list_field", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "pfx", PFFactory: providers.PFXProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_data_object_attr_list_field/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_object_attr_list_field/main.tf
@@ -1,0 +1,13 @@
+data "pfx_obj_lookup" "this" {
+  obj_attr = {
+    item = ["a", "b"]
+  }
+}
+
+output "value" {
+  value = data.pfx_obj_lookup.this.value
+}
+
+output "item" {
+  value = data.pfx_obj_lookup.this.obj_attr.item
+}

--- a/tests/tfcompat/testdata/cases/l2_object_attr_list_field/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_object_attr_list_field/main.tf
@@ -1,0 +1,9 @@
+resource "pfx_obj" "this" {
+  obj_attr = {
+    item = ["a", "b"]
+  }
+}
+
+output "value" {
+  value = pfx_obj.this.obj_attr.item
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/417.

Any `azapi_resource` with a `retry` block failed input conversion: the bridged schema pluralizes the list-typed `error_message_regex` field nested inside the object-typed `retry` attribute to `errorMessageRegexes`, but the HCL→Pulumi input conversion translated the name with plain camelCasing (`errorMessageRegex`), so the lookup missed and registration failed. OpenTofu accepts the same configuration.

Top-level attribute names already resolve through the bridge's `BodyMapping`, and the output direction (`propertyObjectToCtyMap`) already threads the mapping into nested objects. Only the input direction was missing it: the contents of an object-typed attribute reach `ctyToObject` with their raw TF names and were resolved by the snake↔camel convention alone, which cannot recover pluralization.

The fix threads the field's nested `BodyMapping` through `ctyToObject` and `ctyToResourceProperty` (object, array-element, map-element, union, and secret recursion), resolving each nested name through the mapping first and falling back to the convention. The resolution logic is shared with the existing top-level path (`resolvePulumiProperty`).

The first commit adds `TestL2ObjectAttrListField`, a tfcompat test reproducing the divergence with a generic plugin-framework resource — an object-typed attribute whose `item` field is a list of strings, pluralized by the bridge to `items`. The test's output also references the nested field, exercising the (already-correct) reverse translation.