### PR TITLE
Convert map values to the attribute's element type

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-449.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-449.yaml
@@ -1,0 +1,7 @@
+kind: bug-fixes
+body: Convert map values to the attribute's element type, so a `map(list(...))` holding
+    lists of different lengths no longer panics
+time: 2026-07-21T00:00:00Z
+custom:
+    Component: runtime
+    PR: "449"

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -540,21 +540,31 @@ func conformUnmarkedCtyToType(val cty.Value, typ cty.Type) cty.Value {
 	if val.Type().IsObjectType() && typ.IsMapType() {
 		elemType := typ.ElementType()
 		m := make(map[string]cty.Value, val.LengthInt())
+		uniform := true
 		for attrs := val.ElementIterator(); attrs.Next(); {
 			k, v := attrs.Element()
 			v = conformCtyToType(v, elemType)
-			// Coerce primitive elements to the target type so a literal like
-			// {fromBool = true, fromString = "true"} becomes a uniform map<bool>.
-			// Without this, cty.MapVal panics on mixed-type values.
-			if elemType.IsPrimitiveType() && !v.Type().Equals(elemType) {
+			// Coerce elements to the target type so that a literal like
+			// {fromBool = true, fromString = "true"} becomes a uniform map<bool>,
+			// and so that {a = [x, y], b = [z]} becomes a uniform map<list<...>>
+			// instead of two differently sized tuples. Without this, cty.MapVal
+			// panics on mixed-type values.
+			if !v.Type().Equals(elemType) {
 				if converted, err := convert.Convert(v, elemType); err == nil {
 					v = converted
+				} else {
+					uniform = false
 				}
 			}
 			m[k.AsString()] = v
 		}
 		if len(m) == 0 {
 			return cty.MapValEmpty(elemType)
+		}
+		// An element that cannot be converted (a null of an unrelated type, say)
+		// would make cty.MapVal panic, so keep the object shape instead.
+		if !uniform {
+			return cty.ObjectVal(m)
 		}
 		return cty.MapVal(m)
 	}

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -2082,6 +2082,41 @@ func TestConformCtyToType_UnknownAndNull(t *testing.T) {
 	}
 }
 
+// TestConformCtyToType_CollectionElements pins that map values are converted
+// to the target element type before the map is assembled: two lists of
+// different lengths are differently typed tuples, and cty.MapVal would panic
+// on them.
+func TestConformCtyToType_CollectionElements(t *testing.T) {
+	t.Parallel()
+
+	obj := cty.Object(map[string]cty.Type{"name": cty.String})
+	name := func(s string) cty.Value { return cty.ObjectVal(map[string]cty.Value{"name": cty.StringVal(s)}) }
+
+	val := cty.ObjectVal(map[string]cty.Value{
+		"left":  cty.TupleVal([]cty.Value{name("a"), name("b")}),
+		"right": cty.TupleVal([]cty.Value{name("c")}),
+	})
+
+	assert.Equal(t, cty.MapVal(map[string]cty.Value{
+		"left":  cty.ListVal([]cty.Value{name("a"), name("b")}),
+		"right": cty.ListVal([]cty.Value{name("c")}),
+	}), conformCtyToType(val, cty.Map(cty.List(obj))))
+}
+
+// TestConformCtyToType_UnconvertibleElement pins that an element that cannot be
+// converted to the map's element type leaves the value as an object rather than
+// panicking in cty.MapVal.
+func TestConformCtyToType_UnconvertibleElement(t *testing.T) {
+	t.Parallel()
+
+	val := cty.ObjectVal(map[string]cty.Value{
+		"list":   cty.ListVal([]cty.Value{cty.StringVal("a")}),
+		"number": cty.NumberIntVal(1),
+	})
+
+	assert.Equal(t, val, conformCtyToType(val, cty.Map(cty.List(cty.String))))
+}
+
 // TestUnifyPreservesNestedElementTypes pins that a heterogeneous collection
 // whose unification would coerce primitive leaves — at any depth — keeps its
 // per-element types instead of collapsing to a common type. cty unifies

--- a/tests/testutil/tfcompat/providers/pf.go
+++ b/tests/testutil/tfcompat/providers/pf.go
@@ -64,6 +64,7 @@ func (p *pfxProvider) Resources(context.Context) []func() resource.Resource {
 		func() resource.Resource { return &pfxWidget{} },
 		func() resource.Resource { return &pfxRes{} },
 		func() resource.Resource { return &pfxObj{} },
+		func() resource.Resource { return &pfxMatrix{} },
 	}
 }
 
@@ -480,3 +481,61 @@ func (d *pfxLookup) Read(ctx context.Context, _ datasource.ReadRequest, resp *da
 	state := pfxLookupModel{Value: types.StringValue("pfx-value")}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
+
+// pfxMatrix carries a single map-of-list-of-object attribute. The values of
+// the map are lists, so two keys may hold lists of different lengths while the
+// attribute as a whole stays one well-typed map(list(object)). Create and
+// Update echo the plan into state so a stack output shows what the runtime
+// planned.
+type pfxMatrix struct{}
+
+var _ resource.Resource = (*pfxMatrix)(nil)
+
+type pfxMatrixModel struct {
+	ID     types.String `tfsdk:"id"`
+	Matrix types.Map    `tfsdk:"matrix"`
+}
+
+func (r *pfxMatrix) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_matrix"
+}
+
+func (r *pfxMatrix) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"id": rschema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"matrix": rschema.MapAttribute{
+				Optional: true,
+				ElementType: types.ListType{ElemType: types.ObjectType{
+					AttrTypes: map[string]attr.Type{"name": types.StringType},
+				}},
+			},
+		},
+	}
+}
+
+func (r *pfxMatrix) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan pfxMatrixModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ID = types.StringValue("pfx-matrix-id")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *pfxMatrix) Read(_ context.Context, _ resource.ReadRequest, _ *resource.ReadResponse) {}
+
+func (r *pfxMatrix) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan pfxMatrixModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *pfxMatrix) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {}

--- a/tests/tfcompat/l2_map_list_object_update_test.go
+++ b/tests/tfcompat/l2_map_list_object_update_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2MapListObjectUpdate writes a `map(list(object))` attribute whose two
+// keys hold equal-length lists, then grows one of them on a second apply. An
+// object-literal expression types each map value as a tuple, so once the
+// lengths differ the two values have different tuple types. OpenTofu converts
+// each element to the attribute's list type before assembling the map and
+// applies the update; pulumi-hcl builds the map first, and cty.MapVal panics
+// with "inconsistent map element types".
+func TestL2MapListObjectUpdate(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_map_list_object_update", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "pfx", PFFactory: providers.PFXProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_map_list_object_update/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_map_list_object_update/0/main.tf
@@ -1,0 +1,10 @@
+resource "pfx_matrix" "t" {
+  matrix = {
+    left  = [{ name = "a" }]
+    right = [{ name = "c" }]
+  }
+}
+
+output "matrix" {
+  value = jsonencode(pfx_matrix.t.matrix)
+}

--- a/tests/tfcompat/testdata/cases/l2_map_list_object_update/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_map_list_object_update/1/main.tf
@@ -1,0 +1,13 @@
+# One key's list grows, so the map's values no longer all have the same
+# length. The attribute type is map(list(object)), so this is still a single
+# well-typed value.
+resource "pfx_matrix" "t" {
+  matrix = {
+    left  = [{ name = "a" }, { name = "b" }]
+    right = [{ name = "c" }]
+  }
+}
+
+output "matrix" {
+  value = jsonencode(pfx_matrix.t.matrix)
+}


### PR DESCRIPTION
A plugin-framework attribute typed `map(list(object({name = string})))` where two keys hold lists of **different lengths**.

- **OpenTofu**: converts each element to the attribute's element type, so the map stays well typed. Applies and outputs the value.
- **pulumi-hcl**: assembled the map from the raw tuple values first, so `cty.MapVal` saw two different tuple types and **panicked**.

```
panic: panic in DAG processing: inconsistent map element types
 (cty.Tuple([]cty.Type{cty.Object({"name":cty.String}), cty.Object({"name":cty.String})})
  then cty.Tuple([]cty.Type{cty.Object({"name":cty.String})}))
  github.com/zclconf/go-cty/cty.MapVal(...)
  pkg/hcl/transform.conformUnmarkedCtyToType  transform.go:559
```

## Fix

`conformCtyToType` coerced a map's elements to the target element type only when that element type was **primitive** — added for `{fromBool = true, fromString = "true"}` → `map(bool)`. Every other element type was left with whatever type the expression produced, which is exactly the tuple-vs-tuple case above.

Convert every element, not just primitive ones. An element that cannot be converted (a null of an unrelated type, say) leaves the value as an object rather than reaching `cty.MapVal`, matching the guard `unifyOrObject` already applies a few hundred lines down.

## Tests

- `TestL2MapListObjectUpdate` (the tfcompat case this PR started as): stage 0 applies with both keys holding 1-element lists, stage 1 grows one key to 2 elements. Now matches OpenTofu on both stages.
- Two unit tests in `transform_test.go`, one per branch of the new guard.
- Adds a `pfx_matrix` resource to the existing `PFXProvider` rather than a new provider file.

Swept the sibling assembly points — `unifyOrObject`, `blockListValue`, `unifyOrTuple` all already fall back on heterogeneous element types. This was the only unguarded one.

The SDKv2 update path was probed hard alongside this and is **clean** — set reordering, duplicate set elements, middle-element removal across map/set/list/set-of-blocks, one element of a set-of-objects changing, map key removed vs `""`, collections emptied, collections nested inside a block shrinking, `MaxItems=1` present→absent→present, a 3-level nested block's innermost leaf, Optional+Computed scalar and block dropped from config, and a ForceNew field inside a nested block all match OpenTofu exactly, in outputs and in recorded provider ops.
