### PR TITLE
Pick up the bridge fix for the synthetic `id` on id-less data sources

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-429.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-429.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Drop the synthetic `id` attribute from data sources whose schema declares no `id`
+time: 2026-07-17T00:00:00Z
+custom:
+    Component: runtime
+    PR: "429"

--- a/.changes/unreleased/runtime-bug-fixes-429.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-429.yaml
@@ -1,6 +1,0 @@
-kind: bug-fixes
-body: Drop the synthetic `id` attribute from data sources whose schema declares no `id`
-time: 2026-07-17T00:00:00Z
-custom:
-    Component: runtime
-    PR: "429"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       # terraform_remote_state lowers to the pulumi-terraform getLocalReference
       # invoke; the tfcompat harness disables plugin acquisition, so pre-install it.
       - run: pulumi plugin install resource terraform 6.0.2
-      - run: pulumi plugin install resource terraform-provider 1.2.0
+      - run: pulumi plugin install resource terraform-provider 1.2.1
       - run: pulumi plugin install resource local 0.1.6
       - run: make bin/pulumi-language-hcl bin/pulumi-converter-hcl bin/pulumi-resource-hcl
       - run: echo "$PWD/bin" >> "$GITHUB_PATH"

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/opentofu/svchost v0.0.0-20250610175836-86c9e5e3d8c8
 	github.com/pulumi/providertest v0.7.0
 	github.com/pulumi/pulumi-go-provider v1.3.3-0.20260622142528-c5c3719552bc
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.134.1-0.20260714115759-6744a8e7082e
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.134.1-0.20260720151533-5ffabd1227c9
 	github.com/pulumi/pulumi/pkg/v3 v3.253.1-0.20260715102847-ee776490db8f
 	github.com/pulumi/pulumi/sdk/v3 v3.253.1-0.20260715102847-ee776490db8f
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -3974,8 +3974,8 @@ github.com/pulumi/pulumi-go-provider v1.3.3-0.20260622142528-c5c3719552bc h1:fj6
 github.com/pulumi/pulumi-go-provider v1.3.3-0.20260622142528-c5c3719552bc/go.mod h1:LDSFQaNbYbusvOIdsB7WW+mo3WjLlZSfSZJKyCLFhbw=
 github.com/pulumi/pulumi-java v1.32.0 h1:QqmDIWvVCZE3nRyzJJzDcqTB7fcNOGCErDkDPO/S7mw=
 github.com/pulumi/pulumi-java v1.32.0/go.mod h1:BU7SuyickBmABNHJbN44a2YkMkhGCn6qmotkRDV74eg=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.134.1-0.20260714115759-6744a8e7082e h1:HfeRWWusLS4twDYTfoBDqxMQsZjU3VSYdAzz20Lu3BQ=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.134.1-0.20260714115759-6744a8e7082e/go.mod h1:YtAG3AEHdWxs+uSBkUqQhDRGbbzIASOo+I+WlsH4aF0=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.134.1-0.20260720151533-5ffabd1227c9 h1:RORmCOW9K/RFqF8TwStNXr7vciQc9KXA6KWgERoljk4=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.134.1-0.20260720151533-5ffabd1227c9/go.mod h1:rGCYEDTzafKts3L76JC5GOMwcIBawTCBiqH7TozBKX8=
 github.com/pulumi/pulumi-yaml v1.37.1-0.20260709082604-efc7b02d80e5 h1:hmDN/qbxNuD9gZ8sFWN15Cp/Sptcjpwe2YSdJTW7sLg=
 github.com/pulumi/pulumi-yaml v1.37.1-0.20260709082604-efc7b02d80e5/go.mod h1:B/4UkN/ZuGuAaAn3atJ/2uVwdjsFtPofwubBSbIFj9c=
 github.com/pulumi/pulumi/pkg/v3 v3.253.1-0.20260715102847-ee776490db8f h1:N5JpZ8Fh87htC+6v9Rcw74eY5iBcTgAojZdBVLWa50s=

--- a/tests/tfcompat/l2_data_no_id_shape_test.go
+++ b/tests/tfcompat/l2_data_no_id_shape_test.go
@@ -26,6 +26,7 @@ func TestL2DataNoIDShape(t *testing.T) {
 	tfcompat.RunCase(t, "l2_data_no_id_shape", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "pfx", PFFactory: providers.PFXProvider},
+			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 	})
 }

--- a/tests/tfcompat/l2_data_no_id_shape_test.go
+++ b/tests/tfcompat/l2_data_no_id_shape_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+func TestL2DataNoIDShape(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_no_id_shape", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "pfx", PFFactory: providers.PFXProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_data_no_id_shape/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_no_id_shape/main.tf
@@ -1,0 +1,7 @@
+data "pfx_lookup" "d" {}
+
+# pfx_lookup (a plugin-framework data source) declares only `value` and no `id`.
+# Referencing the whole object must yield the same attribute set on both runtimes.
+output "keys" {
+  value = sort(keys(data.pfx_lookup.d))
+}

--- a/tests/tfcompat/testdata/cases/l2_data_no_id_shape/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_no_id_shape/main.tf
@@ -5,3 +5,12 @@ data "pfx_lookup" "d" {}
 output "keys" {
   value = sort(keys(data.pfx_lookup.d))
 }
+
+data "simple_lookup" "s" {
+  query = "q"
+}
+
+# simple_lookup declares no `id` either, but SDKv2 adds an implicit one.
+output "sdkv2_keys" {
+  value = sort(keys(data.simple_lookup.s))
+}


### PR DESCRIPTION
## Divergence

A plugin-framework data source that declares no `id` attribute exposes only its declared attributes in OpenTofu, but pulumi-hcl surfaced an extra `id` key on the data-source object:

```
tofu:   sort(keys(data.pfx_lookup.d)) == ["value"]
pulumi: sort(keys(data.pfx_lookup.d)) == ["id","value"]
```

## Root cause (upstream)

The bug was in the bridge, not in this repo. tfgen synthesized an `id` result for every data source whose Terraform schema declares none. That is correct for SDKv1/v2 — the SDK injects an implicit `Optional+Computed` `id` into the wire schema (invisible in the `SchemaMap` tfgen reads) and always returns a value for it — but the Plugin Framework has no implicit `id`, so `ReadDataSource` structurally cannot produce the attribute the schema advertised.

Fixed upstream by https://github.com/pulumi/pulumi-terraform-bridge/pull/3541 ("Do not synthesize an `id` output for Plugin Framework data sources").

## Change

No runtime change in this repo — just picking up the upstream fix:

- `github.com/pulumi/pulumi-terraform-bridge/v3` → `v3.134.1-0.20260720151533-5ffabd1227c9`, which is what `tfcompat` bridges providers with in-process (`tests/testutil/pulexec/bridge.go`).
- CI's `terraform-provider` plugin pin `1.2.0` → `1.2.1`, so the runtime path that bridges real providers gets the same fix.

## Test

`TestL2DataNoIDShape` locks in the behavior change from the bump and covers both sides:

- `pfx_lookup` (plugin framework, no declared `id`) — must expose only `["value"]`.
- `simple_lookup` (SDKv2, no declared `id`) — must keep the implicit `["id", ...]`, so a future bridge change cannot over-correct and strip it.

The test fails on the previous bridge version and passes on the new one.

Known related divergence left out of scope: a PF *resource* with no `id` attribute still exposes the engine id on whole-object references — different mechanism (real engine ids, import/refresh implications).
