### PR TITLE
Inherit default provider configurations by source address, not local name

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-444.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-444.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Inherit default provider configurations by source address, not local name
+time: 2026-07-21T13:40:00Z
+custom:
+    Component: runtime
+    PR: "444"

--- a/pkg/hcl/graph/default_provider_test.go
+++ b/pkg/hcl/graph/default_provider_test.go
@@ -309,3 +309,58 @@ module "child" {
 	order := walkOrder(t, g)
 	assert.Less(t, indexOf(order, "simple"), indexOf(order, "module.child.simple_resource.r"))
 }
+
+// TestBareProviderReferenceInheritedRenamedLocalName covers the same
+// inheritance where the child names `hashicorp/simple` `myp`: inheritance is
+// by fully-qualified address, so the resource must still be ordered after the
+// root's `provider "simple"` block.
+func TestBareProviderReferenceInheritedRenamedLocalName(t *testing.T) {
+	t.Parallel()
+
+	childSrc := []byte(`
+terraform {
+  required_providers {
+    myp = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+resource "simple_resource" "r" {
+  provider = myp
+}
+`)
+	child, diags := parser.NewParser().ParseSource("child.hcl", childSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	rootSrc := []byte(`
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+provider "simple" {}
+
+module "child" {
+  source = "./child"
+}
+`)
+	root, diags := parser.NewParser().ParseSource("root.hcl", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	loader := fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: child, SourcePath: "./child"},
+	}}
+
+	g, err := BuildFromConfig(root, loader, ".")
+	require.NoError(t, err)
+
+	assert.Empty(t, g.Validate())
+	assert.True(t, g.HasDependents("simple"))
+
+	order := walkOrder(t, g)
+	assert.Less(t, indexOf(order, "simple"), indexOf(order, "module.child.simple_resource.r"))
+}

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -46,6 +46,12 @@ type ModuleInfo struct {
 	Module     *ast.Module // the module block from the parent config
 	SourcePath string      // resolved source path (for component type name)
 
+	// Terraform is the module's own `terraform` block (nil when it has
+	// none). Its `required_providers` names the providers this module uses,
+	// which the runtime needs to re-key provider references crossing the
+	// module boundary — see [LocalProviderName].
+	Terraform *ast.Terraform
+
 	// ParentSourcePath is the resolved source directory of the parent module
 	// (or the root program dir for top-level calls). It's the dir that
 	// Module.Source is relative to, so the runtime can re-resolve it when
@@ -760,7 +766,7 @@ func (g *Graph) resolvePassedProvider(
 			return nil
 		}
 	}
-	addr := fmt.Sprintf("%sprovider[%q]", parent.prefix, providerFQN(childConfig, strings.SplitN(childKey, ".", 2)[0]))
+	addr := fmt.Sprintf("%sprovider[%q]", parent.prefix, ProviderFQN(childConfig.Terraform, strings.SplitN(childKey, ".", 2)[0]))
 	if aliased {
 		addr += "." + alias
 	}
@@ -781,13 +787,14 @@ func (g *Graph) recordMissingProvider(addr string, rng hcl.Range) {
 	}
 }
 
-// providerFQN returns the fully-qualified address of the provider behind
-// localName in config: the `required_providers` source when declared, else the
-// default namespace, both anchored at the default registry host.
-func providerFQN(config *ast.Config, localName string) string {
+// ProviderFQN returns the fully-qualified address of the provider behind
+// localName in the module whose `terraform` block is tfBlock: the
+// `required_providers` source when declared, else the default namespace, both
+// anchored at the default registry host.
+func ProviderFQN(tfBlock *ast.Terraform, localName string) string {
 	source := localName
-	if config.Terraform != nil {
-		if req, ok := config.Terraform.RequiredProviders[localName]; ok && req.Source != "" {
+	if tfBlock != nil {
+		if req, ok := tfBlock.RequiredProviders[localName]; ok && req.Source != "" {
 			source = req.Source
 		}
 	}
@@ -801,6 +808,28 @@ func providerFQN(config *ast.Config, localName string) string {
 	}
 }
 
+// LocalProviderName returns the name by which the module whose `terraform`
+// block is tfBlock refers to the provider fqn. Provider configurations are
+// shared across module boundaries by fully-qualified address, so a lookup
+// crossing into another module must be re-keyed through this. fallback is
+// returned when the module declares no name for fqn: an undeclared local name
+// stands for itself.
+func LocalProviderName(tfBlock *ast.Terraform, fqn, fallback string) string {
+	if tfBlock == nil || ProviderFQN(tfBlock, fallback) == fqn {
+		return fallback
+	}
+	local := ""
+	for name := range tfBlock.RequiredProviders {
+		if ProviderFQN(tfBlock, name) == fqn && (local == "" || name < local) {
+			local = name
+		}
+	}
+	if local == "" {
+		return fallback
+	}
+	return local
+}
+
 // defaultProviderNode returns an edge to the node that registers the default
 // (un-aliased) provider configuration `name` as seen from scope s: the
 // nearest enclosing scope with a `provider "<name>"` block, or with a
@@ -809,14 +838,19 @@ func providerFQN(config *ast.Config, localName string) string {
 // reference then names the implicit empty default configuration, which needs
 // no ordering edge.
 func (g *Graph) defaultProviderNode(name string, s *moduleScope) []pdag.Node {
+	if s == nil {
+		return nil
+	}
+	fqn := ProviderFQN(s.config.Terraform, name)
 	for ; s != nil; s = s.parent {
-		if _, ok := s.config.Providers[name]; ok {
-			_, idx := g.newNode(s.prefix + name)
+		local := LocalProviderName(s.config.Terraform, fqn, name)
+		if _, ok := s.config.Providers[local]; ok {
+			_, idx := g.newNode(s.prefix + local)
 			return []pdag.Node{idx}
 		}
 		if s.mod != nil {
-			if _, ok := s.mod.Providers[name]; ok {
-				_, idx := g.newNode(s.prefix + name)
+			if _, ok := s.mod.Providers[local]; ok {
+				_, idx := g.newNode(s.prefix + local)
 				return []pdag.Node{idx}
 			}
 		}
@@ -1488,6 +1522,7 @@ func (g *Graph) inlineModule(
 		Path:             path,
 		Module:           mod,
 		SourcePath:       loaded.SourcePath,
+		Terraform:        loaded.Config.Terraform,
 		ParentSourcePath: workDir,
 	}
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1158,23 +1158,33 @@ func (e *Engine) resolveExplicitProvider(
 }
 
 // inheritedDefaultProvider walks up the module tree from modInfo, returning
-// the nearest ancestor's un-aliased default provider config for pkg
-// (URN::ID), or "" if none. An ancestor's default is its own registered block
-// or one passed to it through its module call. The graph adds a matching edge
-// so that block is registered before this resolves.
-func (e *Engine) inheritedDefaultProvider(modInfo *graph.ModuleInfo, pkg string) string {
+// the nearest ancestor's un-aliased default provider config for the provider
+// that modInfo calls name (URN::ID), or "" if none. An ancestor's default is
+// its own registered block or one passed to it through its module call.
+// Inheritance is by fully-qualified provider address, so each ancestor is
+// searched under the name that ancestor gives the provider. The graph adds a
+// matching edge so that block is registered before this resolves.
+func (e *Engine) inheritedDefaultProvider(modInfo *graph.ModuleInfo, name string) string {
+	fqn := graph.ProviderFQN(modInfo.Terraform, name)
 	for path := modInfo.Path; ; {
 		parent, _, ok := path.Parent()
 		if !ok {
 			return ""
 		}
-		if outputs, ok := e.resourceOutputs.Get(parent.PrefixString() + pkg); ok {
+		var parentInfo *graph.ModuleInfo
+		tfBlock := e.config.Terraform
+		if insts, ok := e.moduleInstances.Get(parent); ok && len(insts) > 0 {
+			parentInfo = insts[0].ModuleInfo
+			tfBlock = parentInfo.Terraform
+		}
+		local := graph.LocalProviderName(tfBlock, fqn, name)
+		if outputs, ok := e.resourceOutputs.Get(parent.PrefixString() + local); ok {
 			if ref, err := providerRefFromCty(outputs); err == nil {
 				return ref
 			}
 		}
-		if insts, ok := e.moduleInstances.Get(parent); ok && len(insts) > 0 {
-			if ref := e.resolvePassThroughProvider(insts[0].ModuleInfo, pkg); ref != "" {
+		if parentInfo != nil {
+			if ref := e.resolvePassThroughProvider(parentInfo, local); ref != "" {
 				return ref
 			}
 		}

--- a/tests/tfcompat/l2_module_inherited_provider_renamed_local_name_test.go
+++ b/tests/tfcompat/l2_module_inherited_provider_renamed_local_name_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ModuleInheritedProviderRenamedLocalName pins TF's rule that a child
+// module inherits its parent's default provider configuration by the
+// provider's fully-qualified source address, not by local name. The child
+// here calls `hashicorp/simple` by the local name `myp`, so the resource's
+// `prefix_result` must still carry the root `provider "simple"` block's
+// prefix.
+func TestL2ModuleInheritedProviderRenamedLocalName(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_inherited_provider_renamed_local_name", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_module_inherited_provider_renamed_local_name/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_inherited_provider_renamed_local_name/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    simple = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+provider "simple" {
+  prefix = "root"
+}
+
+module "child" {
+  source = "./modules/child"
+}
+
+output "child_prefix" {
+  value = module.child.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_inherited_provider_renamed_local_name/modules/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_inherited_provider_renamed_local_name/modules/child/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    myp = {
+      source = "hashicorp/simple"
+    }
+  }
+}
+
+resource "simple_resource" "r" {
+  provider  = myp
+  input_one = "world"
+  input_two = true
+}
+
+output "prefix_result" {
+  value = simple_resource.r.prefix_result
+}


### PR DESCRIPTION
A child module that declares the same provider `source` under a **different local name** than its parent did not inherit the parent’s default provider configuration.

Root declares `simple = { source = "hashicorp/simple" }` plus `provider "simple" { prefix = "root" }`. The child declares `myp = { source = "hashicorp/simple" }`, uses `provider = myp`, and the module call passes no `providers` argument. OpenTofu inherits by fully-qualified source address, so the child resource gets the root configuration (`root-world`); pulumi-hcl matched on the *local name*, found nothing, and ran the resource against an unconfigured provider (`-world`).

## Fix

Both the graph edge and the runtime lookup keyed the ancestor scope by the child’s local name. Now the reference is resolved to a fully-qualified address in the module that writes it, and each ancestor is searched under the name *that* ancestor gives the same address:

- `graph.ProviderFQN` (was the unexported `providerFQN`) and the new `graph.LocalProviderName` do the re-keying.
- `defaultProviderNode` walks ancestor scopes under the re-keyed name, so the ordering edge to the root `provider` block exists.
- `Engine.inheritedDefaultProvider` does the same against `resourceOutputs` and pass-through entries.
- `graph.ModuleInfo` now carries the module’s own `terraform` block, which is what the runtime needs to re-key across a module boundary.

## Tests

- `TestL2ModuleInheritedProviderRenamedLocalName` (tfcompat, added by the first commit) now passes.
- `TestBareProviderReferenceInheritedRenamedLocalName` pins the graph ordering edge; verified failing without the graph change.

## Out of scope

When an ancestor declares no name at all for a non-default source address, the lookup still falls back to the bare local name, so two providers sharing a basename across namespaces still collide — that is https://github.com/pulumi-labs/pulumi-hcl/issues/197 and lives in the schema/package-identity layer.