### PR TITLE
Expose a resource's `timeouts` block as a readable attribute

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-439.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-439.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Expose a resource's or data source's `timeouts` block as an attribute typed by the operations it declares; accept `default`
+time: 2026-07-21T13:00:00Z
+custom:
+    Component: runtime
+    PR: "439"

--- a/pkg/hcl/ast/datasource.go
+++ b/pkg/hcl/ast/datasource.go
@@ -69,6 +69,9 @@ type DataSource struct {
 	// Postconditions contains postcondition checks (evaluated after the read).
 	Postconditions []*CheckRule
 
+	// Timeouts contains timeout configuration, if present.
+	Timeouts *Timeouts
+
 	// DeclRange is the source range of the entire data block.
 	DeclRange hcl.Range
 

--- a/pkg/hcl/ast/resource.go
+++ b/pkg/hcl/ast/resource.go
@@ -37,6 +37,8 @@ type Timeouts struct {
 	Update hcl.Expression
 	// Delete is the timeout for delete operations.
 	Delete hcl.Expression
+	// Default is the timeout for operations without one of their own.
+	Default hcl.Expression
 	// DeclRange is the source range of the timeouts block.
 	DeclRange hcl.Range
 }

--- a/pkg/hcl/bridge/mapping.go
+++ b/pkg/hcl/bridge/mapping.go
@@ -15,6 +15,8 @@
 package bridge
 
 import (
+	"time"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -52,6 +54,13 @@ type FieldMapping struct {
 type BodyMapping struct {
 	// Fields is keyed by TF (snake_case) name.
 	Fields map[string]*FieldMapping
+
+	// Timeouts lists the operations (create, read, update, delete, default)
+	// whose timeout the resource or data source declares: the attributes of
+	// the `timeouts` block the SDK implies for it. Nil when it declares none,
+	// or when its schema defines a `timeouts` field of its own, which takes
+	// the block's place.
+	Timeouts []string
 }
 
 // Lookup returns the mapping for tfName, or nil if no such field exists.
@@ -101,7 +110,7 @@ func ResourceBodyMapping(info *tfbridge.ProviderInfo, tfType string) *BodyMappin
 	if r := info.Resources[tfType]; r != nil {
 		fieldOverrides = r.Fields
 	}
-	return bodyMappingFromSchema(res.Schema(), fieldOverrides)
+	return withTimeouts(bodyMappingFromSchema(res.Schema(), fieldOverrides), res)
 }
 
 // DataSourceBodyMapping builds a BodyMapping for the given TF data source.
@@ -117,7 +126,31 @@ func DataSourceBodyMapping(info *tfbridge.ProviderInfo, tfType string) *BodyMapp
 	if d := info.DataSources[tfType]; d != nil {
 		fieldOverrides = d.Fields
 	}
-	return bodyMappingFromSchema(ds.Schema(), fieldOverrides)
+	return withTimeouts(bodyMappingFromSchema(ds.Schema(), fieldOverrides), ds)
+}
+
+// withTimeouts records on m the operations res declares a timeout for, unless
+// res defines a `timeouts` field of its own.
+func withTimeouts(m *BodyMapping, res shim.Resource) *BodyMapping {
+	t := res.Timeouts()
+	if m == nil || t == nil {
+		return m
+	}
+	if _, own := res.Schema().GetOk("timeouts"); own {
+		return m
+	}
+	m.Timeouts = []string{}
+	for _, op := range []struct {
+		name string
+		d    *time.Duration
+	}{
+		{"create", t.Create}, {"read", t.Read}, {"update", t.Update}, {"delete", t.Delete}, {"default", t.Default},
+	} {
+		if op.d != nil {
+			m.Timeouts = append(m.Timeouts, op.name)
+		}
+	}
+	return m
 }
 
 // ProviderConfigBodyMapping builds a BodyMapping for the provider config block.

--- a/pkg/hcl/bridge/mapping_test.go
+++ b/pkg/hcl/bridge/mapping_test.go
@@ -15,8 +15,11 @@
 package bridge_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/bridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
@@ -321,4 +324,41 @@ func TestResourceBodyMapping_MissingResourceReturnsNil(t *testing.T) {
 func TestResourceBodyMapping_NilProviderInfoReturnsNil(t *testing.T) {
 	t.Parallel()
 	require.Nil(t, bridge.ResourceBodyMapping(nil, "any"))
+}
+
+func TestResourceBodyMapping_Timeouts(t *testing.T) {
+	t.Parallel()
+	dur := time.Minute
+	sdk := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"test_timed": {
+				Timeouts: &schema.ResourceTimeout{Create: &dur, Delete: &dur, Default: &dur},
+				Schema:   map[string]*schema.Schema{"name": {Type: schema.TypeString, Optional: true}},
+			},
+			"test_untimed": {
+				Schema: map[string]*schema.Schema{"name": {Type: schema.TypeString, Optional: true}},
+			},
+			"test_own_timeouts": {
+				Timeouts: &schema.ResourceTimeout{Create: &dur},
+				Schema: map[string]*schema.Schema{
+					"timeouts": {Type: schema.TypeString, Optional: true},
+				},
+			},
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"test_source": {
+				Timeouts: &schema.ResourceTimeout{Read: &dur},
+				Schema:   map[string]*schema.Schema{"name": {Type: schema.TypeString, Optional: true}},
+				ReadContext: func(context.Context, *schema.ResourceData, any) diag.Diagnostics {
+					return nil
+				},
+			},
+		},
+	}
+	info := newTestProvider(t, sdk, nil)
+
+	require.Equal(t, []string{"create", "delete", "default"}, bridge.ResourceBodyMapping(info, "test_timed").Timeouts)
+	require.Nil(t, bridge.ResourceBodyMapping(info, "test_untimed").Timeouts)
+	require.Nil(t, bridge.ResourceBodyMapping(info, "test_own_timeouts").Timeouts)
+	require.Equal(t, []string{"read"}, bridge.DataSourceBodyMapping(info, "test_source").Timeouts)
 }

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -848,7 +848,11 @@ func (p *Parser) decodeDataBlock(block *hcl.Block) (*ast.DataSource, hcl.Diagnos
 			diags = append(diags, dataLifecycleArgDiags(lcResult.Lifecycle, subBlock)...)
 			ds.Preconditions = append(ds.Preconditions, lcResult.Preconditions...)
 			ds.Postconditions = append(ds.Postconditions, lcResult.Postconditions...)
-		case "connection", "provisioner", "timeouts":
+		case "timeouts":
+			timeouts, timeoutsDiags := p.parseTimeoutsBlock(subBlock)
+			diags = append(diags, timeoutsDiags...)
+			ds.Timeouts = timeouts
+		case "connection", "provisioner":
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Unsupported block type",
@@ -1312,6 +1316,10 @@ func (p *Parser) parseTimeoutsBlock(block *hcl.Block) (*ast.Timeouts, hcl.Diagno
 
 	if attr, ok := content.Attributes["delete"]; ok {
 		timeouts.Delete = attr.Expr
+	}
+
+	if attr, ok := content.Attributes["default"]; ok {
+		timeouts.Default = attr.Expr
 	}
 
 	return timeouts, diags

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -192,6 +192,28 @@ module "vpc" {
 	}
 }
 
+func TestParseTimeouts(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+resource "aws_instance" "web" {
+  timeouts {
+    create  = "1h"
+    default = "10m"
+  }
+}
+`)
+	config, diags := NewParser().ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	timeouts := config.Resources["aws_instance.web"].Timeouts
+	require.NotNil(t, timeouts)
+	assert.NotNil(t, timeouts.Create)
+	assert.NotNil(t, timeouts.Default)
+	assert.Nil(t, timeouts.Read)
+	assert.Nil(t, timeouts.Update)
+	assert.Nil(t, timeouts.Delete)
+}
+
 func TestParseProvisioners(t *testing.T) {
 	t.Parallel()
 	src := []byte(`
@@ -1287,7 +1309,6 @@ func TestParseDataRejectsResourceSurface(t *testing.T) {
 		{"name", "pulumi {\n  name = \"n\"\n}", "Unsupported argument"},
 		{"provisioner", "provisioner \"local-exec\" {\n  command = \"true\"\n}", "Unsupported block type"},
 		{"connection", "connection {\n  host = \"h\"\n}", "Unsupported block type"},
-		{"timeouts", "timeouts {\n  read = \"1m\"\n}", "Unsupported block type"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -346,6 +346,7 @@ var timeoutsSchema = &hcl.BodySchema{
 		{Name: "read"},
 		{Name: "update"},
 		{Name: "delete"},
+		{Name: "default"},
 	},
 }
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1673,7 +1673,26 @@ func (e *Engine) registerResourceInstanceInContext(
 		}
 	}
 
-	opts, err := e.buildResourceOptions(ctx, node, res, instance, evalCtx, parentURN, modInst, resourceMapping, resSchema.InputProperties, resSchema.Properties, resourceInputs)
+	timeouts, timeoutsRole, err := evalTimeouts(res.Timeouts, resourceMapping, hclCtx)
+	if err != nil {
+		return err
+	}
+	if timeoutsRole == timeoutsInput && !timeouts.IsNull() {
+		pv, err := transform.CtyToPropertyValue(timeouts)
+		if err != nil {
+			return fmt.Errorf("converting timeouts: %w", err)
+		}
+		prop := resourceMapping.Lookup("timeouts").PulumiName
+		resourceInputs = resourceInputs.Set(prop, pv)
+		for _, urn := range eval.CollectDepURNs(timeouts) {
+			idx, found := slices.BinarySearch(dependsOn[prop], urn)
+			if !found {
+				dependsOn[prop] = slices.Insert(dependsOn[prop], idx, urn)
+			}
+		}
+	}
+
+	opts, err := e.buildResourceOptions(ctx, node, res, instance, evalCtx, parentURN, modInst, resourceMapping, resSchema.InputProperties, resSchema.Properties, resourceInputs, timeouts)
 	if err != nil {
 		return err
 	}
@@ -1783,6 +1802,18 @@ func (e *Engine) registerResourceInstanceInContext(
 		outputObj["id"] = cty.StringVal(id)
 	}
 	outputObj["urn"] = cty.StringVal(string(urn)).Mark(eval.SyntheticMark)
+	if timeoutsRole == timeoutsAttribute {
+		outputObj["timeouts"] = timeouts
+	} else if timeoutsRole == timeoutsInput && !resourceMapping.Lookup("timeouts").TFBlock {
+		// The SDK copies the configured timeouts into state on every plan and
+		// apply, so state that lacks them (an imported resource: reads drop
+		// timeouts) is repopulated from config. A concrete provider value wins.
+		if cur, ok := outputObj["timeouts"]; ok {
+			if unmarked, _ := cur.Unmark(); unmarked.IsNull() || !unmarked.IsKnown() {
+				outputObj["timeouts"] = timeouts
+			}
+		}
+	}
 
 	markedOutputs := cty.ObjectVal(outputObj).Mark(eval.DepMark(urn))
 
@@ -1814,12 +1845,144 @@ func (e *Engine) registerResourceInstanceInContext(
 	return nil
 }
 
+// allTimeoutOps is the set of operations a `timeouts` block can configure.
+var allTimeoutOps = []string{"create", "read", "update", "delete", "default"}
+
+// timeoutsRole says how a resource's `timeouts` block is realized.
+type timeoutsRole int
+
+const (
+	// timeoutsNone: the block is not part of the resource value.
+	timeoutsNone timeoutsRole = iota
+	// timeoutsAttribute: the schema strips the block, so the engine exposes
+	// its value as a synthesized attribute of the resource.
+	timeoutsAttribute
+	// timeoutsInput: the schema declares a `timeouts` object of its own (the
+	// wire schema keeps the SDK-injected block; Plugin Framework providers
+	// define one), so the block is sent as an ordinary input property and
+	// reads back through the resource's outputs.
+	timeoutsInput
+)
+
+// timeoutsDeclaredOps returns the operations the resource's schema accepts a
+// timeout for and how the block is realized. nil ops means a `timeouts` block
+// is not accepted at all.
+func timeoutsDeclaredOps(mapping *bridge.BodyMapping) ([]string, timeoutsRole) {
+	if mapping == nil {
+		// No schema knowledge: accept everything, expose nothing.
+		return allTimeoutOps, timeoutsNone
+	}
+	if f := mapping.Lookup("timeouts"); f != nil {
+		if f.Nested == nil {
+			return nil, timeoutsNone
+		}
+		return slices.Sorted(maps.Keys(f.Nested.Fields)), timeoutsInput
+	}
+	if mapping.Timeouts != nil {
+		return mapping.Timeouts, timeoutsAttribute
+	}
+	return nil, timeoutsNone
+}
+
+// evalTimeouts evaluates a `timeouts` block against the operations the
+// resource's schema declares a timeout for, returning the value of the
+// block: null when it is absent, and one string attribute per declared
+// operation otherwise. A block on a resource that accepts none, or an
+// argument for an operation it does not declare, is an error.
+func evalTimeouts(t *ast.Timeouts, mapping *bridge.BodyMapping, hclCtx *hcl.EvalContext) (cty.Value, timeoutsRole, error) {
+	ops, role := timeoutsDeclaredOps(mapping)
+	if ops == nil {
+		if t == nil {
+			return cty.NilVal, timeoutsNone, nil
+		}
+		return cty.NilVal, timeoutsNone, fmt.Errorf("%s: Unsupported block type; Blocks of type \"timeouts\" are not expected here",
+			t.DeclRange)
+	}
+	attrTypes := make(map[string]cty.Type, len(ops))
+	for _, op := range ops {
+		attrTypes[op] = cty.String
+	}
+	ty := cty.Object(attrTypes)
+	if t == nil {
+		return cty.NullVal(ty), role, nil
+	}
+	attrs := make(map[string]cty.Value, len(ops))
+	for _, op := range ops {
+		attrs[op] = cty.NullVal(cty.String)
+	}
+	for name, expr := range map[string]hcl.Expression{
+		"create": t.Create, "read": t.Read, "update": t.Update, "delete": t.Delete, "default": t.Default,
+	} {
+		if expr == nil {
+			continue
+		}
+		if !ty.HasAttribute(name) {
+			return cty.NilVal, role, fmt.Errorf("%s: Unsupported argument; An argument named %q is not expected here",
+				expr.Range(), name)
+		}
+		val, diags := expr.Value(hclCtx)
+		if diags.HasErrors() {
+			return cty.NilVal, role, fmt.Errorf("evaluating timeouts.%s: %s", name, diags.Error())
+		}
+		val, err := ctyconvert.Convert(val, cty.String)
+		if err != nil {
+			return cty.NilVal, role, fmt.Errorf("%s: Incorrect attribute value type; Inappropriate value for attribute %q: %s",
+				expr.Range(), name, err)
+		}
+		attrs[name] = val
+	}
+	return cty.ObjectVal(attrs), role, nil
+}
+
+// customTimeoutsFromValue derives the Pulumi custom timeouts from an evaluated
+// `timeouts` block; an operation without a timeout of its own takes `default`.
+// Unknown timeouts are left unset. Returns nil when none is configured.
+func customTimeoutsFromValue(timeouts cty.Value) (*CustomTimeouts, error) {
+	if timeouts.IsNull() {
+		return nil, nil
+	}
+	attr := func(name string) cty.Value {
+		if !timeouts.Type().HasAttribute(name) {
+			return cty.NullVal(cty.String)
+		}
+		v, _ := timeouts.GetAttr(name).Unmark()
+		return v
+	}
+	dflt := attr("default")
+	ct := &CustomTimeouts{}
+	configured := false
+	for _, op := range []struct {
+		name string
+		dst  *float64
+	}{
+		{"create", &ct.Create}, {"read", &ct.Read}, {"update", &ct.Update}, {"delete", &ct.Delete},
+	} {
+		v := attr(op.name)
+		if v.IsNull() {
+			v = dflt
+		}
+		if v.IsNull() || !v.IsKnown() {
+			continue
+		}
+		d, err := time.ParseDuration(v.AsString())
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q timeout: %w", op.name, err)
+		}
+		*op.dst = d.Seconds()
+		configured = true
+	}
+	if !configured {
+		return nil, nil
+	}
+	return ct, nil
+}
+
 // buildResourceOptions builds resource options using the provided eval context and parent URN.
 func (e *Engine) buildResourceOptions(
 	ctx context.Context, node *graph.Node, res *ast.Resource, instance *graph.ExpandedResource,
 	evalCtx *eval.Context, parentURN urn.URN,
 	modInst *moduleInstance, resourceMapping *bridge.BodyMapping,
-	inputProps, outputProps []*schema.Property, inputs property.Map,
+	inputProps, outputProps []*schema.Property, inputs property.Map, timeouts cty.Value,
 ) (*ResourceOptions, error) {
 	modInfo := node.ModuleInfo
 	opts := &ResourceOptions{}
@@ -1941,48 +2104,11 @@ func (e *Engine) buildResourceOptions(
 		}
 	}
 
-	// Handle timeouts
-	if res.Timeouts != nil {
-		ct := &CustomTimeouts{}
-		hasTimeouts := false
-		evalTimeout := func(expr hcl.Expression) (float64, bool) {
-			if expr == nil {
-				return 0, false
-			}
-			val, diags := e.evaluator.EvaluateExpression(expr)
-			if diags.HasErrors() {
-				return 0, false
-			}
-			val, _ = val.Unmark()
-			if val.Type() != cty.String || val.IsNull() || !val.IsKnown() {
-				return 0, false
-			}
-			d, err := time.ParseDuration(val.AsString())
-			if err != nil {
-				return 0, false
-			}
-			return d.Seconds(), true
-		}
-		if v, ok := evalTimeout(res.Timeouts.Create); ok {
-			ct.Create = v
-			hasTimeouts = true
-		}
-		if v, ok := evalTimeout(res.Timeouts.Read); ok {
-			ct.Read = v
-			hasTimeouts = true
-		}
-		if v, ok := evalTimeout(res.Timeouts.Update); ok {
-			ct.Update = v
-			hasTimeouts = true
-		}
-		if v, ok := evalTimeout(res.Timeouts.Delete); ok {
-			ct.Delete = v
-			hasTimeouts = true
-		}
-		if hasTimeouts {
-			opts.CustomTimeouts = ct
-		}
+	customTimeouts, err := customTimeoutsFromValue(timeouts)
+	if err != nil {
+		return nil, err
 	}
+	opts.CustomTimeouts = customTimeouts
 
 	// Handle moved blocks - resolve aliases from moved blocks that target this resource
 	movedAliases := e.resolveMovedAliases(ctx, res, instance.Index, instance.EachKeyString(), modInst)
@@ -3398,6 +3524,10 @@ func (e *Engine) invokeDataSourceOnce(
 	}
 
 	dataSourceMapping := e.resolver.DataSourceBodyMapping(ctx, ds.Type)
+	timeouts, timeoutsRole, err := evalTimeouts(ds.Timeouts, dataSourceMapping, hclCtx)
+	if err != nil {
+		return cty.NilVal, err
+	}
 	inputEval := evalSchemaInputs(hclCtx, func(_ resource.PropertyKey, val cty.Value) {
 		for _, urn := range eval.CollectDepURNs(val) {
 			addURN(urn)
@@ -3407,6 +3537,16 @@ func (e *Engine) invokeDataSourceOnce(
 		ds.Config, funcSchema, dataSourceMapping, inputEval)
 	if diags.HasErrors() {
 		return cty.NilVal, diags
+	}
+	if timeoutsRole == timeoutsInput && !timeouts.IsNull() {
+		pv, err := transform.CtyToPropertyValue(timeouts)
+		if err != nil {
+			return cty.NilVal, fmt.Errorf("converting timeouts: %w", err)
+		}
+		inputs = inputs.Set(dataSourceMapping.Lookup("timeouts").PulumiName, pv)
+		for _, urn := range eval.CollectDepURNs(timeouts) {
+			addURN(urn)
+		}
 	}
 
 	invokeReq := InvokeRequest{
@@ -3507,6 +3647,14 @@ func (e *Engine) invokeDataSourceOnce(
 	ctyOutputs, err := transform.FunctionOutputToCty(outputs, funcSchema, dataSourceMapping, e.dryRun)
 	if err != nil {
 		return cty.NilVal, fmt.Errorf("converting function outputs to HCL types: %w", err)
+	}
+	if timeoutsRole == timeoutsAttribute && ctyOutputs.Type().IsObjectType() && ctyOutputs.IsKnown() && !ctyOutputs.IsNull() {
+		attrs := ctyOutputs.AsValueMap()
+		if attrs == nil {
+			attrs = map[string]cty.Value{}
+		}
+		attrs["timeouts"] = timeouts
+		ctyOutputs = cty.ObjectVal(attrs)
 	}
 
 	if err := evaluatePostconditionValues(ds.Postconditions, hclCtx, ctyOutputs, node.Key.String()); err != nil {

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -3903,6 +3903,66 @@ resource "aws_instance" "web" {
 	}
 }
 
+func TestEngine_TimeoutsDefault(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "aws_instance" "web" {
+  ami           = "ami-12345"
+  instance_type = "t3.micro"
+
+  timeouts {
+    create  = "60m"
+    default = "5m"
+  }
+}
+`)
+
+	config, diags := parser.NewParser().ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "aws",
+			Resources: map[string]schema.ResourceSpec{
+				"aws:index:Instance": {
+					InputProperties: map[string]schema.PropertySpec{
+						"ami":          {TypeSpec: schema.TypeSpec{Type: "string"}},
+						"instanceType": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"ami":          {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"instanceType": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	var instanceReq *run.RegisterResourceRequest
+	for i := range mock.RegisteredResources {
+		if mock.RegisteredResources[i].Type == "aws:index:Instance" {
+			instanceReq = &mock.RegisteredResources[i]
+			break
+		}
+	}
+
+	require.NotNil(t, instanceReq, "expected aws:index:Instance resource to be registered")
+
+	assert.Equal(t, &run.CustomTimeouts{Create: 3600, Read: 300, Update: 300, Delete: 300}, instanceReq.CustomTimeouts)
+}
+
 func TestEngine_SensitiveResourceOptions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/hcl/run/timeouts_internal_test.go
+++ b/pkg/hcl/run/timeouts_internal_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/ast"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/bridge"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// parseTimeouts returns the ast.Timeouts of a resource whose timeouts block
+// holds the given body.
+func parseTimeouts(t *testing.T, body string) *ast.Timeouts {
+	t.Helper()
+	src := "resource \"test_thing\" \"x\" {\n  timeouts {\n" + body + "\n  }\n}\n"
+	config, diags := parser.NewParser().ParseSource("test.hcl", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+	return config.Resources["test_thing.x"].Timeouts
+}
+
+func wireMapping(ops ...string) *bridge.BodyMapping {
+	nested := &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{}}
+	for _, op := range ops {
+		nested.Fields[op] = &bridge.FieldMapping{TFName: op, PulumiName: op}
+	}
+	return &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+		"timeouts": {TFName: "timeouts", PulumiName: "timeouts", Nested: nested},
+	}}
+}
+
+func TestTimeoutsDeclaredOps(t *testing.T) {
+	t.Parallel()
+
+	ops, role := timeoutsDeclaredOps(nil)
+	assert.Equal(t, allTimeoutOps, ops)
+	assert.Equal(t, timeoutsNone, role)
+
+	ops, role = timeoutsDeclaredOps(wireMapping("delete", "create"))
+	assert.Equal(t, []string{"create", "delete"}, ops)
+	assert.Equal(t, timeoutsInput, role)
+
+	ops, role = timeoutsDeclaredOps(&bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+		"timeouts": {TFName: "timeouts", PulumiName: "timeouts"},
+	}})
+	assert.Nil(t, ops)
+	assert.Equal(t, timeoutsNone, role)
+
+	ops, role = timeoutsDeclaredOps(&bridge.BodyMapping{Timeouts: []string{"create"}})
+	assert.Equal(t, []string{"create"}, ops)
+	assert.Equal(t, timeoutsAttribute, role)
+
+	ops, role = timeoutsDeclaredOps(&bridge.BodyMapping{})
+	assert.Nil(t, ops)
+	assert.Equal(t, timeoutsNone, role)
+}
+
+func TestEvalTimeouts(t *testing.T) {
+	t.Parallel()
+	hclCtx := &hcl.EvalContext{}
+
+	t.Run("configured operations evaluate, unset declared ones are null", func(t *testing.T) {
+		t.Parallel()
+		val, role, err := evalTimeouts(parseTimeouts(t, `create = "5m"`),
+			&bridge.BodyMapping{Timeouts: []string{"create", "delete"}}, hclCtx)
+		require.NoError(t, err)
+		assert.Equal(t, timeoutsAttribute, role)
+		assert.Equal(t, cty.ObjectVal(map[string]cty.Value{
+			"create": cty.StringVal("5m"),
+			"delete": cty.NullVal(cty.String),
+		}), val)
+	})
+
+	t.Run("absent block on a declaring resource is null", func(t *testing.T) {
+		t.Parallel()
+		val, role, err := evalTimeouts(nil, wireMapping("create"), hclCtx)
+		require.NoError(t, err)
+		assert.Equal(t, timeoutsInput, role)
+		assert.Equal(t, cty.NullVal(cty.Object(map[string]cty.Type{"create": cty.String})), val)
+	})
+
+	t.Run("absent block on a non-declaring resource is nothing", func(t *testing.T) {
+		t.Parallel()
+		val, role, err := evalTimeouts(nil, &bridge.BodyMapping{}, hclCtx)
+		require.NoError(t, err)
+		assert.Equal(t, timeoutsNone, role)
+		assert.Equal(t, cty.NilVal, val)
+	})
+
+	t.Run("block on a resource that declares none", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := evalTimeouts(parseTimeouts(t, `create = "5m"`), &bridge.BodyMapping{}, hclCtx)
+		assert.ErrorContains(t, err, "Unsupported block type")
+	})
+
+	t.Run("undeclared operation", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := evalTimeouts(parseTimeouts(t, `read = "1m"`),
+			&bridge.BodyMapping{Timeouts: []string{"create"}}, hclCtx)
+		assert.ErrorContains(t, err, `Unsupported argument; An argument named "read" is not expected here`)
+	})
+
+	t.Run("evaluation failure", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := evalTimeouts(parseTimeouts(t, `create = var.undefined`),
+			&bridge.BodyMapping{Timeouts: []string{"create"}}, hclCtx)
+		assert.ErrorContains(t, err, "evaluating timeouts.create")
+	})
+
+	t.Run("non-string value", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := evalTimeouts(parseTimeouts(t, `create = ["5m"]`),
+			&bridge.BodyMapping{Timeouts: []string{"create"}}, hclCtx)
+		assert.ErrorContains(t, err, `Incorrect attribute value type; Inappropriate value for attribute "create"`)
+	})
+}
+
+func TestCustomTimeoutsFromValue(t *testing.T) {
+	t.Parallel()
+
+	ct, err := customTimeoutsFromValue(cty.NilVal)
+	require.NoError(t, err)
+	assert.Nil(t, ct)
+
+	ct, err = customTimeoutsFromValue(cty.ObjectVal(map[string]cty.Value{
+		"create":  cty.StringVal("1h"),
+		"delete":  cty.NullVal(cty.String),
+		"read":    cty.UnknownVal(cty.String),
+		"default": cty.StringVal("10m"),
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, &CustomTimeouts{Create: 3600, Update: 600, Delete: 600}, ct)
+
+	ct, err = customTimeoutsFromValue(cty.ObjectVal(map[string]cty.Value{
+		"create": cty.NullVal(cty.String),
+	}))
+	require.NoError(t, err)
+	assert.Nil(t, ct)
+
+	_, err = customTimeoutsFromValue(cty.ObjectVal(map[string]cty.Value{
+		"create": cty.StringVal("banana"),
+	}))
+	assert.ErrorContains(t, err, `parsing "create" timeout`)
+}

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -1246,7 +1246,25 @@ func ResourceReferenceType(r *schema.Resource, mapping *bridge.BodyMapping) cty.
 			&schema.Property{Name: "pluginDownloadURL", Type: schema.StringType},
 		)
 	}
-	return ctyObjectType(properties, map[string]cty.Type{"id": cty.String}, mapping)
+	seed := map[string]cty.Type{"id": cty.String}
+	if t, ok := TimeoutsType(mapping); ok {
+		seed["timeouts"] = t
+	}
+	return ctyObjectType(properties, seed, mapping)
+}
+
+// TimeoutsType returns the type of the `timeouts` block implied for a resource
+// or data source — one optional string per declared operation — and false when
+// its schema declares none.
+func TimeoutsType(mapping *bridge.BodyMapping) (cty.Type, bool) {
+	if mapping == nil || mapping.Timeouts == nil {
+		return cty.NilType, false
+	}
+	attrs := make(map[string]cty.Type, len(mapping.Timeouts))
+	for _, op := range mapping.Timeouts {
+		attrs[op] = cty.String
+	}
+	return cty.Object(attrs), true
 }
 
 // DataSourceReferenceType returns the cty type of a `data.<type>.<name>`
@@ -1257,7 +1275,11 @@ func DataSourceReferenceType(fn *schema.Function, mapping *bridge.BodyMapping) c
 	if !ok {
 		return cty.DynamicPseudoType
 	}
-	return ctyObjectType(obj.Properties, nil, mapping)
+	var seed map[string]cty.Type
+	if t, ok := TimeoutsType(mapping); ok {
+		seed = map[string]cty.Type{"timeouts": t}
+	}
+	return ctyObjectType(obj.Properties, seed, mapping)
 }
 
 // FunctionOutputToCty mirrors ResourceOutputToCty for invoke return values.

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -1258,6 +1258,19 @@ func TestResourceReferenceTypeSetField(t *testing.T) {
 	assert.Equal(t, cty.Set(cty.Number), typ.AttributeType("ports"))
 }
 
+// TestResourceReferenceTypeTimeouts pins that a resource declaring operation
+// timeouts types `timeouts` as an object of exactly those operations, matching
+// the runtime value the engine exposes.
+func TestResourceReferenceTypeTimeouts(t *testing.T) {
+	t.Parallel()
+
+	res := &schema.Resource{Token: "test:index:R"}
+	typ := ResourceReferenceType(res, &bridge.BodyMapping{Timeouts: []string{"create", "default"}})
+	assert.Equal(t, cty.Object(map[string]cty.Type{"create": cty.String, "default": cty.String}), typ.AttributeType("timeouts"))
+
+	assert.False(t, ResourceReferenceType(res, &bridge.BodyMapping{}).HasAttribute("timeouts"))
+}
+
 // TestResourceOutputToCtySchemaSecretElided pins that a schema-secret output
 // keeps its sensitive mark even when the provider elides the (unknown) value
 // during preview, so a downstream stack output stays secret.

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -1271,6 +1271,26 @@ func TestResourceReferenceTypeTimeouts(t *testing.T) {
 	assert.False(t, ResourceReferenceType(res, &bridge.BodyMapping{}).HasAttribute("timeouts"))
 }
 
+// TestDataSourceReferenceTypeTimeouts pins that a data source declaring
+// operation timeouts types `timeouts` alongside its return properties, and
+// that a non-object return type stays dynamic.
+func TestDataSourceReferenceTypeTimeouts(t *testing.T) {
+	t.Parallel()
+
+	fn := &schema.Function{
+		Token: "test:index:getR",
+		ReturnType: &schema.ObjectType{Properties: []*schema.Property{
+			{Name: "result", Type: schema.StringType},
+		}},
+	}
+	typ := DataSourceReferenceType(fn, &bridge.BodyMapping{Timeouts: []string{"read"}})
+	assert.Equal(t, cty.Object(map[string]cty.Type{"read": cty.String}), typ.AttributeType("timeouts"))
+	assert.True(t, typ.HasAttribute("result"))
+
+	scalar := &schema.Function{Token: "test:index:getS", ReturnType: schema.StringType}
+	assert.Equal(t, cty.DynamicPseudoType, DataSourceReferenceType(scalar, nil))
+}
+
 // TestResourceOutputToCtySchemaSecretElided pins that a schema-secret output
 // keeps its sensitive mark even when the provider elides the (unknown) value
 // during preview, so a downstream stack output stays secret.

--- a/tests/testutil/tfcompat/providers/timeoutable.go
+++ b/tests/testutil/tfcompat/providers/timeoutable.go
@@ -30,9 +30,10 @@ func TimeoutableProvider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"timeoutable_resource": {
 				Timeouts: &schema.ResourceTimeout{
-					Create: &dur,
-					Update: &dur,
-					Delete: &dur,
+					Create:  &dur,
+					Update:  &dur,
+					Delete:  &dur,
+					Default: &dur,
 				},
 				Schema: map[string]*schema.Schema{
 					"input_one": {Type: schema.TypeString, Optional: true},
@@ -46,6 +47,18 @@ func TimeoutableProvider() *schema.Provider {
 				ReadContext:   func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
 				UpdateContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
 				DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+			},
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"timeoutable_data": {
+				Timeouts: &schema.ResourceTimeout{Read: &dur},
+				Schema: map[string]*schema.Schema{
+					"result": {Type: schema.TypeString, Computed: true},
+				},
+				ReadContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("timeoutable-data-id")
+					return diag.FromErr(d.Set("result", "read"))
+				},
 			},
 		},
 	}

--- a/tests/tfcompat/l2_timeouts_attribute_reference_test.go
+++ b/tests/tfcompat/l2_timeouts_attribute_reference_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+func TestL2TimeoutsAttributeReference(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_timeouts_attribute_reference", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "timeoutable", Factory: providers.TimeoutableProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_timeouts_data_source_test.go
+++ b/tests/tfcompat/l2_timeouts_data_source_test.go
@@ -21,9 +21,10 @@ import (
 	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-func TestL2TimeoutsAttributeReference(t *testing.T) {
+// TestL2TimeoutsDataSource: A data source's `timeouts` block is readable as an attribute.
+func TestL2TimeoutsDataSource(t *testing.T) {
 	t.Parallel()
-	tfcompat.RunCase(t, "l2_timeouts_attribute_reference", tfcompat.Case{
+	tfcompat.RunCase(t, "l2_timeouts_data_source", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "timeoutable", Factory: providers.TimeoutableProvider},
 		},

--- a/tests/tfcompat/l2_timeouts_default_test.go
+++ b/tests/tfcompat/l2_timeouts_default_test.go
@@ -21,9 +21,10 @@ import (
 	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-func TestL2TimeoutsAttributeReference(t *testing.T) {
+// TestL2TimeoutsDefault: A `default` timeout is readable as an attribute alongside the declared operations.
+func TestL2TimeoutsDefault(t *testing.T) {
 	t.Parallel()
-	tfcompat.RunCase(t, "l2_timeouts_attribute_reference", tfcompat.Case{
+	tfcompat.RunCase(t, "l2_timeouts_default", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "timeoutable", Factory: providers.TimeoutableProvider},
 		},

--- a/tests/tfcompat/l2_timeouts_undeclared_argument_test.go
+++ b/tests/tfcompat/l2_timeouts_undeclared_argument_test.go
@@ -21,11 +21,13 @@ import (
 	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-func TestL2TimeoutsAttributeReference(t *testing.T) {
+// TestL2TimeoutsUndeclaredArgument: Setting a timeout for an operation the resource does not declare is an unsupported argument.
+func TestL2TimeoutsUndeclaredArgument(t *testing.T) {
 	t.Parallel()
-	tfcompat.RunCase(t, "l2_timeouts_attribute_reference", tfcompat.Case{
+	tfcompat.RunCase(t, "l2_timeouts_undeclared_argument", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "timeoutable", Factory: providers.TimeoutableProvider},
 		},
+		Stages: []tfcompat.Stage{{ExpectErr: "Unsupported argument"}},
 	})
 }

--- a/tests/tfcompat/l2_timeouts_undeclared_reference_test.go
+++ b/tests/tfcompat/l2_timeouts_undeclared_reference_test.go
@@ -21,11 +21,13 @@ import (
 	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-func TestL2TimeoutsAttributeReference(t *testing.T) {
+// TestL2TimeoutsUndeclaredReference: Reading a timeout for an operation the resource does not declare is an unsupported attribute.
+func TestL2TimeoutsUndeclaredReference(t *testing.T) {
 	t.Parallel()
-	tfcompat.RunCase(t, "l2_timeouts_attribute_reference", tfcompat.Case{
+	tfcompat.RunCase(t, "l2_timeouts_undeclared_reference", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "timeoutable", Factory: providers.TimeoutableProvider},
 		},
+		Stages: []tfcompat.Stage{{ExpectErr: "Unsupported attribute"}},
 	})
 }

--- a/tests/tfcompat/l2_timeouts_unset_null_test.go
+++ b/tests/tfcompat/l2_timeouts_unset_null_test.go
@@ -21,9 +21,10 @@ import (
 	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-func TestL2TimeoutsAttributeReference(t *testing.T) {
+// TestL2TimeoutsUnsetNull: A resource that declares timeouts but configures none reads `timeouts` as null.
+func TestL2TimeoutsUnsetNull(t *testing.T) {
 	t.Parallel()
-	tfcompat.RunCase(t, "l2_timeouts_attribute_reference", tfcompat.Case{
+	tfcompat.RunCase(t, "l2_timeouts_unset_null", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "timeoutable", Factory: providers.TimeoutableProvider},
 		},

--- a/tests/tfcompat/testdata/cases/l2_timeouts_attribute_reference/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_timeouts_attribute_reference/main.tf
@@ -1,0 +1,13 @@
+# A `timeouts` block is part of the resource's schema, so its values round-trip
+# into state and are readable as an ordinary attribute of the resource.
+resource "timeoutable_resource" "test" {
+  input_one = "hello"
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+output "create_timeout" {
+  value = timeoutable_resource.test.timeouts.create
+}

--- a/tests/tfcompat/testdata/cases/l2_timeouts_data_source/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_timeouts_data_source/main.tf
@@ -1,0 +1,13 @@
+data "timeoutable_data" "test" {
+  timeouts {
+    read = "1m"
+  }
+}
+
+output "read_timeout" {
+  value = data.timeoutable_data.test.timeouts.read
+}
+
+output "timeouts" {
+  value = data.timeoutable_data.test.timeouts
+}

--- a/tests/tfcompat/testdata/cases/l2_timeouts_default/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_timeouts_default/main.tf
@@ -1,0 +1,11 @@
+resource "timeoutable_resource" "test" {
+  input_one = "hello"
+
+  timeouts {
+    default = "7m"
+  }
+}
+
+output "timeouts" {
+  value = timeoutable_resource.test.timeouts
+}

--- a/tests/tfcompat/testdata/cases/l2_timeouts_undeclared_argument/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_timeouts_undeclared_argument/main.tf
@@ -1,0 +1,7 @@
+resource "timeoutable_resource" "test" {
+  input_one = "hello"
+
+  timeouts {
+    read = "1m"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_timeouts_undeclared_reference/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_timeouts_undeclared_reference/main.tf
@@ -1,0 +1,11 @@
+resource "timeoutable_resource" "test" {
+  input_one = "hello"
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+output "read_timeout" {
+  value = timeoutable_resource.test.timeouts.read
+}

--- a/tests/tfcompat/testdata/cases/l2_timeouts_unset_null/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_timeouts_unset_null/main.tf
@@ -1,0 +1,7 @@
+resource "timeoutable_resource" "test" {
+  input_one = "hello"
+}
+
+output "is_null" {
+  value = timeoutable_resource.test.timeouts == null
+}


### PR DESCRIPTION
In OpenTofu a resource's `timeouts` block is part of its schema: the configured values round-trip through state, so `<resource>.timeouts.create` reads back as an attribute — `null` when unset, an error for operations the resource does not declare, and the same for data sources. pulumi-hcl consumed the block as a parser-level meta-argument only, so the reference failed with "Unsupported attribute". This PR makes the block part of the resource value, matching OpenTofu: where the schema keeps a `timeouts` field (the dynamic-provider and Plugin Framework paths) it is sent as an ordinary input and read back from outputs, and where the classic bridge strips it the attribute is synthesized from the declared-operation set the bridge now carries in its mapping payload (https://github.com/pulumi/pulumi-terraform-bridge/pull/3590, pinned via https://github.com/pulumi/pulumi-hcl/pull/585). `default` is supported, and misuse errors instead of being silently ignored. Proven by seven tfcompat cases compared against `tofu`, including state-import checks.
