### PR TITLE
Schedule count/for_each instances at instance granularity

### DIFF
--- a/.changes/unreleased/runtime-Improvements-422.yaml
+++ b/.changes/unreleased/runtime-Improvements-422.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Schedule `count`/`for_each` instances individually, so a reference to a single instance no longer waits on the whole resource
+time: 2026-07-17T18:00:00Z
+custom:
+    Component: runtime
+    PR: "422"

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -1543,7 +1543,9 @@ func TestInvokeInRangeOption(t *testing.T) {
 			sinkNames = append(sinkNames, r.Name)
 		}
 	}
-	assert.Equal(t, []string{"targets-0", "targets-1"}, sinkNames)
+	// The two instances register concurrently, so their arrival order is not
+	// fixed; assert the set of names, not the sequence.
+	assert.ElementsMatch(t, []string{"targets-0", "targets-1"}, sinkNames)
 }
 
 // TestInvokeReturnType covers the case where a function declares its outputs via

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -16,6 +16,7 @@ package eval
 
 import (
 	"fmt"
+	"iter"
 	"maps"
 	"path/filepath"
 	"strings"
@@ -162,19 +163,24 @@ type rangedShape struct {
 	isCount  bool
 }
 
-// forEachRangedValue assembles each ranged block's collection value —
-// including blocks with a declared shape but no published instances yet — and
-// hands it to visit keyed by the block's base key.
+// forEachRangedValue yields each ranged block's collection value — including
+// blocks with a declared shape but no published instances yet — keyed by the
+// block's base key.
 func forEachRangedValue(
 	instances map[string][]rangedInstance, shapes map[string]rangedShape,
-	visit func(baseKey string, val cty.Value),
-) {
-	for baseKey, insts := range instances {
-		visit(baseKey, assembleRanged(insts, shapes[baseKey]))
-	}
-	for baseKey, shape := range shapes {
-		if _, ok := instances[baseKey]; !ok {
-			visit(baseKey, assembleRanged(nil, shape))
+) iter.Seq2[string, cty.Value] {
+	return func(yield func(string, cty.Value) bool) {
+		for baseKey, insts := range instances {
+			if !yield(baseKey, assembleRanged(insts, shapes[baseKey])) {
+				return
+			}
+		}
+		for baseKey, shape := range shapes {
+			if _, ok := instances[baseKey]; !ok {
+				if !yield(baseKey, assembleRanged(nil, shape)) {
+					return
+				}
+			}
 		}
 	}
 }
@@ -551,17 +557,17 @@ func (c *Context) HCLContext() *hcl.EvalContext {
 
 	// Assemble ranged resource instances into tuples (count) or objects
 	// (for_each), padded to the declared shape.
-	forEachRangedValue(c.rangedResources, c.rangedShapes, func(baseKey string, val cty.Value) {
+	for baseKey, val := range forEachRangedValue(c.rangedResources, c.rangedShapes) {
 		parts := splitResourceKey(baseKey)
 		if len(parts) != 2 {
-			return
+			continue
 		}
 		typeName, resName := parts[0], parts[1]
 		if resourcesByType[typeName] == nil {
 			resourcesByType[typeName] = make(map[string]cty.Value)
 		}
 		resourcesByType[typeName][resName] = val
-	})
+	}
 
 	for typeName, instances := range resourcesByType {
 		vars[typeName] = cty.ObjectVal(instances)
@@ -585,7 +591,9 @@ func (c *Context) HCLContext() *hcl.EvalContext {
 	for key, value := range c.dataSources {
 		addData(key, value)
 	}
-	forEachRangedValue(c.rangedData, c.rangedDataShapes, addData)
+	for key, val := range forEachRangedValue(c.rangedData, c.rangedDataShapes) {
+		addData(key, val)
+	}
 	if len(typeGroups) > 0 {
 		dataMap := make(map[string]cty.Value)
 		for typeName, instances := range typeGroups {

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -62,19 +62,12 @@ type Context struct {
 	// keyed by the base resource key (e.g., "type.name").
 	rangedResources map[string][]rangedInstance
 
-	// rangedShapes records the declared instance shape of each count/for_each
-	// resource, so a partial assembly stays indexable while instances publish
-	// concurrently: unpublished count indexes and for_each keys read as
-	// unknown. Keys match rangedResources.
-	rangedShapes map[string]rangedShape
-
 	// dataSources contains data source outputs (data.type.name.*)
 	dataSources map[string]cty.Value
 
-	// rangedData and rangedDataShapes mirror rangedResources/rangedShapes for
-	// count/for_each data sources, keyed by the base data-source key.
-	rangedData       map[string][]rangedInstance
-	rangedDataShapes map[string]rangedShape
+	// rangedData mirrors rangedResources for count/for_each data sources,
+	// keyed by the base data-source key.
+	rangedData map[string][]rangedInstance
 
 	// modules contains module outputs (module.name.*)
 	modules map[string]cty.Value
@@ -155,51 +148,29 @@ type rangedInstance struct {
 	isEach  bool
 }
 
-// rangedShape is the declared instance set of one count/for_each block: count
-// instances 0..count-1, or the full for_each key set.
-type rangedShape struct {
-	count    int
-	eachKeys []string
-	isCount  bool
-}
-
-// forEachRangedValue yields each ranged block's collection value — including
-// blocks with a declared shape but no published instances yet — keyed by the
+// forEachRangedValue yields each ranged block's collection value, keyed by the
 // block's base key.
-func forEachRangedValue(
-	instances map[string][]rangedInstance, shapes map[string]rangedShape,
-) iter.Seq2[string, cty.Value] {
+func forEachRangedValue(instances map[string][]rangedInstance) iter.Seq2[string, cty.Value] {
 	return func(yield func(string, cty.Value) bool) {
 		for baseKey, insts := range instances {
-			if !yield(baseKey, assembleRanged(insts, shapes[baseKey])) {
+			if !yield(baseKey, assembleRanged(insts)) {
 				return
-			}
-		}
-		for baseKey, shape := range shapes {
-			if _, ok := instances[baseKey]; !ok {
-				if !yield(baseKey, assembleRanged(nil, shape)) {
-					return
-				}
 			}
 		}
 	}
 }
 
 // assembleRanged builds a ranged block's collection value from its published
-// instances, padded to the declared shape: slots whose instance has not
-// published yet read as unknown, so a consumer holding only a single
-// instance's completion can index that instance while siblings still run. A
-// zero-value shape (nothing declared) pads count tuples to the highest
-// published index.
-func assembleRanged(instances []rangedInstance, shape rangedShape) cty.Value {
-	isCount := shape.isCount || (len(instances) > 0 && instances[0].isCount)
-	if isCount {
-		n := shape.count
+// instances. A consumer only ever reads instances it holds a dependency on,
+// and those have already published by the time it evaluates, so partial
+// assembly is safe: a count tuple is padded to the highest published index
+// (intermediate unpublished slots read as unknown but are never indexed), and
+// a for_each object carries exactly the published keys.
+func assembleRanged(instances []rangedInstance) cty.Value {
+	if len(instances) > 0 && instances[0].isCount {
+		n := 0
 		for _, inst := range instances {
 			n = max(n, inst.index+1)
-		}
-		if n == 0 {
-			return cty.EmptyTupleVal
 		}
 		vals := make([]cty.Value, n)
 		for i := range vals {
@@ -211,10 +182,7 @@ func assembleRanged(instances []rangedInstance, shape rangedShape) cty.Value {
 		return cty.TupleVal(vals)
 	}
 
-	objMap := make(map[string]cty.Value, max(len(instances), len(shape.eachKeys)))
-	for _, k := range shape.eachKeys {
-		objMap[k] = cty.UnknownVal(cty.DynamicPseudoType)
-	}
+	objMap := make(map[string]cty.Value, len(instances))
 	for _, inst := range instances {
 		objMap[inst.eachKey] = inst.value
 	}
@@ -297,14 +265,12 @@ func newContext(path PathContext, rootModuleDir, stack, project, organization st
 	return &Context{
 		mu:              new(sync.RWMutex),
 		rootModuleDir:   rootModuleDir,
-		variables:        make(map[string]cty.Value),
-		locals:           make(map[string]cty.Value),
-		resources:        make(map[string]cty.Value),
-		rangedResources:  make(map[string][]rangedInstance),
-		rangedShapes:     make(map[string]rangedShape),
-		dataSources:      make(map[string]cty.Value),
-		rangedData:       make(map[string][]rangedInstance),
-		rangedDataShapes: make(map[string]rangedShape),
+		variables:       make(map[string]cty.Value),
+		locals:          make(map[string]cty.Value),
+		resources:       make(map[string]cty.Value),
+		rangedResources: make(map[string][]rangedInstance),
+		dataSources:     make(map[string]cty.Value),
+		rangedData:      make(map[string][]rangedInstance),
 		modules:         make(map[string]cty.Value),
 		moduleOutputs:   make(map[string]map[string]cty.Value),
 		calls:           make(map[string]cty.Value),
@@ -392,43 +358,12 @@ func (c *Context) SetEachResource(baseKey string, eachKey string, urn urn.URN, v
 	})
 }
 
-// DeclareCountInstances records that the resource at baseKey expands to n
-// count instances. Declared before instances publish concurrently, it keeps
-// partial assemblies indexable: unpublished indexes read as unknown.
-func (c *Context) DeclareCountInstances(baseKey string, n int) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.rangedShapes[baseKey] = rangedShape{count: n, isCount: true}
-}
-
-// DeclareEachInstances records the full for_each key set of the resource at
-// baseKey; unpublished keys read as unknown until their instance publishes.
-func (c *Context) DeclareEachInstances(baseKey string, keys []string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.rangedShapes[baseKey] = rangedShape{eachKeys: keys}
-}
-
 // SetDataSource sets a data source's output values.
 // The key should be "type.name" (e.g., "aws_ami.ubuntu").
 func (c *Context) SetDataSource(key string, value cty.Value) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.dataSources[key] = value
-}
-
-// DeclareCountData and DeclareEachData mirror the resource declarations for
-// count/for_each data sources.
-func (c *Context) DeclareCountData(baseKey string, n int) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.rangedDataShapes[baseKey] = rangedShape{count: n, isCount: true}
-}
-
-func (c *Context) DeclareEachData(baseKey string, keys []string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.rangedDataShapes[baseKey] = rangedShape{eachKeys: keys}
 }
 
 // SetCountData stores one count instance of a data source's outputs.
@@ -557,7 +492,7 @@ func (c *Context) HCLContext() *hcl.EvalContext {
 
 	// Assemble ranged resource instances into tuples (count) or objects
 	// (for_each), padded to the declared shape.
-	for baseKey, val := range forEachRangedValue(c.rangedResources, c.rangedShapes) {
+	for baseKey, val := range forEachRangedValue(c.rangedResources) {
 		parts := splitResourceKey(baseKey)
 		if len(parts) != 2 {
 			continue
@@ -591,7 +526,7 @@ func (c *Context) HCLContext() *hcl.EvalContext {
 	for key, value := range c.dataSources {
 		addData(key, value)
 	}
-	for key, val := range forEachRangedValue(c.rangedData, c.rangedDataShapes) {
+	for key, val := range forEachRangedValue(c.rangedData) {
 		addData(key, val)
 	}
 	if len(typeGroups) > 0 {
@@ -762,10 +697,8 @@ func (c *Context) Clone() *Context {
 		locals:            maps.Clone(c.locals),
 		resources:         maps.Clone(c.resources),
 		rangedResources:   cloneRanged(c.rangedResources),
-		rangedShapes:      maps.Clone(c.rangedShapes),
 		dataSources:       maps.Clone(c.dataSources),
 		rangedData:        cloneRanged(c.rangedData),
-		rangedDataShapes:  maps.Clone(c.rangedDataShapes),
 		modules:           maps.Clone(c.modules),
 		moduleOutputs:     clonedModuleOutputs,
 		calls:             maps.Clone(c.calls),

--- a/pkg/hcl/eval/context.go
+++ b/pkg/hcl/eval/context.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"maps"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 
@@ -62,8 +61,19 @@ type Context struct {
 	// keyed by the base resource key (e.g., "type.name").
 	rangedResources map[string][]rangedInstance
 
+	// rangedShapes records the declared instance shape of each count/for_each
+	// resource, so a partial assembly stays indexable while instances publish
+	// concurrently: unpublished count indexes and for_each keys read as
+	// unknown. Keys match rangedResources.
+	rangedShapes map[string]rangedShape
+
 	// dataSources contains data source outputs (data.type.name.*)
 	dataSources map[string]cty.Value
+
+	// rangedData and rangedDataShapes mirror rangedResources/rangedShapes for
+	// count/for_each data sources, keyed by the base data-source key.
+	rangedData       map[string][]rangedInstance
+	rangedDataShapes map[string]rangedShape
 
 	// modules contains module outputs (module.name.*)
 	modules map[string]cty.Value
@@ -144,6 +154,70 @@ type rangedInstance struct {
 	isEach  bool
 }
 
+// rangedShape is the declared instance set of one count/for_each block: count
+// instances 0..count-1, or the full for_each key set.
+type rangedShape struct {
+	count    int
+	eachKeys []string
+	isCount  bool
+}
+
+// forEachRangedValue assembles each ranged block's collection value —
+// including blocks with a declared shape but no published instances yet — and
+// hands it to visit keyed by the block's base key.
+func forEachRangedValue(
+	instances map[string][]rangedInstance, shapes map[string]rangedShape,
+	visit func(baseKey string, val cty.Value),
+) {
+	for baseKey, insts := range instances {
+		visit(baseKey, assembleRanged(insts, shapes[baseKey]))
+	}
+	for baseKey, shape := range shapes {
+		if _, ok := instances[baseKey]; !ok {
+			visit(baseKey, assembleRanged(nil, shape))
+		}
+	}
+}
+
+// assembleRanged builds a ranged block's collection value from its published
+// instances, padded to the declared shape: slots whose instance has not
+// published yet read as unknown, so a consumer holding only a single
+// instance's completion can index that instance while siblings still run. A
+// zero-value shape (nothing declared) pads count tuples to the highest
+// published index.
+func assembleRanged(instances []rangedInstance, shape rangedShape) cty.Value {
+	isCount := shape.isCount || (len(instances) > 0 && instances[0].isCount)
+	if isCount {
+		n := shape.count
+		for _, inst := range instances {
+			n = max(n, inst.index+1)
+		}
+		if n == 0 {
+			return cty.EmptyTupleVal
+		}
+		vals := make([]cty.Value, n)
+		for i := range vals {
+			vals[i] = cty.UnknownVal(cty.DynamicPseudoType)
+		}
+		for _, inst := range instances {
+			vals[inst.index] = inst.value
+		}
+		return cty.TupleVal(vals)
+	}
+
+	objMap := make(map[string]cty.Value, max(len(instances), len(shape.eachKeys)))
+	for _, k := range shape.eachKeys {
+		objMap[k] = cty.UnknownVal(cty.DynamicPseudoType)
+	}
+	for _, inst := range instances {
+		objMap[inst.eachKey] = inst.value
+	}
+	if len(objMap) == 0 {
+		return cty.EmptyObjectVal
+	}
+	return cty.ObjectVal(objMap)
+}
+
 // NewContext creates a new evaluation context from its three governing
 // directories:
 //
@@ -217,11 +291,14 @@ func newContext(path PathContext, rootModuleDir, stack, project, organization st
 	return &Context{
 		mu:              new(sync.RWMutex),
 		rootModuleDir:   rootModuleDir,
-		variables:       make(map[string]cty.Value),
-		locals:          make(map[string]cty.Value),
-		resources:       make(map[string]cty.Value),
-		rangedResources: make(map[string][]rangedInstance),
-		dataSources:     make(map[string]cty.Value),
+		variables:        make(map[string]cty.Value),
+		locals:           make(map[string]cty.Value),
+		resources:        make(map[string]cty.Value),
+		rangedResources:  make(map[string][]rangedInstance),
+		rangedShapes:     make(map[string]rangedShape),
+		dataSources:      make(map[string]cty.Value),
+		rangedData:       make(map[string][]rangedInstance),
+		rangedDataShapes: make(map[string]rangedShape),
 		modules:         make(map[string]cty.Value),
 		moduleOutputs:   make(map[string]map[string]cty.Value),
 		calls:           make(map[string]cty.Value),
@@ -309,12 +386,61 @@ func (c *Context) SetEachResource(baseKey string, eachKey string, urn urn.URN, v
 	})
 }
 
+// DeclareCountInstances records that the resource at baseKey expands to n
+// count instances. Declared before instances publish concurrently, it keeps
+// partial assemblies indexable: unpublished indexes read as unknown.
+func (c *Context) DeclareCountInstances(baseKey string, n int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.rangedShapes[baseKey] = rangedShape{count: n, isCount: true}
+}
+
+// DeclareEachInstances records the full for_each key set of the resource at
+// baseKey; unpublished keys read as unknown until their instance publishes.
+func (c *Context) DeclareEachInstances(baseKey string, keys []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.rangedShapes[baseKey] = rangedShape{eachKeys: keys}
+}
+
 // SetDataSource sets a data source's output values.
 // The key should be "type.name" (e.g., "aws_ami.ubuntu").
 func (c *Context) SetDataSource(key string, value cty.Value) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.dataSources[key] = value
+}
+
+// DeclareCountData and DeclareEachData mirror the resource declarations for
+// count/for_each data sources.
+func (c *Context) DeclareCountData(baseKey string, n int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.rangedDataShapes[baseKey] = rangedShape{count: n, isCount: true}
+}
+
+func (c *Context) DeclareEachData(baseKey string, keys []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.rangedDataShapes[baseKey] = rangedShape{eachKeys: keys}
+}
+
+// SetCountData stores one count instance of a data source's outputs.
+func (c *Context) SetCountData(baseKey string, index int, value cty.Value) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.rangedData[baseKey] = append(c.rangedData[baseKey], rangedInstance{
+		value: value, index: index, isCount: true,
+	})
+}
+
+// SetEachData stores one for_each instance of a data source's outputs.
+func (c *Context) SetEachData(baseKey string, eachKey string, value cty.Value) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.rangedData[baseKey] = append(c.rangedData[baseKey], rangedInstance{
+		value: value, eachKey: eachKey, isEach: true,
+	})
 }
 
 // SetModule sets a module's output values.
@@ -423,62 +549,49 @@ func (c *Context) HCLContext() *hcl.EvalContext {
 		}
 	}
 
-	// Assemble ranged resource instances into tuples (count) or objects (for_each).
-	for baseKey, instances := range c.rangedResources {
+	// Assemble ranged resource instances into tuples (count) or objects
+	// (for_each), padded to the declared shape.
+	forEachRangedValue(c.rangedResources, c.rangedShapes, func(baseKey string, val cty.Value) {
 		parts := splitResourceKey(baseKey)
 		if len(parts) != 2 {
-			continue
+			return
 		}
 		typeName, resName := parts[0], parts[1]
 		if resourcesByType[typeName] == nil {
 			resourcesByType[typeName] = make(map[string]cty.Value)
 		}
-		if len(instances) > 0 && instances[0].isCount {
-			sort.Slice(instances, func(i, j int) bool {
-				return instances[i].index < instances[j].index
-			})
-			vals := make([]cty.Value, len(instances))
-			for i, inst := range instances {
-				vals[i] = inst.value
-			}
-			resourcesByType[typeName][resName] = cty.TupleVal(vals)
-		} else {
-			objMap := make(map[string]cty.Value, len(instances))
-			for _, inst := range instances {
-				objMap[inst.eachKey] = inst.value
-			}
-			resourcesByType[typeName][resName] = cty.ObjectVal(objMap)
-		}
-	}
+		resourcesByType[typeName][resName] = val
+	})
 
 	for typeName, instances := range resourcesByType {
 		vars[typeName] = cty.ObjectVal(instances)
 	}
 
 	// Add data.* namespace for data sources
-	// Data sources are referenced as data.type.name.attr
-	if len(c.dataSources) > 0 {
-		// Group by type: data.aws_ami.ubuntu -> data["aws_ami"]["ubuntu"]
-		typeGroups := make(map[string]map[string]cty.Value)
-		for key, value := range c.dataSources {
-			parts := splitResourceKey(key)
-			if len(parts) == 2 {
-				typeName, dsName := parts[0], parts[1]
-				if typeGroups[typeName] == nil {
-					typeGroups[typeName] = make(map[string]cty.Value)
-				}
-				typeGroups[typeName][dsName] = value
-			}
+	// Data sources are referenced as data.type.name.attr; grouped by type:
+	// data.aws_ami.ubuntu -> data["aws_ami"]["ubuntu"]
+	typeGroups := make(map[string]map[string]cty.Value)
+	addData := func(key string, value cty.Value) {
+		parts := splitResourceKey(key)
+		if len(parts) != 2 {
+			return
 		}
+		typeName, dsName := parts[0], parts[1]
+		if typeGroups[typeName] == nil {
+			typeGroups[typeName] = make(map[string]cty.Value)
+		}
+		typeGroups[typeName][dsName] = value
+	}
+	for key, value := range c.dataSources {
+		addData(key, value)
+	}
+	forEachRangedValue(c.rangedData, c.rangedDataShapes, addData)
+	if len(typeGroups) > 0 {
 		dataMap := make(map[string]cty.Value)
 		for typeName, instances := range typeGroups {
 			dataMap[typeName] = cty.ObjectVal(instances)
 		}
-		if len(dataMap) > 0 {
-			vars["data"] = cty.ObjectVal(dataMap)
-		} else {
-			vars["data"] = cty.EmptyObjectVal
-		}
+		vars["data"] = cty.ObjectVal(dataMap)
 	} else {
 		vars["data"] = cty.EmptyObjectVal
 	}
@@ -625,9 +738,12 @@ func (c *Context) Clone() *Context {
 		clonedModuleOutputs[k] = maps.Clone(v)
 	}
 
-	clonedRanged := make(map[string][]rangedInstance, len(c.rangedResources))
-	for k, v := range c.rangedResources {
-		clonedRanged[k] = append([]rangedInstance(nil), v...)
+	cloneRanged := func(m map[string][]rangedInstance) map[string][]rangedInstance {
+		out := make(map[string][]rangedInstance, len(m))
+		for k, v := range m {
+			out[k] = append([]rangedInstance(nil), v...)
+		}
+		return out
 	}
 
 	clone := &Context{
@@ -637,8 +753,11 @@ func (c *Context) Clone() *Context {
 		variables:         maps.Clone(c.variables),
 		locals:            maps.Clone(c.locals),
 		resources:         maps.Clone(c.resources),
-		rangedResources:   clonedRanged,
+		rangedResources:   cloneRanged(c.rangedResources),
+		rangedShapes:      maps.Clone(c.rangedShapes),
 		dataSources:       maps.Clone(c.dataSources),
+		rangedData:        cloneRanged(c.rangedData),
+		rangedDataShapes:  maps.Clone(c.rangedDataShapes),
 		modules:           maps.Clone(c.modules),
 		moduleOutputs:     clonedModuleOutputs,
 		calls:             maps.Clone(c.calls),

--- a/pkg/hcl/graph/classification_test.go
+++ b/pkg/hcl/graph/classification_test.go
@@ -1,0 +1,288 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"cmp"
+	"slices"
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockDepsView is Node.Deps with static deps resolved back to node keys and
+// every slice sorted, so tests can compare whole structs.
+type blockDepsView struct {
+	Static []string
+	Whole  []string
+	Narrow []InstanceDep
+}
+
+func depsView(t *testing.T, g *Graph, key string) blockDepsView {
+	t.Helper()
+	node, ok := g.seen[key]
+	require.True(t, ok, "no node %q", key)
+	require.NotNil(t, node.n.Deps, "node %q has no classified deps", key)
+	bd := node.n.Deps
+	view := blockDepsView{Whole: slices.Clone(bd.Whole), Narrow: slices.Clone(bd.Narrow)}
+	for _, n := range bd.Static {
+		view.Static = append(view.Static, g.keyByDagNode[n])
+	}
+	slices.Sort(view.Static)
+	slices.Sort(view.Whole)
+	slices.SortFunc(view.Narrow, func(a, b InstanceDep) int {
+		return cmp.Or(cmp.Compare(a.Key, b.Key), cmp.Compare(a.Suffix, b.Suffix))
+	})
+	return view
+}
+
+func buildGraph(t *testing.T, src string) *Graph {
+	t.Helper()
+	config, diags := parser.NewParser().ParseSource("test.hcl", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+	g, err := BuildFromConfig(config, nil, "")
+	require.NoError(t, err)
+	return g
+}
+
+func TestClassifyBodyRefs(t *testing.T) {
+	t.Parallel()
+	g := buildGraph(t, `
+resource "order_resource" "a" {
+  for_each = toset(["x", "y"])
+  name     = each.key
+}
+
+resource "order_resource" "b" {
+  name = order_resource.a["x"].result
+}
+
+resource "order_resource" "c" {
+  name = "c-${order_resource.a[0].result}"
+}
+
+resource "order_resource" "wide" {
+  name = join(",", order_resource.a[*].result)
+}
+
+variable "k" {
+  type = string
+}
+
+resource "order_resource" "dyn" {
+  name = order_resource.a[var.k].result
+}
+`)
+
+	assert.Equal(t, blockDepsView{
+		Narrow: []InstanceDep{{Key: "order_resource.a", Suffix: `["x"]`}},
+	}, depsView(t, g, "order_resource.b"))
+
+	assert.Equal(t, blockDepsView{
+		Narrow: []InstanceDep{{Key: "order_resource.a", Suffix: `[0]`}},
+	}, depsView(t, g, "order_resource.c"))
+
+	assert.Equal(t, blockDepsView{
+		Whole: []string{"order_resource.a"},
+	}, depsView(t, g, "order_resource.wide"))
+
+	// A dynamic index splits into two traversals: the whole resource and the
+	// index variable.
+	assert.Equal(t, blockDepsView{
+		Static: []string{"var.k"},
+		Whole:  []string{"order_resource.a"},
+	}, depsView(t, g, "order_resource.dyn"))
+}
+
+func TestClassifyDependsOnAndMetaArgs(t *testing.T) {
+	t.Parallel()
+	g := buildGraph(t, `
+resource "order_resource" "a" {
+  for_each = toset(["x", "y"])
+  name     = each.key
+}
+
+resource "order_resource" "b" {
+  depends_on = [order_resource.a["x"]]
+  name       = "b"
+}
+
+resource "order_resource" "c" {
+  depends_on = [order_resource.a]
+  name       = "c"
+}
+
+resource "order_resource" "d" {
+  count = order_resource.a["x"].name == "x" ? 1 : 0
+  name  = "d"
+}
+`)
+
+	assert.Equal(t, blockDepsView{
+		Narrow: []InstanceDep{{Key: "order_resource.a", Suffix: `["x"]`}},
+	}, depsView(t, g, "order_resource.b"))
+
+	assert.Equal(t, blockDepsView{
+		Whole: []string{"order_resource.a"},
+	}, depsView(t, g, "order_resource.c"))
+
+	assert.Equal(t, blockDepsView{
+		Narrow: []InstanceDep{{Key: "order_resource.a", Suffix: `["x"]`}},
+	}, depsView(t, g, "order_resource.d"))
+}
+
+func TestClassifyWholeSubsumesNarrow(t *testing.T) {
+	t.Parallel()
+	g := buildGraph(t, `
+resource "order_resource" "a" {
+  for_each = toset(["x", "y"])
+  name     = each.key
+}
+
+resource "order_resource" "b" {
+  name = "${order_resource.a["x"].result}-${join(",", [for k, v in order_resource.a : v.result])}"
+}
+`)
+
+	assert.Equal(t, blockDepsView{
+		Whole: []string{"order_resource.a"},
+	}, depsView(t, g, "order_resource.b"))
+}
+
+func TestClassifyDataRefs(t *testing.T) {
+	t.Parallel()
+	g := buildGraph(t, `
+data "order_data" "d" {
+  for_each = toset(["x", "y"])
+  name     = each.key
+}
+
+resource "order_resource" "b" {
+  name = data.order_data.d["x"].result
+}
+
+resource "order_resource" "a" {
+  for_each = toset(["x"])
+  name     = each.key
+}
+
+data "order_data" "narrow" {
+  name = order_resource.a["x"].result
+}
+`)
+
+	assert.Equal(t, blockDepsView{
+		Narrow: []InstanceDep{{Key: "data.order_data.d", Suffix: `["x"]`}},
+	}, depsView(t, g, "order_resource.b"))
+
+	assert.Equal(t, blockDepsView{
+		Narrow: []InstanceDep{{Key: "order_resource.a", Suffix: `["x"]`}},
+	}, depsView(t, g, "data.order_data.narrow"))
+}
+
+func TestClassifyInModule(t *testing.T) {
+	t.Parallel()
+	childSrc := []byte(`
+resource "order_resource" "a" {
+  for_each = toset(["x", "y"])
+  name     = each.key
+}
+
+resource "order_resource" "b" {
+  name = order_resource.a["x"].result
+}
+`)
+	childConfig, diags := parser.NewParser().ParseSource("child.hcl", childSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	rootSrc := []byte(`
+module "m" {
+  source = "./child"
+}
+`)
+	rootConfig, diags := parser.NewParser().ParseSource("root.hcl", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	g, err := BuildFromConfig(rootConfig, fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: childConfig, SourcePath: "./child"},
+	}}, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, blockDepsView{
+		Static: []string{"module.m.__init__"},
+		Narrow: []InstanceDep{{Key: "module.m.order_resource.a", Suffix: `["x"]`}},
+	}, depsView(t, g, "module.m.order_resource.b"))
+}
+
+// A data source inside a module must intern under the "data."-prefixed key
+// that references and the module completion node resolve to.
+func TestClassifyDataSourceInModule(t *testing.T) {
+	t.Parallel()
+	childSrc := []byte(`
+data "order_data" "d" {
+  name = "d"
+}
+
+resource "order_resource" "a" {
+  name = data.order_data.d.result
+}
+`)
+	childConfig, diags := parser.NewParser().ParseSource("child.hcl", childSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	rootSrc := []byte(`
+module "m" {
+  source = "./child"
+}
+`)
+	rootConfig, diags := parser.NewParser().ParseSource("root.hcl", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	g, err := BuildFromConfig(rootConfig, fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: childConfig, SourcePath: "./child"},
+	}}, "")
+	require.NoError(t, err)
+	require.Empty(t, g.Validate())
+
+	assert.Equal(t, NodeTypeDataSource, g.seen["module.m.data.order_data.d"].n.Type)
+	assert.Equal(t, blockDepsView{
+		Static: []string{"module.m.__init__"},
+		Whole:  []string{"module.m.data.order_data.d"},
+	}, depsView(t, g, "module.m.order_resource.a"))
+
+	order := walkOrder(t, g)
+	assert.Less(t, indexOf(order, "module.m.data.order_data.d"), indexOf(order, "module.m.order_resource.a"))
+}
+
+// A narrow reference still creates the block-level graph edge, so completion
+// ordering, Validate, and cycle detection stay block-granular.
+func TestClassifyKeepsBlockEdges(t *testing.T) {
+	t.Parallel()
+	g := buildGraph(t, `
+resource "order_resource" "a" {
+  for_each = toset(["x", "y"])
+  name     = each.key
+}
+
+resource "order_resource" "b" {
+  name = order_resource.a["x"].result
+}
+`)
+
+	order := walkOrder(t, g)
+	assert.Less(t, indexOf(order, "order_resource.a"), indexOf(order, "order_resource.b"))
+}

--- a/pkg/hcl/graph/classification_test.go
+++ b/pkg/hcl/graph/classification_test.go
@@ -268,6 +268,67 @@ module "m" {
 	assert.Less(t, indexOf(order, "module.m.data.order_data.d"), indexOf(order, "module.m.order_resource.a"))
 }
 
+// A root local classifies its value's references and carries no block-level
+// edge to the resources it reads, so the engine's instance-level wiring alone
+// orders its evaluation.
+func TestClassifyRootLocal(t *testing.T) {
+	t.Parallel()
+	g := buildGraph(t, `
+resource "order_resource" "a" {
+  for_each = toset(["x", "y"])
+  name     = each.key
+}
+
+locals {
+  picked = order_resource.a["x"].result
+}
+
+resource "order_resource" "b" {
+  name = "b-${local.picked}"
+}
+`)
+
+	assert.Equal(t, blockDepsView{
+		Narrow: []InstanceDep{{Key: "order_resource.a", Suffix: `["x"]`}},
+	}, depsView(t, g, "local.picked"))
+
+	// No block-level edge from the resource to the local: the local's only
+	// build-time prerequisites are its static deps (none here).
+	local, ok := g.seen["local.picked"]
+	require.True(t, ok)
+	for pred := range g.dag.Predecessors(local.i) {
+		assert.NotEqual(t, "order_resource.a", g.keyByDagNode[pred])
+	}
+}
+
+// create_before_destroy still propagates through a root local even though the
+// local has no block-level edge to the resource it reads.
+func TestForcedCreateBeforeDestroyThroughClassifiedLocal(t *testing.T) {
+	t.Parallel()
+	g := buildGraph(t, `
+resource "order_resource" "a" {
+  for_each = toset(["x", "y"])
+  name     = each.key
+}
+
+locals {
+  picked = order_resource.a["x"].result
+}
+
+resource "order_resource" "b" {
+  name = "b-${local.picked}"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+`)
+
+	assert.Equal(t, map[string]bool{
+		"order_resource.a": true,
+		"order_resource.b": true,
+	}, g.ForcedCreateBeforeDestroy())
+}
+
 // A narrow reference still creates the block-level graph edge, so completion
 // ordering, Validate, and cycle detection stay block-granular.
 func TestClassifyKeepsBlockEdges(t *testing.T) {

--- a/pkg/hcl/graph/expansion.go
+++ b/pkg/hcl/graph/expansion.go
@@ -65,9 +65,9 @@ type BlockExpansion struct {
 
 // NewBlockExpansion creates the expand/complete pair for one block. static
 // marks a skeleton created before the walk starts: its expand node is interned
-// under "<key>!expand" so pre-walk passes (Validate, InjectAfter) see it;
-// skeletons created mid-walk must not touch the interning maps and stay
-// anonymous. expandExec runs on the expand node; finish is deferred around it.
+// under "<key>!expand" so InjectAfter sees it; skeletons created mid-walk must
+// not touch the interning maps and stay anonymous. expandExec runs on the
+// expand node; finish is deferred around it.
 func (g *Graph) NewBlockExpansion(key string, static bool, expandExec func(context.Context) error) *BlockExpansion {
 	b := &BlockExpansion{
 		g:     g,
@@ -79,11 +79,7 @@ func (g *Graph) NewBlockExpansion(key string, static bool, expandExec func(conte
 		return expandExec(ctx)
 	}
 	if static {
-		expandKey := key + "!expand"
-		i, done := g.dag.NewNode(dagNode{key: expandKey, exec: exec})
-		g.seen[expandKey] = internedNode{i: i, n: &Node{Key: expandKey, Type: NodeTypeBuiltin}}
-		g.keyByDagNode[i] = expandKey
-		b.expand, b.armExpand = i, done
+		b.expand, b.armExpand = g.internExecNode(key+"!expand", exec)
 	} else {
 		b.expand, b.armExpand = g.dag.NewNode(dagNode{exec: exec})
 	}
@@ -124,6 +120,13 @@ func (b *BlockExpansion) Gate(suffix string) pdag.Node {
 // Arm makes the expand node runnable. Call once all deps and consumer gates
 // are wired.
 func (b *BlockExpansion) Arm() { b.armExpand() }
+
+// CompleteBefore orders n after this block's completion, so a node outside
+// the expansion (the block's own graph node, in particular) waits for every
+// instance.
+func (b *BlockExpansion) CompleteBefore(n pdag.Node) error {
+	return b.g.dag.NewEdge(b.complete, n)
+}
 
 // AddInstance creates the node that runs one instance's work, ordered before
 // complete and standing behind the instance's gate if a consumer created one.

--- a/pkg/hcl/graph/expansion.go
+++ b/pkg/hcl/graph/expansion.go
@@ -1,0 +1,167 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/pkg/v3/util/pdag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// BlockExpansion schedules one block's count/for_each instances independently
+// of the block's graph node, so a consumer that needs a single instance can
+// run before the block's other instances finish.
+//
+// Node structure (all created lazily during a walk except for static blocks):
+//
+//	deps ──▶ expand ──▶ instance… ──▶ complete
+//	              │          │
+//	              └──────────┴──────▶ gate[suffix] ──▶ (consumers)
+//
+// expand evaluates count/for_each and creates the instance nodes. complete
+// becomes ready only after every instance finishes, so whole-block consumers
+// bind to it. A gate stands for one instance identified by its key suffix
+// (`[0]`, `["x"]`): consumers that reference only that instance bind to the
+// gate instead of complete. A gate whose suffix matches no instance falls back
+// to complete, so a bad index degrades to whole-block ordering and the
+// consumer surfaces the evaluation error itself.
+//
+// Liveness holds by construction: complete and every gate are armed at
+// creation with expand as their prerequisite, and the walker marks expand done
+// even when its exec errors, so no dynamically created node can strand the
+// walk. Instances are armed in finish, which runs via defer around the expand
+// exec.
+//
+// A BlockExpansion is not safe for concurrent use. The contract is
+// single-threaded by construction: creation and wiring happen in whichever
+// callback materializes the skeleton (the graph build for static blocks, a
+// module-init node for module blocks), and instance creation happens in the
+// expand exec, which the walker cannot start until wiring armed it.
+type BlockExpansion struct {
+	g         *Graph
+	key       string
+	expand    pdag.Node
+	armExpand pdag.Done
+	complete  pdag.Node
+	// gates holds the gates no instance has claimed yet; AddInstance removes
+	// the gate it wires, and finish gives the leftovers their fallback edge.
+	gates      map[string]pdag.Node
+	armPending []pdag.Done
+	expanded   bool
+}
+
+// NewBlockExpansion creates the expand/complete pair for one block. static
+// marks a skeleton created before the walk starts: its expand node is interned
+// under "<key>!expand" so pre-walk passes (Validate, InjectAfter) see it;
+// skeletons created mid-walk must not touch the interning maps and stay
+// anonymous. expandExec runs on the expand node; finish is deferred around it.
+func (g *Graph) NewBlockExpansion(key string, static bool, expandExec func(context.Context) error) *BlockExpansion {
+	b := &BlockExpansion{
+		g:     g,
+		key:   key,
+		gates: make(map[string]pdag.Node),
+	}
+	exec := func(ctx context.Context) error {
+		defer b.finish()
+		return expandExec(ctx)
+	}
+	if static {
+		expandKey := key + "!expand"
+		i, done := g.dag.NewNode(dagNode{key: expandKey, exec: exec})
+		g.seen[expandKey] = internedNode{i: i, n: &Node{Key: expandKey, Type: NodeTypeBuiltin}}
+		g.keyByDagNode[i] = expandKey
+		b.expand, b.armExpand = i, done
+	} else {
+		b.expand, b.armExpand = g.dag.NewNode(dagNode{exec: exec})
+	}
+
+	complete, armComplete := g.dag.NewNode(dagNode{exec: func(context.Context) error { return nil }})
+	b.complete = complete
+	contract.AssertNoErrorf(g.dag.NewEdge(b.expand, complete), "fresh nodes cannot form a cycle")
+	armComplete()
+	return b
+}
+
+// DependOn orders the expansion after dep: no instance is created (and so no
+// instance work runs) until dep is done.
+func (b *BlockExpansion) DependOn(dep pdag.Node) error {
+	return b.g.dag.NewEdge(dep, b.expand)
+}
+
+// Complete returns the node that is done once every instance has finished.
+// Whole-block consumers bind to it.
+func (b *BlockExpansion) Complete() pdag.Node { return b.complete }
+
+// Gate returns the node standing for the instance with the given key suffix
+// (`[0]`, `["x"]`), creating it on first use. Gates must be created before the
+// expansion runs — consumers wire during skeleton materialization, which
+// happens before Arm.
+func (b *BlockExpansion) Gate(suffix string) pdag.Node {
+	contract.Assertf(!b.expanded, "gate %q%s requested after expansion", b.key, suffix)
+	if gate, ok := b.gates[suffix]; ok {
+		return gate
+	}
+	gate, arm := b.g.dag.NewNode(dagNode{exec: func(context.Context) error { return nil }})
+	contract.AssertNoErrorf(b.g.dag.NewEdge(b.expand, gate), "fresh nodes cannot form a cycle")
+	arm()
+	b.gates[suffix] = gate
+	return gate
+}
+
+// Arm makes the expand node runnable. Call once all deps and consumer gates
+// are wired.
+func (b *BlockExpansion) Arm() { b.armExpand() }
+
+// AddInstance creates the node that runs one instance's work, ordered before
+// complete and standing behind the instance's gate if a consumer created one.
+// Only call from the expand exec. Instances become runnable when the exec
+// returns (finish arms them after all wiring).
+func (b *BlockExpansion) AddInstance(suffix string, exec func(context.Context) error) error {
+	inst, arm := b.g.dag.NewNode(dagNode{exec: exec})
+	// Arm even on the error paths: a node left preparing stalls the walk
+	// forever, while an armed node at worst runs before the walk aborts.
+	b.armPending = append(b.armPending, arm)
+	if err := b.g.dag.NewEdge(inst, b.complete); err != nil {
+		return err
+	}
+	if gate, ok := b.gates[suffix]; ok {
+		if err := b.g.dag.NewEdge(inst, gate); err != nil {
+			return err
+		}
+		delete(b.gates, suffix)
+	}
+	return nil
+}
+
+// finish closes out an expansion: gates that matched no instance fall back to
+// complete, and the created instances become runnable. Idempotent; deferred
+// around the expand exec so an exec error cannot strand gates or instances.
+func (b *BlockExpansion) finish() {
+	if b.expanded {
+		return
+	}
+	b.expanded = true
+	for _, gate := range b.gates {
+		// complete is armed but cannot be processing while expand still is,
+		// so this edge is never reentrant.
+		contract.AssertNoErrorf(b.g.dag.NewEdge(b.complete, gate),
+			"gate fallback edges cannot form a cycle")
+	}
+	for _, arm := range b.armPending {
+		arm()
+	}
+	b.armPending = nil
+}

--- a/pkg/hcl/graph/expansion_test.go
+++ b/pkg/hcl/graph/expansion_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/v3/util/pdag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// eventLog records execution order across concurrent walk goroutines.
+type eventLog struct {
+	mu    sync.Mutex
+	order []string
+}
+
+func (e *eventLog) add(s string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.order = append(e.order, s)
+}
+
+func record(e *eventLog, name string) func(context.Context) error {
+	return func(context.Context) error {
+		e.add(name)
+		return nil
+	}
+}
+
+// consumerNode adds an exec node with the given prerequisites, armed
+// immediately.
+func consumerNode(t *testing.T, g *Graph, exec func(context.Context) error, deps ...pdag.Node) pdag.Node {
+	t.Helper()
+	n, arm := g.dag.NewNode(dagNode{exec: exec})
+	for _, dep := range deps {
+		require.NoError(t, g.dag.NewEdge(dep, n))
+	}
+	arm()
+	return n
+}
+
+// A consumer gated on one instance runs as soon as that instance finishes,
+// before a delayed sibling instance; a consumer bound to Complete waits for
+// every instance.
+func TestBlockExpansionGateRunsBeforeDelayedSibling(t *testing.T) {
+	t.Parallel()
+	g := NewGraph()
+	log := &eventLog{}
+
+	narrowDone := make(chan struct{})
+
+	var b *BlockExpansion
+	b = g.NewBlockExpansion("order_resource.a", false, func(context.Context) error {
+		if err := b.AddInstance(`["x"]`, record(log, "a-x")); err != nil {
+			return err
+		}
+		return b.AddInstance(`["y"]`, func(context.Context) error {
+			// Simulate the delayed sibling: hold the instance open until the
+			// narrow consumer has run. If the gate wrongly waits for the whole
+			// block this times out and the recorded order flips.
+			select {
+			case <-narrowDone:
+			case <-time.After(5 * time.Second):
+				log.add("timeout")
+			}
+			log.add("a-y")
+			return nil
+		})
+	})
+
+	consumerNode(t, g, func(context.Context) error {
+		log.add("narrow")
+		close(narrowDone)
+		return nil
+	}, b.Gate(`["x"]`))
+	consumerNode(t, g, record(log, "whole"), b.Complete())
+
+	b.Arm()
+	require.NoError(t, g.dag.Walk(t.Context(), func(ctx context.Context, n dagNode) error {
+		return n.exec(ctx)
+	}, pdag.MaxProcs(4)))
+
+	assert.Equal(t, []string{"a-x", "narrow", "a-y", "whole"}, log.order)
+}
+
+// A gate whose suffix matches no instance falls back to whole-block ordering:
+// the consumer runs only after every instance completes.
+func TestBlockExpansionUnmatchedGateFallsBack(t *testing.T) {
+	t.Parallel()
+	g := NewGraph()
+	log := &eventLog{}
+
+	var b *BlockExpansion
+	b = g.NewBlockExpansion("order_resource.a", false, func(context.Context) error {
+		return b.AddInstance(`[0]`, record(log, "a-0"))
+	})
+
+	consumerNode(t, g, record(log, "consumer"), b.Gate(`[5]`))
+
+	b.Arm()
+	require.NoError(t, g.dag.Walk(t.Context(), func(ctx context.Context, n dagNode) error {
+		return n.exec(ctx)
+	}, pdag.MaxProcs(4)))
+
+	assert.Equal(t, []string{"a-0", "consumer"}, log.order)
+}
+
+// An expand exec that errors must not strand its gates, complete node, or
+// consumers: the walk terminates and reports the error.
+func TestBlockExpansionExpandErrorDoesNotHang(t *testing.T) {
+	t.Parallel()
+	g := NewGraph()
+
+	expandErr := errors.New("count evaluation failed")
+	var b *BlockExpansion
+	b = g.NewBlockExpansion("order_resource.a", false, func(context.Context) error {
+		if err := b.AddInstance(`[0]`, func(context.Context) error { return nil }); err != nil {
+			return err
+		}
+		return expandErr
+	})
+
+	consumerNode(t, g, func(context.Context) error { return nil }, b.Gate(`["missing"]`))
+	consumerNode(t, g, func(context.Context) error { return nil }, b.Complete())
+
+	b.Arm()
+	err := g.dag.Walk(t.Context(), func(ctx context.Context, n dagNode) error {
+		return n.exec(ctx)
+	}, pdag.MaxProcs(4))
+	require.ErrorIs(t, err, expandErr)
+}
+
+// A static expansion interns its expand node so pre-walk passes (Validate,
+// InjectAfter) can see it.
+func TestBlockExpansionStaticInterning(t *testing.T) {
+	t.Parallel()
+	g := NewGraph()
+
+	b := g.NewBlockExpansion("order_resource.a", true, func(context.Context) error { return nil })
+	b.Arm()
+
+	interned, ok := g.seen["order_resource.a!expand"]
+	require.True(t, ok)
+	assert.Equal(t, &Node{Key: "order_resource.a!expand", Type: NodeTypeBuiltin}, interned.n)
+	assert.Empty(t, g.Validate())
+}

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -389,15 +389,33 @@ func (g *Graph) ForcedCreateBeforeDestroy() map[string]bool {
 			return
 		}
 		visited[node] = true
+		var n *Node
 		if key, ok := g.keyByDagNode[node]; ok {
-			if n, ok := g.seen[key]; ok && n.n.Type == NodeTypeResource {
-				forced[key] = true
+			if in, ok := g.seen[key]; ok {
+				n = in.n
+				if n.Type == NodeTypeResource {
+					forced[key] = true
+				}
 			}
 		}
 		// Recurse into dependencies through any node type, so a dependency
 		// reached via a local or other intermediary is still forced.
 		for dep := range g.dag.Predecessors(node) {
 			mark(dep)
+		}
+		// A node whose classified deps omit block-level edges (root locals)
+		// still forces the blocks it reads.
+		if n != nil && n.Deps != nil {
+			for _, whole := range n.Deps.Whole {
+				if in, ok := g.seen[whole]; ok {
+					mark(in.i)
+				}
+			}
+			for _, narrow := range n.Deps.Narrow {
+				if in, ok := g.seen[narrow.Key]; ok {
+					mark(in.i)
+				}
+			}
 		}
 	}
 
@@ -431,9 +449,10 @@ func (g *Graph) KeyNode(key string) (pdag.Node, bool) {
 	return n.i, ok
 }
 
-// ExpandableNodes returns the resource/data nodes carrying classified deps —
-// the blocks the engine schedules through BlockExpansion cells — sorted by
-// key for deterministic materialization.
+// ExpandableNodes returns the nodes carrying classified deps — resource/data
+// blocks the engine schedules through BlockExpansion cells, plus root locals
+// it wires at instance granularity — sorted by key for deterministic
+// materialization.
 func (g *Graph) ExpandableNodes() []*Node {
 	var out []*Node
 	for _, n := range g.seen {
@@ -476,13 +495,18 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 		}
 	}
 
-	// Add local value nodes
+	// Add local value nodes. Root locals carry classified deps and no
+	// block-level edges: the engine wires their resource/data dependencies at
+	// instance granularity, so narrowness flows through them. (Module locals
+	// keep block-level edges — references through them widen across module
+	// instances.)
 	for name, local := range config.Locals {
-		deps := g.exprDeps(local.Value, "")
+		bd, deps := g.localDeps(local, "")
 		err := g.AddNode(&Node{
 			Key:   "local." + name,
 			Type:  NodeTypeLocal,
 			Local: local,
+			Deps:  bd,
 		}, deps)
 		if err != nil {
 			return nil, err
@@ -842,45 +866,8 @@ func packageNameFromResourceType(token string) string {
 // dependency kind (provider refs, ResourceParent, DeletedWith, ReplaceWith,
 // replace_triggered_by, aliases) stays static (block-granular).
 func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) (*BlockDeps, []pdag.Node) {
-	bd := &BlockDeps{}
-	seen := make(map[pdag.Node]bool)
-	staticSeen := make(map[pdag.Node]bool)
-	wholeSeen := make(map[string]bool)
-	narrowSeen := make(map[InstanceDep]bool)
-
-	addStatic := func(n pdag.Node) {
-		seen[n] = true
-		if !staticSeen[n] {
-			staticSeen[n] = true
-			bd.Static = append(bd.Static, n)
-		}
-	}
-	addStaticRefs := func(refs []depRef) {
-		for _, ref := range refs {
-			_, n := g.newNode(ref.key)
-			addStatic(n)
-		}
-	}
-	classify := func(refs []depRef) {
-		for _, ref := range refs {
-			_, n := g.newNode(ref.key)
-			id, sameScope := g.classifyDep(ref, prefix)
-			if !sameScope {
-				addStatic(n)
-				continue
-			}
-			seen[n] = true
-			if id.Suffix == "" {
-				if !wholeSeen[ref.key] {
-					wholeSeen[ref.key] = true
-					bd.Whole = append(bd.Whole, ref.key)
-				}
-			} else if !narrowSeen[id] {
-				narrowSeen[id] = true
-				bd.Narrow = append(bd.Narrow, id)
-			}
-		}
-	}
+	c := g.newDepClassifier(prefix, true)
+	addStatic, addStaticRefs, classify := c.addStatic, c.addStaticRefs, c.classify
 
 	classify(g.exprDepRefs(resource.Count, prefix, nil))
 	classify(g.exprDepRefs(resource.ForEach, prefix, nil))
@@ -944,14 +931,95 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) (*BlockDeps,
 	}
 	addStaticRefs(g.exprDepRefs(resource.Aliases, prefix, nil))
 
-	// A whole-block dependency already waits for every instance; drop narrow
-	// entries it subsumes.
-	bd.Narrow = slices.DeleteFunc(bd.Narrow, func(d InstanceDep) bool { return wholeSeen[d.Key] })
-	if len(bd.Narrow) == 0 {
-		bd.Narrow = nil
-	}
+	return c.finish()
+}
 
-	return bd, slices.Collect(maps.Keys(seen))
+// localDeps classifies a local value's dependencies. Unlike resourceDeps, the
+// returned edge set omits same-scope resource/data blocks entirely: the
+// engine wires those at instance granularity (completion or gate), so the
+// local evaluates as soon as the instances it actually reads are available.
+func (g *Graph) localDeps(local *ast.Local, prefix string) (*BlockDeps, []pdag.Node) {
+	c := g.newDepClassifier(prefix, false)
+	c.classify(g.exprDepRefs(local.Value, prefix, nil))
+	return c.finish()
+}
+
+// depClassifier accumulates one block's dependencies into a BlockDeps and the
+// pdag edge set for the block's graph node. blockEdges controls whether
+// same-scope resource/data targets also get a block-level edge (resources
+// keep them so completion ordering, cycle detection, and Validate stay
+// block-granular; locals drop them so only the instance-level wiring orders
+// the local's evaluation).
+type depClassifier struct {
+	g          *Graph
+	prefix     string
+	blockEdges bool
+	bd         *BlockDeps
+	seen       map[pdag.Node]bool
+	staticSeen map[pdag.Node]bool
+	wholeSeen  map[string]bool
+	narrowSeen map[InstanceDep]bool
+}
+
+func (g *Graph) newDepClassifier(prefix string, blockEdges bool) *depClassifier {
+	return &depClassifier{
+		g:          g,
+		prefix:     prefix,
+		blockEdges: blockEdges,
+		bd:         &BlockDeps{},
+		seen:       make(map[pdag.Node]bool),
+		staticSeen: make(map[pdag.Node]bool),
+		wholeSeen:  make(map[string]bool),
+		narrowSeen: make(map[InstanceDep]bool),
+	}
+}
+
+func (c *depClassifier) addStatic(n pdag.Node) {
+	c.seen[n] = true
+	if !c.staticSeen[n] {
+		c.staticSeen[n] = true
+		c.bd.Static = append(c.bd.Static, n)
+	}
+}
+
+func (c *depClassifier) addStaticRefs(refs []depRef) {
+	for _, ref := range refs {
+		_, n := c.g.newNode(ref.key)
+		c.addStatic(n)
+	}
+}
+
+func (c *depClassifier) classify(refs []depRef) {
+	for _, ref := range refs {
+		_, n := c.g.newNode(ref.key)
+		id, sameScope := c.g.classifyDep(ref, c.prefix)
+		if !sameScope {
+			c.addStatic(n)
+			continue
+		}
+		if c.blockEdges {
+			c.seen[n] = true
+		}
+		if id.Suffix == "" {
+			if !c.wholeSeen[ref.key] {
+				c.wholeSeen[ref.key] = true
+				c.bd.Whole = append(c.bd.Whole, ref.key)
+			}
+		} else if !c.narrowSeen[id] {
+			c.narrowSeen[id] = true
+			c.bd.Narrow = append(c.bd.Narrow, id)
+		}
+	}
+}
+
+// finish subsumes narrow entries under whole-block dependencies and returns
+// the classified deps with the node's edge set.
+func (c *depClassifier) finish() (*BlockDeps, []pdag.Node) {
+	c.bd.Narrow = slices.DeleteFunc(c.bd.Narrow, func(d InstanceDep) bool { return c.wholeSeen[d.Key] })
+	if len(c.bd.Narrow) == 0 {
+		c.bd.Narrow = nil
+	}
+	return c.bd, slices.Collect(maps.Keys(c.seen))
 }
 
 // classifyDep reports whether ref names a resource/data block declared in the

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -28,12 +28,12 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/zclconf/go-cty/cty"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
 	"github.com/pulumi/pulumi/pkg/v3/util/pdag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // ModuleInfo holds metadata for nodes that are part of an inlined module.

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -22,11 +22,13 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math/big"
 	"slices"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
@@ -128,6 +130,30 @@ type Node struct {
 
 	// ModuleInfo is set for nodes that belong to an inlined module.
 	ModuleInfo *ModuleInfo
+
+	// Deps is set for resource/data nodes: the same dependencies that back the
+	// node's graph edges, kept in classified form so the engine's expansion
+	// layer can wire them per module instance at instance granularity.
+	Deps *BlockDeps
+}
+
+// BlockDeps classifies a resource/data block's dependencies for the expansion
+// layer. Static deps are graph nodes outside the block's own scope's
+// resource/data blocks (variables, locals, providers, module init, …) and are
+// wired as-is. Whole and Narrow name same-scope resource/data blocks by node
+// key; the engine resolves them against the consumer's own module instance —
+// Whole binds to the target's completion, Narrow to the gate of one instance.
+type BlockDeps struct {
+	Static []pdag.Node
+	Whole  []string
+	Narrow []InstanceDep
+}
+
+// InstanceDep names one instance of a same-scope resource/data block: the
+// block's node key plus the instance's key suffix (`[0]`, `["x"]`).
+type InstanceDep struct {
+	Key    string
+	Suffix string
 }
 
 // NodeType indicates what type of configuration element a node represents.
@@ -451,12 +477,15 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 
 	// Add resource nodes
 	for key, resource := range config.Resources {
-		deps := g.resourceDeps(resource, "")
-		deps = append(deps, g.defaultProviderDeps(resource, config, "")...)
+		bd, deps := g.resourceDeps(resource, "")
+		provDeps := g.defaultProviderDeps(resource, config, "")
+		bd.Static = append(bd.Static, provDeps...)
+		deps = append(deps, provDeps...)
 		err := g.AddNode(&Node{
 			Key:      key,
 			Type:     NodeTypeResource,
 			Resource: resource,
+			Deps:     bd,
 		}, deps)
 		if err != nil {
 			return nil, err
@@ -465,12 +494,15 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 
 	// Add data source nodes
 	for key, dataSource := range config.DataSources {
-		deps := g.resourceDeps(dataSource, "")
-		deps = append(deps, g.defaultProviderDeps(dataSource, config, "")...)
+		bd, deps := g.resourceDeps(dataSource, "")
+		provDeps := g.defaultProviderDeps(dataSource, config, "")
+		bd.Static = append(bd.Static, provDeps...)
+		deps = append(deps, provDeps...)
 		err := g.AddNode(&Node{
 			Key:      "data." + key,
 			Type:     NodeTypeDataSource,
 			Resource: dataSource,
+			Deps:     bd,
 		}, deps)
 		if err != nil {
 			return nil, err
@@ -718,44 +750,86 @@ func packageNameFromResourceType(token string) string {
 	return strings.SplitN(token, "_", 2)[0]
 }
 
-// resourceDeps extracts all dependencies from a resource, applying prefix to resolved keys.
-func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node {
+// resourceDeps extracts all dependencies from a resource, applying prefix to
+// resolved keys. It returns the block-level edge set for the node (unchanged
+// coarse semantics: cycle detection, Validate, and completion ordering all
+// stay block-granular) alongside the same dependencies in classified form for
+// the engine's expansion layer. References in the body, count/for_each, and
+// depends_on classify as whole-block or single-instance; every other
+// dependency kind (provider refs, ResourceParent, DeletedWith, ReplaceWith,
+// replace_triggered_by, aliases) stays static (block-granular).
+func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) (*BlockDeps, []pdag.Node) {
+	bd := &BlockDeps{}
 	seen := make(map[pdag.Node]bool)
+	staticSeen := make(map[pdag.Node]bool)
+	wholeSeen := make(map[string]bool)
+	narrowSeen := make(map[InstanceDep]bool)
 
-	for _, dep := range g.exprDeps(resource.Count, prefix) {
-		seen[dep] = true
+	addStatic := func(n pdag.Node) {
+		seen[n] = true
+		if !staticSeen[n] {
+			staticSeen[n] = true
+			bd.Static = append(bd.Static, n)
+		}
 	}
-	for _, dep := range g.exprDeps(resource.ForEach, prefix) {
-		seen[dep] = true
+	addStaticRefs := func(refs []depRef) {
+		for _, ref := range refs {
+			_, n := g.newNode(ref.key)
+			addStatic(n)
+		}
 	}
+	classify := func(refs []depRef) {
+		for _, ref := range refs {
+			_, n := g.newNode(ref.key)
+			id, sameScope := g.classifyDep(ref, prefix)
+			if !sameScope {
+				addStatic(n)
+				continue
+			}
+			seen[n] = true
+			if id.Suffix == "" {
+				if !wholeSeen[ref.key] {
+					wholeSeen[ref.key] = true
+					bd.Whole = append(bd.Whole, ref.key)
+				}
+			} else if !narrowSeen[id] {
+				narrowSeen[id] = true
+				bd.Narrow = append(bd.Narrow, id)
+			}
+		}
+	}
+
+	classify(g.exprDepRefs(resource.Count, prefix, nil))
+	classify(g.exprDepRefs(resource.ForEach, prefix, nil))
 	for _, traversal := range resource.DependsOn {
 		if dep := formatTraversal(traversal); dep != "" {
 			g.recordRef(prefix+dep, traversal.SourceRange())
-			_, idx := g.newNode(prefix + dep)
-			seen[idx] = true
+			classify([]depRef{{key: prefix + dep, traversal: traversal}})
 		}
 	}
+	if resource.Config != nil {
+		classify(g.bodyDepRefs(resource.Config, prefix, nil))
+	}
+
 	if resource.ResourceParent != nil {
 		if dep := formatTraversal(resource.ResourceParent); dep != "" {
 			g.recordRef(prefix+dep, resource.ResourceParent.SourceRange())
 			_, idx := g.newNode(prefix + dep)
-			seen[idx] = true
+			addStatic(idx)
 		}
 	}
-	for _, dep := range g.exprDeps(resource.Provider, prefix) {
-		seen[dep] = true
-	}
+	addStaticRefs(g.exprDepRefs(resource.Provider, prefix, nil))
 	// A bare `provider = name` reference (no alias) is a single-segment
-	// traversal, which exprDeps drops because it carries no attribute after the
-	// root. It names the default configuration, which resolves through
+	// traversal, which exprDepRefs drops because it carries no attribute after
+	// the root. It names the default configuration, which resolves through
 	// inheritance and may be implicit, so order the resource after whichever
 	// node registers it (if any). Aliased (`name.alias`) and call-based
 	// (`call.x.y`) provider expressions have further segments and are already
-	// resolved by exprDeps above.
+	// resolved by exprDepRefs above.
 	if resource.Provider != nil {
 		if vars := resource.Provider.Variables(); len(vars) == 1 && len(vars[0]) == 1 {
 			for _, dep := range g.defaultProviderNode(vars[0].RootName(), g.scopes[prefix]) {
-				seen[dep] = true
+				addStatic(dep)
 			}
 		}
 	}
@@ -763,40 +837,88 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) []pdag.Node 
 		if dep := formatTraversal(traversal); dep != "" {
 			g.recordRef(prefix+dep, traversal.SourceRange())
 			_, idx := g.newNode(prefix + dep)
-			seen[idx] = true
-		}
-	}
-	if resource.Config != nil {
-		for _, dep := range g.bodyDeps(resource.Config, prefix, nil) {
-			seen[dep] = true
+			addStatic(idx)
 		}
 	}
 	if resource.DeletedWith != nil {
 		if dep := formatTraversal(resource.DeletedWith); dep != "" {
 			g.recordRef(prefix+dep, resource.DeletedWith.SourceRange())
 			_, idx := g.newNode(prefix + dep)
-			seen[idx] = true
+			addStatic(idx)
 		}
 	}
 	for _, traversal := range resource.ReplaceWith {
 		if dep := formatTraversal(traversal); dep != "" {
 			g.recordRef(prefix+dep, traversal.SourceRange())
 			_, idx := g.newNode(prefix + dep)
-			seen[idx] = true
+			addStatic(idx)
 		}
 	}
 	if resource.Lifecycle != nil {
 		for _, expr := range resource.Lifecycle.ReplaceTriggeredBy {
-			for _, dep := range g.exprDeps(expr, prefix) {
-				seen[dep] = true
-			}
+			addStaticRefs(g.exprDepRefs(expr, prefix, nil))
 		}
 	}
-	for _, dep := range g.exprDeps(resource.Aliases, prefix) {
-		seen[dep] = true
+	addStaticRefs(g.exprDepRefs(resource.Aliases, prefix, nil))
+
+	// A whole-block dependency already waits for every instance; drop narrow
+	// entries it subsumes.
+	bd.Narrow = slices.DeleteFunc(bd.Narrow, func(d InstanceDep) bool { return wholeSeen[d.Key] })
+	if len(bd.Narrow) == 0 {
+		bd.Narrow = nil
 	}
 
-	return slices.Collect(maps.Keys(seen))
+	return bd, slices.Collect(maps.Keys(seen))
+}
+
+// classifyDep reports whether ref names a resource/data block declared in the
+// scope at prefix (sameScope), and if so which instance it addresses: a
+// non-empty Suffix when the traversal indexes the block with a literal string
+// or whole-number key, "" for a whole-block reference.
+func (g *Graph) classifyDep(ref depRef, prefix string) (id InstanceDep, sameScope bool) {
+	scope := g.scopes[prefix]
+	if scope == nil || ref.traversal == nil {
+		return InstanceDep{}, false
+	}
+	base := strings.TrimPrefix(ref.key, prefix)
+	// The index step follows the two naming steps (type.name), or three for
+	// data sources (data.type.name).
+	idxPos := 2
+	blockKey, isData := strings.CutPrefix(base, "data.")
+	if isData {
+		idxPos = 3
+		if _, ok := scope.config.DataSources[blockKey]; !ok {
+			return InstanceDep{}, false
+		}
+	} else if _, ok := scope.config.Resources[base]; !ok {
+		return InstanceDep{}, false
+	}
+	return InstanceDep{Key: ref.key, Suffix: literalIndexSuffix(ref.traversal, idxPos)}, true
+}
+
+// literalIndexSuffix returns the instance-key suffix (`[0]`, `["x"]`) when the
+// traversal step at idxPos indexes by a literal string or whole non-negative
+// number, and "" otherwise — dynamic indexes, splats, and out-of-domain keys
+// all fall back to whole-block granularity.
+func literalIndexSuffix(t hcl.Traversal, idxPos int) string {
+	if idxPos >= len(t) {
+		return ""
+	}
+	idx, ok := t[idxPos].(hcl.TraverseIndex)
+	if !ok || idx.Key.IsNull() || !idx.Key.IsKnown() {
+		return ""
+	}
+	switch idx.Key.Type() {
+	case cty.String:
+		return fmt.Sprintf("[%q]", idx.Key.AsString())
+	case cty.Number:
+		i, acc := idx.Key.AsBigFloat().Int64()
+		if acc != big.Exact || i < 0 {
+			return ""
+		}
+		return fmt.Sprintf("[%d]", i)
+	}
+	return ""
 }
 
 // providerDeps extracts all dependencies from a provider block, applying prefix
@@ -819,19 +941,23 @@ func (g *Graph) providerDeps(provider *ast.Provider, key, prefix string) []pdag.
 
 // bodyDeps extracts dependencies from an HCL body, applying prefix to resolved keys.
 func (g *Graph) bodyDeps(body hcl.Body, prefix string, exclude map[string]bool) []pdag.Node {
+	return g.refsToNodes(g.bodyDepRefs(body, prefix, exclude))
+}
+
+// bodyDepRefs extracts one depRef per referencing traversal in an HCL body,
+// applying prefix to resolved keys.
+func (g *Graph) bodyDepRefs(body hcl.Body, prefix string, exclude map[string]bool) []depRef {
 	if eb, ok := body.(*ast.EscapedBody); ok {
 		// Scan the underlying bodies so the native-syntax walk below still
 		// sees dynamic and lifecycle blocks; the merged body hides them.
-		return append(g.bodyDeps(eb.Base, prefix, exclude), g.bodyDeps(eb.Escape, prefix, exclude)...)
+		return append(g.bodyDepRefs(eb.Base, prefix, exclude), g.bodyDepRefs(eb.Escape, prefix, exclude)...)
 	}
 
-	seen := make(map[pdag.Node]bool)
+	var refs []depRef
 
 	attrs, _ := body.JustAttributes()
 	for _, attr := range attrs {
-		for _, dep := range g.exprDepsExcluding(attr.Expr, prefix, exclude) {
-			seen[dep] = true
-		}
+		refs = append(refs, g.exprDepRefs(attr.Expr, prefix, exclude)...)
 	}
 
 	if syntaxBody, ok := body.(*hclsyntax.Body); ok {
@@ -846,9 +972,7 @@ func (g *Graph) bodyDeps(body hcl.Body, prefix string, exclude map[string]bool) 
 				childExclude := make(map[string]bool, len(exclude)+1)
 				maps.Copy(childExclude, exclude)
 				childExclude[iterName] = true
-				for _, dep := range g.bodyDeps(block.Body, prefix, childExclude) {
-					seen[dep] = true
-				}
+				refs = append(refs, g.bodyDepRefs(block.Body, prefix, childExclude)...)
 			} else if block.Type == "lifecycle" {
 				// lifecycle blocks contain ignore_changes which holds property
 				// paths (e.g. tags["env"]), not dependency references. We must
@@ -857,25 +981,19 @@ func (g *Graph) bodyDeps(body hcl.Body, prefix string, exclude map[string]bool) 
 					if attrName == "ignore_changes" {
 						continue
 					}
-					for _, dep := range g.exprDepsExcluding(attr.Expr, prefix, exclude) {
-						seen[dep] = true
-					}
+					refs = append(refs, g.exprDepRefs(attr.Expr, prefix, exclude)...)
 				}
 				// Still recurse into nested blocks (precondition, postcondition).
 				for _, nested := range block.Body.Blocks {
-					for _, dep := range g.bodyDeps(nested.Body, prefix, exclude) {
-						seen[dep] = true
-					}
+					refs = append(refs, g.bodyDepRefs(nested.Body, prefix, exclude)...)
 				}
 			} else {
-				for _, dep := range g.bodyDeps(block.Body, prefix, exclude) {
-					seen[dep] = true
-				}
+				refs = append(refs, g.bodyDepRefs(block.Body, prefix, exclude)...)
 			}
 		}
 	}
 
-	return slices.Collect(maps.Keys(seen))
+	return refs
 }
 
 // outputDeps gathers an output node's dependencies: its value expression plus
@@ -953,17 +1071,46 @@ func (g *Graph) addVariableNodes(key string, v *ast.Variable, modInfo *ModuleInf
 	}, append(validationDeps, valueIdx))
 }
 
+// depRef is one dependency occurrence extracted from an expression: the
+// resolved node key plus the raw traversal it came from (nil for
+// provider-function deps, which have no traversal).
+type depRef struct {
+	key       string
+	traversal hcl.Traversal
+}
+
 // exprDeps extracts all dependencies from an expression, applying prefix to resolved keys.
 func (g *Graph) exprDeps(expr hcl.Expression, prefix string) []pdag.Node {
 	return g.exprDepsExcluding(expr, prefix, nil)
 }
 
 func (g *Graph) exprDepsExcluding(expr hcl.Expression, prefix string, exclude map[string]bool) []pdag.Node {
+	return g.refsToNodes(g.exprDepRefs(expr, prefix, exclude))
+}
+
+// refsToNodes dedups refs by key and interns each as a graph node.
+func (g *Graph) refsToNodes(refs []depRef) []pdag.Node {
+	var deps []string
+	for _, ref := range refs {
+		addToSortedListAsSet(&deps, ref.key)
+	}
+	result := make([]pdag.Node, len(deps))
+	for i, dep := range deps {
+		_, n := g.newNode(dep)
+		result[i] = n
+	}
+	return result
+}
+
+// exprDepRefs extracts one depRef per referencing traversal (no dedup, so a
+// classifier can see each instance-keyed occurrence), applying prefix to
+// resolved keys.
+func (g *Graph) exprDepRefs(expr hcl.Expression, prefix string, exclude map[string]bool) []depRef {
 	if expr == nil {
 		return nil
 	}
 
-	var deps []string
+	var refs []depRef
 
 	for _, traversal := range expr.Variables() {
 		namespace, parts := eval.ParseTraversal(traversal)
@@ -1008,7 +1155,7 @@ func (g *Graph) exprDepsExcluding(expr hcl.Expression, prefix string, exclude ma
 
 		if dep != "" {
 			g.recordRef(dep, traversal.SourceRange())
-			addToSortedListAsSet(&deps, dep)
+			refs = append(refs, depRef{key: dep, traversal: traversal})
 		}
 	}
 
@@ -1017,16 +1164,11 @@ func (g *Graph) exprDepsExcluding(expr hcl.Expression, prefix string, exclude ma
 	// an implicit default-provider reference would.
 	for _, providerName := range ast.ProviderFunctionCallsInExpr(expr) {
 		if dep, ok := g.providerFunctionDep(prefix, providerName); ok {
-			addToSortedListAsSet(&deps, dep)
+			refs = append(refs, depRef{key: dep})
 		}
 	}
 
-	result := make([]pdag.Node, len(deps))
-	for i, dep := range deps {
-		_, n := g.newNode(dep)
-		result[i] = n
-	}
-	return result
+	return refs
 }
 
 // providerFunctionDep resolves the provider block a provider-defined function
@@ -1298,20 +1440,23 @@ func (g *Graph) inlineModule(
 
 	// Resources
 	for key, resource := range loaded.Config.Resources {
-		deps := g.resourceDeps(resource, prefix)
-		deps = append(deps, initIdx)
-		ownDeps := g.defaultProviderDeps(resource, loaded.Config, prefix)
+		bd, deps := g.resourceDeps(resource, prefix)
+		provDeps := g.defaultProviderDeps(resource, loaded.Config, prefix)
 		passDeps := g.passThroughProviderDeps(resource, scope)
-		deps = append(deps, ownDeps...)
-		deps = append(deps, passDeps...)
-		if len(ownDeps) == 0 && len(passDeps) == 0 {
-			deps = append(deps, g.inheritedProviderDeps(resource, parent)...)
+		provDeps = append(provDeps, passDeps...)
+		if len(provDeps) == 0 {
+			provDeps = g.inheritedProviderDeps(resource, parent)
 		}
+		bd.Static = append(bd.Static, initIdx)
+		bd.Static = append(bd.Static, provDeps...)
+		deps = append(deps, initIdx)
+		deps = append(deps, provDeps...)
 		if err := g.AddNode(&Node{
 			Key:        prefix + key,
 			Type:       NodeTypeResource,
 			Resource:   resource,
 			ModuleInfo: modInfo,
+			Deps:       bd,
 		}, deps); err != nil {
 			return err
 		}
@@ -1319,20 +1464,23 @@ func (g *Graph) inlineModule(
 
 	// Data sources
 	for key, ds := range loaded.Config.DataSources {
-		deps := g.resourceDeps(ds, prefix)
-		deps = append(deps, initIdx)
-		ownDeps := g.defaultProviderDeps(ds, loaded.Config, prefix)
+		bd, deps := g.resourceDeps(ds, prefix)
+		provDeps := g.defaultProviderDeps(ds, loaded.Config, prefix)
 		passDeps := g.passThroughProviderDeps(ds, scope)
-		deps = append(deps, ownDeps...)
-		deps = append(deps, passDeps...)
-		if len(ownDeps) == 0 && len(passDeps) == 0 {
-			deps = append(deps, g.inheritedProviderDeps(ds, parent)...)
+		provDeps = append(provDeps, passDeps...)
+		if len(provDeps) == 0 {
+			provDeps = g.inheritedProviderDeps(ds, parent)
 		}
+		bd.Static = append(bd.Static, initIdx)
+		bd.Static = append(bd.Static, provDeps...)
+		deps = append(deps, initIdx)
+		deps = append(deps, provDeps...)
 		if err := g.AddNode(&Node{
 			Key:        prefix + "data." + key,
 			Type:       NodeTypeDataSource,
 			Resource:   ds,
 			ModuleInfo: modInfo,
+			Deps:       bd,
 		}, deps); err != nil {
 			return err
 		}

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -135,6 +135,13 @@ type Node struct {
 	// node's graph edges, kept in classified form so the engine's expansion
 	// layer can wire them per module instance at instance granularity.
 	Deps *BlockDeps
+
+	// PlanTimeRead is set on data-source nodes whose transitive prerequisites
+	// contain no resource: the read needs nothing a plan cannot know, so it
+	// completes before any resource instance is created (the plan/apply phase
+	// boundary). Deferred reads — those reaching a resource, directly or
+	// through their module's expansion — are false.
+	PlanTimeRead bool
 }
 
 // BlockDeps classifies a resource/data block's dependencies for the expansion
@@ -418,6 +425,26 @@ func (g *Graph) HasDependents(key string) bool {
 	return g.dependents[key] > 0
 }
 
+// KeyNode returns the dag node interned under key.
+func (g *Graph) KeyNode(key string) (pdag.Node, bool) {
+	n, ok := g.seen[key]
+	return n.i, ok
+}
+
+// ExpandableNodes returns the resource/data nodes carrying classified deps —
+// the blocks the engine schedules through BlockExpansion cells — sorted by
+// key for deterministic materialization.
+func (g *Graph) ExpandableNodes() []*Node {
+	var out []*Node
+	for _, n := range g.seen {
+		if n.n.Deps != nil {
+			out = append(out, n.n)
+		}
+	}
+	slices.SortFunc(out, func(a, b *Node) int { return cmp.Compare(a.Key, b.Key) })
+	return out
+}
+
 // BuildFromConfig builds a dependency graph from an HCL configuration.
 // moduleLoader is required when config contains modules.
 func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir string) (*Graph, error) {
@@ -533,7 +560,63 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 		}
 	}
 
+	g.classifyPlanTimeReads()
+
 	return g, nil
+}
+
+// classifyPlanTimeReads marks each data-source node whose transitive
+// prerequisites contain no resource node. Reachability runs over the
+// block-level graph, so a data source inside a module whose expansion depends
+// on a resource (through the module's init node) classifies as deferred.
+func (g *Graph) classifyPlanTimeReads() {
+	memo := make(map[pdag.Node]bool)
+	var reachesResource func(n pdag.Node) bool
+	reachesResource = func(n pdag.Node) bool {
+		if v, ok := memo[n]; ok {
+			return v
+		}
+		memo[n] = false
+		if in, ok := g.seen[g.keyByDagNode[n]]; ok && in.n.Type == NodeTypeResource {
+			memo[n] = true
+			return true
+		}
+		for p := range g.dag.Predecessors(n) {
+			if reachesResource(p) {
+				memo[n] = true
+				return true
+			}
+		}
+		return false
+	}
+	for _, in := range g.seen {
+		if in.n.Type == NodeTypeDataSource {
+			in.n.PlanTimeRead = !reachesResource(in.i)
+		}
+	}
+}
+
+// internExecNode creates an exec node interned under key (as a Builtin, so
+// pre-walk passes see it but Validate accepts it), leaving arming to the
+// caller.
+func (g *Graph) internExecNode(key string, exec func(context.Context) error) (pdag.Node, pdag.Done) {
+	i, done := g.dag.NewNode(dagNode{key: key, exec: exec})
+	g.seen[key] = internedNode{i: i, n: &Node{Key: key, Type: NodeTypeBuiltin}}
+	g.keyByDagNode[i] = key
+	return i, done
+}
+
+// NewJoinNode creates an armed no-op node interned under key, for the engine
+// to use as a synchronization point (edges added via Order).
+func (g *Graph) NewJoinNode(key string) pdag.Node {
+	i, done := g.internExecNode(key, func(context.Context) error { return nil })
+	done()
+	return i
+}
+
+// Order adds the edge from → to.
+func (g *Graph) Order(from, to pdag.Node) error {
+	return g.dag.NewEdge(from, to)
 }
 
 // defaultProviderDeps returns an implicit dependency on the un-aliased

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -1232,11 +1232,7 @@ type depRef struct {
 
 // exprDeps extracts all dependencies from an expression, applying prefix to resolved keys.
 func (g *Graph) exprDeps(expr hcl.Expression, prefix string) []pdag.Node {
-	return g.exprDepsExcluding(expr, prefix, nil)
-}
-
-func (g *Graph) exprDepsExcluding(expr hcl.Expression, prefix string, exclude map[string]bool) []pdag.Node {
-	return g.refsToNodes(g.exprDepRefs(expr, prefix, exclude))
+	return g.refsToNodes(g.exprDepRefs(expr, prefix, nil))
 }
 
 // refsToNodes dedups refs by key and interns each as a graph node.

--- a/pkg/hcl/run/cells.go
+++ b/pkg/hcl/run/cells.go
@@ -49,16 +49,30 @@ func cellKey(node *graph.Node, mi *moduleInstance) expansionCell {
 	return c
 }
 
+// cell returns the expansion cell for a block within one module instance ("" =
+// root), erroring when materialization never created it.
+func (e *Engine) cell(block, mi string) (*graph.BlockExpansion, error) {
+	b, ok := e.expansions.Get(expansionCell{block: block, mi: mi})
+	if !ok {
+		return nil, fmt.Errorf("no expansion cell for %q in module instance %q", block, mi)
+	}
+	return b, nil
+}
+
 // materializeRootCells creates, wires, and arms the cells for every top-level
 // resource/data block, plus the plan barrier separating plan-time data reads
 // from resource creation. Runs after graph validation and before the walk.
 func (e *Engine) materializeRootCells(g *graph.Graph) error {
 	e.planBarrier = g.NewJoinNode("!plan-reads")
 
-	var blocks []*graph.Node
+	var blocks, locals []*graph.Node
 	for _, node := range g.ExpandableNodes() {
 		if node.ModuleInfo == nil {
-			blocks = append(blocks, node)
+			if node.Type == graph.NodeTypeLocal {
+				locals = append(locals, node)
+			} else {
+				blocks = append(blocks, node)
+			}
 			continue
 		}
 		// A module holding a plan-time data source keeps the barrier open
@@ -77,7 +91,45 @@ func (e *Engine) materializeRootCells(g *graph.Graph) error {
 			}
 		}
 	}
-	return e.materializeCells(g, blocks, []*moduleInstance{nil}, true)
+	if err := e.materializeCells(g, blocks, []*moduleInstance{nil}, true); err != nil {
+		return err
+	}
+	return e.wireRootLocals(g, locals)
+}
+
+// wireRootLocals gives each classified root local its instance-granular
+// dependency edges: whole-block references bind to the target cell's
+// completion, literal-indexed references to that instance's gate. The local's
+// static deps were wired at graph build; block-level edges were deliberately
+// omitted there so narrowness flows through the local to its consumers.
+// Although the cells are already armed, nothing executes until the walk
+// starts, so creating gates here still precedes every expansion.
+func (e *Engine) wireRootLocals(g *graph.Graph, locals []*graph.Node) error {
+	for _, node := range locals {
+		ln, ok := g.KeyNode(node.Key)
+		if !ok {
+			return fmt.Errorf("no graph node for %q", node.Key)
+		}
+		for _, whole := range node.Deps.Whole {
+			target, err := e.cell(whole, "")
+			if err != nil {
+				return err
+			}
+			if err := g.Order(target.Complete(), ln); err != nil {
+				return err
+			}
+		}
+		for _, narrow := range node.Deps.Narrow {
+			target, err := e.cell(narrow.Key, "")
+			if err != nil {
+				return err
+			}
+			if err := g.Order(target.Gate(narrow.Suffix), ln); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // materializeModuleCells creates, wires, and arms the cells for one module's
@@ -147,18 +199,18 @@ func (e *Engine) wireCell(g *graph.Graph, node *graph.Node, mi *moduleInstance) 
 		}
 	}
 	for _, whole := range node.Deps.Whole {
-		target, ok := e.expansions.Get(expansionCell{block: whole, mi: key.mi})
-		if !ok {
-			return fmt.Errorf("no expansion cell for dependency %q of %v", whole, key)
+		target, err := e.cell(whole, key.mi)
+		if err != nil {
+			return err
 		}
 		if err := b.DependOn(target.Complete()); err != nil {
 			return err
 		}
 	}
 	for _, narrow := range node.Deps.Narrow {
-		target, ok := e.expansions.Get(expansionCell{block: narrow.Key, mi: key.mi})
-		if !ok {
-			return fmt.Errorf("no expansion cell for dependency %q of %v", narrow.Key, key)
+		target, err := e.cell(narrow.Key, key.mi)
+		if err != nil {
+			return err
 		}
 		if err := b.DependOn(target.Gate(narrow.Suffix)); err != nil {
 			return err

--- a/pkg/hcl/run/cells.go
+++ b/pkg/hcl/run/cells.go
@@ -1,0 +1,438 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/graph"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// A cell is one (resource/data block × module instance) unit of expansion.
+// Each cell owns a graph.BlockExpansion: its expand node evaluates
+// count/for_each in the cell's evaluation context and creates one node per
+// instance, so instances of different cells — and of the same cell — run
+// concurrently, and a consumer that references a single instance waits only
+// for that instance's gate rather than the whole block.
+//
+// Root cells materialize before the walk starts; a module's cells materialize
+// when its init node runs and the instance set is known. Either way the order
+// is: create every cell of the scope, wire dependencies and gates, then arm —
+// so a gate is always created before its target's expansion runs.
+type expansionCell struct {
+	block string // graph node key, module-prefixed
+	mi    string // module instance path, "" at the root
+}
+
+func cellKey(node *graph.Node, mi *moduleInstance) expansionCell {
+	c := expansionCell{block: node.Key}
+	if mi != nil {
+		c.mi = mi.Path.String()
+	}
+	return c
+}
+
+// materializeRootCells creates, wires, and arms the cells for every top-level
+// resource/data block, plus the plan barrier separating plan-time data reads
+// from resource creation. Runs after graph validation and before the walk.
+func (e *Engine) materializeRootCells(g *graph.Graph) error {
+	e.planBarrier = g.NewJoinNode("!plan-reads")
+
+	var blocks []*graph.Node
+	for _, node := range g.ExpandableNodes() {
+		if node.ModuleInfo == nil {
+			blocks = append(blocks, node)
+			continue
+		}
+		// A module holding a plan-time data source keeps the barrier open
+		// until its init runs: init wires the data cells' completions to the
+		// barrier before the barrier's init prerequisite is met. (Such an
+		// init never transitively depends on a resource — that would have
+		// classified the data source as deferred — so this cannot cycle with
+		// the barrier gating resource expansion.)
+		if node.Type == graph.NodeTypeDataSource && node.PlanTimeRead {
+			init, ok := g.KeyNode(node.ModuleInfo.Prefix() + "__init__")
+			if !ok {
+				return fmt.Errorf("no init node for module %q", node.ModuleInfo.Prefix())
+			}
+			if err := g.Order(init, e.planBarrier); err != nil {
+				return err
+			}
+		}
+	}
+	return e.materializeCells(g, blocks, []*moduleInstance{nil}, true)
+}
+
+// materializeModuleCells creates, wires, and arms the cells for one module's
+// blocks across its just-created instances. Called from the module's init
+// node.
+func (e *Engine) materializeModuleCells(modInfo *graph.ModuleInfo, instances []*moduleInstance) error {
+	var blocks []*graph.Node
+	for _, node := range e.graph.ExpandableNodes() {
+		if node.ModuleInfo != nil && node.ModuleInfo.Prefix() == modInfo.Prefix() {
+			blocks = append(blocks, node)
+		}
+	}
+	return e.materializeCells(e.graph, blocks, instances, false)
+}
+
+func (e *Engine) materializeCells(g *graph.Graph, blocks []*graph.Node, mis []*moduleInstance, static bool) error {
+	for _, node := range blocks {
+		for _, mi := range mis {
+			e.newCell(g, node, mi, static)
+		}
+	}
+	for _, node := range blocks {
+		for _, mi := range mis {
+			if err := e.wireCell(g, node, mi); err != nil {
+				return err
+			}
+		}
+	}
+	for _, node := range blocks {
+		for _, mi := range mis {
+			cell, ok := e.expansions.Get(cellKey(node, mi))
+			if !ok {
+				return fmt.Errorf("no expansion cell for %v", cellKey(node, mi))
+			}
+			cell.Arm()
+		}
+	}
+	return nil
+}
+
+func (e *Engine) newCell(g *graph.Graph, node *graph.Node, mi *moduleInstance, static bool) {
+	var b *graph.BlockExpansion
+	b = g.NewBlockExpansion(node.Key, static, func(ctx context.Context) error {
+		if node.Type == graph.NodeTypeDataSource {
+			return e.expandDataCell(ctx, node, b, mi)
+		}
+		return e.expandResourceCell(ctx, node, b, mi)
+	})
+	e.expansions.Set(cellKey(node, mi), b)
+}
+
+// wireCell wires one cell's classified dependencies: static graph nodes
+// directly, whole-block references to the target cell's completion, and
+// instance references to the target cell's gate — targets resolved within the
+// same module instance. The block's own graph node is ordered after the
+// cell's completion, so whole-module aggregation still waits for every
+// instance.
+func (e *Engine) wireCell(g *graph.Graph, node *graph.Node, mi *moduleInstance) error {
+	key := cellKey(node, mi)
+	b, ok := e.expansions.Get(key)
+	if !ok {
+		return fmt.Errorf("no expansion cell for %v", key)
+	}
+	for _, dep := range node.Deps.Static {
+		if err := b.DependOn(dep); err != nil {
+			return err
+		}
+	}
+	for _, whole := range node.Deps.Whole {
+		target, ok := e.expansions.Get(expansionCell{block: whole, mi: key.mi})
+		if !ok {
+			return fmt.Errorf("no expansion cell for dependency %q of %v", whole, key)
+		}
+		if err := b.DependOn(target.Complete()); err != nil {
+			return err
+		}
+	}
+	for _, narrow := range node.Deps.Narrow {
+		target, ok := e.expansions.Get(expansionCell{block: narrow.Key, mi: key.mi})
+		if !ok {
+			return fmt.Errorf("no expansion cell for dependency %q of %v", narrow.Key, key)
+		}
+		if err := b.DependOn(target.Gate(narrow.Suffix)); err != nil {
+			return err
+		}
+	}
+
+	// The plan/apply phase boundary: plan-time reads complete before the
+	// barrier, resource expansion waits for it. Deferred reads participate in
+	// neither — they transitively wait on a resource, so they land after the
+	// barrier on their own.
+	switch {
+	case node.Type == graph.NodeTypeResource:
+		if err := b.DependOn(e.planBarrier); err != nil {
+			return err
+		}
+	case node.PlanTimeRead:
+		if err := b.CompleteBefore(e.planBarrier); err != nil {
+			return err
+		}
+	}
+
+	blockNode, ok := g.KeyNode(node.Key)
+	if !ok {
+		return fmt.Errorf("no graph node for %q", node.Key)
+	}
+	return b.CompleteBefore(blockNode)
+}
+
+// cellEvalState resolves the evaluation context, parent URN, and module
+// instance for a cell.
+func cellEvalState(e *Engine, mi *moduleInstance) (*eval.Context, urn.URN, *moduleInstance) {
+	if mi != nil {
+		return mi.EvalCtx, mi.URN, mi
+	}
+	return e.evaluator.Context(), e.stackURN, nil
+}
+
+// metaArgs is the result of evaluating a block's count/for_each into an
+// expander: the meta-argument dependency keys (references there establish
+// dependencies that govern destroy ordering even when the body never uses the
+// target), which argument if any was unknown, and the count-mode details the
+// shape declarations need.
+type metaArgs struct {
+	deps       []string
+	unknownArg string
+	boolCount  bool
+	count      int
+}
+
+func evalMetaArgs(evalCtx *eval.Context, node *graph.Node, expander *graph.ResourceExpander) (metaArgs, error) {
+	res := node.Resource
+	tempEvaluator := eval.NewEvaluator(evalCtx)
+	var m metaArgs
+	if res.Count != nil {
+		count, isBool, unknown, deps, diags := tempEvaluator.EvaluateCount(res.Count)
+		if diags.HasErrors() {
+			return m, fmt.Errorf("evaluating count: %s", diags.Error())
+		}
+		m.deps = append(m.deps, deps...)
+		switch {
+		case unknown:
+			m.unknownArg = "count"
+		case isBool:
+			m.boolCount = true
+			expander.SetBoolCount(node.Key, count)
+		default:
+			m.count = count
+			expander.SetCount(node.Key, count)
+		}
+	}
+	if res.ForEach != nil {
+		forEach, unknown, deps, diags := tempEvaluator.EvaluateForEach(res.ForEach)
+		if diags.HasErrors() {
+			return m, fmt.Errorf("evaluating for_each: %s", diags.Error())
+		}
+		m.deps = append(m.deps, deps...)
+		if unknown {
+			m.unknownArg = "for_each"
+		} else {
+			expander.SetForEach(node.Key, forEach)
+		}
+	}
+	return m, nil
+}
+
+// expandResourceCell evaluates a resource cell's count/for_each and creates
+// one instance node per expanded instance.
+func (e *Engine) expandResourceCell(
+	ctx context.Context, node *graph.Node, b *graph.BlockExpansion, mi *moduleInstance,
+) error {
+	res := node.Resource
+	if res == nil {
+		return fmt.Errorf("resource node missing Resource field")
+	}
+	evalCtx, parentURN, modInst := cellEvalState(e, mi)
+
+	resSchema, err := e.resolver.ResolveResource(ctx, res.Type)
+	if err != nil {
+		if diag := unknownTokenDiag("resource", res.TypeRange, err); diag != err {
+			return diag
+		}
+		return fmt.Errorf("resolving resource type %s: %w", res.Type, err)
+	}
+
+	expander := graph.NewResourceExpander()
+	meta, err := evalMetaArgs(evalCtx, node, expander)
+	if err != nil {
+		return err
+	}
+
+	baseKey := node.Key
+	if node.ModuleInfo != nil {
+		baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix())
+	}
+
+	// A count/for_each that reads values this operation has not yet produced
+	// cannot be expanded. During preview, register no instances and bind the
+	// resource address to unknown so downstream references resolve to unknown
+	// rather than an empty collection.
+	if meta.unknownArg != "" {
+		if !e.dryRun {
+			return fmt.Errorf("%s: the %s value depends on values that are not yet known", node.Key, meta.unknownArg)
+		}
+		evalCtx.SetResource(baseKey, "", cty.UnknownVal(cty.DynamicPseudoType))
+		return nil
+	}
+
+	result := expander.Expand(node)
+
+	// Empty count/for_each still needs the resource address bound so
+	// downstream references see an empty collection rather than "no such
+	// attribute".
+	if len(result.Instances) == 0 {
+		if res.Count != nil || res.ForEach != nil {
+			empty := cty.EmptyObjectVal
+			if res.Count != nil {
+				empty = cty.EmptyTupleVal
+			}
+			evalCtx.SetResource(baseKey, "", empty)
+		}
+		return nil
+	}
+
+	// Declare the instance shape before any instance publishes, so a narrow
+	// consumer that runs between two publications still indexes correctly.
+	switch {
+	case res.ForEach != nil:
+		keys := make([]string, 0, len(result.Instances))
+		for _, instance := range result.Instances {
+			keys = append(keys, instance.EachKey.AsString())
+		}
+		evalCtx.DeclareEachInstances(baseKey, keys)
+	case res.Count != nil && !meta.boolCount:
+		evalCtx.DeclareCountInstances(baseKey, meta.count)
+	}
+
+	for _, instance := range result.Instances {
+		inst := instance
+		err := b.AddInstance(strings.TrimPrefix(inst.Key, node.Key), func(ctx context.Context) error {
+			if e.hasFailedDependency(res) {
+				e.failedNodes.Set(inst.Key, fmt.Errorf("skipped: dependency failed"))
+				return nil
+			}
+			if err := e.registerResourceInstanceInContext(
+				ctx, node, res, resSchema, inst, evalCtx, parentURN, modInst, meta.deps,
+			); err != nil {
+				return fmt.Errorf("registering %s: %w", inst.Key, err)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// expandDataCell evaluates a data cell's count/for_each and creates one
+// instance node per read.
+func (e *Engine) expandDataCell(
+	ctx context.Context, node *graph.Node, b *graph.BlockExpansion, mi *moduleInstance,
+) error {
+	ds := node.Resource
+	if ds == nil {
+		return fmt.Errorf("data source node missing Resource field")
+	}
+	evalCtx, _, _ := cellEvalState(e, mi)
+
+	funcSchema, err := e.resolver.ResolveFunction(ctx, ds.Type)
+	if err != nil {
+		if diag := unknownTokenDiag("data source", ds.TypeRange, err); diag != err {
+			return diag
+		}
+		return fmt.Errorf("resolving data source type %s: %w", ds.Type, err)
+	}
+
+	dsKey := node.Key
+	if node.ModuleInfo != nil {
+		dsKey = strings.TrimPrefix(dsKey, node.ModuleInfo.Prefix())
+	}
+	dsKey = strings.TrimPrefix(dsKey, "data.")
+
+	if ds.Count == nil && ds.ForEach == nil {
+		return b.AddInstance("", func(ctx context.Context) error {
+			ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx)
+			if err != nil {
+				return err
+			}
+			evalCtx.SetDataSource(dsKey, ctyOutputs)
+			return nil
+		})
+	}
+
+	expander := graph.NewResourceExpander()
+	meta, err := evalMetaArgs(evalCtx, node, expander)
+	if err != nil {
+		return err
+	}
+
+	// See the matching case in expandResourceCell: unexpandable during
+	// preview means no invokes and an unknown aggregate value.
+	if meta.unknownArg != "" {
+		if !e.dryRun {
+			return fmt.Errorf("%s: the %s value depends on values that are not yet known", node.Key, meta.unknownArg)
+		}
+		evalCtx.SetDataSource(dsKey, cty.UnknownVal(cty.DynamicPseudoType))
+		return nil
+	}
+
+	result := expander.Expand(node)
+
+	if len(result.Instances) == 0 {
+		empty := cty.EmptyObjectVal
+		if ds.Count != nil {
+			empty = cty.EmptyTupleVal
+		}
+		evalCtx.SetDataSource(dsKey, empty)
+		return nil
+	}
+
+	switch {
+	case ds.ForEach != nil:
+		keys := make([]string, 0, len(result.Instances))
+		for _, instance := range result.Instances {
+			keys = append(keys, instance.EachKey.AsString())
+		}
+		evalCtx.DeclareEachData(dsKey, keys)
+	case ds.Count != nil && !meta.boolCount:
+		evalCtx.DeclareCountData(dsKey, meta.count)
+	}
+
+	for _, instance := range result.Instances {
+		inst := instance
+		err := b.AddInstance(strings.TrimPrefix(inst.Key, node.Key), func(ctx context.Context) error {
+			instCtx := evalCtx.WithIteration(inst.Index, inst.EachKey, inst.EachValue)
+			ctyOut, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, instCtx)
+			if err != nil {
+				return err
+			}
+			switch {
+			case inst.EachKey != nil:
+				evalCtx.SetEachData(dsKey, inst.EachKey.AsString(), ctyOut)
+			case inst.Index != nil:
+				evalCtx.SetCountData(dsKey, *inst.Index, ctyOut)
+			default:
+				// A bool-derived count expands to a single unsuffixed
+				// instance whose aggregate value is a one-element tuple.
+				evalCtx.SetDataSource(dsKey, cty.TupleVal([]cty.Value{ctyOut}))
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/hcl/run/cells.go
+++ b/pkg/hcl/run/cells.go
@@ -17,7 +17,9 @@ package run
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
+	"sync"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/graph"
@@ -57,6 +59,58 @@ func (e *Engine) cell(block, mi string) (*graph.BlockExpansion, error) {
 		return nil, fmt.Errorf("no expansion cell for %q in module instance %q", block, mi)
 	}
 	return b, nil
+}
+
+// urnRegistry accumulates the URNs of the resource instances each cell has
+// registered so far, so dependency metadata can be recorded at resource
+// granularity: destroy ordering is resource-wide — an instance-keyed
+// reference or depends_on still makes every instance of the target wait for
+// the consumer — so a URN collected from one instance widens to every
+// registered sibling. Instances that register later cannot be recorded (their
+// URNs do not exist yet), so a consumer that raced ahead of a delayed sibling
+// leaves that sibling free to destroy independently.
+type urnRegistry struct {
+	mu   sync.Mutex
+	m    map[expansionCell][]string
+	cell map[string]expansionCell // URN → owning cell
+}
+
+func newURNRegistry() *urnRegistry {
+	return &urnRegistry{
+		m:    make(map[expansionCell][]string),
+		cell: make(map[string]expansionCell),
+	}
+}
+
+func (r *urnRegistry) add(c expansionCell, urn string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.m[c] = append(r.m[c], urn)
+	r.cell[urn] = c
+}
+
+func (r *urnRegistry) get(c expansionCell) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.m[c])
+}
+
+// widen replaces each URN owned by a known cell with that cell's full
+// registered instance set, passing unknown URNs through, and returns the
+// deduplicated, sorted result.
+func (r *urnRegistry) widen(urns []string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []string
+	for _, u := range urns {
+		if c, ok := r.cell[u]; ok {
+			out = append(out, r.m[c]...)
+		} else {
+			out = append(out, u)
+		}
+	}
+	slices.Sort(out)
+	return slices.Compact(out)
 }
 
 // materializeRootCells creates, wires, and arms the cells for every top-level
@@ -415,7 +469,7 @@ func (e *Engine) expandDataCell(
 
 	if ds.Count == nil && ds.ForEach == nil {
 		return b.AddInstance("", func(ctx context.Context) error {
-			ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx)
+			ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx, cellKey(node, mi).mi)
 			if err != nil {
 				return err
 			}
@@ -466,7 +520,7 @@ func (e *Engine) expandDataCell(
 		inst := instance
 		err := b.AddInstance(strings.TrimPrefix(inst.Key, node.Key), func(ctx context.Context) error {
 			instCtx := evalCtx.WithIteration(inst.Index, inst.EachKey, inst.EachValue)
-			ctyOut, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, instCtx)
+			ctyOut, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, instCtx, cellKey(node, mi).mi)
 			if err != nil {
 				return err
 			}

--- a/pkg/hcl/run/cells.go
+++ b/pkg/hcl/run/cells.go
@@ -305,13 +305,10 @@ func cellEvalState(e *Engine, mi *moduleInstance) (*eval.Context, urn.URN, *modu
 // metaArgs is the result of evaluating a block's count/for_each into an
 // expander: the meta-argument dependency keys (references there establish
 // dependencies that govern destroy ordering even when the body never uses the
-// target), which argument if any was unknown, and the count-mode details the
-// shape declarations need.
+// target) and which argument if any was unknown.
 type metaArgs struct {
 	deps       []string
 	unknownArg string
-	boolCount  bool
-	count      int
 }
 
 func evalMetaArgs(evalCtx *eval.Context, node *graph.Node, expander *graph.ResourceExpander) (metaArgs, error) {
@@ -328,10 +325,8 @@ func evalMetaArgs(evalCtx *eval.Context, node *graph.Node, expander *graph.Resou
 		case unknown:
 			m.unknownArg = "count"
 		case isBool:
-			m.boolCount = true
 			expander.SetBoolCount(node.Key, count)
 		default:
-			m.count = count
 			expander.SetCount(node.Key, count)
 		}
 	}
@@ -406,19 +401,6 @@ func (e *Engine) expandResourceCell(
 			evalCtx.SetResource(baseKey, "", empty)
 		}
 		return nil
-	}
-
-	// Declare the instance shape before any instance publishes, so a narrow
-	// consumer that runs between two publications still indexes correctly.
-	switch {
-	case res.ForEach != nil:
-		keys := make([]string, 0, len(result.Instances))
-		for _, instance := range result.Instances {
-			keys = append(keys, instance.EachKey.AsString())
-		}
-		evalCtx.DeclareEachInstances(baseKey, keys)
-	case res.Count != nil && !meta.boolCount:
-		evalCtx.DeclareCountInstances(baseKey, meta.count)
 	}
 
 	for _, instance := range result.Instances {
@@ -503,17 +485,6 @@ func (e *Engine) expandDataCell(
 		}
 		evalCtx.SetDataSource(dsKey, empty)
 		return nil
-	}
-
-	switch {
-	case ds.ForEach != nil:
-		keys := make([]string, 0, len(result.Instances))
-		for _, instance := range result.Instances {
-			keys = append(keys, instance.EachKey.AsString())
-		}
-		evalCtx.DeclareEachData(dsKey, keys)
-	case ds.Count != nil && !meta.boolCount:
-		evalCtx.DeclareCountData(dsKey, meta.count)
 	}
 
 	for _, instance := range result.Instances {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1496,12 +1496,9 @@ func (e *Engine) registerResourceInstanceInContext(
 			opts.HideDiffs = append(opts.HideDiffs, glob)
 		}
 	}
+	// The per-source collection may repeat URNs; widen dedups below.
 	for _, deps := range dependsOn {
-		for _, dep := range deps {
-			if !slices.Contains(opts.DependsOn, dep) {
-				opts.DependsOn = append(opts.DependsOn, dep)
-			}
-		}
+		opts.DependsOn = append(opts.DependsOn, deps...)
 	}
 	// count/for_each, lifecycle precondition/postcondition, and
 	// provisioner/connection references are not tied to any body property, so
@@ -1510,11 +1507,7 @@ func (e *Engine) registerResourceInstanceInContext(
 	checkDeps := checkRuleDeps(res.Preconditions, hclCtx)
 	checkDeps = append(checkDeps, checkRuleDeps(res.Postconditions, hclCtx)...)
 	provDeps := provisionerDeps(res, hclCtx)
-	for _, dep := range slices.Concat(metaArgDeps, checkDeps, provDeps) {
-		if !slices.Contains(opts.DependsOn, dep) {
-			opts.DependsOn = append(opts.DependsOn, dep)
-		}
-	}
+	opts.DependsOn = append(opts.DependsOn, slices.Concat(metaArgDeps, checkDeps, provDeps)...)
 	// Widen every collected instance URN to its resource's registered
 	// instance set: destroy ordering is resource-wide, so a reference to one
 	// instance makes every sibling wait for this resource. Sources that

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -441,6 +441,10 @@ type Engine struct {
 	// materializeRootCells.
 	planBarrier pdag.Node
 
+	// cellURNs records each cell's registered instance URNs, consumed by
+	// dependency-metadata recording. See urnRegistry.
+	cellURNs *urnRegistry
+
 	// failedNodes tracks resource nodes that failed to register, keyed by instance key.
 	// Dependent nodes check this map and are skipped when a dependency failed.
 	failedNodes *util.SyncMap[string, error]
@@ -588,6 +592,7 @@ func NewEngine(ctx context.Context, config *ast.Config, opts *EngineOptions) (*E
 		moduleInstances:         util.NewSyncMap[modulepath.Path, []*moduleInstance](),
 		parallel:                opts.Parallel,
 		expansions:              util.NewSyncMap[expansionCell, *graph.BlockExpansion](),
+		cellURNs:                newURNRegistry(),
 		failedNodes:             util.NewSyncMap[string, error](),
 		alwaysRegisterProviders: opts.AlwaysRegisterProviders,
 		resolver: packages.NewResolver(
@@ -1466,7 +1471,7 @@ func (e *Engine) registerResourceInstanceInContext(
 		}
 	}
 
-	opts, err := e.buildResourceOptionsInContext(ctx, res, instance, evalCtx, parentURN, node.ModuleInfo, modInst, resourceMapping, resSchema.InputProperties, resSchema.Properties, resourceInputs)
+	opts, err := e.buildResourceOptionsInContext(ctx, node, res, instance, evalCtx, parentURN, modInst, resourceMapping, resSchema.InputProperties, resSchema.Properties, resourceInputs)
 	if err != nil {
 		return err
 	}
@@ -1510,7 +1515,12 @@ func (e *Engine) registerResourceInstanceInContext(
 			opts.DependsOn = append(opts.DependsOn, dep)
 		}
 	}
-	slices.Sort(opts.DependsOn)
+	// Widen every collected instance URN to its resource's registered
+	// instance set: destroy ordering is resource-wide, so a reference to one
+	// instance makes every sibling wait for this resource. Sources that
+	// contribute no dependency (a destroy-time provisioner's self-reference,
+	// say) stay excluded — widening only amplifies what was collected.
+	opts.DependsOn = e.cellURNs.widen(opts.DependsOn)
 
 	if opts.Version == "" {
 		pkgName := packageNameFromResourceType(res.Type)
@@ -1555,6 +1565,8 @@ func (e *Engine) registerResourceInstanceInContext(
 		e.failedNodes.Set(instance.Key, fmt.Errorf("registering resource: %w", err))
 		return nil
 	}
+
+	e.cellURNs.add(cellKey(node, modInst), string(urn))
 
 	outputs = outputs.Delete("id", "urn")
 
@@ -1612,11 +1624,12 @@ func (e *Engine) registerResourceInstanceInContext(
 
 // buildResourceOptionsInContext builds resource options using the provided eval context and parent URN.
 func (e *Engine) buildResourceOptionsInContext(
-	ctx context.Context, res *ast.Resource, instance *graph.ExpandedResource,
+	ctx context.Context, node *graph.Node, res *ast.Resource, instance *graph.ExpandedResource,
 	evalCtx *eval.Context, parentURN urn.URN,
-	modInfo *graph.ModuleInfo, modInst *moduleInstance, resourceMapping *bridge.BodyMapping,
+	modInst *moduleInstance, resourceMapping *bridge.BodyMapping,
 	inputProps, outputProps []*schema.Property, inputs property.Map,
 ) (*ResourceOptions, error) {
+	modInfo := node.ModuleInfo
 	opts := &ResourceOptions{}
 	opts.Parent = parentURN
 
@@ -1625,16 +1638,20 @@ func (e *Engine) buildResourceOptionsInContext(
 		resPrefix = modInfo.Prefix()
 	}
 
+	// depends_on records every registered instance of the target block,
+	// keyed or not — dependency metadata is resource-wide (see urnRegistry).
+	// The registry lookup also covers expanded targets, whose instance
+	// outputs are not addressable by the block key.
+	miPath := ""
+	if modInst != nil {
+		miPath = modInst.Path.String()
+	}
 	for _, dep := range res.DependsOn {
 		depKey := graph.FormatTraversal(dep)
 		if depKey == "" {
 			continue
 		}
-		if outputs, ok := e.resourceOutputs.Get(resPrefix + depKey); ok {
-			if urn := ctyAsString(outputs.GetAttr("urn")); urn != "" {
-				opts.DependsOn = append(opts.DependsOn, urn)
-			}
-		}
+		opts.DependsOn = append(opts.DependsOn, e.cellURNs.get(expansionCell{block: resPrefix + depKey, mi: miPath})...)
 	}
 
 	// Handle lifecycle options
@@ -3054,7 +3071,7 @@ func (e *Engine) readResource(
 // without a separate dependency map.
 func (e *Engine) invokeDataSourceOnce(
 	ctx context.Context, node *graph.Node, ds *ast.Resource, funcSchema *schema.Function,
-	evalCtx *eval.Context,
+	evalCtx *eval.Context, miPath string,
 ) (cty.Value, error) {
 	hclCtx := evalCtx.HCLContext()
 
@@ -3148,6 +3165,9 @@ func (e *Engine) invokeDataSourceOnce(
 		}
 	}
 
+	// depends_on marks the outputs with every registered instance URN of the
+	// target block, keyed or not — dependency metadata is resource-wide (see
+	// buildResourceOptionsInContext).
 	for _, dep := range ds.DependsOn {
 		depKey := graph.FormatTraversal(dep)
 		if depKey == "" {
@@ -3157,8 +3177,8 @@ func (e *Engine) invokeDataSourceOnce(
 		if node.ModuleInfo != nil {
 			fullDepKey = node.ModuleInfo.Prefix() + depKey
 		}
-		if outputs, ok := e.resourceOutputs.Get(fullDepKey); ok {
-			addURN(ctyAsString(outputs.GetAttr("urn")))
+		for _, urn := range e.cellURNs.get(expansionCell{block: fullDepKey, mi: miPath}) {
+			addURN(urn)
 		}
 	}
 
@@ -4458,7 +4478,7 @@ func (e *Engine) readScopedDataSource(ctx context.Context, ds *ast.Resource, eva
 		}
 		return fmt.Errorf("resolving data source type %s: %w", ds.Type, err)
 	}
-	ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx)
+	ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1392,8 +1392,6 @@ func (e *Engine) registerProviderInContext(
 	return nil
 }
 
-
-
 // registerResourceInstanceInContext registers a single resource instance with Pulumi.
 func (e *Engine) registerResourceInstanceInContext(
 	ctx context.Context,
@@ -3053,9 +3051,6 @@ func (e *Engine) readResource(
 
 	return resp.URN, resp.ID, resp.Outputs, nil
 }
-
-
-
 
 // invokeDataSourceOnce performs a single data-source invocation using the
 // current state of evalCtx (which may have each/count set by the caller).

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/util"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/util/pdag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -431,6 +432,15 @@ type Engine struct {
 
 	parallel int
 
+	// expansions maps each (block, module instance) cell to the expansion
+	// skeleton scheduling its instances. See cells.go.
+	expansions *util.SyncMap[expansionCell, *graph.BlockExpansion]
+
+	// planBarrier is the plan/apply phase boundary: every plan-time data read
+	// completes before it, and every resource expansion waits for it. See
+	// materializeRootCells.
+	planBarrier pdag.Node
+
 	// failedNodes tracks resource nodes that failed to register, keyed by instance key.
 	// Dependent nodes check this map and are skipped when a dependency failed.
 	failedNodes *util.SyncMap[string, error]
@@ -577,6 +587,7 @@ func NewEngine(ctx context.Context, config *ast.Config, opts *EngineOptions) (*E
 		moduleLoader:            opts.ModuleLoader,
 		moduleInstances:         util.NewSyncMap[modulepath.Path, []*moduleInstance](),
 		parallel:                opts.Parallel,
+		expansions:              util.NewSyncMap[expansionCell, *graph.BlockExpansion](),
 		failedNodes:             util.NewSyncMap[string, error](),
 		alwaysRegisterProviders: opts.AlwaysRegisterProviders,
 		resolver: packages.NewResolver(
@@ -624,6 +635,13 @@ func (e *Engine) Run(ctx context.Context) error {
 	}
 	e.graph = g
 	e.forcedCBD = g.ForcedCreateBeforeDestroy()
+
+	// Resource/data instances are scheduled by expansion cells; their graph
+	// nodes serve as completion barriers only. Root cells materialize before
+	// the walk; each module's cells materialize when its init node runs.
+	if err := e.materializeRootCells(g); err != nil {
+		return fmt.Errorf("materializing expansion cells: %w", err)
+	}
 
 	// Process nodes in parallel where possible
 	if err := e.processGraph(ctx, g); err != nil {
@@ -704,10 +722,10 @@ func (e *Engine) processNode(ctx context.Context, node *graph.Node) error {
 		return e.processVariableValidation(node)
 	case graph.NodeTypeLocal:
 		return e.processLocal(ctx, node)
-	case graph.NodeTypeResource:
-		return e.processResource(ctx, node)
-	case graph.NodeTypeDataSource:
-		return e.processDataSource(ctx, node)
+	case graph.NodeTypeResource, graph.NodeTypeDataSource:
+		// Instances run in expansion cells (cells.go); the node itself is a
+		// completion barrier ordered after every cell via CompleteBefore.
+		return nil
 	case graph.NodeTypeModuleInit:
 		return e.processModuleInit(ctx, node)
 	case graph.NodeTypeModule:
@@ -1369,121 +1387,7 @@ func (e *Engine) registerProviderInContext(
 	return nil
 }
 
-// processResource processes a resource definition.
-func (e *Engine) processResource(ctx context.Context, node *graph.Node) error {
-	res := node.Resource
-	if res == nil {
-		return fmt.Errorf("resource node missing Resource field")
-	}
 
-	if node.ModuleInfo != nil {
-		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-			return e.processResourceInContext(ctx, node, res, inst.EvalCtx, inst.URN, inst)
-		})
-	}
-
-	return e.processResourceInContext(ctx, node, res, e.evaluator.Context(), e.stackURN, nil)
-}
-
-func (e *Engine) processResourceInContext(
-	ctx context.Context, node *graph.Node, res *ast.Resource,
-	evalCtx *eval.Context, parentURN urn.URN, modInst *moduleInstance,
-) error {
-	resSchema, err := e.resolver.ResolveResource(ctx, res.Type)
-	if err != nil {
-		if diag := unknownTokenDiag("resource", res.TypeRange, err); diag != err {
-			return diag
-		}
-		return fmt.Errorf("resolving resource type %s: %w", res.Type, err)
-	}
-
-	tempEvaluator := eval.NewEvaluator(evalCtx)
-
-	expander := graph.NewResourceExpander()
-
-	// A reference in count/for_each establishes a dependency (as in TF) that
-	// governs destroy ordering, even when nothing in the body references the
-	// target. Collect those references so every instance depends on them.
-	var metaArgDeps []string
-	unknownArg := ""
-	if res.Count != nil {
-		count, isBool, unknown, deps, diags := tempEvaluator.EvaluateCount(res.Count)
-		if diags.HasErrors() {
-			return fmt.Errorf("evaluating count: %s", diags.Error())
-		}
-		metaArgDeps = append(metaArgDeps, deps...)
-		switch {
-		case unknown:
-			unknownArg = "count"
-		case isBool:
-			expander.SetBoolCount(node.Key, count)
-		default:
-			expander.SetCount(node.Key, count)
-		}
-	}
-
-	if res.ForEach != nil {
-		forEach, unknown, deps, diags := tempEvaluator.EvaluateForEach(res.ForEach)
-		if diags.HasErrors() {
-			return fmt.Errorf("evaluating for_each: %s", diags.Error())
-		}
-		metaArgDeps = append(metaArgDeps, deps...)
-		if unknown {
-			unknownArg = "for_each"
-		} else {
-			expander.SetForEach(node.Key, forEach)
-		}
-	}
-
-	// A count/for_each that reads values this operation has not yet produced
-	// cannot be expanded. During preview, register no instances and bind the
-	// resource address to unknown so downstream references resolve to unknown
-	// rather than an empty collection.
-	if unknownArg != "" {
-		if !e.dryRun {
-			return fmt.Errorf("%s: the %s value depends on values that are not yet known", node.Key, unknownArg)
-		}
-		baseKey := node.Key
-		if node.ModuleInfo != nil {
-			baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix())
-		}
-		evalCtx.SetResource(baseKey, "", cty.UnknownVal(cty.DynamicPseudoType))
-		return nil
-	}
-
-	result := expander.Expand(node)
-
-	for _, instance := range result.Instances {
-		if e.hasFailedDependency(res) {
-			e.failedNodes.Set(instance.Key, fmt.Errorf("skipped: dependency failed"))
-			continue
-		}
-		if err := e.registerResourceInstanceInContext(
-			ctx, node, res, resSchema, instance, evalCtx, parentURN, modInst, metaArgDeps,
-		); err != nil {
-			return fmt.Errorf("registering %s: %w", instance.Key, err)
-		}
-	}
-
-	// Empty count/for_each still needs the resource address bound so downstream
-	// references (e.g. an unconditional module output that walks the resource)
-	// see an empty collection rather than "no such attribute".
-	if len(result.Instances) == 0 && (res.Count != nil || res.ForEach != nil) {
-		baseKey := node.Key
-		if node.ModuleInfo != nil {
-			baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix())
-		}
-		var empty cty.Value
-		if res.Count != nil {
-			empty = cty.EmptyTupleVal
-		} else {
-			empty = cty.EmptyObjectVal
-		}
-		evalCtx.SetResource(baseKey, "", empty)
-	}
-
-	return nil
-}
 
 // registerResourceInstanceInContext registers a single resource instance with Pulumi.
 func (e *Engine) registerResourceInstanceInContext(
@@ -3140,139 +3044,8 @@ func (e *Engine) readResource(
 	return resp.URN, resp.ID, resp.Outputs, nil
 }
 
-// processDataSource processes a data source definition.
-func (e *Engine) processDataSource(ctx context.Context, node *graph.Node) error {
-	ds := node.Resource
-	if ds == nil {
-		return fmt.Errorf("data source node missing Resource field")
-	}
 
-	if node.ModuleInfo != nil {
-		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-			return e.processDataSourceInContext(ctx, node, ds, inst.EvalCtx)
-		})
-	}
 
-	return e.processDataSourceInContext(ctx, node, ds, e.evaluator.Context())
-}
-
-func (e *Engine) processDataSourceInContext(
-	ctx context.Context, node *graph.Node, ds *ast.Resource, evalCtx *eval.Context,
-) error {
-	funcSchema, err := e.resolver.ResolveFunction(ctx, ds.Type)
-	if err != nil {
-		if diag := unknownTokenDiag("data source", ds.TypeRange, err); diag != err {
-			return diag
-		}
-		return fmt.Errorf("resolving data source type %s: %w", ds.Type, err)
-	}
-
-	dsKey := node.Key
-	if node.ModuleInfo != nil {
-		dsKey = strings.TrimPrefix(dsKey, node.ModuleInfo.Prefix())
-	}
-	dsKey = strings.TrimPrefix(dsKey, "data.")
-
-	if ds.Count != nil || ds.ForEach != nil {
-		return e.processRangedDataSource(ctx, node, ds, funcSchema, evalCtx, dsKey)
-	}
-
-	ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx)
-	if err != nil {
-		return err
-	}
-	evalCtx.SetDataSource(dsKey, ctyOutputs)
-	return nil
-}
-
-// processRangedDataSource handles a data source with count or for_each.
-// It expands into N instances, invokes each, and stores the aggregated
-// outputs as a tuple (count) or object keyed by each.key (for_each) so that
-// `data.<type>.<name>[<index>|<key>].<attr>` resolves as expected.
-func (e *Engine) processRangedDataSource(
-	ctx context.Context, node *graph.Node, ds *ast.Resource, funcSchema *schema.Function,
-	evalCtx *eval.Context, dsKey string,
-) error {
-	tempEvaluator := eval.NewEvaluator(evalCtx)
-	expander := graph.NewResourceExpander()
-
-	unknownArg := ""
-	if ds.Count != nil {
-		count, isBool, unknown, _, diags := tempEvaluator.EvaluateCount(ds.Count)
-		if diags.HasErrors() {
-			return fmt.Errorf("evaluating count: %s", diags.Error())
-		}
-		switch {
-		case unknown:
-			unknownArg = "count"
-		case isBool:
-			expander.SetBoolCount(node.Key, count)
-		default:
-			expander.SetCount(node.Key, count)
-		}
-	}
-
-	if ds.ForEach != nil {
-		forEach, unknown, _, diags := tempEvaluator.EvaluateForEach(ds.ForEach)
-		if diags.HasErrors() {
-			return fmt.Errorf("evaluating for_each: %s", diags.Error())
-		}
-		if unknown {
-			unknownArg = "for_each"
-		} else {
-			expander.SetForEach(node.Key, forEach)
-		}
-	}
-
-	// See the matching case in processResourceInContext: unexpandable during
-	// preview means no invokes and an unknown aggregate value.
-	if unknownArg != "" {
-		if !e.dryRun {
-			return fmt.Errorf("%s: the %s value depends on values that are not yet known", node.Key, unknownArg)
-		}
-		evalCtx.SetDataSource(dsKey, cty.UnknownVal(cty.DynamicPseudoType))
-		return nil
-	}
-
-	result := expander.Expand(node)
-
-	var tupleOutputs []cty.Value
-	eachOutputs := make(map[string]cty.Value)
-	isForEach := ds.ForEach != nil
-
-	for _, instance := range result.Instances {
-		instCtx := evalCtx.WithIteration(instance.Index, instance.EachKey, instance.EachValue)
-
-		ctyOut, invokeErr := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, instCtx)
-
-		if invokeErr != nil {
-			return invokeErr
-		}
-		if isForEach {
-			eachOutputs[instance.EachKey.AsString()] = ctyOut
-		} else {
-			tupleOutputs = append(tupleOutputs, ctyOut)
-		}
-	}
-
-	var aggregated cty.Value
-	if isForEach {
-		if len(eachOutputs) == 0 {
-			aggregated = cty.EmptyObjectVal
-		} else {
-			aggregated = cty.ObjectVal(eachOutputs)
-		}
-	} else {
-		if len(tupleOutputs) == 0 {
-			aggregated = cty.EmptyTupleVal
-		} else {
-			aggregated = cty.TupleVal(tupleOutputs)
-		}
-	}
-
-	evalCtx.SetDataSource(dsKey, aggregated)
-	return nil
-}
 
 // invokeDataSourceOnce performs a single data-source invocation using the
 // current state of evalCtx (which may have each/count set by the caller).
@@ -3957,7 +3730,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 		instances = append(instances, insts...)
 	}
 	e.moduleInstances.Set(modInfo.Path, instances)
-	return nil
+	return e.materializeModuleCells(modInfo, instances)
 }
 
 // initModuleCallIn creates the instances of one module call within a single
@@ -4669,14 +4442,28 @@ func (e *Engine) evaluateCheck(ctx context.Context, name string, check *ast.Chec
 }
 
 // readScopedDataSource reads a check's scoped data source into evalCtx, making
-// it available as data.<type>.<name> within that context only.
+// it available as data.<type>.<name> within that context only. Scoped data
+// sources are single reads: they run after the walk, synchronously, outside
+// the expansion-cell machinery.
 func (e *Engine) readScopedDataSource(ctx context.Context, ds *ast.Resource, evalCtx *eval.Context) error {
 	node := &graph.Node{
 		Key:      "data." + ast.ResourceKey(ds.Type, ds.Name),
 		Type:     graph.NodeTypeDataSource,
 		Resource: ds,
 	}
-	return e.processDataSourceInContext(ctx, node, ds, evalCtx)
+	funcSchema, err := e.resolver.ResolveFunction(ctx, ds.Type)
+	if err != nil {
+		if diag := unknownTokenDiag("data source", ds.TypeRange, err); diag != err {
+			return diag
+		}
+		return fmt.Errorf("resolving data source type %s: %w", ds.Type, err)
+	}
+	ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx)
+	if err != nil {
+		return err
+	}
+	evalCtx.SetDataSource(ast.ResourceKey(ds.Type, ds.Name), ctyOutputs)
+	return nil
 }
 
 // warnf emits a best-effort warning diagnostic. A transport failure emitting it

--- a/tests/testutil/tfcompat/providers/ordering.go
+++ b/tests/testutil/tfcompat/providers/ordering.go
@@ -22,21 +22,39 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// OrderProvider exposes `order_resource`, a minimal resource for
-// Case.OrderDeterministic ordering tests: the recorded op sequence itself
-// asserts ordering, so the resource carries no assertion logic of its own.
+// OrderProvider exposes `order_resource` and the `order_data` data source,
+// minimal objects for Case.OrderDeterministic ordering tests: the recorded op
+// sequence itself asserts ordering, so they carry no assertion logic of their
+// own.
 //
-// `delay_create`/`delay_delete` hold that operation open briefly. Set the
-// delay on the op that must complete *first* in the correct order. When the
-// dependency edge under test is honored the delay only stretches the already
-// serialized sequence; when the edge is missing the two ops run concurrently
-// and the undelayed op reliably records ahead of the delayed one, so the
-// regression flips the recorded order deterministically instead of leaving
-// the comparison to a race.
+// `delay_create`/`delay_delete`/`delay_read` hold that operation open briefly.
+// Set the delay on the op that must complete *first* in the correct order.
+// When the dependency edge under test is honored the delay only stretches the
+// already serialized sequence; when the edge is missing the two ops run
+// concurrently and the undelayed op reliably records ahead of the delayed one,
+// so the regression flips the recorded order deterministically instead of
+// leaving the comparison to a race.
 func OrderProvider() *schema.Provider {
 	const delay = 1 * time.Second
 	noop := func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil }
 	return &schema.Provider{
+		DataSourcesMap: map[string]*schema.Resource{
+			"order_data": {
+				Schema: map[string]*schema.Schema{
+					"name":       {Type: schema.TypeString, Required: true},
+					"delay_read": {Type: schema.TypeBool, Optional: true},
+					"result":     {Type: schema.TypeString, Computed: true},
+				},
+				ReadContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					if b, _ := d.Get("delay_read").(bool); b {
+						time.Sleep(delay)
+					}
+					name, _ := d.Get("name").(string)
+					d.SetId(name)
+					return diag.FromErr(d.Set("result", name))
+				},
+			},
+		},
 		ResourcesMap: map[string]*schema.Resource{
 			"order_resource": {
 				Schema: map[string]*schema.Schema{

--- a/tests/tfcompat/l2_count_meta_instance_ref_test.go
+++ b/tests/tfcompat/l2_count_meta_instance_ref_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A `count` meta-argument referencing a single for_each instance
+// (`a["x"].name`, config-known since count must be known at plan) must, like
+// a body reference, depend on only that instance: `b` expands and creates
+// without waiting for the delayed `a["y"]`. The recorded op order proves
+// whether meta-argument references narrow.
+func TestL2CountMetaInstanceRef(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_count_meta_instance_ref", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_data_for_each_set_flow_test.go
+++ b/tests/tfcompat/l2_data_for_each_set_flow_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A for_each resource feeding a for_each data source through a dynamic index
+// (`a[each.key].result`). The dynamic index references the whole resource, so
+// values must flow and every read must wait for every instance; the recorded
+// op order pins the scheduling either way.
+func TestL2DataForEachSetFlow(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_for_each_set_flow", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_data_plan_read_barrier_test.go
+++ b/tests/tfcompat/l2_data_plan_read_barrier_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// OpenTofu reads data sources whose config is fully known during plan, and
+// apply starts only after plan completes — so a delayed read of `d` records
+// before the create of the completely independent `r`. The recorded op order
+// pins that plan-phase reads precede every apply-phase operation, a phase
+// barrier rather than a dependency edge.
+func TestL2DataPlanReadBarrier(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_plan_read_barrier", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_data_ref_instance_test.go
+++ b/tests/tfcompat/l2_data_ref_instance_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A data source read deferred to apply (its config references resource `a`)
+// that names a single instance (`a["x"].result`) must wait only for that
+// instance, not for the delayed `a["y"]`. The recorded op order proves
+// whether deferred data reads participate in instance-narrow scheduling.
+func TestL2DataRefInstance(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_ref_instance", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_data_static_read_order_test.go
+++ b/tests/tfcompat/l2_data_static_read_order_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// Data sources whose config is fully known read during OpenTofu's plan
+// phase, before any create runs. `b` references only `d["x"]`, yet its
+// create must still record after both reads. Guards against over-narrowing
+// references into plan-time data reads.
+func TestL2DataStaticReadOrder(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_static_read_order", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_depends_on_count_chain_test.go
+++ b/tests/tfcompat/l2_depends_on_count_chain_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A chain of instance-addressed depends_on across count resources — each
+// resource waits on the next one's instance [0], the last on nothing — must
+// create in reverse declaration order, and the narrow edges must let the chain
+// finish ahead of the last resource's delayed sibling instance.
+func TestL2DependsOnCountChain(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_depends_on_count_chain", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_depends_on_expanded_destroy_test.go
+++ b/tests/tfcompat/l2_depends_on_expanded_destroy_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// depends_on naming a whole for_each resource must govern destroy ordering:
+// `a["x"]`'s delete waits for `b`'s delayed delete. A runtime that resolves
+// depends_on targets by unexpanded address finds no instance state, records
+// no dependency, and lets a["x"] delete ahead of b.
+func TestL2DependsOnExpandedDestroy(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_depends_on_expanded_destroy", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply},
+			{Mode: tfcompat.StageDestroy},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_depends_on_for_each_instance_destroy_test.go
+++ b/tests/tfcompat/l2_depends_on_for_each_instance_destroy_test.go
@@ -21,10 +21,12 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-// The destroy sibling of TestL2DependsOnForEachInstance: an
-// instance-addressed depends_on (`a["x"]`) must make only that instance's
-// delete wait for `b` — `a["y"]` deletes immediately, ahead of the delayed
-// `b`. The recorded op order proves the persisted dependency is narrow.
+// The destroy sibling of TestL2DependsOnForEachInstance: destroy dependencies
+// are resource-wide in tofu, so an instance-addressed depends_on (`a["x"]`)
+// makes BOTH instances' deletes wait for `b`. The recorded op order proves
+// the persisted dependency covers every registered instance of the target,
+// including expanded targets whose instance outputs are not addressable by
+// the block key.
 func TestL2DependsOnForEachInstanceDestroy(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_depends_on_for_each_instance_destroy", tfcompat.Case{

--- a/tests/tfcompat/l2_depends_on_for_each_instance_destroy_test.go
+++ b/tests/tfcompat/l2_depends_on_for_each_instance_destroy_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// The destroy sibling of TestL2DependsOnForEachInstance: an
+// instance-addressed depends_on (`a["x"]`) must make only that instance's
+// delete wait for `b` — `a["y"]` deletes immediately, ahead of the delayed
+// `b`. The recorded op order proves the persisted dependency is narrow.
+func TestL2DependsOnForEachInstanceDestroy(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_depends_on_for_each_instance_destroy", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply},
+			{Mode: tfcompat.StageDestroy},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_depends_on_for_each_instance_test.go
+++ b/tests/tfcompat/l2_depends_on_for_each_instance_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// depends_on referencing a single for_each instance (`a["x"]`) must create a
+// dependency on only that instance, not the whole resource. OpenTofu honors
+// the instance address; the recorded op order proves whether the runtime keeps
+// the edge narrow or widens it to every instance of `a`.
+func TestL2DependsOnForEachInstance(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_depends_on_for_each_instance", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_local_ref_instance_test.go
+++ b/tests/tfcompat/l2_local_ref_instance_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A single-instance reference (`a["x"].result`) routed through a local must
+// stay narrow: `b` consumes the local and waits only for `a["x"]`, not for
+// the delayed `a["y"]`. The recorded op order proves whether the runtime
+// keeps instance addresses narrow across local values.
+func TestL2LocalRefInstance(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_local_ref_instance", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_module_count_instance_flow_test.go
+++ b/tests/tfcompat/l2_module_count_instance_flow_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// The count sibling of TestL2ModuleForEachInstanceFlow: a reference inside a
+// count module resolves within the same module instance, so m[0].b waits only
+// for m[0].a, never for the delayed m[1].a. The recorded op order proves
+// whether the runtime keeps module-internal edges per module instance for
+// count-keyed instances too.
+func TestL2ModuleCountInstanceFlow(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_count_instance_flow", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_module_for_each_instance_flow_test.go
+++ b/tests/tfcompat/l2_module_for_each_instance_flow_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A reference inside a for_each module resolves within the same module
+// instance: m["x"].b waits only for m["x"].a, never for the delayed
+// m["y"].a. The recorded op order proves whether the runtime keeps
+// module-internal edges per module instance or widens them across all
+// instances of the module.
+func TestL2ModuleForEachInstanceFlow(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_for_each_instance_flow", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_module_instance_depends_on_test.go
+++ b/tests/tfcompat/l2_module_instance_depends_on_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// depends_on referencing a single module instance (`module.m["x"]`) is
+// accepted by tofu, but the dependency applies to the whole module call:
+// `b` waits for the delayed m["y"].a as well. Guards against over-narrowing
+// instance-keyed module depends_on.
+func TestL2ModuleInstanceDependsOn(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_instance_depends_on", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_module_instance_output_ref_test.go
+++ b/tests/tfcompat/l2_module_instance_output_ref_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A parent-scope reference to a single module instance's output
+// (`module.m["x"].result`) does NOT narrow in tofu: module output references
+// resolve at the module-call level, so `b` waits for the delayed m["y"].a as
+// well. Guards against over-narrowing instance-keyed module output
+// references.
+func TestL2ModuleInstanceOutputRef(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_instance_output_ref", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_module_local_instance_flow_test.go
+++ b/tests/tfcompat/l2_module_local_instance_flow_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// Like TestL2ModuleForEachInstanceFlow but with the module-internal `a` → `b`
+// reference routed through a local. Locals evaluate per module instance, so
+// m["x"].b still creates ahead of the delayed m["y"].a. The recorded op order
+// proves whether the runtime keeps locals module-instance-scoped or evaluates
+// them once across all instances of the module.
+func TestL2ModuleLocalInstanceFlow(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_local_instance_flow", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_module_local_instance_flow_test.go
+++ b/tests/tfcompat/l2_module_local_instance_flow_test.go
@@ -22,10 +22,10 @@ import (
 )
 
 // Like TestL2ModuleForEachInstanceFlow but with the module-internal `a` → `b`
-// reference routed through a local. Locals evaluate per module instance, so
-// m["x"].b still creates ahead of the delayed m["y"].a. The recorded op order
-// proves whether the runtime keeps locals module-instance-scoped or evaluates
-// them once across all instances of the module.
+// reference routed through a local. Verified against real tofu: the local
+// WIDENS the edge across module instances — both `b`s wait for the delayed
+// m["y"].a (unlike a direct reference, which stays per-instance). Guards
+// against over-narrowing module locals.
 func TestL2ModuleLocalInstanceFlow(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_module_local_instance_flow", tfcompat.Case{

--- a/tests/tfcompat/l2_ref_count_dynamic_index_test.go
+++ b/tests/tfcompat/l2_ref_count_dynamic_index_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A count resource indexed by a value computed from a data source
+// (`r0[tonumber(data.order_data.idx.result)]`). The dynamic index is a
+// whole-resource reference, so `r1` waits for every `r0` instance — including
+// the delayed `r0[1]` — even though the resolved index selects `r0[0]`. The
+// recorded op order proves the wide dependency, and the stack output proves
+// the index still resolves to the right instance's value once every instance
+// has registered.
+func TestL2RefCountDynamicIndex(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_ref_count_dynamic_index", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_ref_count_index_test.go
+++ b/tests/tfcompat/l2_ref_count_index_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A body reference to a single count instance (`a[0].result`) must create a
+// dependency on only that instance, like a for_each key reference does. The
+// recorded op order proves whether the runtime keeps the edge narrow or widens
+// it to every instance of `a`.
+func TestL2RefCountIndex(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_ref_count_index", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_ref_deferred_data_instance_test.go
+++ b/tests/tfcompat/l2_ref_deferred_data_instance_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A body reference to a single instance of a for_each data source whose reads
+// are deferred to apply (`data.order_data.d["x"].result`) must create a
+// dependency on only that read, not on the delayed `d["y"]` read. The
+// recorded op order proves whether apply-phase data reads are instance-narrow
+// targets like resources are.
+func TestL2RefDeferredDataInstance(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_ref_deferred_data_instance", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_ref_for_each_instance_destroy_test.go
+++ b/tests/tfcompat/l2_ref_for_each_instance_destroy_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// The destroy sibling of TestL2RefForEachInstance: a body reference to
+// `a["x"]` must make only that instance's delete wait for `b` — `a["y"]`
+// deletes immediately, ahead of the delayed `b`. The recorded op order proves
+// the dependency is persisted per instance, not against the whole resource.
+func TestL2RefForEachInstanceDestroy(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_ref_for_each_instance_destroy", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply},
+			{Mode: tfcompat.StageDestroy},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_ref_for_each_instance_destroy_test.go
+++ b/tests/tfcompat/l2_ref_for_each_instance_destroy_test.go
@@ -21,10 +21,10 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-// The destroy sibling of TestL2RefForEachInstance: a body reference to
-// `a["x"]` must make only that instance's delete wait for `b` — `a["y"]`
-// deletes immediately, ahead of the delayed `b`. The recorded op order proves
-// the dependency is persisted per instance, not against the whole resource.
+// The destroy sibling of TestL2RefForEachInstance: destroy dependencies are
+// resource-wide in tofu, so a body reference to `a["x"]` makes BOTH
+// instances' deletes wait for `b`. The recorded op order proves the persisted
+// dependency covers every registered instance of the referenced resource.
 func TestL2RefForEachInstanceDestroy(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_ref_for_each_instance_destroy", tfcompat.Case{

--- a/tests/tfcompat/l2_ref_for_each_instance_test.go
+++ b/tests/tfcompat/l2_ref_for_each_instance_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A body reference to a single for_each instance (`a["x"].result`) must, like
+// an instance-addressed depends_on, create a dependency on only that instance.
+// The recorded op order proves whether the runtime keeps the edge narrow or
+// widens it to every instance of `a`.
+func TestL2RefForEachInstance(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_ref_for_each_instance", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/l2_ref_splat_wide_test.go
+++ b/tests/tfcompat/l2_ref_splat_wide_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A splat reference (`a[*].result`) addresses every instance, so `b` must
+// wait for the delayed `a[1]` too: [a[0], a[1], b]. Guards against a runtime
+// treating the splat's index step as a single-instance address.
+func TestL2RefSplatWide(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_ref_splat_wide", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		OrderDeterministic: true,
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_count_meta_instance_ref/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_count_meta_instance_ref/main.tf
@@ -1,0 +1,22 @@
+# `b`'s count references a single for_each instance. Count must be known at
+# plan time, so it references the config-known `name` (a computed attribute
+# would make tofu fail with "Invalid count argument") — the reference still
+# creates a dependency edge. OpenTofu resolves the literal-indexed
+# meta-argument reference to the exact instance: `b` creates after `a["x"]`
+# only, not after the delayed `a["y"]`, so the recorded create order is
+# [a["x"], b, a["y"]]. A runtime that widens meta-argument references to the
+# whole resource makes `b` wait for `a["y"]` too — a deterministic flip.
+resource "order_resource" "a" {
+  for_each     = toset(["x", "y"])
+  name         = each.key
+  delay_create = each.key == "y"
+}
+
+resource "order_resource" "b" {
+  count = order_resource.a["x"].name == "x" ? 1 : 0
+  name  = "b"
+}
+
+output "b_result" {
+  value = order_resource.b[0].result
+}

--- a/tests/tfcompat/testdata/cases/l2_data_for_each_set_flow/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_for_each_set_flow/main.tf
@@ -1,0 +1,20 @@
+# A resource over a set feeding a data source over the same set through a
+# dynamic index (`a[each.key]`). The dynamic index means the reference is to
+# the whole resource, so every `d` read waits for every `a` instance
+# (including the delayed `a["y"]`): [a["x"], a["y"], d["x"], d["y"]], with
+# `d["y"]`'s read delayed to keep the two reads totally ordered.
+resource "order_resource" "a" {
+  for_each     = toset(["x", "y"])
+  name         = each.key
+  delay_create = each.key == "y"
+}
+
+data "order_data" "d" {
+  for_each   = toset(["x", "y"])
+  name       = order_resource.a[each.key].result
+  delay_read = each.key == "y"
+}
+
+output "d_results" {
+  value = join(",", [for k in sort(keys(data.order_data.d)) : data.order_data.d[k].result])
+}

--- a/tests/tfcompat/testdata/cases/l2_data_plan_read_barrier/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_plan_read_barrier/main.tf
@@ -1,0 +1,17 @@
+# `d` and `r` are completely independent, but OpenTofu reads data sources
+# whose config is fully known during plan, and apply starts only after plan
+# completes: the delayed read still records before the create, [read d,
+# create r]. A runtime that schedules the two concurrently lets the undelayed
+# create record ahead of the delayed read — a deterministic order flip.
+data "order_data" "d" {
+  name       = "d"
+  delay_read = true
+}
+
+resource "order_resource" "r" {
+  name = "r"
+}
+
+output "d_result" {
+  value = data.order_data.d.result
+}

--- a/tests/tfcompat/testdata/cases/l2_data_ref_instance/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_ref_instance/main.tf
@@ -1,0 +1,19 @@
+# A data source references a single for_each instance (`a["x"].result`). The
+# resource dependency defers the read to the apply phase, where OpenTofu
+# resolves the literal-indexed reference to the exact instance: the read waits
+# only for `a["x"]`, not for the delayed `a["y"]`, so the recorded order is
+# [create a["x"], read d, create a["y"]]. A runtime that widens the reference
+# to the whole resource reads after `a["y"]` — a deterministic order flip.
+resource "order_resource" "a" {
+  for_each     = toset(["x", "y"])
+  name         = each.key
+  delay_create = each.key == "y"
+}
+
+data "order_data" "d" {
+  name = order_resource.a["x"].result
+}
+
+output "d_result" {
+  value = data.order_data.d.result
+}

--- a/tests/tfcompat/testdata/cases/l2_data_static_read_order/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_static_read_order/main.tf
@@ -1,0 +1,19 @@
+# A data source whose config is fully known reads during OpenTofu's plan
+# phase, and apply starts only after plan completes. `b` references only
+# `d["x"]`, yet its create still records after BOTH reads (including the
+# delayed `d["y"]`): [read d["x"], read d["y"], create b]. This guards
+# against over-narrowing: a runtime that lets `b` create as soon as `d["x"]`
+# is read records b ahead of the delayed d["y"] — a deterministic flip.
+data "order_data" "d" {
+  for_each   = toset(["x", "y"])
+  name       = each.key
+  delay_read = each.key == "y"
+}
+
+resource "order_resource" "b" {
+  name = "b-${data.order_data.d["x"].result}"
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_depends_on_count_chain/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_depends_on_count_chain/main.tf
@@ -1,0 +1,33 @@
+# A reverse chain across count resources: r0 depends on r1[0], r1 on r2[0],
+# r2 on r3[0], and r3 depends on nothing, so creates run in reverse
+# declaration order. r3's second instance is delayed: the instance-addressed
+# edges let the whole chain complete before r3[1], recording
+# [r3-0, r2, r1, r0, r3-1]. A runtime that widens any hop to the whole
+# resource waits for the delayed r3[1] mid-chain — a deterministic flip.
+resource "order_resource" "r0" {
+  count      = 1
+  name       = "r0"
+  depends_on = [order_resource.r1[0]]
+}
+
+resource "order_resource" "r1" {
+  count      = 1
+  name       = "r1"
+  depends_on = [order_resource.r2[0]]
+}
+
+resource "order_resource" "r2" {
+  count      = 1
+  name       = "r2"
+  depends_on = [order_resource.r3[0]]
+}
+
+resource "order_resource" "r3" {
+  count        = 2
+  name         = "r3-${count.index}"
+  delay_create = count.index == 1
+}
+
+output "r0_result" {
+  value = order_resource.r0[0].result
+}

--- a/tests/tfcompat/testdata/cases/l2_depends_on_expanded_destroy/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_depends_on_expanded_destroy/main.tf
@@ -1,0 +1,22 @@
+# `b` depends_on the whole of an expanded (for_each) resource `a`, with no
+# body reference between them. The depends_on edge must govern destroy
+# ordering: `a["x"]`'s delete waits for `b`'s delayed delete, so the recorded
+# sequence is [create a["x"], create b, delete b, delete a["x"]]. A runtime
+# that fails to resolve depends_on against expanded instance state records no
+# dependency, letting a["x"]'s undelayed delete record ahead of b — a
+# deterministic order flip.
+resource "order_resource" "a" {
+  for_each     = toset(["x"])
+  name         = each.key
+  delay_create = true
+}
+
+resource "order_resource" "b" {
+  depends_on   = [order_resource.a]
+  name         = "b"
+  delay_delete = true
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_depends_on_for_each_instance/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_depends_on_for_each_instance/main.tf
@@ -1,0 +1,22 @@
+# `b` depends_on a single for_each instance `a["x"]`. OpenTofu honors the
+# instance address: `b` waits only for `a["x"]`, not for the delayed `a["y"]`,
+# so the recorded create order is [a["x"], b, a["y"]].
+#
+# The `a["y"]` create is delayed. With the correct narrow edge, `b` (which does
+# not depend on `a["y"]`) records ahead of the delayed `a["y"]`. A runtime that
+# widens the edge to the whole resource `a` makes `b` wait for `a["y"]`, so
+# `a["y"]` records ahead of `b` — a deterministic order flip.
+resource "order_resource" "a" {
+  for_each     = toset(["x", "y"])
+  name         = each.key
+  delay_create = each.key == "y"
+}
+
+resource "order_resource" "b" {
+  depends_on = [order_resource.a["x"]]
+  name       = "b"
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_depends_on_for_each_instance_destroy/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_depends_on_for_each_instance_destroy/main.tf
@@ -1,13 +1,19 @@
-# The destroy sibling of l2_depends_on_for_each_instance: `b` depends_on only
-# `a["x"]`, so on destroy only `a["x"]` must wait for `b` — `a["y"]` deletes
-# immediately. Creates: [a["x"], b, a["y"]] (a["y"]'s create delayed).
-# Destroys: [a["y"], b, a["x"]] (b's delete delayed). A runtime that records
-# the dependency against the whole resource — or drops it entirely because the
-# target is expanded — flips the recorded order deterministically.
+# Destroy ordering for an instance-addressed depends_on. Verified against
+# real tofu: destroy dependencies are resource-wide — even though `b`
+# depends_on only `a["x"]`, BOTH instances' deletes wait for `b`'s delayed
+# delete.
+#
+# Creates: a["x"]'s create is delayed, so `b` (whose depends_on waits for it)
+# registers after both instances exist: [a["y"], a["x"], b]. Destroys: both
+# `a`s wait for the delayed `b`; a["x"]'s delete is also delayed so the two
+# otherwise concurrent deletes record in a total order: [b, a["y"], a["x"]].
+# A runtime that drops the dependency because the target is expanded lets the
+# undelayed a["y"] delete record ahead of `b` — a deterministic order flip.
 resource "order_resource" "a" {
   for_each     = toset(["x", "y"])
   name         = each.key
-  delay_create = each.key == "y"
+  delay_create = each.key == "x"
+  delay_delete = each.key == "x"
 }
 
 resource "order_resource" "b" {

--- a/tests/tfcompat/testdata/cases/l2_depends_on_for_each_instance_destroy/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_depends_on_for_each_instance_destroy/main.tf
@@ -1,0 +1,21 @@
+# The destroy sibling of l2_depends_on_for_each_instance: `b` depends_on only
+# `a["x"]`, so on destroy only `a["x"]` must wait for `b` — `a["y"]` deletes
+# immediately. Creates: [a["x"], b, a["y"]] (a["y"]'s create delayed).
+# Destroys: [a["y"], b, a["x"]] (b's delete delayed). A runtime that records
+# the dependency against the whole resource — or drops it entirely because the
+# target is expanded — flips the recorded order deterministically.
+resource "order_resource" "a" {
+  for_each     = toset(["x", "y"])
+  name         = each.key
+  delay_create = each.key == "y"
+}
+
+resource "order_resource" "b" {
+  depends_on   = [order_resource.a["x"]]
+  name         = "b"
+  delay_delete = true
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_local_ref_instance/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_local_ref_instance/main.tf
@@ -1,0 +1,22 @@
+# `b` references `a["x"]` only through a local. OpenTofu resolves references
+# through locals transitively, keeping the instance address narrow: `b` waits
+# only for `a["x"]`, not for the delayed `a["y"]`, so the recorded create
+# order is [a["x"], b, a["y"]]. A runtime that widens the reference at the
+# local makes `b` wait for `a["y"]` too — a deterministic order flip.
+resource "order_resource" "a" {
+  for_each     = toset(["x", "y"])
+  name         = each.key
+  delay_create = each.key == "y"
+}
+
+locals {
+  picked = order_resource.a["x"].result
+}
+
+resource "order_resource" "b" {
+  name = "b-${local.picked}"
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_count_instance_flow/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_count_instance_flow/child/main.tf
@@ -1,0 +1,16 @@
+variable "idx" {
+  type = number
+}
+
+resource "order_resource" "a" {
+  name         = "a-${var.idx}"
+  delay_create = var.idx == 1
+}
+
+resource "order_resource" "b" {
+  name = "b-${order_resource.a.result}"
+}
+
+output "result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_count_instance_flow/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_count_instance_flow/main.tf
@@ -1,0 +1,15 @@
+# The count sibling of l2_module_for_each_instance_flow: each module
+# instance's `b` depends only on its own instance's `a`. OpenTofu expands
+# modules per count instance, so m[0].b creates as soon as m[0].a is done,
+# ahead of the delayed m[1].a: [a-0, b-0, a-1, b-1]. A runtime that widens
+# module-internal edges across module instances makes both `b`s wait for the
+# delayed a-1 — a deterministic order flip.
+module "m" {
+  source = "./child"
+  count  = 2
+  idx    = count.index
+}
+
+output "results" {
+  value = join(",", [for inst in module.m : inst.result])
+}

--- a/tests/tfcompat/testdata/cases/l2_module_for_each_instance_flow/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_for_each_instance_flow/child/main.tf
@@ -1,0 +1,16 @@
+variable "key" {
+  type = string
+}
+
+resource "order_resource" "a" {
+  name         = "a-${var.key}"
+  delay_create = var.key == "y"
+}
+
+resource "order_resource" "b" {
+  name = "b-${order_resource.a.result}"
+}
+
+output "result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_for_each_instance_flow/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_for_each_instance_flow/main.tf
@@ -1,0 +1,14 @@
+# Each module instance's `b` depends only on its own instance's `a`. OpenTofu
+# expands modules per instance, so m["x"].b creates as soon as m["x"].a is
+# done, ahead of the delayed m["y"].a: [a-x, b-x, a-y, b-y]. A runtime that
+# widens module-internal edges across module instances makes both `b`s wait
+# for the delayed a-y — a deterministic order flip.
+module "m" {
+  source   = "./child"
+  for_each = toset(["x", "y"])
+  key      = each.key
+}
+
+output "results" {
+  value = join(",", [for k in sort(keys(module.m)) : module.m[k].result])
+}

--- a/tests/tfcompat/testdata/cases/l2_module_instance_depends_on/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_instance_depends_on/child/main.tf
@@ -1,0 +1,12 @@
+variable "key" {
+  type = string
+}
+
+resource "order_resource" "a" {
+  name         = "a-${var.key}"
+  delay_create = var.key == "y"
+}
+
+output "result" {
+  value = order_resource.a.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_instance_depends_on/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_instance_depends_on/main.tf
@@ -1,0 +1,20 @@
+# `b` depends_on a single module instance (`module.m["x"]`). Verified against
+# real tofu: the instance key is accepted but the dependency applies to the
+# whole module call — `b` waits for the delayed m["y"].a as well, so the
+# recorded create order is [a-x, a-y, b]. This guards against over-narrowing:
+# a runtime that honors the instance key records b ahead of the delayed a-y —
+# a deterministic order flip.
+module "m" {
+  source   = "./child"
+  for_each = toset(["x", "y"])
+  key      = each.key
+}
+
+resource "order_resource" "b" {
+  depends_on = [module.m["x"]]
+  name       = "b"
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_instance_output_ref/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_instance_output_ref/child/main.tf
@@ -1,0 +1,12 @@
+variable "key" {
+  type = string
+}
+
+resource "order_resource" "a" {
+  name         = "a-${var.key}"
+  delay_create = var.key == "y"
+}
+
+output "result" {
+  value = order_resource.a.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_instance_output_ref/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_instance_output_ref/main.tf
@@ -1,0 +1,20 @@
+# `b` references a single module instance's output (`module.m["x"].result`).
+# Verified against real tofu: unlike an instance-keyed *resource* reference,
+# this does NOT narrow — module output references resolve at the module-call
+# level, so `b` waits for the delayed m["y"].a as well and the recorded
+# create order is [a-x, a-y, b]. This guards against over-narrowing: a
+# runtime that lets `b` create after only m["x"] records b ahead of the
+# delayed a-y — a deterministic order flip.
+module "m" {
+  source   = "./child"
+  for_each = toset(["x", "y"])
+  key      = each.key
+}
+
+resource "order_resource" "b" {
+  name = "b-${module.m["x"].result}"
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_local_instance_flow/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_local_instance_flow/child/main.tf
@@ -1,0 +1,20 @@
+variable "key" {
+  type = string
+}
+
+resource "order_resource" "a" {
+  name         = "a-${var.key}"
+  delay_create = var.key == "y"
+}
+
+locals {
+  r = order_resource.a.result
+}
+
+resource "order_resource" "b" {
+  name = "b-${local.r}"
+}
+
+output "result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_local_instance_flow/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_local_instance_flow/child/main.tf
@@ -12,7 +12,8 @@ locals {
 }
 
 resource "order_resource" "b" {
-  name = "b-${local.r}"
+  name         = "b-${local.r}"
+  delay_create = var.key == "y"
 }
 
 output "result" {

--- a/tests/tfcompat/testdata/cases/l2_module_local_instance_flow/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_local_instance_flow/main.tf
@@ -1,0 +1,15 @@
+# Like l2_module_for_each_instance_flow, but the module-internal reference
+# from `b` to `a` is routed through a local. OpenTofu evaluates locals per
+# module instance, so m["x"].b still creates as soon as m["x"].a is done,
+# ahead of the delayed m["y"].a: [a-x, b-x, a-y, b-y]. A runtime that
+# evaluates the local once across all module instances makes both `b`s wait
+# for the delayed a-y — a deterministic order flip.
+module "m" {
+  source   = "./child"
+  for_each = toset(["x", "y"])
+  key      = each.key
+}
+
+output "results" {
+  value = join(",", [for k in sort(keys(module.m)) : module.m[k].result])
+}

--- a/tests/tfcompat/testdata/cases/l2_module_local_instance_flow/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_local_instance_flow/main.tf
@@ -1,9 +1,11 @@
-# Like l2_module_for_each_instance_flow, but the module-internal reference
-# from `b` to `a` is routed through a local. OpenTofu evaluates locals per
-# module instance, so m["x"].b still creates as soon as m["x"].a is done,
-# ahead of the delayed m["y"].a: [a-x, b-x, a-y, b-y]. A runtime that
-# evaluates the local once across all module instances makes both `b`s wait
-# for the delayed a-y — a deterministic order flip.
+# A module-internal reference routed through a local, in a for_each module.
+# Verified against real tofu: unlike a direct resource reference (which stays
+# per-instance, see l2_module_for_each_instance_flow), a reference THROUGH a
+# module local widens across module instances — both `b`s wait for the delayed
+# m["y"].a. b-y's own create is also delayed so the two otherwise-concurrent
+# `b`s record in a total order: [a-x, a-y, b-x, b-y]. This guards against
+# over-narrowing module locals: a runtime that scopes the local per module
+# instance records b-x ahead of the delayed a-y — a deterministic order flip.
 module "m" {
   source   = "./child"
   for_each = toset(["x", "y"])

--- a/tests/tfcompat/testdata/cases/l2_ref_count_dynamic_index/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ref_count_dynamic_index/main.tf
@@ -1,0 +1,26 @@
+# A count resource indexed by a value computed from a data source
+# (`r0[tonumber(data.order_data.idx.result)]`). The index is dynamic, so the
+# reference is to the whole resource: `r1` must wait for every `r0` instance,
+# including the delayed `r0[1]`, even though the resolved index selects
+# `r0[0]`. The data source's config is fully known, so it reads at plan time,
+# ahead of every create: the recorded order is [read idx, r0[0], r0[1], r1].
+# `r0[1]`'s create is delayed, so a runtime that narrowed the edge to only the
+# selected instance would record `r1` ahead of `r0[1]` — a deterministic order
+# flip. The output pins that the dynamic index still resolves to r0[0]'s value.
+data "order_data" "idx" {
+  name = "0"
+}
+
+resource "order_resource" "r0" {
+  count        = 2
+  name         = "r0-${count.index}"
+  delay_create = count.index == 1
+}
+
+resource "order_resource" "r1" {
+  name = "r1-${order_resource.r0[tonumber(data.order_data.idx.result)].result}"
+}
+
+output "r1_result" {
+  value = order_resource.r1.result
+}

--- a/tests/tfcompat/testdata/cases/l2_ref_count_index/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ref_count_index/main.tf
@@ -1,0 +1,16 @@
+# `b` references a single count instance `a[0]` in its body. OpenTofu resolves
+# a literal-indexed reference to the exact instance: `b` waits only for `a[0]`,
+# not for the delayed `a[1]`, so the recorded create order is [a[0], b, a[1]].
+resource "order_resource" "a" {
+  count        = 2
+  name         = "a-${count.index}"
+  delay_create = count.index == 1
+}
+
+resource "order_resource" "b" {
+  name = "b-${order_resource.a[0].result}"
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_ref_deferred_data_instance/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ref_deferred_data_instance/main.tf
@@ -1,0 +1,23 @@
+# `b` references a single instance of a for_each data source whose reads are
+# deferred to apply (they depend on resource `a`). In OpenTofu's apply graph
+# each read is its own node, so `b` waits only for the `d["x"]` read, not for
+# the delayed `d["y"]` read: [create a, read d["x"], create b, read d["y"]].
+# A runtime that widens the reference to the whole data source makes `b` wait
+# for the delayed d["y"] — a deterministic order flip.
+resource "order_resource" "a" {
+  name = "a"
+}
+
+data "order_data" "d" {
+  for_each   = toset(["x", "y"])
+  name       = "${order_resource.a.result}-${each.key}"
+  delay_read = each.key == "y"
+}
+
+resource "order_resource" "b" {
+  name = "b-${data.order_data.d["x"].result}"
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_ref_for_each_instance/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ref_for_each_instance/main.tf
@@ -1,0 +1,18 @@
+# `b` references a single for_each instance `a["x"]` in its body. OpenTofu
+# resolves a literal-indexed reference to the exact instance: `b` waits only
+# for `a["x"]`, not for the delayed `a["y"]`, so the recorded create order is
+# [a["x"], b, a["y"]]. A runtime that widens the reference to the whole
+# resource `a` makes `b` wait for `a["y"]` too — a deterministic order flip.
+resource "order_resource" "a" {
+  for_each     = toset(["x", "y"])
+  name         = each.key
+  delay_create = each.key == "y"
+}
+
+resource "order_resource" "b" {
+  name = "b-${order_resource.a["x"].result}"
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_ref_for_each_instance_destroy/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ref_for_each_instance_destroy/main.tf
@@ -1,0 +1,21 @@
+# The destroy sibling of l2_ref_for_each_instance: `b` references only
+# `a["x"]`, so on destroy only `a["x"]` must wait for `b` — `a["y"]` deletes
+# immediately. Creates: [a["x"], b, a["y"]] (a["y"]'s create delayed).
+# Destroys: [a["y"], b, a["x"]] (b's delete delayed, so the undelayed a["y"]
+# records first and a["x"] must record after b). A runtime that records a
+# dependency on the whole resource makes a["y"]'s delete wait for b — its
+# delete then records after the delayed b, a deterministic order flip.
+resource "order_resource" "a" {
+  for_each     = toset(["x", "y"])
+  name         = each.key
+  delay_create = each.key == "y"
+}
+
+resource "order_resource" "b" {
+  name         = "b-${order_resource.a["x"].result}"
+  delay_delete = true
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_ref_for_each_instance_destroy/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ref_for_each_instance_destroy/main.tf
@@ -1,14 +1,19 @@
-# The destroy sibling of l2_ref_for_each_instance: `b` references only
-# `a["x"]`, so on destroy only `a["x"]` must wait for `b` — `a["y"]` deletes
-# immediately. Creates: [a["x"], b, a["y"]] (a["y"]'s create delayed).
-# Destroys: [a["y"], b, a["x"]] (b's delete delayed, so the undelayed a["y"]
-# records first and a["x"] must record after b). A runtime that records a
-# dependency on the whole resource makes a["y"]'s delete wait for b — its
-# delete then records after the delayed b, a deterministic order flip.
+# Destroy ordering for a body reference to a single for_each instance.
+# Verified against real tofu: destroy dependencies are resource-wide — even
+# though `b` references only `a["x"]`, BOTH instances' deletes wait for `b`'s
+# delayed delete.
+#
+# Creates: a["x"]'s create is delayed, so `b` (which waits for it) registers
+# after both instances exist: [a["y"], a["x"], b]. Destroys: both `a`s wait
+# for the delayed `b`; a["x"]'s delete is also delayed so the two otherwise
+# concurrent deletes record in a total order: [b, a["y"], a["x"]]. A runtime
+# that records no dependency on the expanded target lets the undelayed
+# a["y"] delete record ahead of `b` — a deterministic order flip.
 resource "order_resource" "a" {
   for_each     = toset(["x", "y"])
   name         = each.key
-  delay_create = each.key == "y"
+  delay_create = each.key == "x"
+  delay_delete = each.key == "x"
 }
 
 resource "order_resource" "b" {

--- a/tests/tfcompat/testdata/cases/l2_ref_splat_wide/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ref_splat_wide/main.tf
@@ -1,0 +1,18 @@
+# `b` references `a` through a splat (`a[*].result`), which addresses every
+# instance: `b` must wait for the delayed `a[1]` as well, so the recorded
+# create order is [a[0], a[1], b]. This guards against over-narrowing: a
+# runtime that treats the splat's index step as a single-instance address lets
+# `b` record ahead of the delayed a[1] — a deterministic order flip.
+resource "order_resource" "a" {
+  count        = 2
+  name         = "a-${count.index}"
+  delay_create = count.index == 1
+}
+
+resource "order_resource" "b" {
+  name = "b-${join(",", order_resource.a[*].result)}"
+}
+
+output "b_result" {
+  value = order_resource.b.result
+}


### PR DESCRIPTION
## What

The engine executed a block-level dependency graph: an edge meant "b starts after *everything* in a finishes." That is coarser than Terraform/OpenTofu, which schedule at the granularity of individual `count`/`for_each` instances. This PR keeps the block-level graph as a validation-and-completion skeleton and adds an instance-level scheduling layer inside the same parallel walk, so ordering happens per instance while the block graph still anchors cycle detection, `Validate`, completion, and create-before-destroy.

A body reference or `depends_on` to a single instance (`a["x"]`, `a[0]`) now waits only for that instance, not the whole resource; independent instances of the same block run concurrently; and data sources whose inputs are fully known read before any resource is created, reproducing the plan/apply phase boundary. Dependency *metadata* stays resource-wide, so destroy ordering still makes every instance of a referenced resource wait for its consumers.

## How

Three layers, each landed in its own commit:

1. **Classification** (`pkg/hcl/graph`) — every resource/data block and root local records its dependencies in classified form (`BlockDeps`): static graph nodes, whole-block references, and literal-indexed single-instance references. The pre-existing block-level edge set is unchanged, so cycle detection, `Validate`, and completion ordering stay block-granular.
2. **Scheduling primitive** (`pkg/hcl/graph/expansion.go`) — `BlockExpansion` expresses per-instance expansion in `pdag` terms: an `expand` node evaluates `count`/`for_each` and creates one node per instance, a `complete` node fires after all instances, and per-instance `gate` nodes let a narrow consumer bind to a single instance. Liveness holds by construction — no error path can strand the walk.
3. **Engine driver** (`pkg/hcl/run/cells.go`) — a *cell* is one (block × module instance). Root cells materialize before the walk; a module's cells materialize in its init node, so module-internal edges resolve per module instance. Also here: the plan-read barrier and the per-cell URN registry that records resource-wide dependency metadata.

The evaluation context assembles partial `count`/`for_each` collections from the instances published so far; a consumer only ever reads instances it holds a dependency edge on, and those have already published, so no declared-shape bookkeeping is needed.

## Behavior, verified against real `tofu`

The tfcompat harness runs real `tofu apply` and `pulumi up` against the same in-memory providers and compares the recorded provider-op order. Several of my initial assumptions were wrong and were corrected against actual `tofu`:

| Dimension | Semantics |
|---|---|
| Instance refs, `depends_on`, `count` meta-args (creates) | narrow |
| Dynamic index, splat | wide |
| Module-internal edges | per module instance |
| Module boundary (outputs, `module.m["x"]`, module-instance `depends_on`) | wide |
| Root locals | narrow |
| Module locals | wide |
| Plan-time data reads | all before any create |
| Destroy dependencies | resource-wide |

## Tests

The first commit extends the `OrderDeterministic` tfcompat suite to cover every dimension above (each case delays the operation that must complete first, so a missing or mis-scoped edge flips the recorded order deterministically). The guard cases — the "wide" rows that must *not* narrow — matter as much as the narrow ones. All 26 ordering cases pass at `-count=3`; the full tfcompat suite and `pkg/...` unit tests are green and race-clean.

## Known ceilings

- An instance that registers after its consumer cannot appear in that consumer's recorded destroy dependencies (its URN does not exist yet), so on destroy Pulumi is strictly narrower than `tofu` in that one window.
- `deleted_with` / `replace_triggered_by` still resolve a whole-expanded reference by the bare block key; the right single-URN semantics there is a separate decision.
- `hasFailedDependency` stays block-coarse.

Closes https://github.com/pulumi-labs/pulumi-hcl/pull/416