### PR TITLE
Gzip the module parameterization value baked into schema.json

### DIFF
--- a/.changes/unreleased/runtime-Improvements-436.yaml
+++ b/.changes/unreleased/runtime-Improvements-436.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Compress the module parameterization value baked into the generated `schema.json`
+time: 2026-07-20T12:37:06Z
+custom:
+    Component: runtime
+    PR: "436"

--- a/pkg/server/parameterize.go
+++ b/pkg/server/parameterize.go
@@ -88,17 +88,32 @@ type bundle struct {
 	Archive []byte `json:"archive"`
 }
 
-// encodeBundle serialises a bundle to the parameterization Value.
+// encodeBundle serialises a bundle to the parameterization Value: gzipped JSON,
+// so the base64-encoded copy the engine bakes into schema.json stays small.
 func (b bundle) encode() []byte {
 	data, err := json.Marshal(b)
 	contract.AssertNoErrorf(err, "bundle is always serializable")
-	return data
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err = gz.Write(data)
+	contract.AssertNoErrorf(err, "gzipping bundle is always possible")
+	contract.AssertNoErrorf(gz.Close(), "closing gzip writer is always possible")
+	return buf.Bytes()
 }
 
-// decodeBundle parses a parameterization Value produced by encodeBundle.
+// decodeBundle parses a parameterization Value produced by encode.
 func decodeBundle(value []byte) (bundle, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(value))
+	if err != nil {
+		return bundle{}, fmt.Errorf("decompressing bundle: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+	data, err := io.ReadAll(gz)
+	if err != nil {
+		return bundle{}, fmt.Errorf("decompressing bundle: %w", err)
+	}
 	var b bundle
-	if err := json.Unmarshal(value, &b); err != nil {
+	if err := json.Unmarshal(data, &b); err != nil {
 		return bundle{}, fmt.Errorf("decoding bundle: %w", err)
 	}
 	return b, nil


### PR DESCRIPTION
## What

The `hcl` module provider's parameterization Value is a JSON-encoded `bundle`. Its largest field is an already-gzipped module archive, which `json.Marshal` base64-encodes into the JSON, and the engine then base64-encodes the whole Value again into the generated `schema.json`. The archive was therefore carried through two base64 layers.

Gzip the encoded bundle in `bundle.encode` and gunzip it in `decodeBundle`, so the copy baked into `schema.json` is compressed. The Value is opaque to every downstream consumer, so nothing else changes.

## Notes

No backward-compat sniff: `decodeBundle` now requires gzip. There are no published raw-JSON parameterization values to support yet.

## Test

Existing `TestBundleRoundTrip*` and `TestBundleBakesPackages` already round-trip through `encode` → `decodeBundle`; all pass.