### PR TITLE
Regression test: `ignore_changes` index beyond the prior state

### DIFF
--- a/tests/tfcompat/l2_ignore_changes_index_beyond_state_test.go
+++ b/tests/tfcompat/l2_ignore_changes_index_beyond_state_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2IgnoreChangesIndexBeyondState exercises an indexed `ignore_changes`
+// path whose index exists in the new configuration but not in the prior
+// state. Stage 0 creates `zones = ["a"]`, so `zones[1]` is absent from state;
+// stage 1 appends an element.
+func TestL2IgnoreChangesIndexBeyondState(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_ignore_changes_index_beyond_state", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "collections", Factory: providers.CollectionsProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_ignore_changes_index_beyond_state/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ignore_changes_index_beyond_state/0/main.tf
@@ -1,0 +1,11 @@
+# `zones[1]` is ignored, but at creation the list has a single element, so
+# index 1 does not exist in the resource's prior state.
+resource "collections_thing" "grow" {
+  zones = ["a"]
+
+  lifecycle {
+    ignore_changes = [zones[1]]
+  }
+}
+
+output "zones" { value = collections_thing.grow.zones }

--- a/tests/tfcompat/testdata/cases/l2_ignore_changes_index_beyond_state/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_ignore_changes_index_beyond_state/1/main.tf
@@ -1,0 +1,12 @@
+# The config now appends a second element. OpenTofu drops an ignore_changes
+# entry whose path does not resolve in the prior state, so the new element is
+# applied verbatim and `zones` becomes ["a", "z"].
+resource "collections_thing" "grow" {
+  zones = ["a", "z"]
+
+  lifecycle {
+    ignore_changes = [zones[1]]
+  }
+}
+
+output "zones" { value = collections_thing.grow.zones }


### PR DESCRIPTION
Adds `TestL2IgnoreChangesIndexBeyondState` as a regression test for an upstream bridge bug this test uncovered.

With `lifecycle { ignore_changes = [zones[1]] }` on a list attribute whose prior state holds only one element, appending a second element produced `zones = ["a", ""]` instead of OpenTofu's `["a", "z"]`. The root cause was in the classic bridge's sdk-v2 shim: an `ignoreChanges` path that does not resolve against prior state was still applied to the flatmap diff, dropping `zones.1` while keeping `zones.#`, so SDKv2 materialized an empty element.

- Upstream issue: https://github.com/pulumi/pulumi-terraform-bridge/issues/3560
- Upstream fix: https://github.com/pulumi/pulumi-terraform-bridge/pull/3561

This PR contains only the test; it passes on CI and guards against the bridge regressing.
