### PR TITLE
Defer a child read whose module call `depends_on` a pending resource

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-454.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-454.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Defer a data source read inside a module whose call `depends_on` a pending resource
+time: 2026-07-21T21:11:16Z
+custom:
+    Component: runtime
+    PR: "454"

--- a/pkg/hcl/run/cells.go
+++ b/pkg/hcl/run/cells.go
@@ -451,7 +451,7 @@ func (e *Engine) expandDataCell(
 
 	if ds.Count == nil && ds.ForEach == nil {
 		return b.AddInstance("", func(ctx context.Context) error {
-			ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx, cellKey(node, mi).mi)
+			ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx, mi)
 			if err != nil {
 				return err
 			}
@@ -491,7 +491,7 @@ func (e *Engine) expandDataCell(
 		inst := instance
 		err := b.AddInstance(strings.TrimPrefix(inst.Key, node.Key), func(ctx context.Context) error {
 			instCtx := evalCtx.WithIteration(inst.Index, inst.EachKey, inst.EachValue)
-			ctyOut, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, instCtx, cellKey(node, mi).mi)
+			ctyOut, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, instCtx, mi)
 			if err != nil {
 				return err
 			}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -3375,9 +3375,14 @@ func (e *Engine) readResource(
 // without a separate dependency map.
 func (e *Engine) invokeDataSourceOnce(
 	ctx context.Context, node *graph.Node, ds *ast.Resource, funcSchema *schema.Function,
-	evalCtx *eval.Context, miPath string,
+	evalCtx *eval.Context, mi *moduleInstance,
 ) (cty.Value, error) {
 	hclCtx := evalCtx.HCLContext()
+
+	miPath := ""
+	if mi != nil {
+		miPath = mi.Path.String()
+	}
 
 	// Failed preconditions prevent the read; unknown conditions defer.
 	if err := evaluatePreconditions(ds.Preconditions, hclCtx, node.Key); err != nil {
@@ -3470,7 +3475,7 @@ func (e *Engine) invokeDataSourceOnce(
 	// depends_on marks the outputs with every registered instance URN of the
 	// target block, keyed or not — dependency metadata is resource-wide (see
 	// buildResourceOptionsInContext).
-	dependsOnPending := false
+	dependsOnPending := e.moduleDependsOnPending(mi)
 	for _, dep := range ds.DependsOn {
 		depKey := graph.FormatTraversal(dep)
 		if depKey == "" {
@@ -3512,6 +3517,33 @@ func (e *Engine) invokeDataSourceOnce(
 	}
 
 	return ctyOutputs.WithMarks(depMarks), nil
+}
+
+// moduleDependsOnPending reports whether any enclosing module call
+// `depends_on`s a resource whose changes have not been applied yet. A module's
+// depends_on covers everything the module contains, so such a dependency
+// defers the reads inside it just as one written on the data block would.
+func (e *Engine) moduleDependsOnPending(mi *moduleInstance) bool {
+	for inst := mi; inst != nil; inst = inst.Parent {
+		// The targets are addressed from the calling module's scope.
+		parentMI := ""
+		if inst.Parent != nil {
+			parentMI = inst.Parent.Path.String()
+		}
+		for _, dep := range inst.ModuleInfo.Module.DependsOn {
+			depKey := graph.FormatTraversal(dep)
+			if depKey == "" {
+				continue
+			}
+			cell := expansionCell{block: inst.ModuleInfo.ParentPrefix() + depKey, mi: parentMI}
+			for _, urn := range e.cellURNs.get(cell) {
+				if _, pending := e.pendingURNs.Get(urn); pending {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // processCall processes a call block (method invocation on a resource).
@@ -4830,7 +4862,7 @@ func (e *Engine) readScopedDataSource(ctx context.Context, ds *ast.Resource, eva
 		}
 		return fmt.Errorf("resolving data source type %s: %w", ds.Type, err)
 	}
-	ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx, "")
+	ctyOutputs, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, evalCtx, nil)
 	if err != nil {
 		return err
 	}

--- a/tests/tfcompat/l2_module_depends_on_deferred_read_test.go
+++ b/tests/tfcompat/l2_module_depends_on_deferred_read_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// `depends_on` on a module call covers everything inside the module, so a data
+// source in the child defers its read until the dependency is applied — even
+// though the read's own arguments are known and no value flows from the
+// resource into the module.
+func TestL2ModuleDependsOnDeferredRead(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_depends_on_deferred_read", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "pending", Factory: providers.PendingProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StagePreview},
+			{},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_module_depends_on_deferred_read/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_depends_on_deferred_read/main.tf
@@ -1,0 +1,17 @@
+# `depends_on` on a module call applies to everything the module contains,
+# data sources included: OpenTofu holds the child's read until after
+# `pending_thing.thing` is created, even though the read's own arguments are
+# known and the module takes no input from the resource.
+resource "pending_thing" "thing" {
+  name = "widget"
+}
+
+module "reader" {
+  source = "./modules/reader"
+
+  depends_on = [pending_thing.thing]
+}
+
+output "looked_up" {
+  value = module.reader.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_depends_on_deferred_read/modules/reader/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_depends_on_deferred_read/modules/reader/main.tf
@@ -1,0 +1,7 @@
+data "pending_lookup" "lookup" {
+  name = "widget"
+}
+
+output "result" {
+  value = data.pending_lookup.lookup.result
+}


### PR DESCRIPTION
A module's `depends_on` applies to everything the module contains, data sources included: OpenTofu holds a child module's read until after the dependency is applied, even when the read's own arguments are known and no value flows from the resource into the module.

Deferral was decided from the data block's own `depends_on` alone (added in https://github.com/pulumi-labs/pulumi-hcl/pull/452), so a read inside the module ran during preview against state the dependency had not produced yet — here that surfaces as a hard preview failure from the provider.

The fix walks the enclosing module instances at invoke time and defers the read when any of their calls `depends_on` a resource whose URN is still pending. Nesting is covered by the walk: an ancestor call's `depends_on` defers reads in every descendant.

The first commit adds the failing tfcompat test; the second is the fix.