### PR TITLE
Fix flaky TestConvertedPCLRange ref subtests

### DIFF
--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -408,6 +408,20 @@ func TestConvertedPCLRange(t *testing.T) {
 		assert.Equal(t, "test:index:Item", mock.RegisteredResources[2].Type)
 	})
 
+	// Registration order between independent resources is not deterministic:
+	// target only waits on source[0], so it can register before source[1].
+	// Look the target up by name instead of position.
+	findResource := func(t *testing.T, mock *testutil.MockResourceMonitor, name string) hclrun.RegisterResourceRequest {
+		t.Helper()
+		for _, r := range mock.RegisteredResources {
+			if r.Name == name {
+				return r
+			}
+		}
+		t.Fatalf("no registered resource named %q", name)
+		return hclrun.RegisterResourceRequest{}
+	}
+
 	t.Run("range_count_ref", func(t *testing.T) {
 		t.Parallel()
 
@@ -428,7 +442,7 @@ resource target "test:index:Item" {
 		require.Len(t, mock.RegisteredResources, 4, "expected stack + 2 sources + 1 target")
 		assert.Equal(t, "pulumi:pulumi:Stack", mock.RegisteredResources[0].Type)
 
-		target := mock.RegisteredResources[3]
+		target := findResource(t, mock, "target")
 		assert.Equal(t, "test:index:Item", target.Type)
 		assert.Equal(t, property.New("src-0-ref"), target.Inputs.Get("name"))
 	})
@@ -455,7 +469,7 @@ resource target "test:index:Item" {
 		// stack + 2 source items + 1 target
 		require.Len(t, mock.RegisteredResources, 4, "expected stack + 2 sources + 1 target")
 
-		target := mock.RegisteredResources[3]
+		target := findResource(t, mock, "target")
 		assert.Equal(t, "test:index:Item", target.Type)
 		assert.Equal(t, property.New("alpha-ref"), target.Inputs.Get("name"))
 	})


### PR DESCRIPTION
The `range_count_ref` and `range_map_ref` subtests assumed the `target` resource always registers last, at `RegisteredResources[3]`. The target only depends on `source[0]`, so with instance-granularity scheduling (https://github.com/pulumi-labs/pulumi-hcl/pull/422) it can register before the second source instance and the positional index races — CI caught `RegisteredResources[3]` holding `src-1` instead of the target: https://github.com/pulumi-labs/pulumi-hcl/actions/runs/29610020209/job/87982262975

Look the target up by resource name instead. The `require.Len` count assertions stay: the total registration count is deterministic, only the order is not.

Verified with `go test ./cmd/pulumi-language-hcl/ -run TestConvertedPCLRange -count=50 -race`.