### PR TITLE
Accept and ignore the terraform block `experiments` argument

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-430.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-430.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Accept and ignore the `experiments` argument in the `terraform` block
+time: 2026-07-20T00:00:00Z
+custom:
+    Component: runtime
+    PR: "430"

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -190,6 +190,16 @@ func (p *Parser) parseTerraformBlock(config *ast.Config, block *hcl.Block) hcl.D
 		})
 	}
 
+	if attr, ok := content.Attributes["experiments"]; ok {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "Ignoring terraform experiments argument",
+			Detail: "Language experiments are a Terraform concept with no Pulumi HCL " +
+				"equivalent; the `experiments` argument is accepted and ignored.",
+			Subject: attr.Range.Ptr(),
+		})
+	}
+
 	for _, subBlock := range content.Blocks {
 		switch subBlock.Type {
 		case "required_providers":

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -501,6 +501,28 @@ terraform {
 		}
 		require.True(t, found, "expected warning for required_version, got %v", diags)
 	})
+
+	t.Run("experiments_warns_continues", func(t *testing.T) {
+		t.Parallel()
+		src := `
+terraform {
+  experiments = [module_variable_optional_attrs]
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "6.19.0" }
+  }
+}`
+		cfg, diags := NewParser().ParseSource("test.hcl", []byte(src))
+		require.False(t, diags.HasErrors(), "unexpected errors: %v", diags)
+		require.Contains(t, cfg.Terraform.RequiredProviders, "aws")
+		var found bool
+		for _, d := range diags {
+			if d.Severity == hcl.DiagWarning && d.Summary == "Ignoring terraform experiments argument" {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected warning for experiments, got %v", diags)
+	})
 }
 
 func TestParseUnknownBlockType(t *testing.T) {

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -47,13 +47,14 @@ var checkSchema = &hcl.BodySchema{
 
 // terraformSchema defines the structure of a terraform block.
 //
-// `required_version`, `backend`, and `provider_meta` are accepted for
-// Terraform compatibility: the parser warns and ignores them rather than
-// failing.
+// `required_version`, `experiments`, `backend`, and `provider_meta` are
+// accepted for Terraform compatibility: the parser warns and ignores them
+// rather than failing.
 var terraformSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{Name: "required_version_range"},
 		{Name: "required_version"},
+		{Name: "experiments"},
 	},
 	Blocks: []hcl.BlockHeaderSchema{
 		{Type: "required_providers"},

--- a/tests/tfcompat/l2_terraform_experiments_test.go
+++ b/tests/tfcompat/l2_terraform_experiments_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL2TerraformExperiments proves pulumi-hcl's terraform-block parser rejects
+// the `experiments` argument, which OpenTofu accepts and applies cleanly.
+func TestL2TerraformExperiments(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_terraform_experiments", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_experiments/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_experiments/main.tf
@@ -1,0 +1,9 @@
+# `experiments = [module_variable_optional_attrs]` is a graduated experiment
+# opt-in that OpenTofu still accepts for backward compatibility with configs
+# written during the experiment period. It applies cleanly (no warning, no
+# error). Real Terraform 0.14-era configs still carry this line.
+terraform {
+  experiments = [module_variable_optional_attrs]
+}
+
+output "ok" { value = "hello" }


### PR DESCRIPTION
## Divergence

OpenTofu accepts the `experiments` argument in the `terraform {}` block — a graduated-experiment opt-in still honored for backward compatibility with configs written during the experiment period — and applies cleanly. pulumi-hcl's parser rejected it at parse time:

```
tofu apply:  Apply complete (experiments = [module_variable_optional_attrs] accepted-and-ignored)
pulumi up:   Unsupported argument; An argument named "experiments" is not expected here.
```

Real Terraform 0.14-era configs still carry this line.

## Fix

`terraformSchema` in `pkg/hcl/parser/schema.go` listed no `experiments` attribute, and the terraform block is decoded with strict `Content(terraformSchema)`, so the argument was rejected. Add `experiments` to the schema and warn-and-ignore it in `parseTerraformBlock`, matching the existing handling of `required_version`, `backend`, and `provider_meta`. The attribute expression is never evaluated, so the bare identifiers it references (e.g. `module_variable_optional_attrs`) cause no error.

## Tests

- `TestL2TerraformExperiments` (`tests/tfcompat/l2_terraform_experiments_test.go`) — proves the config applies; failed 3/3 on master, passes with the fix.
- `experiments_warns_continues` subtest in `TestTerraformBlockCompat` (`pkg/hcl/parser/parser_test.go`) — unit coverage for the accept-and-ignore warning.
