### PR TITLE
Substitute the default for a nullable=false root variable set to null

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-435.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-435.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Substitute the default when a root variable declared `nullable = false` is set to null
+time: 2026-07-17T22:30:00Z
+custom:
+    Component: runtime
+    PR: "435"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -845,6 +845,21 @@ func (e *Engine) processVariable(ctx context.Context, node *graph.Node) error {
 		val = converted
 	}
 
+	// A `nullable = false` variable rejects an explicit null value: the
+	// default is substituted when one is declared, otherwise it is an
+	// error.
+	if val.IsNull() && !v.Nullable && valueSource != "default" {
+		if v.Default == nil {
+			return fmt.Errorf("variable %q must not be set to null: it is declared with nullable = false and has no default", varName)
+		}
+		var diags hcl.Diagnostics
+		val, diags = e.evaluator.EvaluateExpression(v.Default)
+		if diags.HasErrors() {
+			return fmt.Errorf("evaluating variable default: %s", diags.Error())
+		}
+		valueSource = "default"
+	}
+
 	// Fill in optional()-attribute defaults before sensitive marking.
 	if v.TypeDefaults != nil && !val.IsNull() {
 		val = v.TypeDefaults.Apply(val)

--- a/tests/tfcompat/l1_nullable_false_root_test.go
+++ b/tests/tfcompat/l1_nullable_false_root_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1NullableFalseRoot assigns the null literal to a root variable declared
+// with `nullable = false` and a default. OpenTofu substitutes the default (so
+// `var.v == null` is false and `var.v` is the optional-filled object);
+// pulumi-hcl leaves the value null at the root scope, diverging. The module
+// input path already substitutes (see TestL1NullableFalseDefault); only the
+// root variable path is affected.
+func TestL1NullableFalseRoot(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_nullable_false_root", tfcompat.Case{
+		Config: map[string]string{"v": "null"},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l1_nullable_false_root/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_nullable_false_root/main.tf
@@ -1,0 +1,17 @@
+# A root variable declared `nullable = false` with a default. Assigning the
+# null literal (here via stack config / -var) must substitute the variable's
+# default, exactly as it does for a module input. The declared type is a
+# complex (non-primitive) type, so the config string `null` parses as the HCL
+# null literal rather than the four-character string "null".
+variable "v" {
+  type     = object({ a = string, b = optional(number, 5) })
+  default  = { a = "aa" }
+  nullable = false
+}
+
+# false in both runtimes if the default was substituted; true only if the
+# variable was left null.
+output "is_null" { value = var.v == null }
+
+# The substituted, optional-filled default.
+output "value" { value = var.v }


### PR DESCRIPTION
## Divergence

A **root** variable declared `nullable = false` with a `default`, assigned the null literal via stack config (`-var` / `pulumi config set`):

- **OpenTofu** substitutes the variable's default (the same behavior it applies to module inputs), so `var.v == null` is `false` and `var.v` is the optional-filled object `{"a":"aa","b":5}`.
- **pulumi-hcl** left the value `null` at the root scope, so `var.v == null` was `true` and any attribute access (`var.v.a`) errored "Attempt to get attribute from null value".

Only observable for a **complex (non-primitive)** type — for a primitive type the config string `null` is taken literally as the 4-char string `"null"` and never becomes the null literal that triggers substitution.

Distinct from the closed https://github.com/pulumi-labs/pulumi-hcl/issues/183, which fixed the module-input path; the existing `l1_nullable_false_default` case exercises only that path.

## Fix

The null-substitution step existed only in the module variable path (`processModuleVariable`); `processVariable` now performs the same step: after string-source parsing (which is what produces the null literal) and before the optional-defaults fill, a null value for a `nullable = false` variable substitutes the declared default, or errors when no default is declared.

## Test

`TestL1NullableFalseRoot` in `tests/tfcompat/l1_nullable_false_root_test.go` (`Config: {"v": "null"}`). Failed 3/3 on master; passes with the fix, as do `TestL1NullableFalseDefault` and `TestL1Variable*`.