### PR TITLE
Error on repeated `MaxItems=1` blocks instead of keeping the last

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-419.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-419.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Error on repeated `MaxItems=1` blocks instead of keeping the last block
+time: 2026-07-16T16:00:00Z
+custom:
+    Component: runtime
+    PR: "419"

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -213,9 +213,16 @@ func evalBlockWithSchema(config hcl.Body, props []*schema.Property, mapping *bri
 		if isList {
 			appendBlockListValues(resourceInputs, key, []cty.Value{evaluated})
 		} else {
+			if existing, ok := resourceInputs[key]; ok {
+				// An earlier dynamic block with an unknown for_each owns the
+				// value; its expansion cannot be counted.
+				if unmarked, _ := existing.Unmark(); !unmarked.IsKnown() {
+					continue
+				}
+				diags = append(diags, tooManySingularBlocks(name, block.DefRange))
+				return cty.Value{}, nil, diags
+			}
 			// TF block flattened to a single Pulumi object (MaxItemsOne).
-			// Repeated blocks keep the last; the provider's later validation
-			// surfaces the user error.
 			resourceInputs[key] = evaluated
 		}
 	}
@@ -443,9 +450,22 @@ func evalDynamicBlock(
 		case isList:
 			appendBlockListValues(resourceInputs, key, values)
 		default:
-			// Singular block (MaxItemsOne): a dynamic expansion of length 1
-			// fills it; >1 is a user error the provider will validate.
-			resourceInputs[key] = values[len(values)-1]
+			// Singular block (MaxItemsOne): only an expansion of length 1
+			// fills it, and only if nothing else already has.
+			if len(values) > 1 {
+				diags = append(diags, tooManySingularBlocks(propName, block.DefRange))
+				return diags
+			}
+			if existing, ok := resourceInputs[key]; ok {
+				// An earlier unknown expansion owns the value; its element
+				// count cannot be checked.
+				if unmarked, _ := existing.Unmark(); !unmarked.IsKnown() {
+					return diags
+				}
+				diags = append(diags, tooManySingularBlocks(propName, block.DefRange))
+				return diags
+			}
+			resourceInputs[key] = values[0]
 		}
 	}
 	return diags
@@ -473,6 +493,17 @@ func appendBlockListValues(resourceInputs map[string]cty.Value, key string, valu
 	// for absent keys), so blockListValue falls back to a tuple rather than
 	// cty.ListVal, which would panic.
 	resourceInputs[key] = blockListValue(values)
+}
+
+// tooManySingularBlocks reports more than one block (static or dynamically
+// expanded) for a MaxItems=1 field.
+func tooManySingularBlocks(name string, rng hcl.Range) *hcl.Diagnostic {
+	return &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  fmt.Sprintf("Too many %s blocks", name),
+		Detail:   fmt.Sprintf("No more than 1 %q blocks are allowed", name),
+		Subject:  rng.Ptr(),
+	}
 }
 
 // schemaToCtyPrimitive returns the cty primitive type corresponding to a

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -513,6 +513,81 @@ resource "fake" "f" {
 	assert.Equal(t, expected, out)
 }
 
+// More than one block (static, dynamically expanded, or a mix) for a
+// MaxItems=1 field is an error, not last-block-wins.
+func TestSingularBlockRepeated(t *testing.T) {
+	t.Parallel()
+
+	r := &schema.Resource{
+		Token: "fake:index:F",
+		InputProperties: []*schema.Property{{
+			Name: "settings",
+			Type: &schema.ObjectType{
+				Properties: []*schema.Property{{Name: "mode", Type: schema.StringType}},
+			},
+		}},
+	}
+	mapping := &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+		"settings": {TFName: "settings", PulumiName: "settings", TFBlock: true, MaxItemsOne: true},
+	}}
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{"two static blocks", `
+resource "fake" "f" {
+  settings { mode = "a" }
+  settings { mode = "b" }
+}`},
+		{"dynamic expansion of two", `
+resource "fake" "f" {
+  dynamic "settings" {
+    for_each = ["a", "b"]
+    content { mode = settings.value }
+  }
+}`},
+		{"static and dynamic", `
+resource "fake" "f" {
+  settings { mode = "a" }
+  dynamic "settings" {
+    for_each = ["b"]
+    content { mode = settings.value }
+  }
+}`},
+		{"two dynamic expansions", `
+resource "fake" "f" {
+  dynamic "settings" {
+    for_each = ["a"]
+    content { mode = settings.value }
+  }
+  dynamic "settings" {
+    for_each = ["b"]
+    content { mode = settings.value }
+  }
+}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			file, diags := hclsyntax.ParseConfig([]byte(tt.src), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+			require.False(t, diags.HasErrors(), diags.Error())
+			resourceBody := file.Body.(*hclsyntax.Body).Blocks[0].Body
+
+			evalFn := func(_ resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
+				return expr.Value(&hcl.EvalContext{Variables: extraVars})
+			}
+
+			_, _, diags = EvalResourceWithSchema(resourceBody, r, mapping, evalFn)
+			require.Len(t, diags, 1)
+			assert.Equal(t, "Too many settings blocks", diags[0].Summary)
+			assert.Equal(t, `No more than 1 "settings" blocks are allowed`, diags[0].Detail)
+		})
+	}
+}
+
 func TestCtyToPropertyValue_Primitives(t *testing.T) {
 	t.Parallel()
 

--- a/tests/tfcompat/l2_repeated_max_items_one_block_test.go
+++ b/tests/tfcompat/l2_repeated_max_items_one_block_test.go
@@ -21,9 +21,8 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-// Two static `settings` blocks for a TypeList MaxItems=1 attribute. tofu
-// rejects the config at plan time; pulumi-hcl silently keeps the last block,
-// so the apply succeeds where tofu errors.
+// tofu rejects repeated blocks for a MaxItems=1 attribute at plan time;
+// pulumi-hcl keeps the last block and succeeds.
 func TestL2RepeatedMaxItemsOneBlock(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_repeated_max_items_one_block", tfcompat.Case{

--- a/tests/tfcompat/l2_repeated_max_items_one_block_test.go
+++ b/tests/tfcompat/l2_repeated_max_items_one_block_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// Two static `settings` blocks for a TypeList MaxItems=1 attribute. tofu
+// rejects the config at plan time; pulumi-hcl silently keeps the last block,
+// so the apply succeeds where tofu errors.
+func TestL2RepeatedMaxItemsOneBlock(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_repeated_max_items_one_block", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "blocky", Factory: providers.BlockyProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{ExpectErr: "Too many settings blocks"},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_repeated_max_items_one_block/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_repeated_max_items_one_block/main.tf
@@ -1,7 +1,3 @@
-# Two static blocks for a TypeList MaxItems=1 attribute. tofu rejects the
-# config at plan time ("Too many settings blocks"); pulumi-hcl flattens
-# MaxItemsOne blocks by keeping the last one, so the provider only ever sees a
-# single block and the apply succeeds.
 resource "blocky_thing" "x" {
   name = "y"
 

--- a/tests/tfcompat/testdata/cases/l2_repeated_max_items_one_block/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_repeated_max_items_one_block/main.tf
@@ -1,0 +1,15 @@
+# Two static blocks for a TypeList MaxItems=1 attribute. tofu rejects the
+# config at plan time ("Too many settings blocks"); pulumi-hcl flattens
+# MaxItemsOne blocks by keeping the last one, so the provider only ever sees a
+# single block and the apply succeeds.
+resource "blocky_thing" "x" {
+  name = "y"
+
+  settings {
+    mode = "first"
+  }
+
+  settings {
+    mode = "second"
+  }
+}


### PR DESCRIPTION
## Divergence

Two static blocks (or a `dynamic` block expanding to more than one element) for a TypeList `MaxItems=1` attribute are rejected by OpenTofu at plan time:

```
Error: Too many settings blocks
```

pulumi-hcl's MaxItemsOne flattening kept only the last block, so the provider never saw the duplicate and `pulumi up` succeeded where tofu errors.

## Fix

Block evaluation in `pkg/hcl/transform/transform.go` now emits `Too many <name> blocks` / `No more than 1 "<name>" blocks are allowed` (hcldec's wording) whenever a singular (MaxItemsOne) block field would receive more than one value, in both the static-block and dynamic-expansion paths, including a static/dynamic mix for the same field. An unknown dynamic `for_each` keeps the existing whole-property-unknown behavior, since its element count cannot be checked.

Related to https://github.com/pulumi-labs/pulumi-hcl/pull/408 (static/dynamic source order for the same list attribute), which fixed ordering but preserved the keep-the-last behavior for singular blocks.

## Tests

- `TestL2RepeatedMaxItemsOneBlock` (tfcompat): both runtimes now fail with `Too many settings blocks`.
- `TestSingularBlockRepeated` (unit): two static blocks, a dynamic expansion of two, a static+dynamic mix, and two dynamic expansions each error regardless of block-processing order.