### PR TITLE
Test: a resource carrying a destroy-time provisioner can be removed

### DIFF
--- a/tests/tfcompat/l2_provisioner_destroy_orphaned_test.go
+++ b/tests/tfcompat/l2_provisioner_destroy_orphaned_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// Deleting a resource that carries a `when = destroy` provisioner from the
+// configuration must destroy it, without running the provisioner: the block
+// went away with the resource block.
+func TestL2Provisioner_DestroyOrphaned(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_provisioner_destroy_orphaned", tfcompat.Case{
+		Stages: []tfcompat.Stage{{}, {}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_destroy_orphaned/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_destroy_orphaned/0/main.tf
@@ -3,7 +3,8 @@ resource "terraform_data" "r" {
   input = "a"
 
   provisioner "local-exec" {
-    when    = destroy
-    command = "true"
+    when = destroy
+    # This should never run, if it does it will fail.
+    command = "false"
   }
 }

--- a/tests/tfcompat/testdata/cases/l2_provisioner_destroy_orphaned/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_destroy_orphaned/0/main.tf
@@ -1,0 +1,9 @@
+# A resource carrying a `when = destroy` provisioner.
+resource "terraform_data" "r" {
+  input = "a"
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "true"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_provisioner_destroy_orphaned/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_destroy_orphaned/1/main.tf
@@ -1,5 +1,1 @@
-# The resource is gone from the configuration, so it is destroyed as an orphan.
-# The destroy-time provisioner went away with the resource block and does not
-# run; the apply succeeds. Nothing here declares a provisioner, so the run also
-# covers a program that must service a hook it never declares.
-output "gone" { value = "gone" }
+

--- a/tests/tfcompat/testdata/cases/l2_provisioner_destroy_orphaned/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provisioner_destroy_orphaned/1/main.tf
@@ -1,0 +1,5 @@
+# The resource is gone from the configuration, so it is destroyed as an orphan.
+# The destroy-time provisioner went away with the resource block and does not
+# run; the apply succeeds. Nothing here declares a provisioner, so the run also
+# covers a program that must service a hook it never declares.
+output "gone" { value = "gone" }


### PR DESCRIPTION
Regression coverage for removing a resource that carries a `when = destroy` provisioner from the configuration: the orphan is destroyed cleanly and the provisioner does not run, because the provisioner block went away with the resource block.

This started as a failing test — the delete used to fail, permanently, with:

```
-  pulumi:index:Stash r deleting (0s) error: hook "terraform_data.r:provisioner:0" was not registered
```

https://github.com/pulumi-labs/pulumi-hcl/pull/462 fixed it by binding destroy-time provisioners to a single constant hook name and dispatching by URN, so the test passes as of that change. What is left is the coverage, which is worth landing on its own.

### Why this case and not one of the existing ones

It is the only tfcompat case whose orphan has **nothing left in the configuration to claim it**:

| case | stage-1 config for the orphan | dispatcher path |
| --- | --- | --- |
| `l2_provisioner_destroy_count_zero`, `..._count_shrink` | block still live (`count = 0`, shrunk count) | matches a `blockEntry` |
| `l2_removed`, `l2_removed_module` | a `removed` block re-declares the provisioners | matches a `blockEntry` |
| `l2_provisioner_destroy_orphaned` | resource block simply deleted | no match |

That pins two properties of `pkg/hcl/run/destroy_dispatch.go` nothing else reaches:

- `registerDestroyDispatcher` runs unconditionally, so the constant hook name is registered even by a program that declares no provisioners at all. Stage 1 here is a single `output` block.
- A hook invocation matching no dispatch entry no-ops instead of erroring, which is how a delete proceeds once the block is gone.

Reverting destroy provisioners to a per-resource hook name reproduces `hook ... was not registered` and fails only this test. `TestEngine_DestroyProvisionerHookBinding` asserts hook names are bound, but never exercises the gone-block path.

No Docker, ssh, or filesystem side effects: the fixture uses `terraform_data` and a `local-exec` command.

```
make build && PATH="$PWD/bin:$PATH" go test ./tests/tfcompat/ -run TestL2Provisioner_DestroyOrphaned -count=1 -v
```

Test-only, so no changelog fragment.
