### PR TITLE
Support `for_each` and dynamic index keys on `import` blocks

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-424.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-424.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Support `for_each` and dynamic index keys on `import` blocks
+time: 2026-07-17T22:30:00Z
+custom:
+    Component: runtime
+    PR: "424"

--- a/pkg/hcl/ast/import.go
+++ b/pkg/hcl/ast/import.go
@@ -29,8 +29,14 @@ import (
 //
 // This maps to Pulumi's ImportId resource option on the target resource.
 type Import struct {
-	// To is the target resource address.
-	To hcl.Traversal
+	// To is the target resource address expression. Its traversal parts are
+	// static, but index keys may be arbitrary expressions (e.g. each.key when
+	// the block has for_each), so they are evaluated at runtime.
+	To hcl.Expression
+
+	// ForEach expands the block into one import per element, with
+	// each.key/each.value in scope for To and Id.
+	ForEach hcl.Expression
 
 	// Id is the expression for the external resource ID to import. It is
 	// evaluated at runtime and must produce a known, non-null, non-sensitive

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
 	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -1413,11 +1414,8 @@ func (p *Parser) parseImportBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	}
 
 	if attr, ok := content.Attributes["to"]; ok {
-		traversal, travDiags := hcl.AbsTraversalForExpr(attr.Expr)
-		diags = append(diags, travDiags...)
-		if traversal != nil {
-			imp.To = traversal
-		}
+		diags = append(diags, validateImportToExpr(attr.Expr)...)
+		imp.To = attr.Expr
 	}
 
 	if attr, ok := content.Attributes["id"]; ok {
@@ -1428,6 +1426,33 @@ func (p *Parser) parseImportBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 		imp.Provider = attr.Expr
 	}
 
+	if attr, ok := content.Attributes["for_each"]; ok {
+		imp.ForEach = attr.Expr
+	}
+
 	config.Imports = append(config.Imports, imp)
 	return diags
+}
+
+// validateImportToExpr checks that an import block's `to` expression has the
+// shape of a resource address. Traversal parts must be static, but index keys
+// may be arbitrary expressions (e.g. each.key), so they are not inspected
+// here; they are evaluated at runtime.
+func validateImportToExpr(expr hcl.Expression) hcl.Diagnostics {
+	if _, diags := hcl.AbsTraversalForExpr(expr); !diags.HasErrors() {
+		return nil
+	}
+	switch e := expr.(type) {
+	case *hclsyntax.IndexExpr:
+		return validateImportToExpr(e.Collection)
+	case *hclsyntax.RelativeTraversalExpr:
+		return validateImportToExpr(e.Source)
+	default:
+		return hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid import address expression",
+			Detail:   "Import address must be a reference to a resource's address, and only allows for indexing with dynamic keys.",
+			Subject:  expr.Range().Ptr(),
+		}}
+	}
 }

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -304,5 +304,6 @@ var importSchema = &hcl.BodySchema{
 		{Name: "to", Required: true},
 		{Name: "id", Required: true},
 		{Name: "provider"},
+		{Name: "for_each"},
 	},
 }

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2390,7 +2390,8 @@ func instanceKeysEqual(aIdx *int, aEach *string, bIdx *int, bEach *string) bool 
 // and returns its import ID. An import address names a single instance: its
 // module-call steps must match the resource's module instance path, and on a
 // count/for_each resource each instance takes only the ID of the import block
-// keyed with its own instance key.
+// keyed with its own instance key. An import block with for_each expands into
+// one import per element, with each.key/each.value in scope for `to` and `id`.
 func (e *Engine) resolveImportId(
 	res *ast.Resource, index *int, eachKey *string, modInst *moduleInstance,
 ) (string, error) {
@@ -2400,27 +2401,135 @@ func (e *Engine) resolveImportId(
 	}
 
 	for _, imp := range e.config.Imports {
-		to, ok := parseTargetAddr(imp.To)
-		if !ok || to.Type != res.Type || to.Name != res.Name {
-			continue
-		}
-		if appendModuleSteps(modulepath.Root(), to.modules) != resPath {
-			continue
-		}
-		if to.keyed() || index != nil || eachKey != nil {
-			if !instanceKeysEqual(index, eachKey, to.keyIndex, to.keyEach) {
-				continue
+		evs := []*eval.Evaluator{e.evaluator}
+		if imp.ForEach != nil {
+			forEach, unknown, _, diags := e.evaluator.EvaluateForEach(imp.ForEach)
+			if diags.HasErrors() {
+				return "", diags
+			}
+			if unknown {
+				return "", hcl.Diagnostics{{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid for_each argument",
+					Detail:   `The import block "for_each" argument depends on resource attributes that cannot be determined until apply.`,
+					Subject:  imp.ForEach.Range().Ptr(),
+				}}
+			}
+			evs = evs[:0]
+			for k, v := range forEach {
+				kVal := cty.StringVal(k)
+				evs = append(evs, eval.NewEvaluator(e.evaluator.Context().WithIteration(nil, &kVal, &v)))
 			}
 		}
-		return e.evaluateImportId(imp)
+		for _, ev := range evs {
+			id, matched, err := e.matchImport(imp, ev, res, index, eachKey, resPath)
+			if matched || err != nil {
+				return id, err
+			}
+		}
 	}
 
 	return "", nil
 }
 
+// matchImport reports whether imp targets the given resource instance and, if
+// so, returns its import ID. ev carries each.key/each.value when the import
+// block has for_each.
+func (e *Engine) matchImport(
+	imp *ast.Import, ev *eval.Evaluator,
+	res *ast.Resource, index *int, eachKey *string, resPath modulepath.Path,
+) (string, bool, error) {
+	traversal, diags := importToTraversal(ev, imp.To)
+	if diags.HasErrors() {
+		return "", false, diags
+	}
+	to, ok := parseTargetAddr(traversal)
+	if !ok || to.Type != res.Type || to.Name != res.Name {
+		return "", false, nil
+	}
+	if appendModuleSteps(modulepath.Root(), to.modules) != resPath {
+		return "", false, nil
+	}
+	if to.keyed() || index != nil || eachKey != nil {
+		if !instanceKeysEqual(index, eachKey, to.keyIndex, to.keyEach) {
+			return "", false, nil
+		}
+	}
+	id, err := e.evaluateImportId(imp, ev)
+	return id, true, err
+}
+
+// importToTraversal converts an import block's `to` expression into a static
+// traversal. Index keys may be arbitrary expressions (e.g. each.key); they are
+// evaluated with ev and must produce a known, non-null, non-sensitive string
+// or number.
+func importToTraversal(ev *eval.Evaluator, expr hcl.Expression) (hcl.Traversal, hcl.Diagnostics) {
+	if t, diags := hcl.AbsTraversalForExpr(expr); !diags.HasErrors() {
+		return t, nil
+	}
+	switch e := expr.(type) {
+	case *hclsyntax.IndexExpr:
+		t, diags := importToTraversal(ev, e.Collection)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+		key, keyDiags := importIndexKey(ev, e.Key)
+		if keyDiags.HasErrors() {
+			return nil, keyDiags
+		}
+		return append(t, key), nil
+	case *hclsyntax.RelativeTraversalExpr:
+		t, diags := importToTraversal(ev, e.Source)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+		return append(t, e.Traversal...), nil
+	default:
+		return nil, hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid import address expression",
+			Detail:   "Import address must be a reference to a resource's address, and only allows for indexing with dynamic keys.",
+			Subject:  expr.Range().Ptr(),
+		}}
+	}
+}
+
+// importIndexKey evaluates an index-key expression of an import address into a
+// TraverseIndex step.
+func importIndexKey(ev *eval.Evaluator, expr hcl.Expression) (hcl.TraverseIndex, hcl.Diagnostics) {
+	idx := hcl.TraverseIndex{SrcRange: expr.Range()}
+	errf := func(detail string) hcl.Diagnostics {
+		return hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Import block 'to' address contains an invalid key",
+			Detail:   detail,
+			Subject:  expr.Range().Ptr(),
+		}}
+	}
+	val, diags := ev.EvaluateExpression(expr)
+	if diags.HasErrors() {
+		return idx, diags
+	}
+	sensitive := val.HasMark(eval.SensitiveMark)
+	val, _ = val.Unmark()
+	switch {
+	case !val.IsKnown():
+		return idx, errf("The index of an import target address must be known at plan time.")
+	case val.IsNull():
+		return idx, errf("The index of an import target address cannot be null.")
+	case val.Type() != cty.String && val.Type() != cty.Number:
+		return idx, errf("The index of an import target address must be a string or a number.")
+	case sensitive:
+		return idx, errf("The index of an import target address cannot be sensitive.")
+	}
+	idx.Key = val
+	return idx, nil
+}
+
 // evaluateImportId evaluates an import block's id expression, which must
-// produce a known, non-null, non-sensitive string at plan time.
-func (e *Engine) evaluateImportId(imp *ast.Import) (string, error) {
+// produce a known, non-null, non-sensitive string at plan time. ev carries
+// each.key/each.value when the import block has for_each.
+func (e *Engine) evaluateImportId(imp *ast.Import, ev *eval.Evaluator) (string, error) {
 	errf := func(detail string) error {
 		var subject *hcl.Range
 		if imp.Id != nil {
@@ -2439,7 +2548,7 @@ func (e *Engine) evaluateImportId(imp *ast.Import) (string, error) {
 	if imp.Id == nil {
 		return "", errf("The import ID cannot be null.")
 	}
-	val, diags := e.evaluator.EvaluateExpression(imp.Id)
+	val, diags := ev.EvaluateExpression(imp.Id)
 	if diags.HasErrors() {
 		return "", diags
 	}

--- a/tests/tfcompat/l2_import_foreach_test.go
+++ b/tests/tfcompat/l2_import_foreach_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+func TestL2ImportForEach(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_import_foreach", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "importable", Factory: providers.ImportableProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_import_foreach/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_import_foreach/main.tf
@@ -1,0 +1,15 @@
+resource "importable_resource" "foo" {
+  for_each = toset(["a", "b"])
+}
+
+# OpenTofu 1.7+ supports for_each on the import block itself, expanding one
+# block into an import per element with each.key/each.value in scope.
+import {
+  for_each = { a = "id-a", b = "id-b" }
+  to       = importable_resource.foo[each.key]
+  id       = each.value
+}
+
+output "names" {
+  value = { for k, r in importable_resource.foo : k => r.name }
+}

--- a/tests/tfcompat/testdata/cases/l2_import_foreach/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_import_foreach/main.tf
@@ -13,3 +13,21 @@ import {
 output "names" {
   value = { for k, r in importable_resource.foo : k => r.name }
 }
+
+# An import address may also use a dynamic index key without for_each.
+variable "which" {
+  default = "b"
+}
+
+resource "importable_resource" "dyn" {
+  for_each = toset(["a", "b"])
+}
+
+import {
+  to = importable_resource.dyn[var.which]
+  id = "id-dyn"
+}
+
+output "dyn_names" {
+  value = { for k, r in importable_resource.dyn : k => r.name }
+}


### PR DESCRIPTION
## Divergence

OpenTofu 1.7+ supports `for_each` on an `import {}` block, expanding one block into an import per element with `each.key`/`each.value` in scope for `to` and `id`. It also allows dynamic index keys in an import address without `for_each` (e.g. `to = importable_resource.dyn[var.which]`). pulumi-hcl rejected both at parse time:

```
tofu apply:  succeeds (imports importable_resource.foo["a"] and ["b"])
pulumi up:   Unsupported argument; An argument named "for_each" is not expected here. (+1 diagnostic from each.key in `to`)
```

Distinct from the already-fixed https://github.com/pulumi-labs/pulumi-hcl/pull/401 (import id var-ref).

## Fix

Mirrors OpenTofu (`configs/import.go`, `ImportResolver.ExpandAndResolveImport`, `EvaluateImportAddress`):

- `ast.Import.To` is now an `hcl.Expression` (index keys may be dynamic) and the struct gains a `ForEach` field.
- The parser accepts `for_each` in the import schema and validates only the static shape of `to` (traversal parts static, index keys arbitrary expressions).
- `resolveImportId` builds one evaluator per import block — or one per `for_each` element with `each.key`/`each.value` bound — then evaluates the `to` address and, on an instance match, the `id`, in that scope. Index keys must be known, non-null, non-sensitive strings or numbers; an unknown `for_each` errors at plan time, as in OpenTofu.

## Test

`TestL2ImportForEach` (`tests/tfcompat/l2_import_foreach_test.go`) covers a `for_each` import block plus a dynamic-index import without `for_each`, comparing against real `tofu apply`. Failed on master, passes with the fix; existing `TestL2Import`/`TestL2ImportLocalId` still pass.
