### PR TITLE
Scope replacement propagation to real value dependencies (replace_triggered_by, depends_on)

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-428.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-428.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Scope `replace_triggered_by` indexed-instance references to that instance and stop `depends_on` from propagating replacement
+time: 2026-07-17T00:00:00Z
+custom:
+    Component: runtime
+    PR: "428"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1449,6 +1449,16 @@ func (e *Engine) registerResourceInstanceInContext(
 				tdataEvaluated[string(propKey)] = val
 			}
 
+			// Record every evaluated property, even with no dependencies: an
+			// absent PropertyDependencies map makes the engine assume every
+			// property depends on every entry in Dependencies — but those
+			// include ordering-only dependencies (widened instance sets,
+			// depends_on, replace_triggered_by), and a delete-before-replace
+			// of such a target would then spuriously replace this resource.
+			if _, ok := dependsOn[string(propKey)]; !ok {
+				dependsOn[string(propKey)] = nil
+			}
+
 			if plainInputProps[string(propKey)] {
 				return val, diags
 			}

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -5518,9 +5518,10 @@ resource "aws_instance" "base" {
 // TestEngine_LifecycleRefDependencies: a resource referenced only from a
 // lifecycle precondition/postcondition/replace_triggered_by establishes a
 // dependency, as in TF — directly, through a local, and through a data
-// source's check rule — while staying out of PropertyDependencies (no body
-// property carries it). `self` in a postcondition is not a reference and
-// must not break dep collection.
+// source's check rule — while body properties carry explicit empty
+// PropertyDependencies entries (the reference is ordering-only; an absent
+// map would make the engine assume every property depends on it). `self`
+// in a postcondition is not a reference and must not break dep collection.
 func TestEngine_LifecycleRefDependencies(t *testing.T) {
 	t.Parallel()
 
@@ -5591,7 +5592,7 @@ resource "aws_instance" "reader" {
 		r := find(name)
 		require.NotNilf(t, r, "%s resource should be registered", name)
 		assert.Equal(t, []string{firstURN}, r.Dependencies)
-		assert.Empty(t, r.PropertyDependencies)
+		assert.Equal(t, map[string][]string{"ami": nil}, r.PropertyDependencies)
 	}
 
 	reader := find("reader")
@@ -5603,7 +5604,8 @@ resource "aws_instance" "reader" {
 // TestEngine_ProvisionerRefDependencies: a resource referenced only from a
 // provisioner command, a resource-level connection block, or a provisioner's
 // connection override establishes a dependency — directly and through a local
-// — while staying out of PropertyDependencies (no body property carries it).
+// — while body properties carry explicit empty PropertyDependencies entries
+// (the reference is ordering-only).
 // The referent is declared last so the edge, not source order, must sequence
 // its evaluation before the referencing resources register. `self` in a
 // create-time provisioner is not a reference and must not break dep
@@ -5670,7 +5672,7 @@ resource "aws_instance" "first" {
 		r := find(name)
 		require.NotNilf(t, r, "%s resource should be registered", name)
 		assert.Equal(t, []string{firstURN}, r.Dependencies)
-		assert.Empty(t, r.PropertyDependencies)
+		assert.Equal(t, map[string][]string{"ami": nil}, r.PropertyDependencies)
 	}
 
 	dprov := find("dprov")

--- a/tests/tfcompat/l2_depends_on_replace_no_cascade_test.go
+++ b/tests/tfcompat/l2_depends_on_replace_no_cascade_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2DependsOnReplaceNoCascade proves that a depends_on ordering
+// dependency does not propagate replacement.
+//
+// `dependent` names the counted `pool` resource in depends_on and has only
+// literal inputs. Between the two stages pool[0]'s ForceNew `force` changes,
+// so pool[0] is replaced. depends_on carries no values, so `dependent` must
+// be left alone — its inputs cannot have changed. Without explicit (empty)
+// per-property dependency metadata, the engine assumes every input depends
+// on every dependency and its delete-before-replace cascade spuriously
+// replaces `dependent`.
+func TestL2DependsOnReplaceNoCascade(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_depends_on_replace_no_cascade", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "replacer", Factory: providers.ReplacerProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_replace_triggered_by_indexed_instance_test.go
+++ b/tests/tfcompat/l2_replace_triggered_by_indexed_instance_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ReplaceTriggeredByIndexedInstance proves that an indexed instance
+// reference in `lifecycle.replace_triggered_by` is not scoped to that instance
+// in pulumi-hcl.
+//
+// `dependent` references a single indexed instance -- `pool[1]` -- of the
+// counted `pool` resource. Between the two stages only pool[0]'s ForceNew
+// `force` input changes, so pool[0] is replaced while pool[1] is untouched.
+//
+// OpenTofu scopes the indexed reference to that one instance: pool[1] never
+// changes, so `dependent` is left alone (only pool[0] is replaced). pulumi-hcl
+// treats the reference as covering the whole counted resource, so pool[0]'s
+// replacement spuriously replaces `dependent`. The provider-op traces differ
+// (pulumi records an extra create+delete of `dependent`), and the harness
+// fails.
+func TestL2ReplaceTriggeredByIndexedInstance(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_replace_triggered_by_indexed_instance", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "replacer", Factory: providers.ReplacerProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_depends_on_replace_no_cascade/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_depends_on_replace_no_cascade/0/main.tf
@@ -1,0 +1,18 @@
+# `dependent` orders after the counted `pool` resource through depends_on
+# only; its body is all literals. Stage 0 stands up both pool instances and
+# the dependent.
+
+resource "replacer_resource" "pool" {
+  count = 2
+  force = count.index == 0 ? "A" : "const"
+}
+
+resource "replacer_resource" "dependent" {
+  force      = "d"
+  note       = "n"
+  depends_on = [replacer_resource.pool]
+}
+
+output "dep" {
+  value = replacer_resource.dependent.result
+}

--- a/tests/tfcompat/testdata/cases/l2_depends_on_replace_no_cascade/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_depends_on_replace_no_cascade/1/main.tf
@@ -1,0 +1,20 @@
+# Stage 1: change `force` on pool[0] only (A -> B). `force` is ForceNew, so
+# pool[0] is replaced; pool[1] is untouched.
+#
+# depends_on is ordering-only: replacing pool[0] must leave `dependent`
+# alone, as its literal inputs cannot have changed.
+
+resource "replacer_resource" "pool" {
+  count = 2
+  force = count.index == 0 ? "B" : "const"
+}
+
+resource "replacer_resource" "dependent" {
+  force      = "d"
+  note       = "n"
+  depends_on = [replacer_resource.pool]
+}
+
+output "dep" {
+  value = replacer_resource.dependent.result
+}

--- a/tests/tfcompat/testdata/cases/l2_replace_triggered_by_indexed_instance/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_replace_triggered_by_indexed_instance/0/main.tf
@@ -1,0 +1,21 @@
+# `dependent` references a SINGLE indexed instance of the counted `pool`
+# resource (`pool[1]`) in replace_triggered_by. Stage 0 stands up two `pool`
+# instances plus the dependent. `pool[1]` is the instance the dependent tracks;
+# `pool[0]` is a sibling it must ignore.
+
+resource "replacer_resource" "pool" {
+  count = 2
+  force = count.index == 0 ? "A" : "const"
+}
+
+resource "replacer_resource" "dependent" {
+  force = "d"
+  note  = "n"
+  lifecycle {
+    replace_triggered_by = [replacer_resource.pool[1]]
+  }
+}
+
+output "dep" {
+  value = replacer_resource.dependent.result
+}

--- a/tests/tfcompat/testdata/cases/l2_replace_triggered_by_indexed_instance/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_replace_triggered_by_indexed_instance/1/main.tf
@@ -1,0 +1,32 @@
+# Stage 1: change `force` on pool[0] only (A -> B). `force` is ForceNew, so
+# pool[0] is replaced; pool[1] is untouched.
+#
+# `dependent` references `pool[1]`, which does not change, so its trigger must
+# not fire.
+#
+# OpenTofu: the indexed reference is scoped to that single instance -- only a
+# change to pool[1] fires the dependent. pool[0]'s replacement is ignored, so
+# `dependent` is left alone.
+#
+# pulumi-hcl: the indexed instance reference is not scoped to the instance; the
+# dependent reacts to the replacement of ANY instance of the counted `pool`
+# resource. pool[0]'s replacement therefore spuriously replaces `dependent`.
+# The provider-op traces differ (pulumi records an extra create+delete of
+# `dependent`).
+
+resource "replacer_resource" "pool" {
+  count = 2
+  force = count.index == 0 ? "B" : "const"
+}
+
+resource "replacer_resource" "dependent" {
+  force = "d"
+  note  = "n"
+  lifecycle {
+    replace_triggered_by = [replacer_resource.pool[1]]
+  }
+}
+
+output "dep" {
+  value = replacer_resource.dependent.result
+}


### PR DESCRIPTION
## Bug

An indexed instance reference in `lifecycle.replace_triggered_by` (`replace_triggered_by = [replacer_resource.pool[1]]`) is scoped to that single instance in OpenTofu, but pulumi-hcl treated it as covering the whole counted resource: replacing a *sibling* instance (`pool[0]`) spuriously replaced the dependent, which OpenTofu leaves untouched.

The same mechanism made `depends_on` propagate replacement: a resource with only literal inputs and `depends_on = [replacer_resource.pool]` was also spuriously replaced when `pool[0]` was replaced. OpenTofu never propagates replacement through ordering-only edges.

## Root cause

The `replaceWith`/`replacementTrigger` options were already correctly scoped to `pool[1]`; the widening came from dependency *metadata*:

1. Every `DependsOn` URN is widened to the referenced resource's full instance set (`urnRegistry.widen`) — deliberate and correct: destroy ordering is resource-wide, as in TF state.
2. A resource with only literal inputs sent no `propertyDependencies`, and the engine backfills an absent map as "every property depends on every dependency" (legacy-SDK compat in `source_eval.go`).
3. Resources register `deleteBeforeReplace: true` (matching tofu's destroy-then-create default), so replacing `pool[0]` runs the engine's delete-before-replace dependent cascade: it unknown-substitutes the dependent's inputs per the backfilled property dependencies, the provider reports a ForceNew replace, and the dependent is deleted and recreated.

## Fix

Register an explicit — possibly empty — `PropertyDependencies` entry for every evaluated body property. A non-empty map suppresses the engine's backfill, so ordering-only dependencies (`depends_on`, `replace_triggered_by`, widened instance sets) no longer make input properties look value-dependent, and replacement propagation stays scoped to real value references. Whole-resource `replace_triggered_by` replacement still works through `replaceWith` and the replacement trigger.

## Tests

- `TestL2ReplaceTriggeredByIndexedInstance` (from the original failing-test commit): fails on master, passes with the fix.
- `TestL2DependsOnReplaceNoCascade` (new): the `depends_on` sibling from the same root cause; fails on master, passes with the fix.
- `TestEngine_LifecycleRefDependencies` / `TestEngine_ProvisionerRefDependencies` updated to assert the explicit empty per-property entries.

## Relationship to https://github.com/pulumi-labs/pulumi-hcl/pull/422

This is the `replace_triggered_by` sibling of the count/for_each instance-granularity work: https://github.com/pulumi-labs/pulumi-hcl/pull/422 handled scheduling; this PR scopes replacement propagation. Block-granular scheduling and resource-wide destroy ordering are unchanged.