### PR TITLE
Evaluate `check` blocks declared in child modules

### DIFF
--- a/.changes/unreleased/runtime-Improvements-437.yaml
+++ b/.changes/unreleased/runtime-Improvements-437.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Evaluate `check` blocks declared in child modules, once per module instance
+time: 2026-07-21T13:30:00Z
+custom:
+    Component: runtime
+    PR: "437"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -260,7 +260,10 @@ type moduleInstance struct {
 	// instance's Name joined to this instance's step with ".". It prefixes
 	// the derived names of everything inside the instance and is exposed to
 	// the instance as pulumi.module.name.
-	Name    string
+	Name string
+	// Config is the parsed configuration of the called module, shared by
+	// every instance of the call.
+	Config  *ast.Config
 	EvalCtx *eval.Context        // per-instance evaluation context
 	URN     urn.URN              // component URN
 	Parent  *moduleInstance      // enclosing module instance (nil for root-level calls)
@@ -3948,6 +3951,7 @@ func (e *Engine) initModuleCallIn(
 			Path:       instPath,
 			ModuleInfo: modInfo,
 			Name:       instName,
+			Config:     childMod.Config,
 			EvalCtx:    instCtx,
 			URN:        componentURN,
 			Parent:     parent,
@@ -4580,16 +4584,39 @@ func evaluatePrecondition(rule *ast.CheckRule, hclCtx *hcl.EvalContext, index in
 }
 
 // evaluateChecks evaluates every check block after all resources have settled.
-// Both scoped-data-source errors and failed assertions emit warnings and
-// processing continues, matching Terraform: check blocks are the only custom
-// condition that does not block the operation.
+// Checks declared in child modules are evaluated once per module instance, in
+// that instance's scope. Both scoped-data-source errors and failed assertions
+// emit warnings and processing continues, matching Terraform: check blocks are
+// the only custom condition that does not block the operation.
 func (e *Engine) evaluateChecks(ctx context.Context) error {
 	contract.Assertf(e.resmon != nil, "e.resmon cannot be nil")
-	names := slices.Collect(maps.Keys(e.config.Checks))
+	var errs []error
+	errs = append(errs, e.evaluateConfigChecks(ctx, "", e.config, e.evaluator.Context()))
+	var instances []*moduleInstance
+	for insts := range e.moduleInstances.Values() {
+		instances = append(instances, insts...)
+	}
+	slices.SortFunc(instances, func(a, b *moduleInstance) int {
+		return strings.Compare(a.Path.PrefixString(), b.Path.PrefixString())
+	})
+	for _, inst := range instances {
+		errs = append(errs, e.evaluateConfigChecks(
+			ctx, inst.Path.PrefixString()+".", inst.Config, inst.EvalCtx))
+	}
+	return errors.Join(errs...)
+}
+
+// evaluateConfigChecks evaluates the check blocks of one config in the scope
+// given by evalCtx. addrPrefix qualifies the reported check name with its
+// module instance address ("" for the root config).
+func (e *Engine) evaluateConfigChecks(
+	ctx context.Context, addrPrefix string, config *ast.Config, evalCtx *eval.Context,
+) error {
+	names := slices.Collect(maps.Keys(config.Checks))
 	slices.Sort(names)
 	var errs []error
 	for _, name := range names {
-		errs = append(errs, e.evaluateCheck(ctx, name, e.config.Checks[name]))
+		errs = append(errs, e.evaluateCheck(ctx, addrPrefix+name, config.Checks[name], evalCtx))
 	}
 	return errors.Join(errs...)
 }
@@ -4597,8 +4624,7 @@ func (e *Engine) evaluateChecks(ctx context.Context) error {
 // evaluateCheck evaluates one check block. Its scoped data source is read into a
 // cloned context so it is visible only to this check's assertions and cannot
 // collide with a top-level data source of the same address.
-func (e *Engine) evaluateCheck(ctx context.Context, name string, check *ast.Check) error {
-	evalCtx := e.evaluator.Context()
+func (e *Engine) evaluateCheck(ctx context.Context, name string, check *ast.Check, evalCtx *eval.Context) error {
 	var errs []error
 	if ds := check.DataResource; ds != nil {
 		evalCtx = evalCtx.Clone()

--- a/tests/tfcompat/l2_check_in_module_test.go
+++ b/tests/tfcompat/l2_check_in_module_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/stretchr/testify/require"
+)
+
+// TestL2Check_InModule covers a check block declared inside a child module.
+// Terraform evaluates check blocks in every module in the configuration, so a
+// failing assertion in a child module surfaces its error_message as a
+// non-blocking warning just like a root-module check does.
+func TestL2Check_InModule(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_check_in_module", tfcompat.Case{
+		Stages: []tfcompat.Stage{{
+			AssertOutput: func(t *testing.T, output string) {
+				require.Contains(t, output, "module check assertion did not hold")
+			},
+		}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_check_in_module/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_check_in_module/main.tf
@@ -1,0 +1,8 @@
+module "checked" {
+  source = "./modules/checked"
+  name   = "world"
+}
+
+output "result" {
+  value = module.checked.result
+}

--- a/tests/tfcompat/testdata/cases/l2_check_in_module/modules/checked/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_check_in_module/modules/checked/main.tf
@@ -1,0 +1,14 @@
+variable "name" {
+  type = string
+}
+
+check "name_check" {
+  assert {
+    condition     = var.name == "this-will-never-match"
+    error_message = "module check assertion did not hold"
+  }
+}
+
+output "result" {
+  value = var.name
+}


### PR DESCRIPTION
A `check` block declared in a child module was evaluated by OpenTofu but silently ignored by pulumi-hcl.

- **OpenTofu**: evaluates the module's `check` block and, when the assertion fails, emits its `error_message` as a non-blocking warning — the apply still succeeds.
- **pulumi-hcl**: never evaluated it. No warning, no diagnostic; the check block was parsed and dropped.

Root-module `check` blocks already worked (`l2_check_pass`, `l2_check_fail_non_blocking`); only the module-nested case diverged.

## Fix

`evaluateChecks` walked only `e.config.Checks`. It now also walks every module instance, evaluating that module's checks in the instance's own evaluation context, so `var.*`, locals, and resources inside the module resolve. Checks run once per instance of a `count`/`for_each` module call, and the reported check name is qualified with the instance address (`module.checked.name_check`). `moduleInstance` gained a `Config` field so the loaded child configuration is reachable after the walk.

## Test

`TestL2Check_InModule` (added by the first commit, failing on master) now passes.

## Known limitation

A check block's scoped `data` source inside a module still resolves its provider globally, exactly as root-module scoped data sources do today. Unchanged by this PR.