### PR TITLE
Compose a `moved` module-call rename with `moved` blocks inside that module

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-438.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-438.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Compose a `moved` module-call rename with a `moved` rename of a resource inside it
+time: 2026-07-21T13:30:00Z
+custom:
+    Component: runtime
+    PR: "438"

--- a/.changes/unreleased/runtime-bug-fixes-438.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-438.yaml
@@ -1,5 +1,5 @@
 kind: bug-fixes
-body: Compose a `moved` module-call rename with a `moved` rename of a resource inside it
+body: Compose a `moved` module-call rename with a `moved` block that renames a resource inside that module or moves one out of it
 time: 2026-07-21T13:30:00Z
 custom:
     Component: runtime

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2264,6 +2264,22 @@ func (e *Engine) resolveMovedAliases(
 					ParentURN: parentURN,
 					NoParent:  noParent,
 				}})
+
+				// The module the resource moved out of may itself be renamed in
+				// the same apply; the object then lived under the pre-rename
+				// module path, parented to the same component under its
+				// pre-rename name. A prior address in the resource's own module
+				// is handled below instead, where the parent is the resource's
+				// own component and Pulumi supplies it from the component alias.
+				if fromPath != resPath {
+					for _, oldPath := range e.oldModulePaths(fromPath) {
+						aliases = append(aliases, Alias{Spec: &AliasSpec{
+							Name:      prefixWithModulePath(oldPath, buildResourceName(from.Name, priorIdx, priorEach)),
+							Type:      prior.token,
+							ParentURN: string(urn.URN(parentURN).Rename(oldPath.LogicalName())),
+						}})
+					}
+				}
 			}
 		}
 	}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2167,6 +2167,9 @@ func (e *Engine) resolveMovedAliases(
 		name    string
 		index   *int
 		eachKey *string
+		// token is the prior type's Pulumi token, set only when the move also
+		// changes the resource's type.
+		token string
 	}
 	type addrKey struct {
 		typ    string
@@ -2178,6 +2181,11 @@ func (e *Engine) resolveMovedAliases(
 
 	work := []address{{path: resPath, typ: res.Type, name: res.Name, index: index, eachKey: eachKey}}
 	seen := map[addrKey]bool{mkAddrKey(work[0]): true}
+
+	// sameModule holds the addresses the resource had within its own module,
+	// current one first: the names to reconstruct under a prior module path when
+	// the enclosing module call is renamed in the same apply.
+	sameModule := []address{work[0]}
 
 	for len(work) > 0 {
 		cur := work[0]
@@ -2224,8 +2232,23 @@ func (e *Engine) resolveMovedAliases(
 				if seen[mkAddrKey(prior)] {
 					continue
 				}
+
+				// A `moved` may also change the resource's type; the alias then
+				// carries the prior type's token so the engine matches the old URN.
+				if from.Type != res.Type {
+					priorRes, err := e.resolver.ResolveResource(ctx, from.Type)
+					if err != nil {
+						logging.V(5).Infof("moved: cannot resolve prior type %q: %v", from.Type, err)
+						continue
+					}
+					prior.token = priorRes.Token
+				}
+
 				seen[mkAddrKey(prior)] = true
 				work = append(work, prior)
+				if fromPath == resPath {
+					sameModule = append(sameModule, prior)
+				}
 
 				// The prior name is the resource's own name under its prior module
 				// path; the prior parent is described relative to where it is now.
@@ -2235,21 +2258,9 @@ func (e *Engine) resolveMovedAliases(
 					continue
 				}
 
-				// A `moved` may also change the resource's type; the alias then
-				// carries the prior type's token so the engine matches the old URN.
-				var priorType string
-				if from.Type != res.Type {
-					priorRes, err := e.resolver.ResolveResource(ctx, from.Type)
-					if err != nil {
-						logging.V(5).Infof("moved: cannot resolve prior type %q: %v", from.Type, err)
-						continue
-					}
-					priorType = priorRes.Token
-				}
-
 				aliases = append(aliases, Alias{Spec: &AliasSpec{
 					Name:      name,
-					Type:      priorType,
+					Type:      prior.token,
 					ParentURN: parentURN,
 					NoParent:  noParent,
 				}})
@@ -2258,12 +2269,15 @@ func (e *Engine) resolveMovedAliases(
 	}
 
 	// A `moved` block that renames an enclosing module call moves this resource
-	// with it. The resource keeps its own name within the module, so it is
-	// aliased to the name it had under each prior module path; Pulumi combines
-	// that with the renamed component's own alias to recover the old URN.
+	// with it. The resource is aliased to each name it held within the module —
+	// its current one and any it is being renamed from in the same apply — under
+	// each prior module path; Pulumi combines that with the renamed component's
+	// own alias to recover the old URN.
 	for _, oldPath := range e.oldModulePaths(resPath) {
-		name := prefixWithModulePath(oldPath, buildResourceName(res.Name, index, eachKey))
-		aliases = append(aliases, Alias{Spec: &AliasSpec{Name: name}})
+		for _, a := range sameModule {
+			name := prefixWithModulePath(oldPath, buildResourceName(a.name, a.index, a.eachKey))
+			aliases = append(aliases, Alias{Spec: &AliasSpec{Name: name, Type: a.token}})
+		}
 	}
 
 	return aliases

--- a/tests/tfcompat/l2_moved_module_call_rename_inner_test.go
+++ b/tests/tfcompat/l2_moved_module_call_rename_inner_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2MovedModuleCallRenameInner composes two `moved` blocks in one apply: the
+// root renames the module call (module.a -> module.b) and the module itself
+// renames the resource inside it (simple_resource.old -> simple_resource.new).
+// OpenTofu applies both, so module.a.simple_resource.old moves to
+// module.b.simple_resource.new with no create or delete.
+func TestL2MovedModuleCallRenameInner(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_moved_module_call_rename_inner", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_moved_test.go
+++ b/tests/tfcompat/l2_moved_test.go
@@ -61,6 +61,9 @@ func TestL2Moved(t *testing.T) {
 
 		// Moving a resource out of a module back to the root.
 		{name: "consolidate", dir: "l2_moved_consolidate"}, // module.a.r -> r
+
+		// Renaming a module call composed with a move out of it, in one apply.
+		{name: "module_call_rename_out", dir: "l2_moved_module_call_rename_out"}, // module.a.r -> r
 	}
 
 	for _, c := range cases {
@@ -86,3 +89,4 @@ func TestL2Moved(t *testing.T) {
 		})
 	})
 }
+

--- a/tests/tfcompat/l2_moved_test.go
+++ b/tests/tfcompat/l2_moved_test.go
@@ -89,4 +89,3 @@ func TestL2Moved(t *testing.T) {
 		})
 	})
 }
-

--- a/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_inner/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_inner/0/main.tf
@@ -1,0 +1,2 @@
+module "a" { source = "./mod" }
+output "r" { value = module.a.r }

--- a/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_inner/0/mod/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_inner/0/mod/main.tf
@@ -1,0 +1,2 @@
+resource "simple_resource" "old" { input_one = "m" }
+output "r" { value = simple_resource.old.result }

--- a/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_inner/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_inner/1/main.tf
@@ -1,0 +1,11 @@
+module "b" { source = "./mod" }
+
+# The module call is renamed at the same time as the resource inside it, so the
+# object created as module.a.simple_resource.old must move to
+# module.b.simple_resource.new in one apply, with no create or delete.
+moved {
+  from = module.a
+  to   = module.b
+}
+
+output "r" { value = module.b.r }

--- a/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_inner/1/mod/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_inner/1/mod/main.tf
@@ -1,0 +1,8 @@
+resource "simple_resource" "new" { input_one = "m" }
+
+moved {
+  from = simple_resource.old
+  to   = simple_resource.new
+}
+
+output "r" { value = simple_resource.new.result }

--- a/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_out/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_out/0/main.tf
@@ -1,0 +1,2 @@
+module "a" { source = "./mod" }
+output "kept" { value = module.a.kept }

--- a/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_out/0/mod/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_out/0/mod/main.tf
@@ -1,0 +1,3 @@
+resource "simple_resource" "kept" { input_one = "k" }
+resource "simple_resource" "r" { input_one = "x" }
+output "kept" { value = simple_resource.kept.result }

--- a/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_out/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_out/1/main.tf
@@ -1,0 +1,19 @@
+module "b" { source = "./mod" }
+
+resource "simple_resource" "r" { input_one = "x" }
+
+# The module call is renamed at the same time as one of its resources moves out
+# to the root, so the object created as module.a.simple_resource.r must move to
+# simple_resource.r in one apply, with no create or delete.
+moved {
+  from = module.a
+  to   = module.b
+}
+
+moved {
+  from = module.b.simple_resource.r
+  to   = simple_resource.r
+}
+
+output "kept" { value = module.b.kept }
+output "r" { value = simple_resource.r.result }

--- a/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_out/1/mod/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_moved_module_call_rename_out/1/mod/main.tf
@@ -1,0 +1,2 @@
+resource "simple_resource" "kept" { input_one = "k" }
+output "kept" { value = simple_resource.kept.result }


### PR DESCRIPTION
Two `moved` blocks in the same apply — one renaming a module call, one renaming or relocating a resource *inside* that module — together describe a single composed move. OpenTofu resolves the composed prior address and moves the object; pulumi-hcl never formed the composed address, failed to match the prior URN, and **replaced** the resource (extra Create + Delete).

Two compositions are fixed here:

| Case | Composed move |
| --- | --- |
| `l2_moved_module_call_rename_inner` | `module.a.simple_resource.old` → `module.b.simple_resource.new` |
| `l2_moved_module_call_rename_out` | `module.a.simple_resource.r` → `simple_resource.r` (root), while `module.a` → `module.b` |

Each rename alone already worked (`l2_moved_rename`, `l2_moved_consolidate`, `l2_moved_module_call_rename`); only the compositions diverged.

## Cause

`resolveMovedAliases` produced the halves of a composed move separately:

1. the prior resource addresses, under the module path the resource has *now* (the `moved`-chain walk), and
2. the *current* resource name, under each prior module path (the module-call rename loop).

It never produced their product, so no alias described the object's actual prior address.

## Fix

- For a prior address in the resource's own module: alias every name the resource held there under each prior module path. Parent is left inherited, as before, so Pulumi composes it with the renamed component's own alias.
- For a prior address in another module: alias it under each prior module path of *that* module, parented to the same component renamed to its pre-rename name.

The prior type token moved onto the address, so a move that also changes the resource's type composes as well.

Not covered: a resource moving out of a module whose call is renamed *to a call that does not exist in the new configuration*. Its component type is derived from the module source, so with no live call there is nothing to derive the prior parent URN from, and the resource is still replaced. The inverse composition — moving a resource *into* a renamed module — already worked and is unchanged (verified locally; the prior address lies outside the renamed module, so nothing needs composing).

## Tests

- `tests/tfcompat/l2_moved_module_call_rename_inner_test.go` — added as a failing test in the first commit.
- `TestL2Moved/module_call_rename_out` in `tests/tfcompat/l2_moved_test.go`.