### PR TITLE
Accept the pre-0.12 quoted reference form in `depends_on` and `ignore_changes`

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-447.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-447.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Accept the pre-0.12 quoted reference form in `depends_on` and `ignore_changes`, with a deprecation warning
+time: 2026-07-21T13:30:00Z
+custom:
+    Component: runtime
+    PR: "447"

--- a/pkg/hcl/parser/compat_shim.go
+++ b/pkg/hcl/parser/compat_shim.go
@@ -1,0 +1,81 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// shimTraversalInString re-parses a native-syntax quoted string as a traversal,
+// supporting the pre-0.12 form of reference arguments (`depends_on =
+// ["null_resource.a"]`), and reports a deprecation warning. Any other
+// expression is returned verbatim, including JSON-syntax expressions: there,
+// traversals in strings are the required form rather than a legacy one.
+func shimTraversalInString(expr hcl.Expression) (hcl.Expression, hcl.Diagnostics) {
+	if _, ok := expr.(*hclsyntax.TemplateExpr); !ok {
+		return expr, nil
+	}
+
+	strVal, diags := expr.Value(nil)
+	if diags.HasErrors() || strVal.IsNull() || !strVal.IsKnown() {
+		// Not shimmable (e.g. the string interpolates something); leave the
+		// caller's own error handling to report it.
+		return expr, nil
+	}
+
+	// The start position ignores escape sequences in the literal, which is
+	// close enough for error reporting.
+	srcRange := expr.Range()
+	startPos := srcRange.Start
+	startPos.Column++
+	startPos.Byte++
+
+	// On a parse failure the traversal is empty, which callers skip; reporting
+	// the parse error here beats letting them report a generic one.
+	traversal, tDiags := hclsyntax.ParseTraversalAbs([]byte(strVal.AsString()), srcRange.Filename, startPos)
+	diags = append(diags, tDiags...)
+	diags = append(diags, &hcl.Diagnostic{
+		Severity: hcl.DiagWarning,
+		Summary:  "Quoted references are deprecated",
+		Detail: "In this context, references are expected literally rather than in quotes. " +
+			"Terraform 0.11 and earlier required quotes, but quoted references are now deprecated. " +
+			"Remove the quotes surrounding this reference to silence this warning.",
+		Subject: &srcRange,
+	})
+
+	return &hclsyntax.ScopeTraversalExpr{
+		Traversal: traversal,
+		SrcRange:  srcRange,
+	}, diags
+}
+
+// decodeDependsOn decodes a `depends_on` argument into the references it names.
+func decodeDependsOn(attr *hcl.Attribute) ([]hcl.Traversal, hcl.Diagnostics) {
+	exprs, diags := hcl.ExprList(attr.Expr)
+
+	var ret []hcl.Traversal
+	for _, expr := range exprs {
+		expr, shimDiags := shimTraversalInString(expr)
+		diags = append(diags, shimDiags...)
+
+		traversal, travDiags := hcl.AbsTraversalForExpr(expr)
+		diags = append(diags, travDiags...)
+		if len(traversal) != 0 {
+			ret = append(ret, traversal)
+		}
+	}
+	return ret, diags
+}

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -690,16 +690,9 @@ func (p *Parser) decodeResourceBlock(block *hcl.Block, isDataSource bool) (*ast.
 	}
 
 	if attr, ok := content.Attributes["depends_on"]; ok {
-		// depends_on should be a list of references
-		exprs, exprDiags := hcl.ExprList(attr.Expr)
-		diags = append(diags, exprDiags...)
-		for _, expr := range exprs {
-			traversal, travDiags := hcl.AbsTraversalForExpr(expr)
-			diags = append(diags, travDiags...)
-			if traversal != nil {
-				resource.DependsOn = append(resource.DependsOn, traversal)
-			}
-		}
+		deps, depsDiags := decodeDependsOn(attr)
+		diags = append(diags, depsDiags...)
+		resource.DependsOn = append(resource.DependsOn, deps...)
 	}
 
 	if attr, ok := content.Attributes["provider"]; ok {
@@ -882,6 +875,9 @@ func (p *Parser) parseLifecycleBlock(block *hcl.Block) (*lifecycleResult, hcl.Di
 			exprs, exprDiags := hcl.ExprList(attr.Expr)
 			diags = append(diags, exprDiags...)
 			for _, expr := range exprs {
+				expr, shimDiags := shimTraversalInString(expr)
+				diags = append(diags, shimDiags...)
+
 				traversal, travDiags := hcl.RelTraversalForExpr(expr)
 				diags = append(diags, travDiags...)
 				if traversal != nil {
@@ -1121,15 +1117,9 @@ func (p *Parser) parseOutputBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	}
 
 	if attr, ok := content.Attributes["depends_on"]; ok {
-		exprs, exprDiags := hcl.ExprList(attr.Expr)
-		diags = append(diags, exprDiags...)
-		for _, expr := range exprs {
-			traversal, travDiags := hcl.AbsTraversalForExpr(expr)
-			diags = append(diags, travDiags...)
-			if traversal != nil {
-				output.DependsOn = append(output.DependsOn, traversal)
-			}
-		}
+		deps, depsDiags := decodeDependsOn(attr)
+		diags = append(diags, depsDiags...)
+		output.DependsOn = append(output.DependsOn, deps...)
 	}
 
 	// Parse preconditions
@@ -1280,15 +1270,9 @@ func (p *Parser) parseModuleBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 	}
 
 	if attr, ok := content.Attributes["depends_on"]; ok {
-		exprs, exprDiags := hcl.ExprList(attr.Expr)
-		diags = append(diags, exprDiags...)
-		for _, expr := range exprs {
-			traversal, travDiags := hcl.AbsTraversalForExpr(expr)
-			diags = append(diags, travDiags...)
-			if traversal != nil {
-				module.DependsOn = append(module.DependsOn, traversal)
-			}
-		}
+		deps, depsDiags := decodeDependsOn(attr)
+		diags = append(diags, depsDiags...)
+		module.DependsOn = append(module.DependsOn, deps...)
 	}
 
 	// Parse providers map. Keys may be bare provider names ("simple"),

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1095,4 +1096,45 @@ func contains(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+// Quoted references are the pre-0.12 form of `depends_on` and `ignore_changes`
+// entries. They are still accepted, with a deprecation warning.
+func TestParseQuotedReferences(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+resource "aws_instance" "web" {
+  depends_on = ["aws_vpc.main"]
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
+}
+`)
+
+	p := NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), "%s", diags)
+
+	r, ok := config.Resources["aws_instance.web"]
+	require.True(t, ok)
+	assert.Equal(t, []string{"aws_vpc.main"}, traversalStrings(r.DependsOn))
+	require.NotNil(t, r.Lifecycle)
+	assert.Equal(t, []string{".tags"}, traversalStrings(r.Lifecycle.IgnoreChanges))
+
+	require.Len(t, diags, 2)
+	for _, d := range diags {
+		assert.Equal(t, hcl.DiagWarning, d.Severity)
+		assert.Equal(t, "Quoted references are deprecated", d.Summary)
+	}
+}
+
+// traversalStrings renders each traversal as it would be written in source. A
+// relative traversal keeps its leading dot (`.tags`).
+func traversalStrings(traversals []hcl.Traversal) []string {
+	var ret []string
+	for _, t := range traversals {
+		ret = append(ret, string(hclwrite.TokensForTraversal(t).Bytes()))
+	}
+	return ret
 }

--- a/tests/tfcompat/l2_depends_on_quoted_ref_test.go
+++ b/tests/tfcompat/l2_depends_on_quoted_ref_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2DependsOnQuotedRef exercises the pre-0.12 quoted form of `depends_on`
+// entries. OpenTofu re-parses the string as a traversal and emits only a
+// deprecation warning, so the program still applies.
+func TestL2DependsOnQuotedRef(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_depends_on_quoted_ref", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_depends_on_quoted_ref/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_depends_on_quoted_ref/main.tf
@@ -1,0 +1,22 @@
+# OpenTofu 0.11 and earlier required `depends_on` entries to be quoted strings.
+# The form is deprecated but still accepted: `configs.shimTraversalInString`
+# re-parses the string as a traversal and emits only a warning.
+
+resource "simple_resource" "first" {
+  input_one = "first"
+  input_two = true
+}
+
+resource "simple_resource" "second" {
+  input_one  = "second"
+  input_two  = false
+  depends_on = ["simple_resource.first"]
+}
+
+output "first_result" {
+  value = simple_resource.first.result
+}
+
+output "second_result" {
+  value = simple_resource.second.result
+}


### PR DESCRIPTION
The pre-0.12 quoted reference form `depends_on = ["simple_resource.first"]` applies under OpenTofu but failed to parse under pulumi-hcl:

```
main.tf:13,17-40: Invalid expression; A single static variable reference
is required: only attribute access and indexing with constant keys. ...
```

OpenTofu re-parses the string as a traversal (`configs/compat_shim.go::shimTraversalInString`) and emits only a `DiagWarning`, so the program applies.

## The fix

`pkg/hcl/parser/compat_shim.go` adds `shimTraversalInString`: a native-syntax quoted string (`*hclsyntax.TemplateExpr`) is re-parsed with `hclsyntax.ParseTraversalAbs`, wrapped back into a `ScopeTraversalExpr`, and a `Quoted references are deprecated` warning is reported. Anything else — including every JSON-syntax expression, where traversals in strings are the *required* form — passes through verbatim.

The three `depends_on` sites (resource/data, output, module call) now share a `decodeDependsOn` helper that runs the shim, replacing three copies of the same loop.

## Sibling fixed in the same pass

Quoted `ignore_changes = ["tags"]` entries are the same legacy form and were rejected for the same reason, so they take the same shim before `hcl.RelTraversalForExpr`.

## Deliberately not changed

- Quoted `provider = "name"` references and quoted type constraints (`type = "list"`) are hard errors upstream too, so rejecting them is already parity.
- The legacy `ignore_changes = ["*"]` wildcard stays an error (it is one upstream as well), just with a different message.
- Quoted provisioner keywords (`when = "destroy"`) were already accepted by `exprAsKeywordOrString`, so the shim needs no `wantKeyword` mode.

## Testing

- `TestL2DependsOnQuotedRef` (the tfcompat case added in the first commit) now passes.
- `TestParseQuotedReferences` covers both arguments at the parser level and asserts exactly two deprecation warnings are emitted.