### PR TITLE
Accept the bare `list` and `map` variable type constraints

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-440.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-440.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Accept the bare `list` and `map` variable type constraints
+time: 2026-07-21T13:30:00Z
+custom:
+    Component: runtime
+    PR: "440"

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -515,11 +515,21 @@ func (p *Parser) parseVariableBlock(config *ast.Config, block *hcl.Block) hcl.Di
 
 	if attr, ok := content.Attributes["type"]; ok {
 		variable.Type = attr.Expr
-		ty, defs, typeDiags := typeexpr.TypeConstraintWithDefaults(attr.Expr)
-		diags = append(diags, typeDiags...)
-		if !typeDiags.HasErrors() {
-			variable.TypeConstraint = ty
-			variable.TypeDefaults = defs
+		// The bare keywords `list` and `map` are shorthand forms that the
+		// HCL-level type expression parser doesn't include, equivalent to
+		// list(any) and map(any).
+		switch hcl.ExprAsKeyword(attr.Expr) {
+		case "list":
+			variable.TypeConstraint = cty.List(cty.DynamicPseudoType)
+		case "map":
+			variable.TypeConstraint = cty.Map(cty.DynamicPseudoType)
+		default:
+			ty, defs, typeDiags := typeexpr.TypeConstraintWithDefaults(attr.Expr)
+			diags = append(diags, typeDiags...)
+			if !typeDiags.HasErrors() {
+				variable.TypeConstraint = ty
+				variable.TypeDefaults = defs
+			}
 		}
 	}
 

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -939,6 +939,25 @@ variable "subnets" {
 	}
 }
 
+// The pre-0.12 bare keywords `list` and `map` are shorthand for `list(any)`
+// and `map(any)`; typeexpr itself rejects them.
+func TestVariableTypeBareListMap(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+variable "l" {
+  type = list
+}
+
+variable "m" {
+  type = map
+}
+`)
+	config, diags := NewParser().ParseSource("test.tf", src)
+	require.False(t, diags.HasErrors(), "unexpected errors: %v", diags.Errs())
+	assert.Equal(t, cty.List(cty.DynamicPseudoType), config.Variables["l"].TypeConstraint)
+	assert.Equal(t, cty.Map(cty.DynamicPseudoType), config.Variables["m"].TypeConstraint)
+}
+
 func TestParseEphemeral(t *testing.T) {
 	t.Parallel()
 	src := []byte(`

--- a/tests/tfcompat/l1_var_bare_list_map_test.go
+++ b/tests/tfcompat/l1_var_bare_list_map_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1VarBareListMap exercises `tolist` / `toset` / `tomap` over tuples and
+// objects whose elements have differing types. Both paths must unify the
+// element types to a single common type rather than erroring on the mismatch.
+func TestL1VarBareListMap(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_var_bare_list_map", tfcompat.Case{})
+}

--- a/tests/tfcompat/l1_var_bare_list_map_test.go
+++ b/tests/tfcompat/l1_var_bare_list_map_test.go
@@ -20,9 +20,9 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
 )
 
-// TestL1VarBareListMap exercises `tolist` / `toset` / `tomap` over tuples and
-// objects whose elements have differing types. Both paths must unify the
-// element types to a single common type rather than erroring on the mismatch.
+// TestL1VarBareListMap exercises the pre-0.12 shorthand type constraints
+// `type = list` and `type = map` on a variable block, which are equivalent to
+// `list(any)` and `map(any)`.
 func TestL1VarBareListMap(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l1_var_bare_list_map", tfcompat.Case{})

--- a/tests/tfcompat/testdata/cases/l1_var_bare_list_map/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_var_bare_list_map/main.tf
@@ -1,0 +1,16 @@
+# `type = list` and `type = map` are OpenTofu's pre-0.12 shorthands for
+# `list(any)` and `map(any)`: the bare keyword is accepted and the value's
+# elements are unified to a single common element type.
+
+variable "l" {
+  type    = list
+  default = ["a", 1, true]
+}
+
+variable "m" {
+  type    = map
+  default = { x = 1, y = "two" }
+}
+
+output "l" { value = var.l }
+output "m" { value = var.m }


### PR DESCRIPTION
The pre-0.12 shorthand type constraints `type = list` and `type = map` on a `variable` block are accepted by OpenTofu and were rejected by pulumi-hcl:

```
main.tf:6,13-17: Invalid type specification; The list type constructor
requires one argument specifying the element type., and 1 other diagnostic(s)
```

OpenTofu's `configs/named_values.go::decodeVariableType` special-cases the bare keywords, expanding them to `list(any)` / `map(any)` before calling `typeexpr`. `pkg/hcl/parser` called `typeexpr.TypeConstraintWithDefaults` directly with no shorthand handling, so the whole program failed at parse.

This adds the same pre-pass at the parser's single type-constraint call site. The fixture now applies and yields `l = ["a","1","true"]` (`list(string)`) and `m = {"x":"1","y":"two"}` (`map(string)`), matching OpenTofu.

The quoted legacy forms (`type = "list"`, `type = "string"`) are left alone: OpenTofu errors on those too, so there is no divergence there.

Tests: `TestL1VarBareListMap` (tfcompat, added here first as a failing test, now passing) and `TestVariableTypeBareListMap` (parser unit).

The rest of the type-constraint seam was probed and matches exactly — nested `optional()` defaults, defaults inside `list`/`map`/`set` of objects, convertible-type defaults, `any` unification, and tuple coercion all agree. `hcl/ext/typeexpr` is byte-identical between the two forks; only the shorthand pre-pass differed.
