### PR TITLE
Evaluate `prevent_destroy` at runtime, allowing non-literal expressions

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-434.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-434.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Evaluate `prevent_destroy` at runtime, allowing non-literal expressions
+time: 2026-07-17T23:00:00Z
+custom:
+    Component: runtime
+    PR: "434"

--- a/pkg/hcl/ast/resource.go
+++ b/pkg/hcl/ast/resource.go
@@ -164,8 +164,10 @@ type Lifecycle struct {
 
 	// PreventDestroy indicates whether destruction of the resource should be prevented.
 	// In Pulumi, this maps to the "protect" resource option.
-	// nil means not explicitly set (may inherit from parent), true/false means explicitly set.
-	PreventDestroy *bool
+	// The expression is evaluated at runtime, so it may reference variables,
+	// locals, or other resources. nil means not explicitly set (may inherit
+	// from parent).
+	PreventDestroy hcl.Expression
 
 	// IgnoreChanges lists the attributes whose changes should be ignored.
 	IgnoreChanges []hcl.Traversal

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -858,7 +858,7 @@ func (p *Parser) parseLifecycleBlock(block *hcl.Block) (*lifecycleResult, hcl.Di
 	}
 
 	if attr, ok := content.Attributes["prevent_destroy"]; ok {
-		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &lifecycle.PreventDestroy)...)
+		lifecycle.PreventDestroy = attr.Expr
 	}
 
 	if attr, ok := content.Attributes["ignore_changes"]; ok {

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -149,7 +149,9 @@ module "vpc" {
 		}
 		if r.Lifecycle == nil {
 			t.Error("Expected lifecycle block")
-		} else if r.Lifecycle.PreventDestroy == nil || !*r.Lifecycle.PreventDestroy {
+		} else if r.Lifecycle.PreventDestroy == nil {
+			t.Error("Expected prevent_destroy to be set")
+		} else if v, _ := r.Lifecycle.PreventDestroy.Value(nil); !cty.True.RawEquals(v) {
 			t.Error("Expected prevent_destroy to be true")
 		}
 	} else {
@@ -625,7 +627,9 @@ module "vpc" {
 	assert.True(t, cty.NumberIntVal(2).RawEquals(countVal))
 	require.NotNil(t, res.Lifecycle)
 	require.NotNil(t, res.Lifecycle.PreventDestroy)
-	assert.True(t, *res.Lifecycle.PreventDestroy)
+	pdVal, valDiags := res.Lifecycle.PreventDestroy.Value(nil)
+	require.False(t, valDiags.HasErrors())
+	assert.True(t, cty.True.RawEquals(pdVal))
 
 	content, _, contentDiags := res.Config.PartialContent(&hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{{Name: "ami"}, {Name: "count"}},
@@ -987,7 +991,6 @@ func TestParseConstantAttributeTypes(t *testing.T) {
 		"output sensitive":         `output "o" { value = "v", sensitive = 3 }`,
 		"output description":       `output "o" { value = "v", description = {} }`,
 		"lifecycle cbd":            `resource "r" "r" { lifecycle { create_before_destroy = "x" } }`,
-		"lifecycle prevent":        `resource "r" "r" { lifecycle { prevent_destroy = [true] } }`,
 		"provider alias":           `provider "p" { alias = ["a"] }`,
 		"module source":            `module "m" { source = ["./m"] }`,
 		"required_providers src":   `terraform { required_providers { p = { source = ["x"] } } }`,

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1645,10 +1645,25 @@ func (e *Engine) buildResourceOptionsInContext(
 		opts.DependsOn = append(opts.DependsOn, e.cellURNs.get(expansionCell{block: resPrefix + depKey, mi: miPath})...)
 	}
 
+	hclCtx := evalCtx.HCLContext()
+
 	// Handle lifecycle options
 	if res.Lifecycle != nil {
-		if res.Lifecycle.PreventDestroy != nil && *res.Lifecycle.PreventDestroy {
-			opts.Protect = true
+		if res.Lifecycle.PreventDestroy != nil {
+			val, diags := res.Lifecycle.PreventDestroy.Value(hclCtx)
+			if diags.HasErrors() {
+				return nil, fmt.Errorf("evaluating prevent_destroy on %q: %s",
+					res.Type+"."+res.Name, diags.Error())
+			}
+			val, _ = val.Unmark()
+			val, err := ctyconvert.Convert(val, cty.Bool)
+			if err != nil {
+				return nil, fmt.Errorf("invalid prevent_destroy value on %q: %w",
+					res.Type+"."+res.Name, err)
+			}
+			if cty.True.RawEquals(val) {
+				opts.Protect = true
+			}
 		}
 		// ignore_changes maps to ignoreChanges. The traversal names are TF
 		// (snake_case) attribute names; the Pulumi engine matches ignoreChanges
@@ -1806,8 +1821,6 @@ func (e *Engine) buildResourceOptionsInContext(
 		return nil, err
 	}
 	opts.ImportId = importId
-
-	hclCtx := evalCtx.HCLContext()
 
 	for _, t := range res.AdditionalSecretOutputs {
 		name, err := translateSecretOutputName(t, resourceMapping, outputProps)

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -987,6 +987,81 @@ resource "aws_instance" "web" {
 	assert.Equal(t, []property.Glob{property.GlobFromSegments(property.NewSegment("tags"))}, req.IgnoreChanges)
 }
 
+// TestEngine_PreventDestroyExpression verifies that prevent_destroy accepts a
+// non-literal expression, evaluated against the program's scope.
+func TestEngine_PreventDestroyExpression(t *testing.T) {
+	t.Parallel()
+
+	runEngine := func(t *testing.T, lifecycle string) (*testutil.MockResourceMonitor, error) {
+		src := []byte(`
+variable "flag" {
+  default = true
+}
+
+resource "aws_instance" "web" {
+  ami = "ami-12345"
+
+  lifecycle {
+    prevent_destroy = ` + lifecycle + `
+  }
+}
+`)
+		p := parser.NewParser()
+		config, diags := p.ParseSource("test.hcl", src)
+		if diags.HasErrors() {
+			t.Fatalf("parse error: %s", diags.Error())
+		}
+
+		mock := &testutil.MockResourceMonitor{}
+		engine := newTestEngine(t, config, &run.EngineOptions{
+			ModuleLoader:    testModuleLoader(t),
+			ProjectName:     "test-project",
+			StackName:       "dev",
+			ResourceMonitor: mock,
+			WorkDir:         t.TempDir(),
+			RootDir:         t.TempDir(),
+			SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+				Name: "aws",
+				Resources: map[string]schema.ResourceSpec{
+					"aws:index:Instance": {
+						InputProperties: map[string]schema.PropertySpec{
+							"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+						ObjectTypeSpec: schema.ObjectTypeSpec{
+							Properties: map[string]schema.PropertySpec{
+								"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+							},
+						},
+					},
+				},
+			}),
+		})
+		return mock, engine.Run(t.Context())
+	}
+
+	t.Run("variable", func(t *testing.T) {
+		t.Parallel()
+		mock, err := runEngine(t, "var.flag")
+		require.NoError(t, err)
+		require.Len(t, mock.RegisteredResources, 2)
+		assert.True(t, mock.RegisteredResources[1].Protect)
+	})
+
+	t.Run("negated variable", func(t *testing.T) {
+		t.Parallel()
+		mock, err := runEngine(t, "!var.flag")
+		require.NoError(t, err)
+		require.Len(t, mock.RegisteredResources, 2)
+		assert.False(t, mock.RegisteredResources[1].Protect)
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		t.Parallel()
+		_, err := runEngine(t, "[true]")
+		require.ErrorContains(t, err, `invalid prevent_destroy value on "aws_instance.web"`)
+	})
+}
+
 func TestEngine_CreateBeforeDestroy(t *testing.T) {
 	t.Parallel()
 

--- a/tests/tfcompat/l2_prevent_destroy_var_test.go
+++ b/tests/tfcompat/l2_prevent_destroy_var_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2PreventDestroyVar proves that pulumi-hcl rejects a non-literal
+// `prevent_destroy` expression that OpenTofu accepts.
+//
+// The resource sets `prevent_destroy = var.flag`. OpenTofu evaluates the
+// expression and applies successfully (and, with flag=true, protects the
+// resource exactly as a literal `prevent_destroy = true` would). pulumi-hcl
+// decodes the `prevent_destroy` expression with a nil HCL eval context, so the
+// `var.flag` reference fails to resolve and `pulumi up` aborts with "Variables
+// not allowed" before the resource is created. The harness fails because
+// pulumi errors on a program OpenTofu runs cleanly.
+func TestL2PreventDestroyVar(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_prevent_destroy_var", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Config: map[string]string{"flag": "true"},
+	})
+}

--- a/tests/tfcompat/l2_prevent_destroy_var_test.go
+++ b/tests/tfcompat/l2_prevent_destroy_var_test.go
@@ -21,16 +21,9 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-// TestL2PreventDestroyVar proves that pulumi-hcl rejects a non-literal
-// `prevent_destroy` expression that OpenTofu accepts.
-//
-// The resource sets `prevent_destroy = var.flag`. OpenTofu evaluates the
-// expression and applies successfully (and, with flag=true, protects the
-// resource exactly as a literal `prevent_destroy = true` would). pulumi-hcl
-// decodes the `prevent_destroy` expression with a nil HCL eval context, so the
-// `var.flag` reference fails to resolve and `pulumi up` aborts with "Variables
-// not allowed" before the resource is created. The harness fails because
-// pulumi errors on a program OpenTofu runs cleanly.
+// TestL2PreventDestroyVar verifies that a non-literal `prevent_destroy`
+// expression (`prevent_destroy = var.flag`) is evaluated rather than rejected
+// at parse time, protecting the resource just as a literal `true` would.
 func TestL2PreventDestroyVar(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_prevent_destroy_var", tfcompat.Case{

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_var/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_var/main.tf
@@ -1,0 +1,22 @@
+# `prevent_destroy` is set from a variable rather than a literal bool. OpenTofu
+# accepts a non-literal `prevent_destroy` expression (a variable or a
+# conditional) and evaluates it -- `prevent_destroy = var.flag` with flag=true
+# protects the resource just like `prevent_destroy = true`.
+#
+# pulumi-hcl decodes the `prevent_destroy` expression with a nil HCL eval
+# context, so any reference to a variable fails to resolve and the program is
+# rejected with "Variables not allowed" before anything is created.
+variable "flag" {
+  type = bool
+}
+
+resource "simple_resource" "t" {
+  input_one = "x"
+  lifecycle {
+    prevent_destroy = var.flag
+  }
+}
+
+output "result" {
+  value = simple_resource.t.result
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_var/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_var/main.tf
@@ -1,11 +1,6 @@
-# `prevent_destroy` is set from a variable rather than a literal bool. OpenTofu
-# accepts a non-literal `prevent_destroy` expression (a variable or a
-# conditional) and evaluates it -- `prevent_destroy = var.flag` with flag=true
-# protects the resource just like `prevent_destroy = true`.
-#
-# pulumi-hcl decodes the `prevent_destroy` expression with a nil HCL eval
-# context, so any reference to a variable fails to resolve and the program is
-# rejected with "Variables not allowed" before anything is created.
+# `prevent_destroy` is set from a variable rather than a literal bool. The
+# expression is evaluated at runtime, so `prevent_destroy = var.flag` with
+# flag=true protects the resource just like `prevent_destroy = true`.
 variable "flag" {
   type = bool
 }


### PR DESCRIPTION
## Divergence

OpenTofu accepts and evaluates a non-literal `prevent_destroy` expression (`prevent_destroy = var.flag`), applying successfully and honoring the value at runtime. pulumi-hcl rejected the program:

```
tofu apply:  succeeds (prevent_destroy = var.flag honored — verified: flag=true blocks a triggered replace, flag=false allows it)
pulumi up:   Variables not allowed; Variables may not be used here.  (at the var.flag reference)
```

Root cause: the parser decoded `prevent_destroy` with a nil HCL eval context (`gohcl.DecodeExpression(attr.Expr, nil, ...)`), so any variable/symbol reference failed to resolve. OpenTofu 1.12 changed `prevent_destroy` from a parse-time literal to a stored expression evaluated at plan time in the instance scope (`internal/configs/resource.go`, `checkPreventDestroy` in `internal/tofu/node_resource_abstract_instance.go` at v1.12.3).

## Fix

Store the `prevent_destroy` expression on the lifecycle AST node (`ast.Lifecycle.PreventDestroy` is now `hcl.Expression`) and evaluate it in `buildResourceOptionsInContext` against the live eval context, following the existing `retain_on_delete` pattern. A value that fails to evaluate or convert to bool is a hard error; unknown or null leaves the resource unprotected. The wrong-type error (e.g. `prevent_destroy = [true]`) consequently moves from parse time to runtime, which is also where OpenTofu reports it.

## Testing

- `TestL2PreventDestroyVar` (tfcompat, `SimpleProvider`, `flag=true` via `Config`): failed on master, passes with the fix. The pre-existing literal `TestL2PreventDestroy` still passes.
- New `TestEngine_PreventDestroyExpression` unit test: variable → protected, negated variable → unprotected, `[true]` → runtime error.
- Parser tests updated for the type change.

## Sibling sweep

- `create_before_destroy` remains a nil-context literal decode in OpenTofu 1.12, so that path is parity and stays as-is (verified in source and with `tofu validate`).
- Deliberate divergence: OpenTofu forbids `count.index`/`each.key` references in `prevent_destroy` because its destroy-time evaluation cannot see removed instances. pulumi-hcl evaluates per instance at registration, so such references simply work. This is more permissive than OpenTofu and not migration-affecting, so it is left as-is.