### PR TITLE
terraform_data: honor ignore_changes on triggers_replace

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-433.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-433.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Honor `ignore_changes` targeting a `terraform_data` `triggers_replace`, so an ignored change no longer forces a replacement
+time: 2026-07-20T10:00:00Z
+custom:
+    Component: runtime
+    PR: "433"

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -10,6 +10,7 @@ A small number of Terraform features are not modeled:
 - **WinRM `connection` blocks** are not supported — `connection` accepts `type = "ssh"` only.
 - **`List<Object>` empty vs null** — HCL block syntax cannot distinguish an empty `List<Object>` from a null one, a known incompatibility with some Pulumi programs.
 - **Resource-wide destroy ordering of late-created instances** — Terraform rebuilds destroy-time dependencies from configuration, so every instance of a `count`/`for_each` resource waits for a consumer's delete even when the consumer referenced only one instance (`depends_on = [a["x"]]`). Pulumi records each resource's dependencies once, when it is created, and cannot depend on an instance that registers later. A sibling instance created *after* the consumer is therefore not held back by it during destroy and may be deleted first.
+- **`ignore_changes` on `terraform_data`'s `triggers_replace`** is honored only when it is present from the resource's creation. Adding `ignore_changes = [triggers_replace]` in the same update that changes `triggers_replace` (on a resource first created without it) still forces one replacement: `triggers_replace` is carried as a replacement trigger rather than a stored input, so it cannot be reconciled against the prior state the way an ignored input is.
 
 State files are not interchangeable: import existing resources with `pulumi import` rather than reusing a Terraform state file. By default `create_before_destroy` matches Terraform's delete-first replacement order.
 

--- a/pkg/hcl/run/terraform_data.go
+++ b/pkg/hcl/run/terraform_data.go
@@ -50,22 +50,55 @@ func lowerTerraformDataInputs(resType string, inputs property.Map, opts *Resourc
 	if resType != packages.TerraformDataType {
 		return inputs
 	}
-	// An ignore_changes path into input (input["k"], input[0]) ignores the
-	// whole attribute: input is a single dynamic attribute, and its keys live
-	// under the {type, value} wrapper in the engine's encoding, where a nested
-	// glob would match nothing.
-	for i, g := range opts.IgnoreChanges {
+	// triggers_replace is not a Stash input but the engine's replacement trigger,
+	// which processIgnoreChanges (input-only) cannot suppress. An ignore_changes
+	// entry naming it is handled here instead: the trigger slot is held null so a
+	// later value change never diffs against the stored trigger.
+	//
+	// Known limitation: this reconciles only against a trigger that was itself
+	// recorded under ignore (null). If ignore_changes is added in the same update
+	// that changes triggers_replace, the prior state still holds the real value,
+	// so nulling the slot registers as a change and forces one replacement — the
+	// engine substitutes prior state for ignored *inputs* only, and Stash rejects
+	// triggers_replace as an input, so the language host cannot see it here.
+	triggersIgnored := false
+	kept := opts.IgnoreChanges[:0]
+	for _, g := range opts.IgnoreChanges {
 		text, err := g.MarshalText()
 		if err != nil {
+			kept = append(kept, g)
 			continue
 		}
-		if s := string(text); strings.HasPrefix(s, "input.") || strings.HasPrefix(s, "input[") {
-			opts.IgnoreChanges[i] = property.GlobFromSegments(property.NewSegment("input"))
+		s := string(text)
+		switch {
+		// An ignore_changes path into input (input["k"], input[0]) ignores the
+		// whole attribute: input is a single dynamic attribute, and its keys live
+		// under the {type, value} wrapper in the engine's encoding, where a nested
+		// glob would match nothing.
+		case strings.HasPrefix(s, "input.") || strings.HasPrefix(s, "input["):
+			kept = append(kept, property.GlobFromSegments(property.NewSegment("input")))
+		// A glob rooted at triggers_replace (exact or nested) ignores the whole
+		// trigger. It is dropped rather than kept: triggers_replace is no engine
+		// property, so the engine would flag it as an unresolved ignore path.
+		case s == "triggers_replace" ||
+			strings.HasPrefix(s, "triggers_replace.") || strings.HasPrefix(s, "triggers_replace["):
+			triggersIgnored = true
+		// ignore_changes = all (the "[*]" splat) covers triggers_replace too; the
+		// splat still applies to the Stash input, so it is kept.
+		case s == "[*]":
+			triggersIgnored = true
+			kept = append(kept, g)
+		default:
+			kept = append(kept, g)
 		}
 	}
+	opts.IgnoreChanges = kept
 	triggers := inputs.Get("triggers_replace")
 	inputs = inputs.Delete("triggers_replace")
 	delete(opts.PropertyDependencies, "triggers_replace")
+	if triggersIgnored {
+		triggers = property.New(property.Null)
+	}
 	opts.ReplacementTrigger = property.New([]property.Value{triggers, opts.ReplacementTrigger})
 	if _, ok := inputs.GetOk("input"); !ok {
 		inputs = inputs.Set("input", property.New(property.Null))

--- a/pkg/hcl/run/terraform_data_internal_test.go
+++ b/pkg/hcl/run/terraform_data_internal_test.go
@@ -81,6 +81,34 @@ func TestLowerTerraformDataInputs(t *testing.T) {
 				property.New("x"), property.New("lifecycle"),
 			}),
 		},
+		{
+			name: "ignored triggers_replace holds a null trigger slot",
+			inputs: property.NewMap(map[string]property.Value{
+				"input":            property.New("a"),
+				"triggers_replace": property.New("x"),
+			}),
+			opts: ResourceOptions{IgnoreChanges: []property.Glob{
+				property.GlobFromSegments(property.NewSegment("triggers_replace")),
+			}},
+			wantInputs: property.NewMap(map[string]property.Value{
+				"input": property.New("a"),
+			}),
+			wantTrigger: property.New([]property.Value{null, null}),
+		},
+		{
+			name: "ignore_changes = all nulls the trigger slot too",
+			inputs: property.NewMap(map[string]property.Value{
+				"input":            property.New("a"),
+				"triggers_replace": property.New("x"),
+			}),
+			opts: ResourceOptions{IgnoreChanges: []property.Glob{
+				property.GlobFromSegments(property.Splat),
+			}},
+			wantInputs: property.NewMap(map[string]property.Value{
+				"input": property.New("a"),
+			}),
+			wantTrigger: property.New([]property.Value{null, null}),
+		},
 	}
 
 	for _, tt := range tests {
@@ -105,7 +133,7 @@ func TestLowerTerraformDataInputs(t *testing.T) {
 		assert.Equal(t, ResourceOptions{}, opts)
 	})
 
-	t.Run("ignore_changes paths into input collapse to the whole attribute", func(t *testing.T) {
+	t.Run("input ignore_changes collapse to the whole attribute; triggers_replace ones drop", func(t *testing.T) {
 		t.Parallel()
 
 		glob := func(s string) property.Glob {
@@ -114,11 +142,14 @@ func TestLowerTerraformDataInputs(t *testing.T) {
 			return g
 		}
 		opts := ResourceOptions{IgnoreChanges: []property.Glob{
-			glob("input.k"), glob("input[0]"), glob("input"), glob("triggers_replace.k"),
+			glob("input.k"), glob("input[0]"), glob("input"),
+			glob("triggers_replace"), glob("triggers_replace.k"),
+			property.GlobFromSegments(property.Splat), glob("other"),
 		}}
 		lowerTerraformDataInputs(packages.TerraformDataType, property.Map{}, &opts)
 		assert.Equal(t, []property.Glob{
-			glob("input"), glob("input"), glob("input"), glob("triggers_replace.k"),
+			glob("input"), glob("input"), glob("input"),
+			property.GlobFromSegments(property.Splat), glob("other"),
 		}, opts.IgnoreChanges)
 	})
 }

--- a/tests/tfcompat/l2_tdata_ignore_triggers_test.go
+++ b/tests/tfcompat/l2_tdata_ignore_triggers_test.go
@@ -37,3 +37,70 @@ func TestL2TdataIgnoreTriggers(t *testing.T) {
 		Stages: []tfcompat.Stage{{Mode: tfcompat.StageApply}, {Mode: tfcompat.StageApply}},
 	})
 }
+
+// TestL2TdataIgnoreAll is the ignore_changes = all sibling of
+// TestL2TdataIgnoreTriggers: the splat entry covers triggers_replace too, so a
+// later change to it is ignored and the dependent is not replaced.
+func TestL2TdataIgnoreAll(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_ignore_all", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{Mode: tfcompat.StageApply}, {Mode: tfcompat.StageApply}},
+	})
+}
+
+// TestL2TdataIgnoreTriggersIndex ignores a single key of a map-valued
+// triggers_replace (triggers_replace["drop"]). triggers_replace is one dynamic
+// attribute, so the traversal ignores the whole attribute and even a change to
+// an un-named key is suppressed, leaving the dependent untouched.
+func TestL2TdataIgnoreTriggersIndex(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_ignore_triggers_index", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{Mode: tfcompat.StageApply}, {Mode: tfcompat.StageApply}},
+	})
+}
+
+// TestL2TdataIgnoreAllInput checks that ignore_changes = all suppresses a later
+// input change as well as triggers_replace: the retained input still flows to
+// output and no replacement occurs.
+func TestL2TdataIgnoreAllInput(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_ignore_all_input", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{Mode: tfcompat.StageApply}, {Mode: tfcompat.StageApply}},
+	})
+}
+
+// TestL2TdataIgnoreTriggersKeepsReplaceTriggeredBy checks that ignoring
+// triggers_replace does not clobber a replace_triggered_by on the same
+// terraform_data: when the referenced value changes, the resource is still
+// replaced and its dependent recreated.
+func TestL2TdataIgnoreTriggersKeepsReplaceTriggeredBy(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_ignore_triggers_keeps_rtb", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{Mode: tfcompat.StageApply}, {Mode: tfcompat.StageApply}},
+	})
+}
+
+// TestL2TdataIgnoreTriggersInputUpdate checks that ignoring triggers_replace
+// does not suppress an un-ignored input change: the input updates in place (no
+// replacement, stable id) while the triggers_replace change is dropped.
+func TestL2TdataIgnoreTriggersInputUpdate(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_ignore_triggers_input_update", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{Mode: tfcompat.StageApply}, {Mode: tfcompat.StageApply}},
+	})
+}

--- a/tests/tfcompat/l2_tdata_ignore_triggers_test.go
+++ b/tests/tfcompat/l2_tdata_ignore_triggers_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2TdataIgnoreTriggers covers `ignore_changes = [triggers_replace]` on a
+// terraform_data resource. OpenTofu honors the ignore: a later change to
+// triggers_replace produces no diff and no replacement, so the terraform_data
+// id stays stable and a replace_triggered_by dependent is not touched (1 op
+// total across both stages). pulumi-hcl routes triggers_replace to the engine's
+// ReplacementTrigger before ignore_changes is applied, so the change still
+// forces a replacement and the dependent is re-created + deleted (3 ops).
+func TestL2TdataIgnoreTriggers(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_tdata_ignore_triggers", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{Mode: tfcompat.StageApply}, {Mode: tfcompat.StageApply}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_all/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_all/0/main.tf
@@ -1,0 +1,20 @@
+# triggers_replace changes are ignored via ignore_changes = all, so a later
+# change to it must NOT force a replacement. simple_resource.dependent witnesses
+# terraform_data.t.id stability through replace_triggered_by.
+resource "terraform_data" "t" {
+  input            = "a"
+  triggers_replace = "x"
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" { value = terraform_data.t.output }
+output "dependent_result" { value = simple_resource.dependent.result }

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_all/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_all/1/main.tf
@@ -1,0 +1,20 @@
+# Stage 1: triggers_replace changes "x" -> "y" but is ignored by ignore_changes
+# = all. No replacement of terraform_data.t; id stays stable; dependent is NOT
+# replaced.
+resource "terraform_data" "t" {
+  input            = "a"
+  triggers_replace = "y"
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" { value = terraform_data.t.output }
+output "dependent_result" { value = simple_resource.dependent.result }

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_all_input/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_all_input/0/main.tf
@@ -1,0 +1,21 @@
+# Stage 0: create. ignore_changes = all covers every attribute, so later changes
+# to both input and triggers_replace must be suppressed. output mirrors input, so
+# `value` witnesses the retained input; simple_resource.dependent witnesses
+# terraform_data.t's id stability via replace_triggered_by.
+resource "terraform_data" "t" {
+  input            = "a"
+  triggers_replace = "x"
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" { value = terraform_data.t.output }
+output "dependent_result" { value = simple_resource.dependent.result }

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_all_input/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_all_input/1/main.tf
@@ -1,0 +1,20 @@
+# Stage 1: input "a" -> "b" and triggers_replace "x" -> "y". ignore_changes = all
+# suppresses both: no in-place update and no replacement. output stays "a" (the
+# retained input), id stays stable, and simple_resource.dependent is not touched.
+resource "terraform_data" "t" {
+  input            = "b"
+  triggers_replace = "y"
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" { value = terraform_data.t.output }
+output "dependent_result" { value = simple_resource.dependent.result }

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers/0/main.tf
@@ -1,0 +1,20 @@
+# triggers_replace changes are ignored via ignore_changes, so a later change to
+# it must NOT force a replacement. simple_resource.dependent witnesses
+# terraform_data.t.id stability through replace_triggered_by.
+resource "terraform_data" "t" {
+  input            = "a"
+  triggers_replace = "x"
+  lifecycle {
+    ignore_changes = [triggers_replace]
+  }
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" { value = terraform_data.t.output }
+output "dependent_result" { value = simple_resource.dependent.result }

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers/1/main.tf
@@ -1,0 +1,19 @@
+# Stage 1: triggers_replace changes "x" -> "y" but is ignored. No replacement of
+# terraform_data.t; id stays stable; dependent is NOT replaced.
+resource "terraform_data" "t" {
+  input            = "a"
+  triggers_replace = "y"
+  lifecycle {
+    ignore_changes = [triggers_replace]
+  }
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" { value = terraform_data.t.output }
+output "dependent_result" { value = simple_resource.dependent.result }

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers_index/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers_index/0/main.tf
@@ -1,0 +1,22 @@
+# Stage 0: create. triggers_replace is a map, and ignore_changes names a single
+# key (triggers_replace["drop"]). triggers_replace is a single dynamic attribute,
+# so an ignore_changes traversal into it ignores the whole attribute — the same
+# way it does for input. simple_resource.dependent witnesses whether
+# terraform_data.t is replaced across stages via replace_triggered_by.
+resource "terraform_data" "t" {
+  input            = "a"
+  triggers_replace = { keep = "1", drop = "a" }
+  lifecycle {
+    ignore_changes = [triggers_replace["drop"]]
+  }
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" { value = terraform_data.t.output }
+output "dependent_result" { value = simple_resource.dependent.result }

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers_index/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers_index/1/main.tf
@@ -1,0 +1,21 @@
+# Stage 1: both keys change (keep "1" -> "2", drop "a" -> "b"). The nested
+# ignore_changes entry ignores the whole triggers_replace attribute, so even the
+# un-named "keep" key is suppressed: no replacement, id stays stable, and
+# simple_resource.dependent is NOT replaced.
+resource "terraform_data" "t" {
+  input            = "a"
+  triggers_replace = { keep = "2", drop = "b" }
+  lifecycle {
+    ignore_changes = [triggers_replace["drop"]]
+  }
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" { value = terraform_data.t.output }
+output "dependent_result" { value = simple_resource.dependent.result }

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers_input_update/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers_input_update/0/main.tf
@@ -1,0 +1,21 @@
+# Stage 0: create. Only triggers_replace is ignored; input is not. A later input
+# change must still update in place — suppressing the trigger must not suppress
+# the input path. simple_resource.dependent witnesses terraform_data.t's id
+# stability via replace_triggered_by.
+resource "terraform_data" "t" {
+  input            = "a"
+  triggers_replace = "x"
+  lifecycle {
+    ignore_changes = [triggers_replace]
+  }
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" { value = terraform_data.t.output }
+output "dependent_result" { value = simple_resource.dependent.result }

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers_input_update/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers_input_update/1/main.tf
@@ -1,0 +1,21 @@
+# Stage 1: input "a" -> "b" (not ignored) and triggers_replace "x" -> "y"
+# (ignored). The trigger change is suppressed so there is no replacement — id
+# stays stable and simple_resource.dependent is not touched — but the input
+# update still applies in place, so output follows the new input ("b").
+resource "terraform_data" "t" {
+  input            = "b"
+  triggers_replace = "y"
+  lifecycle {
+    ignore_changes = [triggers_replace]
+  }
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" { value = terraform_data.t.output }
+output "dependent_result" { value = simple_resource.dependent.result }

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers_keeps_rtb/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers_keeps_rtb/0/main.tf
@@ -1,0 +1,26 @@
+# Stage 0: create. terraform_data.t ignores triggers_replace but ALSO carries a
+# replace_triggered_by on simple_resource.driver.result. The ignored trigger must
+# not clobber the working one: when driver.result changes, t must still be
+# replaced. simple_resource.dependent witnesses that replacement.
+resource "simple_resource" "driver" {
+  input_one = "p"
+}
+
+resource "terraform_data" "t" {
+  input            = "a"
+  triggers_replace = "x"
+  lifecycle {
+    ignore_changes       = [triggers_replace]
+    replace_triggered_by = [simple_resource.driver.result]
+  }
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" { value = terraform_data.t.output }
+output "dependent_result" { value = simple_resource.dependent.result }

--- a/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers_keeps_rtb/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_tdata_ignore_triggers_keeps_rtb/1/main.tf
@@ -1,0 +1,27 @@
+# Stage 1: driver.result changes (input_one "p" -> "q") and triggers_replace
+# changes "x" -> "y". triggers_replace is ignored, but the replace_triggered_by
+# on driver.result still fires, so terraform_data.t is replaced, its id rolls,
+# and simple_resource.dependent is replaced (Delete+Create on the simple
+# provider).
+resource "simple_resource" "driver" {
+  input_one = "q"
+}
+
+resource "terraform_data" "t" {
+  input            = "a"
+  triggers_replace = "y"
+  lifecycle {
+    ignore_changes       = [triggers_replace]
+    replace_triggered_by = [simple_resource.driver.result]
+  }
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [terraform_data.t.id]
+  }
+}
+
+output "value" { value = terraform_data.t.output }
+output "dependent_result" { value = simple_resource.dependent.result }


### PR DESCRIPTION
## What

`ignore_changes` targeting a `terraform_data` resource's `triggers_replace` was
not honored: a later change to `triggers_replace` still forced a replacement
(re-creating any `replace_triggered_by` dependent). This fixes the common case
and documents the one edge that cannot be closed without an engine change.

## Root cause

`triggers_replace` is lowered onto the engine's replacement-trigger option in
`lowerTerraformDataInputs`, not a stored Stash input. The engine's
`processIgnoreChanges` substitutes prior state only for provider *inputs*, so it
never reaches the replacement trigger — an `ignore_changes` entry naming
`triggers_replace` had no effect.

## Fix

`lowerTerraformDataInputs` detects an `ignore_changes` glob rooted at
`triggers_replace` (exact, nested, or the `[*]` splat from
`ignore_changes = all`) and holds the trigger slot null, so a later change no
longer diffs against the stored trigger. The non-splat glob is dropped from the
ignore list (it names no engine property).

## Known limitation

The trigger slot is reconciled only against a value recorded under ignore
(null). If `ignore_changes = [triggers_replace]` is added in the *same* update
that changes `triggers_replace`, on a resource first created without it, the
prior state still holds the real value, so nulling the slot registers as a
change and forces one replacement. Closing this requires the engine's built-in
Stash provider to accept `triggers_replace` as an input, so the engine's
input-level `ignore_changes` applies. Recorded in
`docs/terraform-compatibility.md`.

## Tests

- `pkg/hcl/run/terraform_data_internal_test.go`: nulling the trigger slot under
  ignore (exact and `ignore_changes = all`) and dropping the glob.
- tfcompat (real `tofu apply` vs `pulumi up`):
  - `TestL2TdataIgnoreTriggers` — scalar trigger ignored, no replacement.
  - `TestL2TdataIgnoreAll` — `ignore_changes = all` suppresses the trigger.
  - `TestL2TdataIgnoreTriggersIndex` — an indexed ignore suppresses the whole
    dynamic attribute.
  - `TestL2TdataIgnoreAllInput` — the splat also suppresses a concurrent `input`
    change.
  - `TestL2TdataIgnoreTriggersKeepsReplaceTriggeredBy` — an ignored trigger does
    not clobber an active `replace_triggered_by` on the same resource.
  - `TestL2TdataIgnoreTriggersInputUpdate` — an ignored trigger does not suppress
    an un-ignored `input` update.

The change was stress-tested with in- and out-of-process adversarial case
authors; the out-of-process pass surfaced the "ignore added later" edge
documented above.
