### PR TITLE
Surface error_message eval failures in variable validation

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-427.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-427.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Surface `error_message` evaluation failures when a variable `validation` fails, instead of a generic message
+time: 2026-07-20T12:00:00Z
+custom:
+    Component: runtime
+    PR: "427"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -924,11 +924,13 @@ func runVariableValidations(ev *eval.Evaluator, varName string, validations []*a
 
 		if !condOK {
 			errMsgVal, diags := ev.EvaluateExpression(validation.ErrorMessage)
+			if diags.HasErrors() {
+				return fmt.Errorf("validation failed for variable %q (could not evaluate error message: %s)",
+					varName, diags.Error())
+			}
 			errMsg := "validation failed"
-			if !diags.HasErrors() {
-				if s := renderErrorMessage(errMsgVal); s != "" {
-					errMsg = s
-				}
+			if s := renderErrorMessage(errMsgVal); s != "" {
+				errMsg = s
 			}
 			return fmt.Errorf("validation failed for variable %q: %s", varName, errMsg)
 		}

--- a/tests/tfcompat/l1_validation_msg_eval_error_test.go
+++ b/tests/tfcompat/l1_validation_msg_eval_error_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1ValidationMsgEvalError asserts that when a failing variable validation's
+// error_message cannot be rendered (here it interpolates a null value, which is
+// not allowed in a string template), both runtimes surface that
+// template-interpolation failure. OpenTofu reports an "Invalid template
+// interpolation value" diagnostic pointing at the error_message; pulumi-hcl
+// swallows the evaluation error and falls back to a generic "validation failed"
+// message, so the real problem never reaches the user.
+func TestL1ValidationMsgEvalError(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_validation_msg_eval_error", tfcompat.Case{
+		Stages: []tfcompat.Stage{{
+			ExpectErr: "Invalid template interpolation value",
+		}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l1_validation_msg_eval_error/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_validation_msg_eval_error/main.tf
@@ -1,0 +1,23 @@
+variable "other" {
+  type     = string
+  nullable = true
+  default  = null
+}
+
+variable "name" {
+  type    = string
+  default = "ab"
+
+  # The condition fails (name is 2 chars). Rendering error_message then fails
+  # too, because interpolating a null value into a string template is an error.
+  # OpenTofu surfaces that template-interpolation error; the question is whether
+  # pulumi-hcl does the same or swallows it behind a generic message.
+  validation {
+    condition     = length(var.name) > 5
+    error_message = "name too short (ctx: ${var.other})"
+  }
+}
+
+output "name" {
+  value = var.name
+}


### PR DESCRIPTION
## Problem

When a variable `validation` condition fails **and** its `error_message` cannot be rendered (here it interpolates a null value, illegal in a string template), pulumi-hcl discarded the error_message evaluation diagnostics and reported a generic `validation failed for variable "name": validation failed`. OpenTofu surfaces the underlying `Invalid template interpolation value` diagnostic.

## Fix

`runVariableValidations` in `pkg/hcl/run/run.go` now returns the error_message evaluation diagnostics when they fail, matching the precondition path (`evaluatePrecondition`), which already surfaces `could not evaluate error message: ...`. All callers route through this single shared function.

## Test

`TestL1ValidationMsgEvalError` in `tests/tfcompat/l1_validation_msg_eval_error_test.go` asserts the surfaced error contains `Invalid template interpolation value`. Fails on master, passes with this fix.