### PR TITLE
Defer a data source read whose depends_on target has pending changes

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-452.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-452.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Defer a data source read during preview when its `depends_on` target has pending changes, instead of reading state the dependency has not produced yet
+time: 2026-07-21T21:40:00Z
+custom:
+    Component: runtime
+    PR: "452"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -452,6 +452,12 @@ type Engine struct {
 	// dependency-metadata recording. See urnRegistry.
 	cellURNs *urnRegistry
 
+	// pendingURNs holds the URNs of resource instances whose outputs came back
+	// with unknowns, so a data source that `depends_on` one of them can defer
+	// its read to apply. An update that leaves every output known does not land
+	// here; catching those needs the engine's diff, not the outputs.
+	pendingURNs *util.SyncMap[string, struct{}]
+
 	// failedNodes tracks resource nodes that failed to register, keyed by instance key.
 	// Dependent nodes check this map and are skipped when a dependency failed.
 	failedNodes *util.SyncMap[string, error]
@@ -618,6 +624,7 @@ func NewEngine(ctx context.Context, config *ast.Config, opts *EngineOptions) (*E
 		parallel:                opts.Parallel,
 		expansions:              util.NewSyncMap[expansionCell, *graph.BlockExpansion](),
 		cellURNs:                newURNRegistry(),
+		pendingURNs:             util.NewSyncMap[string, struct{}](),
 		failedNodes:             util.NewSyncMap[string, error](),
 		alwaysRegisterProviders: opts.AlwaysRegisterProviders,
 		resolver: packages.NewResolver(
@@ -1707,6 +1714,10 @@ func (e *Engine) registerResourceInstanceInContext(
 	markedOutputs := cty.ObjectVal(outputObj).Mark(eval.DepMark(urn))
 
 	e.resourceOutputs.Set(instance.Key, markedOutputs)
+
+	if !markedOutputs.IsWhollyKnown() {
+		e.pendingURNs.Set(string(urn), struct{}{})
+	}
 
 	var iOpts inheritableOpts
 	if opts.Protect {
@@ -3460,6 +3471,7 @@ func (e *Engine) invokeDataSourceOnce(
 	// depends_on marks the outputs with every registered instance URN of the
 	// target block, keyed or not — dependency metadata is resource-wide (see
 	// buildResourceOptionsInContext).
+	dependsOnPending := false
 	for _, dep := range ds.DependsOn {
 		depKey := graph.FormatTraversal(dep)
 		if depKey == "" {
@@ -3471,14 +3483,19 @@ func (e *Engine) invokeDataSourceOnce(
 		}
 		for _, urn := range e.cellURNs.get(expansionCell{block: fullDepKey, mi: miPath}) {
 			addURN(urn)
+			if _, pending := e.pendingURNs.Get(urn); pending {
+				dependsOnPending = true
+			}
 		}
 	}
 
 	// Match the Node.js / Python SDK behavior: during preview, if any input
 	// to the invoke is unknown, skip the provider call and synthesize an
-	// all-unknown result.
+	// all-unknown result. A pending `depends_on` target defers the read too,
+	// even with every input known: the read would observe state that the
+	// dependency has not produced yet.
 	var outputs property.Map
-	if !e.dryRun || !property.New(inputs).HasComputed() {
+	if !e.dryRun || (!property.New(inputs).HasComputed() && !dependsOnPending) {
 		var err error
 		outputs, err = e.invokeFunction(ctx, ds.Type, invokeReq)
 		if err != nil {

--- a/tests/testutil/tfcompat/providers/pending.go
+++ b/tests/testutil/tfcompat/providers/pending.go
@@ -1,0 +1,77 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// PendingProvider models a resource that is created and then read back through
+// a data source: `pending_thing` registers its name in per-provider state at
+// Create, and `pending_lookup` errors unless that name is already registered.
+// A read issued before the create is therefore observable as a failure rather
+// than as an extra recorded op.
+func PendingProvider() *schema.Provider {
+	var mu sync.Mutex
+	created := map[string]bool{}
+
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"pending_thing": {
+				Schema: map[string]*schema.Schema{
+					"name": {Type: schema.TypeString, Required: true, ForceNew: true},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					name, _ := d.Get("name").(string)
+					mu.Lock()
+					created[name] = true
+					mu.Unlock()
+					d.SetId(name)
+					return nil
+				},
+				ReadContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				DeleteContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					mu.Lock()
+					delete(created, d.Id())
+					mu.Unlock()
+					return nil
+				},
+			},
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"pending_lookup": {
+				Schema: map[string]*schema.Schema{
+					"name":   {Type: schema.TypeString, Required: true},
+					"result": {Type: schema.TypeString, Computed: true},
+				},
+				ReadContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					name, _ := d.Get("name").(string)
+					mu.Lock()
+					ok := created[name]
+					mu.Unlock()
+					if !ok {
+						return diag.Errorf("pending_lookup: no pending_thing named %q exists", name)
+					}
+					d.SetId(name)
+					return diag.FromErr(d.Set("result", "found-"+name))
+				},
+			},
+		},
+	}
+}

--- a/tests/tfcompat/l2_data_depends_on_deferred_read_test.go
+++ b/tests/tfcompat/l2_data_depends_on_deferred_read_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A `data` block whose arguments are all known, but which `depends_on` a
+// resource with pending changes, is read at apply time — not during plan.
+// Deferral therefore cannot be decided from the inputs alone: `name` here is a
+// literal.
+func TestL2DataDependsOnDeferredRead(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_depends_on_deferred_read", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "pending", Factory: providers.PendingProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StagePreview},
+			{},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_data_depends_on_deferred_read/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_depends_on_deferred_read/main.tf
@@ -1,0 +1,16 @@
+# `pending_lookup` errors unless a `pending_thing` of that name already exists,
+# and its own arguments are fully known: only `depends_on` ties it to the
+# resource that makes the read succeed.
+resource "pending_thing" "thing" {
+  name = "widget"
+}
+
+data "pending_lookup" "lookup" {
+  name = "widget"
+
+  depends_on = [pending_thing.thing]
+}
+
+output "looked_up" {
+  value = data.pending_lookup.lookup.result
+}


### PR DESCRIPTION
Terraform reads a data source during plan only when nothing it depends on is about to change: the plan cannot know what a pending resource will do to whatever the data source reads, so the read belongs to apply. Deferral was decided from the inputs alone, so a data source with literal arguments and a `depends_on` edge read during preview — against state its dependency had not produced yet.

Record the URNs a dry run has not settled — planned for creation, or carrying unknowns in their outputs — and defer any read that depends on one.

Closes https://github.com/pulumi-labs/pulumi-hcl/pull/267