### PR TITLE
Resolve `path.module` file reads against the module directory during schema generation

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-426.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-426.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Resolve `path.module` file reads against the module directory during schema generation, typing missing files as `any`
+time: 2026-07-17T22:15:00Z
+custom:
+    Component: runtime
+    PR: "426"

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -335,7 +335,43 @@ var canFunc = function.New(&function.Spec{
 func TypeInferenceFunctions(baseDir string) map[string]function.Function {
 	funcs := Functions(baseDir)
 	funcs["try"] = typeInferenceTryFunc
+	// The file-reading functions error when their file is absent. During
+	// schema generation the file may legitimately not exist yet (it can be
+	// produced at runtime, or its name may only resolve then), so a failed
+	// read types as an unknown of the function's return type instead of
+	// failing schema generation.
+	for _, name := range []string{
+		"file", "filebase64", "fileexists", "fileset", "templatefile",
+		"filemd5", "filesha1", "filesha256", "filesha512",
+		"filebase64sha256", "filebase64sha512", "fileAsset", "fileArchive",
+	} {
+		funcs[name] = unknownOnError(funcs[name])
+	}
 	return funcs
+}
+
+// unknownOnError wraps fn so a failed call yields an unknown of fn's return
+// type — dynamic when even the return type cannot be computed — rather than an
+// error. See TypeInferenceFunctions.
+func unknownOnError(fn function.Function) function.Function {
+	return function.New(&function.Spec{
+		Params:   fn.Params(),
+		VarParam: fn.VarParam(),
+		Type: func(args []cty.Value) (cty.Type, error) {
+			t, err := fn.ReturnTypeForValues(args)
+			if err != nil {
+				return cty.DynamicPseudoType, nil
+			}
+			return t, nil
+		},
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			v, err := fn.Call(args)
+			if err != nil {
+				return cty.UnknownVal(retType), nil
+			}
+			return v, nil
+		},
+	})
 }
 
 // typeInferenceTryFunc is a type-inference-only variant of tryfunc.TryFunc.

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -207,7 +207,14 @@ func GenerateModuleSchema(
 func buildTypeScope(
 	ctx context.Context, config *ast.Config, binder *Binder, path map[string]bool,
 ) (*eval.Context, error) {
-	scope, err := eval.NewContext(".", ".", ".", "", "", "")
+	// Root the scope at the module's own directory so path.module-relative
+	// file reads resolve against the module's files rather than the
+	// provider's working directory.
+	dir := "."
+	if binder != nil && binder.ModuleDir != "" {
+		dir = binder.ModuleDir
+	}
+	scope, err := eval.NewContext(dir, dir, dir, "", "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -106,6 +106,37 @@ func TestGenerateModuleSchemaGolden(t *testing.T) {
 	}
 }
 
+// TestGenerateModuleSchemaFileLocalUsesModuleDir shows that schema inference
+// evaluates file-backed locals relative to the module directory. A
+// parameterized module is generally not located in the provider's working
+// directory, so using "." for path.module makes the first local fail to seed;
+// the dependent local then reports that local.from_file has no such attribute.
+func TestGenerateModuleSchemaFileLocalUsesModuleDir(t *testing.T) {
+	t.Parallel()
+
+	moduleDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(moduleDir, "data.json"), []byte(`{"count":42}`), 0o644))
+
+	config, diags := parser.NewParser().ParseSource(filepath.Join(moduleDir, "main.tf"), []byte(`
+locals {
+  from_file = jsondecode(file("${path.module}/data.json"))
+  derived   = local.from_file.count
+}
+
+output "count" {
+  value = local.derived
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, &Binder{ModuleDir: moduleDir},
+		componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+	assert.Equal(t, &PropertySpec{Type: "number"}, moduleSchema.OutputProperties["count"])
+}
+
 // stubResolver resolves a fixed set of resources by TF type, plus optionally a
 // fixed set of provider-defined functions, so reference typing can be tested
 // without a provider schema.

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -106,11 +106,10 @@ func TestGenerateModuleSchemaGolden(t *testing.T) {
 	}
 }
 
-// TestGenerateModuleSchemaFileLocalUsesModuleDir shows that schema inference
-// evaluates file-backed locals relative to the module directory. A
+// TestGenerateModuleSchemaFileLocalUsesModuleDir verifies that schema inference
+// evaluates file-backed locals relative to the module directory: a
 // parameterized module is generally not located in the provider's working
-// directory, so using "." for path.module makes the first local fail to seed;
-// the dependent local then reports that local.from_file has no such attribute.
+// directory, so resolving path.module against "." would fail to find the file.
 func TestGenerateModuleSchemaFileLocalUsesModuleDir(t *testing.T) {
 	t.Parallel()
 
@@ -135,6 +134,31 @@ output "count" {
 		componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
 	require.NoError(t, err)
 	assert.Equal(t, &PropertySpec{Type: "number"}, moduleSchema.OutputProperties["count"])
+}
+
+// TestGenerateModuleSchemaFileLocalMissingFile shows that a file-backed local
+// whose file is absent at schema generation time types to any instead of
+// failing schema generation: the file may only be produced at runtime.
+func TestGenerateModuleSchemaFileLocalMissingFile(t *testing.T) {
+	t.Parallel()
+
+	moduleDir := t.TempDir()
+	config, diags := parser.NewParser().ParseSource(filepath.Join(moduleDir, "main.tf"), []byte(`
+locals {
+  from_file = jsondecode(file("${path.module}/missing.json"))
+}
+
+output "count" {
+  value = local.from_file.count
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, &Binder{ModuleDir: moduleDir},
+		componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+	assert.Equal(t, &PropertySpec{Type: "object"}, moduleSchema.OutputProperties["count"])
 }
 
 // stubResolver resolves a fixed set of resources by TF type, plus optionally a


### PR DESCRIPTION
Schema generation built its type scope with `"."` for every path, so `path.module` and file-function reads resolved against the provider's working directory instead of the module's. A parameterized module is generally not located in the provider's working directory, so a file-backed local like:

```hcl
locals {
  from_file = jsondecode(file("${path.module}/data.json"))
  derived   = local.from_file.count
}
```

failed schema generation with:

```text
typing local "derived": Unsupported attribute; This object does not have an attribute named "from_file".
```

Two changes:

1. `GenerateModuleSchema` now roots the type scope at `Binder.ModuleDir`, so a file that is present at schema generation time is read and dependent locals and outputs get their real types (`local.derived` above types as `number`).

2. When the file is absent at schema generation time — it may only be produced at runtime — the type-inference function table wraps the file-reading functions (`file`, `filebase64`, `fileexists`, `fileset`, `templatefile`, the `file*sha*`/`filemd5` hashes, `fileAsset`, `fileArchive`) so a failed read yields an unknown of the function's return type instead of an error. The dependent output then types to `any` rather than failing schema generation. Runtime evaluation is unchanged and still errors on missing files. (An unknown file *name* already typed to `any` via cty's unknown propagation.)

Regression tests cover both the file-present and file-missing cases.