### PR TITLE
Name module components after their declared source

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-451.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-451.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Name module components after their declared source, not the resolved directory
+time: 2026-07-21T15:00:00Z
+custom:
+    Component: runtime
+    PR: "451"

--- a/pkg/hcl/modules/loader.go
+++ b/pkg/hcl/modules/loader.go
@@ -28,6 +28,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -197,6 +198,22 @@ func (l *Loader) resolveSource(source, versionConstraint, callerDir string) (str
 		return resolved, nil
 	}
 	return packageDir, nil
+}
+
+// SourceName is the name a module source declares: the subdirectory it selects,
+// the registry module name, or the last element of the path. It names a module
+// independently of where that module happens to be resolved on disk, which for a
+// bundled module is a numbered directory carrying no name at all.
+func SourceName(source string) string {
+	packageSource, subdir := getmodules.SplitPackageSubdir(source)
+	if subdir != "" {
+		return path.Base(subdir)
+	}
+	if mod, err := regaddr.ParseModuleSource(packageSource); err == nil {
+		return mod.Package.Name
+	}
+	base, _, _ := strings.Cut(packageSource, "?")
+	return strings.TrimSuffix(path.Base(strings.TrimRight(base, "/")), ".git")
 }
 
 func statDir(p string) (string, error) {

--- a/pkg/hcl/modules/loader_test.go
+++ b/pkg/hcl/modules/loader_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/opentofu/svchost"
 	"github.com/opentofu/svchost/disco"
 	"github.com/pulumi-labs/pulumi-hcl/vendored/getmodules"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -465,4 +466,20 @@ func buildModuleTarGz(t *testing.T, files map[string]string) []byte {
 	data, err := os.ReadFile(out)
 	require.NoError(t, err)
 	return data
+}
+
+func TestSourceName(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"../vendor/acme/aws/modules/networking":                "networking",
+		"./modules/vpc":                                        "vpc",
+		"terraform-aws-modules/vpc/aws":                        "vpc",
+		"terraform-aws-modules/vpc/aws//modules/vpc-endpoints": "vpc-endpoints",
+		"github.com/acme/terraform-modules.git?ref=v1.2.0":     "terraform-modules",
+		"git::https://example.com/network.git//subnets":        "subnets",
+	}
+	for source, want := range tests {
+		assert.Equal(t, want, SourceName(source), source)
+	}
 }

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -23,7 +23,6 @@ import (
 	"math"
 	"math/big"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -4015,7 +4014,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 	modInfo := node.ModuleInfo
 	mod := modInfo.Module
 
-	componentType := fmt.Sprintf("components:index:%s", componentTypeName(modInfo.SourcePath))
+	componentType := fmt.Sprintf("components:index:%s", componentTypeName(modules.SourceName(mod.Source)))
 
 	// A nested module call runs once per instance of the enclosing module; a
 	// root-level call runs in the single root scope (a nil parent instance).
@@ -4333,10 +4332,9 @@ func (e *Engine) processModuleComplete(ctx context.Context, node *graph.Node) er
 	return nil
 }
 
-// componentTypeName derives a component type name from its source directory path,
+// componentTypeName derives a component type name from a module's name,
 // replicating PCL's DeclarationName logic.
-func componentTypeName(sourcePath string) string {
-	name := filepath.Base(sourcePath)
+func componentTypeName(name string) string {
 	for _, ch := range []string{"-", ".", " "} {
 		name = strings.ReplaceAll(name, ch, "_")
 	}

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -2715,6 +2715,61 @@ resource "aws_instance" "web" {
 	assert.Equal(t, "web-id\n", string(got))
 }
 
+// A module consumed through `pulumi package add hcl module <source>` is unpacked
+// from its bundle into numbered directories, so the resolved source path carries
+// no name. The component type token must come from the declared source address.
+//
+// https://github.com/pulumi-labs/pulumi-hcl/issues/451
+func TestEngine_ComponentTypeFromDeclaredSource(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	unpackDir := filepath.Join(tmpDir, "pulumi-hcl-module-504221242", "15")
+	require.NoError(t, os.MkdirAll(unpackDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(unpackDir, "main.tf"), []byte(`
+output "id" {
+  value = "net"
+}
+`), 0o644))
+
+	rootDir := filepath.Join(tmpDir, "root")
+	require.NoError(t, os.MkdirAll(rootDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "main.tf"), []byte(`
+module "net" {
+  source = "../vendor/acme/aws/modules/networking"
+}
+`), 0o644))
+
+	p := parser.NewParser()
+	config, diags := p.ParseDirectory(rootDir)
+	require.False(t, diags.HasErrors(), "%s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		// Stands in for the bundle resolver: every source resolves to a
+		// numbered directory under the unpacked bundle.
+		ModuleLoader: modules.NewLoader(func(source, version, callerDir string) (string, error) {
+			return unpackDir, nil
+		}),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         rootDir,
+		RootDir:         rootDir,
+		SchemaLoader:    schemaloader.New(t),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	var componentTypes []string
+	for _, r := range mock.RegisteredResources {
+		if strings.HasPrefix(r.Type, "components:index:") {
+			componentTypes = append(componentTypes, r.Type)
+		}
+	}
+	assert.Equal(t, []string{"components:index:Networking"}, componentTypes)
+}
+
 func TestEngine_SimpleModule(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Nested components of a bundled module were registered as `components:index:12`
instead of `components:index:Networking`.

`componentTypeName` derived the token from the directory the module resolved to
on disk. That reads well for a module consumed by path, but a module consumed
through `pulumi package add hcl module <source>` is unpacked from its bundle
into numbered directories, so `filepath.Base` yielded `15`. The token is
user-visible in `pulumi up`, `pulumi stack`, the Console and state, and it moved
with the bundle layout — an unrelated change to the module set could renumber
existing resources.

The token now comes from the source the module call declares. `modules.SourceName`
takes the subdirectory a source selects (`…//modules/vpc-endpoints` →
`vpc-endpoints`), else the registry module name (`terraform-aws-modules/vpc/aws`
→ `vpc`), else the last element of the path.

Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/451