### PR TITLE
Determine provisioner argument set-ness by null-ness, not emptiness

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-432.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-432.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Treat set-but-empty provisioner arguments (`content = ""`, `source = ""`, `scripts = []`) as set instead of rejecting them as missing
+time: 2026-07-17T22:35:00Z
+custom:
+    Component: runtime
+    PR: "432"

--- a/pkg/provisioner/runtime/file.go
+++ b/pkg/provisioner/runtime/file.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/provisioner/provisioners"
 	"github.com/pulumi-labs/pulumi-hcl/vendored/communicator"
@@ -40,11 +41,11 @@ func runFile(ctx context.Context, spec *Spec, hclCtx *hcl.EvalContext) error {
 		return fmt.Errorf("file: %s", diags.Error())
 	}
 
-	source, err := evalString(content, "source", hclCtx)
+	source, err := evalAttr(content, "source", cty.String, hclCtx)
 	if err != nil {
 		return err
 	}
-	bodyContent, err := evalString(content, "content", hclCtx)
+	bodyContent, err := evalAttr(content, "content", cty.String, hclCtx)
 	if err != nil {
 		return err
 	}
@@ -55,7 +56,7 @@ func runFile(ctx context.Context, spec *Spec, hclCtx *hcl.EvalContext) error {
 	if destination == "" {
 		return fmt.Errorf("file: destination must be non-empty")
 	}
-	if exactlyOneSet(source != "", bodyContent != "") != 1 {
+	if exactlyOneSet(!source.IsNull(), !bodyContent.IsNull()) != 1 {
 		return fmt.Errorf("file: exactly one of source or content must be set")
 	}
 
@@ -78,18 +79,19 @@ func runFile(ctx context.Context, spec *Spec, hclCtx *hcl.EvalContext) error {
 	}
 	defer func() { _ = comm.Disconnect() }()
 
-	if bodyContent != "" {
-		return comm.Upload(destination, strings.NewReader(bodyContent))
+	if !bodyContent.IsNull() {
+		return comm.Upload(destination, strings.NewReader(bodyContent.AsString()))
 	}
 
-	info, err := os.Stat(source)
+	src := source.AsString()
+	info, err := os.Stat(src)
 	if err != nil {
 		return fmt.Errorf("file: stat source: %w", err)
 	}
 	if info.IsDir() {
-		return comm.UploadDir(destination, source)
+		return comm.UploadDir(destination, src)
 	}
-	f, err := os.Open(source)
+	f, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("file: opening source: %w", err)
 	}

--- a/pkg/provisioner/runtime/file_test.go
+++ b/pkg/provisioner/runtime/file_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+// errConnRequired is the error runFile/runRemoteExec return once argument
+// validation has passed but the Spec has no connection block; tests use it as
+// a sentinel for "the config was accepted".
+const errConnRequired = "connection block required for remote-exec / file provisioners"
+
+func TestRunFileArgValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name: "empty content is set",
+			config: `
+content     = ""
+destination = "/tmp/x"
+`,
+			wantErr: errConnRequired,
+		},
+		{
+			name: "empty source is set",
+			config: `
+source      = ""
+destination = "/tmp/x"
+`,
+			wantErr: errConnRequired,
+		},
+		{
+			name:    "neither set",
+			config:  `destination = "/tmp/x"`,
+			wantErr: "file: exactly one of source or content must be set",
+		},
+		{
+			name: "null content is unset",
+			config: `
+content     = null
+destination = "/tmp/x"
+`,
+			wantErr: "file: exactly one of source or content must be set",
+		},
+		{
+			name: "both set",
+			config: `
+source      = "a"
+content     = "b"
+destination = "/tmp/x"
+`,
+			wantErr: "file: exactly one of source or content must be set",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body := parseBody(t, tt.config)
+			err := Run(t.Context(), &Spec{Type: "file", Config: body}, &hcl.EvalContext{})
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}

--- a/pkg/provisioner/runtime/remote_exec.go
+++ b/pkg/provisioner/runtime/remote_exec.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/provisioner/provisioners"
 	"github.com/pulumi-labs/pulumi-hcl/vendored/communicator"
@@ -42,20 +43,40 @@ func runRemoteExec(ctx context.Context, spec *Spec, hclCtx *hcl.EvalContext) err
 		return fmt.Errorf("remote-exec: %s", diags.Error())
 	}
 
-	inline, err := evalStringSlice(content, "inline", hclCtx)
+	inline, err := evalAttr(content, "inline", cty.List(cty.String), hclCtx)
 	if err != nil {
 		return err
 	}
-	script, err := evalString(content, "script", hclCtx)
+	script, err := evalAttr(content, "script", cty.String, hclCtx)
 	if err != nil {
 		return err
 	}
-	scripts, err := evalStringSlice(content, "scripts", hclCtx)
+	scripts, err := evalAttr(content, "scripts", cty.List(cty.String), hclCtx)
 	if err != nil {
 		return err
 	}
-	if exactlyOneSet(len(inline) > 0, script != "", len(scripts) > 0) != 1 {
+	if exactlyOneSet(!inline.IsNull(), !script.IsNull(), !scripts.IsNull()) != 1 {
 		return fmt.Errorf("remote-exec: exactly one of inline, script, or scripts must be set")
+	}
+
+	var lines, paths []string
+	switch {
+	case !inline.IsNull():
+		if lines, err = commandElems(inline, "inline"); err != nil {
+			return err
+		}
+		if len(lines) == 0 {
+			return fmt.Errorf("remote-exec: inline must contain at least one command")
+		}
+	case !script.IsNull():
+		if script.AsString() == "" {
+			return fmt.Errorf(`remote-exec: invalid empty string in "script"`)
+		}
+		paths = []string{script.AsString()}
+	default:
+		if paths, err = commandElems(scripts, "scripts"); err != nil {
+			return err
+		}
 	}
 
 	connVal, err := evalConnection(spec.Conn, hclCtx)
@@ -79,15 +100,27 @@ func runRemoteExec(ctx context.Context, spec *Spec, hclCtx *hcl.EvalContext) err
 	}
 	defer func() { _ = comm.Disconnect() }()
 
-	switch {
-	case len(inline) > 0:
-		return runInline(comm, inline, stdout, stderr)
-	case script != "":
-		return runScripts(comm, []string{script}, stdout, stderr)
-	case len(scripts) > 0:
-		return runScripts(comm, scripts, stdout, stderr)
+	if !inline.IsNull() {
+		return runInline(comm, lines, stdout, stderr)
 	}
-	return fmt.Errorf("remote-exec: no commands specified")
+	return runScripts(comm, paths, stdout, stderr)
+}
+
+// commandElems flattens a list attribute whose elements must be set,
+// non-empty strings.
+func commandElems(list cty.Value, attr string) ([]string, error) {
+	var out []string
+	for it := list.ElementIterator(); it.Next(); {
+		_, v := it.Element()
+		if v.IsNull() {
+			return nil, fmt.Errorf("remote-exec: invalid null string in %q", attr)
+		}
+		if v.AsString() == "" {
+			return nil, fmt.Errorf("remote-exec: invalid empty string in %q", attr)
+		}
+		out = append(out, v.AsString())
+	}
+	return out, nil
 }
 
 // TF joins inline lines into a single shell invocation.

--- a/pkg/provisioner/runtime/remote_exec_test.go
+++ b/pkg/provisioner/runtime/remote_exec_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunRemoteExecArgValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name:    "empty inline list",
+			config:  `inline = []`,
+			wantErr: "remote-exec: inline must contain at least one command",
+		},
+		{
+			name:    "empty scripts list is set",
+			config:  `scripts = []`,
+			wantErr: errConnRequired,
+		},
+		{
+			name:    "empty script string",
+			config:  `script = ""`,
+			wantErr: `remote-exec: invalid empty string in "script"`,
+		},
+		{
+			name:    "empty inline element",
+			config:  `inline = ["echo hi", ""]`,
+			wantErr: `remote-exec: invalid empty string in "inline"`,
+		},
+		{
+			name:    "null inline element",
+			config:  `inline = [null]`,
+			wantErr: `remote-exec: invalid null string in "inline"`,
+		},
+		{
+			name:    "null scripts element",
+			config:  `scripts = [null]`,
+			wantErr: `remote-exec: invalid null string in "scripts"`,
+		},
+		{
+			name:    "none set",
+			config:  ``,
+			wantErr: "remote-exec: exactly one of inline, script, or scripts must be set",
+		},
+		{
+			name:    "null inline is unset",
+			config:  `inline = null`,
+			wantErr: "remote-exec: exactly one of inline, script, or scripts must be set",
+		},
+		{
+			name: "two set",
+			config: `
+inline = ["x"]
+script = "y"
+`,
+			wantErr: "remote-exec: exactly one of inline, script, or scripts must be set",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body := parseBody(t, tt.config)
+			err := Run(t.Context(), &Spec{Type: "remote-exec", Config: body}, &hcl.EvalContext{})
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}

--- a/tests/tfcompat/l2_provisioner_file_empty_content_test.go
+++ b/tests/tfcompat/l2_provisioner_file_empty_content_test.go
@@ -22,10 +22,12 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-// TestL2Provisioner_FileEmptyContent exercises a file provisioner whose
-// `content` is an explicit empty string. OpenTofu treats the attribute as set
-// (non-null) and uploads an empty file; pulumi-hcl treats empty-string content
-// as unset and rejects the config, so the apply fails where OpenTofu succeeds.
+// TestL2Provisioner_FileEmptyContent exercises provisioner attributes that are
+// set but empty: a file provisioner with `content = ""` (uploads an empty
+// file) and a remote-exec provisioner with `scripts = []` (runs nothing).
+// OpenTofu treats set-ness as non-null, so both succeed; pulumi-hcl treated
+// empty values as unset and rejected the config, so the apply failed where
+// OpenTofu succeeds.
 func TestL2Provisioner_FileEmptyContent(t *testing.T) {
 	t.Parallel()
 	c := sshd.Start(t.Context(), t)

--- a/tests/tfcompat/l2_provisioner_file_empty_content_test.go
+++ b/tests/tfcompat/l2_provisioner_file_empty_content_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/sshd"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2Provisioner_FileEmptyContent exercises a file provisioner whose
+// `content` is an explicit empty string. OpenTofu treats the attribute as set
+// (non-null) and uploads an empty file; pulumi-hcl treats empty-string content
+// as unset and rejects the config, so the apply fails where OpenTofu succeeds.
+func TestL2Provisioner_FileEmptyContent(t *testing.T) {
+	t.Parallel()
+	c := sshd.Start(t.Context(), t)
+
+	tfcompat.RunCase(t, "l2_provisioner_file_empty_content", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Config: sshConfig(c, nil),
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_file_empty_content/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_file_empty_content/main.tf
@@ -1,7 +1,11 @@
-# OpenTofu's file provisioner distinguishes a null (unset) attribute from an
-# empty string. `content = ""` is set-but-empty: OpenTofu uploads an empty file
-# to the destination. pulumi-hcl treats an empty-string content as "unset" and
-# rejects the config with "exactly one of source or content must be set".
+# OpenTofu's provisioners distinguish a null (unset) attribute from a set-but-
+# empty value. `content = ""` on a file provisioner is set: OpenTofu uploads an
+# empty file to the destination. Likewise `scripts = []` on a remote-exec
+# provisioner is set and apply succeeds, running nothing. pulumi-hcl treated
+# both as "unset" and rejected the config with "exactly one of ... must be
+# set". (`inline = []` is set but fails in OpenTofu — the generated empty
+# script cannot be uploaded — so it stays an apply error and is out of this
+# case.)
 variable "host" { type = string }
 variable "port" { type = number }
 variable "user" { type = string }
@@ -22,5 +26,9 @@ resource "simple_resource" "target" {
   provisioner "file" {
     content     = ""
     destination = "/config/empty-from-content.txt"
+  }
+
+  provisioner "remote-exec" {
+    scripts = []
   }
 }

--- a/tests/tfcompat/testdata/cases/l2_provisioner_file_empty_content/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_file_empty_content/main.tf
@@ -1,0 +1,26 @@
+# OpenTofu's file provisioner distinguishes a null (unset) attribute from an
+# empty string. `content = ""` is set-but-empty: OpenTofu uploads an empty file
+# to the destination. pulumi-hcl treats an empty-string content as "unset" and
+# rejects the config with "exactly one of source or content must be set".
+variable "host" { type = string }
+variable "port" { type = number }
+variable "user" { type = string }
+variable "password" { type = string }
+
+resource "simple_resource" "target" {
+  input_one = "a"
+
+  connection {
+    type     = "ssh"
+    host     = var.host
+    port     = var.port
+    user     = var.user
+    password = var.password
+    timeout  = "30s"
+  }
+
+  provisioner "file" {
+    content     = ""
+    destination = "/config/empty-from-content.txt"
+  }
+}


### PR DESCRIPTION
## Divergence

The `file` and `remote-exec` provisioners computed argument set-ness from string emptiness (`source != ""`, `len(scripts) > 0`), and `evalString` collapses both null and `""` to `""` — so a set-but-empty attribute was indistinguishable from unset. OpenTofu branches on `IsNull()`:

- `content = ""` on a `file` provisioner: OpenTofu uploads an empty file; pulumi-hcl rejected the config with `file: exactly one of source or content must be set`.
- `scripts = []` on a `remote-exec` provisioner: OpenTofu runs nothing and succeeds; pulumi-hcl rejected the config.
- `script = "" scripts = [...]`: OpenTofu rejects both-set; pulumi-hcl treated `script` as unset and silently ran the scripts.

## Fix

Evaluate the arguments as cty values and branch on null-ness (`pkg/provisioner/runtime/file.go`, `remote_exec.go`). Element rules for `remote-exec` now also match OpenTofu's `collectScripts`: null or empty strings in `inline`/`scripts` error, and `script = ""` errors.

Sweep notes:

- `source = ""` is set: validation passes and the apply fails at `os.Stat`, matching OpenTofu's copy failure.
- `inline = []` fails the apply in OpenTofu too (the generated empty script cannot be uploaded — `Error reading script: EOF`), verified empirically via the harness. It stays an apply error (`remote-exec: inline must contain at least one command`) and is excluded from the success fixture.

## Tests

- `TestL2Provisioner_FileEmptyContent` (fails on master, passes here), fixture extended with `scripts = []`; uses the `sshd.Start` container harness.
- Unit tables `TestRunFileArgValidation` / `TestRunRemoteExecArgValidation` pin the validation semantics.
- Related provisioner tfcompat tests (`RemoteExecInline/Script/Scripts`, `FileFromContent/Source`, `ScriptPath`, `EscapeBlock`) pass locally.