### PR TITLE
terraform_remote_state: expose `backend`, `config`, `workspace` and `defaults`

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-442.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-442.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Expose `backend`, `config`, `workspace` and `defaults` on `terraform_remote_state`
+time: 2026-07-21T13:40:00Z
+custom:
+    Component: runtime
+    PR: "442"

--- a/pkg/hcl/packages/builtins.go
+++ b/pkg/hcl/packages/builtins.go
@@ -68,8 +68,8 @@ func TerraformDataSchema() *schema.Resource {
 // TerraformRemoteStateSchema is the synthetic schema terraform_remote_state
 // resolves to: the TF data source surface as inputs. lowerRemoteStateInvoke
 // selects the concrete pulumi-terraform invoke (local or remote) by backend and
-// translates the inputs to its arguments, and applyRemoteStateDefaults overlays
-// `defaults` on the result. The placeholder Token is always overridden there.
+// translates the inputs to its arguments, and remoteStateResult assembles the
+// data source's object from it. The placeholder Token is always overridden there.
 func TerraformRemoteStateSchema() *schema.Function {
 	opt := func(t schema.Type) schema.Type { return &schema.OptionalType{ElementType: t} }
 	return &schema.Function{
@@ -82,8 +82,16 @@ func TerraformRemoteStateSchema() *schema.Function {
 				{Name: "defaults", Type: opt(schema.AnyType)},
 			},
 		},
+		// The data source's own arguments are readable attributes of it, so they
+		// are part of the result too; remoteStateResult stores them back.
 		ReturnType: &schema.ObjectType{
-			Properties: []*schema.Property{{Name: "outputs", Type: schema.AnyType}},
+			Properties: []*schema.Property{
+				{Name: "outputs", Type: schema.AnyType},
+				{Name: "backend", Type: opt(schema.StringType)},
+				{Name: "config", Type: opt(schema.AnyType)},
+				{Name: "workspace", Type: opt(schema.StringType)},
+				{Name: "defaults", Type: opt(schema.AnyType)},
+			},
 		},
 	}
 }

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -3611,6 +3611,7 @@ func (e *Engine) providerFunctionImpl(
 
 // invokeFunction invokes a Pulumi function (data source).
 func (e *Engine) invokeFunction(ctx context.Context, tfType string, req InvokeRequest) (property.Map, error) {
+	dsArgs := req.Args
 	req, defaults, err := lowerRemoteStateInvoke(tfType, req)
 	if err != nil {
 		return property.Map{}, err
@@ -3625,7 +3626,10 @@ func (e *Engine) invokeFunction(ctx context.Context, tfType string, req InvokeRe
 		return property.Map{}, fmt.Errorf("function invocation failed: %v", resp.Failures)
 	}
 
-	return applyRemoteStateDefaults(defaults, resp.Return), nil
+	if tfType == packages.RemoteStateType {
+		return remoteStateResult(dsArgs, defaults, resp.Return), nil
+	}
+	return resp.Return, nil
 }
 
 func (e *Engine) getResourceState(ctx context.Context, ref property.ResourceReference) (property.Map, error) {

--- a/pkg/hcl/run/terraform_remote_state.go
+++ b/pkg/hcl/run/terraform_remote_state.go
@@ -156,6 +156,19 @@ func lowerRemoteStateInvoke(tfType string, req InvokeRequest) (InvokeRequest, pr
 	return req, defaults, nil
 }
 
+// remoteStateResult builds the terraform_remote_state data source's object from
+// the state-reference invoke's result. The data source's own `backend`,
+// `config`, `workspace` and `defaults` arguments are readable attributes of it,
+// so they are stored back alongside `outputs`; the invoke reports only the
+// outputs. Absent arguments read as null.
+func remoteStateResult(args, defaults, ret property.Map) property.Map {
+	ret = applyRemoteStateDefaults(defaults, ret)
+	for _, k := range []string{"backend", "config", "workspace", "defaults"} {
+		ret = ret.Set(k, args.Get(k))
+	}
+	return ret
+}
+
 // applyRemoteStateDefaults overlays the data source's `defaults` beneath the
 // outputs returned by the state-reference invoke: each default supplies the
 // value for an output the referenced state does not define, matching OpenTofu's

--- a/pkg/hcl/run/terraform_remote_state_test.go
+++ b/pkg/hcl/run/terraform_remote_state_test.go
@@ -307,3 +307,23 @@ func TestApplyRemoteStateDefaults(t *testing.T) {
 		}), applyRemoteStateDefaults(defaults, ret))
 	})
 }
+
+func TestRemoteStateResult(t *testing.T) {
+	t.Parallel()
+
+	args := property.NewMap(map[string]property.Value{
+		"backend": property.New("local"),
+		"config":  property.New(map[string]property.Value{"path": property.New("remote.tfstate")}),
+	})
+	ret := property.NewMap(map[string]property.Value{
+		"outputs": property.New(map[string]property.Value{"greeting": property.New("hello")}),
+	})
+
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"outputs":   property.New(map[string]property.Value{"greeting": property.New("hello")}),
+		"backend":   property.New("local"),
+		"config":    property.New(map[string]property.Value{"path": property.New("remote.tfstate")}),
+		"workspace": property.Value{},
+		"defaults":  property.Value{},
+	}), remoteStateResult(args, property.Map{}, ret))
+}

--- a/pkg/hcl/run/terraform_remote_state_test.go
+++ b/pkg/hcl/run/terraform_remote_state_test.go
@@ -323,7 +323,7 @@ func TestRemoteStateResult(t *testing.T) {
 		"outputs":   property.New(map[string]property.Value{"greeting": property.New("hello")}),
 		"backend":   property.New("local"),
 		"config":    property.New(map[string]property.Value{"path": property.New("remote.tfstate")}),
-		"workspace": property.Value{},
-		"defaults":  property.Value{},
+		"workspace": {},
+		"defaults":  {},
 	}), remoteStateResult(args, property.Map{}, ret))
 }

--- a/tests/tfcompat/l2_remote_state_attributes_test.go
+++ b/tests/tfcompat/l2_remote_state_attributes_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL2RemoteStateAttributes references the terraform_remote_state attributes
+// other than `outputs`. OpenTofu's data source stores `backend`, `config`,
+// `workspace` and `defaults` back into its own object, so `.backend` and
+// `.config.path` are readable alongside `.outputs`. pulumi-language-hcl lowers
+// the data source onto the pulumi-terraform state-reference invoke, whose
+// result must expose the same attributes.
+func TestL2RemoteStateAttributes(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_remote_state_attributes", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_remote_state_attributes/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_remote_state_attributes/main.tf
@@ -1,0 +1,24 @@
+# terraform_remote_state exposes more than `outputs`: the data source stores its
+# own `backend`, `config`, `workspace` and `defaults` arguments back as readable
+# attributes, so a program can reference them (a module that takes the backend
+# config as a variable and echoes back where it read from, for instance).
+# OpenTofu writes all of them into the data source's object, so
+# `.backend` reads "local" and `.config.path` reads the configured path.
+data "terraform_remote_state" "rs" {
+  backend = "local"
+  config = {
+    path = "remote.tfstate"
+  }
+}
+
+output "greeting" {
+  value = data.terraform_remote_state.rs.outputs.greeting
+}
+
+output "backend" {
+  value = data.terraform_remote_state.rs.backend
+}
+
+output "config_path" {
+  value = data.terraform_remote_state.rs.config.path
+}

--- a/tests/tfcompat/testdata/cases/l2_remote_state_attributes/remote.tfstate
+++ b/tests/tfcompat/testdata/cases/l2_remote_state_attributes/remote.tfstate
@@ -1,0 +1,14 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.1",
+  "serial": 1,
+  "lineage": "3d6f6d7b-4429-46cb-d10f-10ab291859f7",
+  "outputs": {
+    "greeting": {
+      "value": "hello",
+      "type": "string"
+    }
+  },
+  "resources": [],
+  "check_results": null
+}


### PR DESCRIPTION
Referencing a `terraform_remote_state` attribute other than `outputs` works in OpenTofu and errored in pulumi-hcl:

```
error: an unhandled error occurred: processing output backend: evaluating output value:
  .../main.tf:19,41-49: Unsupported attribute; This object does not have an attribute named "backend".
```

OpenTofu's `dataSourceRemoteStateRead` (`internal/builtin/providers/tf/data_source_state.go`) stores the data source's own `backend`, `config`, `workspace` and `defaults` back into its object alongside `outputs`. All four are echoes of the configuration — nothing is read from the state file — so no change to pulumi-terraform's state-reference invokes is needed:

- `packages.TerraformRemoteStateSchema` declares them on the return type.
- `remoteStateResult` stores them back onto the invoke's result, absent arguments reading as null.

Covered by the `l2_remote_state_attributes` tfcompat case (added as a failing test in the first commit) and a `remoteStateResult` unit test.