### PR TITLE
Accept a tuple in an `import` block's `for_each`

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-443.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-443.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Accept a tuple in an `import` block's `for_each`
+time: 2026-07-21T13:30:00Z
+custom:
+    Component: runtime
+    PR: "443"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2443,22 +2443,10 @@ func (e *Engine) resolveImportId(
 	for _, imp := range e.config.Imports {
 		evs := []*eval.Evaluator{e.evaluator}
 		if imp.ForEach != nil {
-			forEach, unknown, _, diags := e.evaluator.EvaluateForEach(imp.ForEach)
-			if diags.HasErrors() {
-				return "", diags
-			}
-			if unknown {
-				return "", hcl.Diagnostics{{
-					Severity: hcl.DiagError,
-					Summary:  "Invalid for_each argument",
-					Detail:   `The import block "for_each" argument depends on resource attributes that cannot be determined until apply.`,
-					Subject:  imp.ForEach.Range().Ptr(),
-				}}
-			}
-			evs = evs[:0]
-			for k, v := range forEach {
-				kVal := cty.StringVal(k)
-				evs = append(evs, eval.NewEvaluator(e.evaluator.Context().WithIteration(nil, &kVal, &v)))
+			var err error
+			evs, err = e.expandImportForEach(imp.ForEach)
+			if err != nil {
+				return "", err
 			}
 		}
 		for _, ev := range evs {
@@ -2470,6 +2458,48 @@ func (e *Engine) resolveImportId(
 	}
 
 	return "", nil
+}
+
+// expandImportForEach expands an import block's for_each into one evaluator
+// per element, each carrying that element's each.key/each.value. Beyond the
+// map, object and set a resource's for_each accepts, an import block also
+// accepts a tuple, whose each.key is the element's index — so a tuple can key
+// a counted resource directly.
+func (e *Engine) expandImportForEach(expr hcl.Expression) ([]*eval.Evaluator, error) {
+	newEvaluator := func(k, v cty.Value) *eval.Evaluator {
+		return eval.NewEvaluator(e.evaluator.Context().WithIteration(nil, &k, &v))
+	}
+
+	val, diags := e.evaluator.Evaluate(expr)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	if unmarked, _ := val.Unmark(); !val.HasMark(eval.SensitiveMark) &&
+		unmarked.IsKnown() && !unmarked.IsNull() && unmarked.Type().IsTupleType() {
+		evs := make([]*eval.Evaluator, 0, unmarked.LengthInt())
+		for i, v := range unmarked.AsValueSlice() {
+			evs = append(evs, newEvaluator(cty.NumberIntVal(int64(i)), v))
+		}
+		return evs, nil
+	}
+
+	forEach, unknown, _, diags := e.evaluator.EvaluateForEach(expr)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	if unknown {
+		return nil, hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid for_each argument",
+			Detail:   `The import block "for_each" argument depends on resource attributes that cannot be determined until apply.`,
+			Subject:  expr.Range().Ptr(),
+		}}
+	}
+	evs := make([]*eval.Evaluator, 0, len(forEach))
+	for k, v := range forEach {
+		evs = append(evs, newEvaluator(cty.StringVal(k), v))
+	}
+	return evs, nil
 }
 
 // matchImport reports whether imp targets the given resource instance and, if

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -3837,6 +3837,27 @@ import {
 		}, importIdsByName(t, tmpDir))
 	})
 
+	t.Run("tuple_for_each", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := writeRoot(t, `
+resource "aws_instance" "web" {
+  count = 2
+  ami   = "ami-12345"
+}
+
+import {
+  for_each = ["id-a", "id-b"]
+  to       = aws_instance.web[each.key]
+  id       = each.value
+}
+`)
+		assert.Equal(t, map[string]string{
+			"web[0]": "id-a",
+			"web[1]": "id-b",
+		}, importIdsByName(t, tmpDir))
+	})
+
 	t.Run("unkeyed_import_does_not_match_expanded_resource", func(t *testing.T) {
 		t.Parallel()
 

--- a/tests/tfcompat/l2_import_foreach_tuple_test.go
+++ b/tests/tfcompat/l2_import_foreach_tuple_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+func TestL2ImportForEachTuple(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_import_foreach_tuple", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "importable", Factory: providers.ImportableProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_import_foreach_tuple/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_import_foreach_tuple/main.tf
@@ -1,0 +1,16 @@
+resource "importable_resource" "foo" {
+  count = 2
+}
+
+# An import block's for_each accepts a map, a set of strings, or a tuple. For a
+# tuple each.key is the element's index, so it can key a counted resource
+# directly.
+import {
+  for_each = ["id-a", "id-b"]
+  to       = importable_resource.foo[each.key]
+  id       = each.value
+}
+
+output "names" {
+  value = importable_resource.foo[*].name
+}


### PR DESCRIPTION
An `import` block's `for_each` accepts a map, an object, a set of strings, or a tuple, while a resource's accepts everything but the tuple. `resolveImportId` routed the import block through the resource `for_each` evaluator, so a tuple literal aborted the update with `for_each must be a map or set, not tuple`.

Import blocks now expand their own `for_each`: a known, non-sensitive tuple yields one element per index with `each.key` set to that index, so a tuple can key a counted resource directly. Every other value delegates to the resource evaluator unchanged, so map, object, set, list, null, unknown and sensitive values keep their current behavior.

Covered by the `l2_import_foreach_tuple` tfcompat case added in the first commit.