### PR TITLE
Support nested template function calls inside rendered templates

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-425.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-425.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Support `templatestring` and recursion-limited `templatefile` calls inside rendered templates
+time: 2026-07-17T12:00:00Z
+custom:
+    Component: runtime
+    PR: "425"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -236,18 +236,15 @@ func Functions(baseDir string) map[string]function.Function {
 	}
 
 	// templatefile and templatestring render a file or string as a template. The
-	// functions available inside that template are every function except the
-	// template functions themselves, which keeps a template from invoking itself
-	// recursively without bound.
-	nestedTemplateFuncs := make(map[string]function.Function, len(funcs))
-	for name, fn := range funcs {
-		if name == "templatefile" || name == "templatestring" {
-			continue
-		}
-		nestedTemplateFuncs[name] = fn
-	}
-	funcs["templatefile"] = templateFileFunc(baseDir, nestedTemplateFuncs)
-	funcs["templatestring"] = templateStringFunc(nestedTemplateFuncs)
+	// rendered template may itself call the template functions: templatestring
+	// passes the full table through unchanged, and templatefile replaces itself
+	// inside each rendered template with a variant that counts recursion depth
+	// and errors past the limit. The callback defers the table lookup so the map
+	// can refer to itself, and so later additions to it (e.g. provider
+	// functions) are visible inside templates too.
+	funcsCb := func() map[string]function.Function { return funcs }
+	funcs["templatefile"] = templateFileFunc(baseDir, funcsCb, 0)
+	funcs["templatestring"] = templateStringFunc(funcsCb)
 
 	return funcs
 }
@@ -1433,14 +1430,39 @@ func fileBase64Func(baseDir string) function.Function {
 	})
 }
 
+// templateMaxRecursionDepth returns the maximum number of nested templatefile
+// renders allowed, from the TF_TEMPLATE_RECURSION_DEPTH environment variable
+// or a default of 1024.
+func templateMaxRecursionDepth() (int, error) {
+	const envkey = "TF_TEMPLATE_RECURSION_DEPTH"
+	if val := os.Getenv(envkey); val != "" {
+		i, err := strconv.Atoi(val)
+		if err != nil {
+			return -1, fmt.Errorf("invalid value for %s: %w", envkey, err)
+		}
+		return i, nil
+	}
+	return 1024, nil
+}
+
 // templateFileFunc reads the file at its first argument and renders it as an HCL
 // template using the variables in its second argument, just like OpenTofu: the
 // file's interpolations may call functions and use `%{ for }` / `%{ if }`
-// directives. nestedFuncs is the function table made available inside the
-// template; it omits the template functions themselves to prevent unbounded
-// recursion.
-func templateFileFunc(baseDir string, nestedFuncs map[string]function.Function) function.Function {
+// directives. funcsCb supplies the function table made available inside the
+// template, with templatefile itself replaced by a variant whose recursion
+// depth is one greater; depth counts how many templatefile renders are already
+// on the stack, and rendering fails past the limit.
+func templateFileFunc(
+	baseDir string, funcsCb func() map[string]function.Function, depth int,
+) function.Function {
 	render := func(args []cty.Value) (cty.Value, error) {
+		maxDepth, err := templateMaxRecursionDepth()
+		if err != nil {
+			return cty.NilVal, err
+		}
+		if depth > maxDepth {
+			return cty.NilVal, fmt.Errorf("maximum recursion depth %d reached", maxDepth)
+		}
 		path := args[0].AsString()
 		fullPath, err := resolveFilePath(baseDir, path)
 		if err != nil {
@@ -1449,6 +1471,14 @@ func templateFileFunc(baseDir string, nestedFuncs map[string]function.Function) 
 		content, err := os.ReadFile(fullPath)
 		if err != nil {
 			return cty.NilVal, err
+		}
+		given := funcsCb()
+		nestedFuncs := make(map[string]function.Function, len(given))
+		for name, fn := range given {
+			if name == "templatefile" {
+				fn = templateFileFunc(baseDir, funcsCb, depth+1)
+			}
+			nestedFuncs[name] = fn
 		}
 		return renderTemplate(path, cty.StringVal(string(content)), args[1], nestedFuncs)
 	}
@@ -1477,9 +1507,9 @@ func templateFileFunc(baseDir string, nestedFuncs map[string]function.Function) 
 }
 
 // templateStringFunc renders its first argument as an HCL template using the
-// variables in its second argument. nestedFuncs is the function table made
-// available inside the template.
-func templateStringFunc(nestedFuncs map[string]function.Function) function.Function {
+// variables in its second argument. funcsCb supplies the function table made
+// available inside the template, unchanged.
+func templateStringFunc(funcsCb func() map[string]function.Function) function.Function {
 	return function.New(&function.Spec{
 		Params: []function.Parameter{
 			{Name: "template", Type: cty.String},
@@ -1492,14 +1522,14 @@ func templateStringFunc(nestedFuncs map[string]function.Function) function.Funct
 			if !args[0].IsKnown() || !args[1].IsKnown() {
 				return cty.DynamicPseudoType, nil
 			}
-			val, err := renderTemplate("<templatestring>", args[0], args[1], nestedFuncs)
+			val, err := renderTemplate("<templatestring>", args[0], args[1], funcsCb())
 			if err != nil {
 				return cty.DynamicPseudoType, err
 			}
 			return val.Type(), nil
 		},
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			return renderTemplate("<templatestring>", args[0], args[1], nestedFuncs)
+			return renderTemplate("<templatestring>", args[0], args[1], funcsCb())
 		},
 	})
 }

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -1369,10 +1369,12 @@ func TestNestedTemplateFunctions(t *testing.T) {
 	write("loop.tpl", `${templatefile("loop.tpl", {})}`)
 
 	t.Run("templatestring inside templatefile", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, cty.StringVal("hi bob"), evalExpr(t, tmpDir, `templatefile("string.tpl", {})`))
 	})
 
 	t.Run("templatefile inside templatefile", func(t *testing.T) {
+		t.Parallel()
 		assert.Equal(t, cty.StringVal("hello eve"), evalExpr(t, tmpDir, `templatefile("chain.tpl", {})`))
 	})
 

--- a/pkg/hcl/eval/functions_test.go
+++ b/pkg/hcl/eval/functions_test.go
@@ -1354,6 +1354,39 @@ func TestFileFunctions(t *testing.T) {
 	})
 }
 
+// TestNestedTemplateFunctions pins that a template rendered by templatefile may
+// itself call templatestring and templatefile, as OpenTofu allows, and that a
+// self-recursive templatefile stops at the recursion depth limit. No t.Parallel:
+// the recursion-limit subtest uses t.Setenv.
+func TestNestedTemplateFunctions(t *testing.T) {
+	tmpDir := t.TempDir()
+	write := func(name, content string) {
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0o644))
+	}
+	write("string.tpl", `${templatestring("hi $${name}", { name = "bob" })}`)
+	write("chain.tpl", `${templatefile("inner.tpl", { name = "eve" })}`)
+	write("inner.tpl", `hello ${name}`)
+	write("loop.tpl", `${templatefile("loop.tpl", {})}`)
+
+	t.Run("templatestring inside templatefile", func(t *testing.T) {
+		assert.Equal(t, cty.StringVal("hi bob"), evalExpr(t, tmpDir, `templatefile("string.tpl", {})`))
+	})
+
+	t.Run("templatefile inside templatefile", func(t *testing.T) {
+		assert.Equal(t, cty.StringVal("hello eve"), evalExpr(t, tmpDir, `templatefile("chain.tpl", {})`))
+	})
+
+	t.Run("recursion limit", func(t *testing.T) {
+		t.Setenv("TF_TEMPLATE_RECURSION_DEPTH", "5")
+		expr, diags := hclsyntax.ParseExpression(
+			[]byte(`templatefile("loop.tpl", {})`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+		require.False(t, diags.HasErrors(), diags.Error())
+		_, diags = expr.Value(&hcl.EvalContext{Functions: Functions(tmpDir)})
+		require.True(t, diags.HasErrors())
+		assert.Contains(t, diags.Error(), "maximum recursion depth 5 reached")
+	})
+}
+
 // TestFileTildeExpansion pins that the file-reading functions expand a leading
 // `~` to the user's home directory, matching OpenTofu's openFile. Before the
 // fix these functions treated `~` as a literal path segment relative to baseDir

--- a/tests/tfcompat/l1_templatestring_nested_test.go
+++ b/tests/tfcompat/l1_templatestring_nested_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1TemplateStringNested pins that a template rendered by `templatefile`
+// can itself call the other template functions, as OpenTofu does: OpenTofu
+// makes `templatestring` (and a recursion-limited `templatefile`) available
+// inside the rendered template.
+func TestL1TemplateStringNested(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_templatestring_nested", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l1_templatestring_nested/chain.tftpl
+++ b/tests/tfcompat/testdata/cases/l1_templatestring_nested/chain.tftpl
@@ -1,0 +1,1 @@
+${templatefile("${dir}/inner.tftpl", { name = "eve" })}

--- a/tests/tfcompat/testdata/cases/l1_templatestring_nested/inner.tftpl
+++ b/tests/tfcompat/testdata/cases/l1_templatestring_nested/inner.tftpl
@@ -1,0 +1,1 @@
+hello ${name}

--- a/tests/tfcompat/testdata/cases/l1_templatestring_nested/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_templatestring_nested/main.tf
@@ -1,0 +1,7 @@
+# A template rendered by `templatefile` may itself call the other template
+# functions, exactly as OpenTofu does: OpenTofu exposes `templatestring` (and a
+# recursion-limited `templatefile`) inside the rendered template. Here the outer
+# template calls `templatestring` to render an inner template.
+output "nested" {
+  value = templatefile("${path.module}/outer.tftpl", {})
+}

--- a/tests/tfcompat/testdata/cases/l1_templatestring_nested/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_templatestring_nested/main.tf
@@ -5,3 +5,9 @@
 output "nested" {
   value = templatefile("${path.module}/outer.tftpl", {})
 }
+
+# The recursion-limited exception: a template rendered by `templatefile` may
+# itself call `templatefile`.
+output "nested_file" {
+  value = templatefile("${path.module}/chain.tftpl", { dir = path.module })
+}

--- a/tests/tfcompat/testdata/cases/l1_templatestring_nested/outer.tftpl
+++ b/tests/tfcompat/testdata/cases/l1_templatestring_nested/outer.tftpl
@@ -1,0 +1,1 @@
+${templatestring("hi $${name}", { name = "bob" })}


### PR DESCRIPTION
## Divergence

A template rendered by `templatefile`/`templatestring` may call the other template functions in OpenTofu — it exposes `templatestring` and a recursion-limited `templatefile` inside the rendered template. pulumi-hcl stripped both from the in-template function table, so any nested template-function call errored:

```
tofu apply:  templatefile(outer.tftpl), where outer.tftpl calls templatestring("hi $${name}", {name="bob"})  ->  nested = "hi bob"
pulumi up:   Call to function "templatefile" failed: Call to unknown function; There is no function named "templatestring".
```

## Fix

Mirror OpenTofu's structure in `pkg/hcl/eval/functions.go`: the in-template function table is supplied by a callback returning the full live map instead of a copy with the template functions removed. `templatestring` passes the table through unchanged; `templatefile` replaces itself inside each rendered template with a variant that counts recursion depth and errors past the limit (default 1024, overridable via `TF_TEMPLATE_RECURSION_DEPTH`, both matching OpenTofu). Because the callback returns the live map, provider functions and the type-inference `try` variant are visible inside templates too, matching OpenTofu's shared scope map.

Sibling swept: nested `templatefile`-in-`templatefile` (OpenTofu's documented recursion-limited exception) is covered by the same fix and fixture.

## Tests

- `TestL1TemplateStringNested` (tfcompat): `templatestring` inside a `templatefile` template, and `templatefile` chaining into a second template file. Failed on master, passes with the fix.
- `TestNestedTemplateFunctions` (unit, `pkg/hcl/eval`): both nestings plus the recursion depth limit erroring on a self-recursive template.