### PR TITLE
Defer reads gated on a module call, and on a conditioned read's indirect dependencies

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-455-2.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-455-2.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Defer a data source read with custom conditions when an indirect dependency has pending changes
+time: 2026-07-21T21:30:24Z
+custom:
+    Component: runtime
+    PR: "455"

--- a/.changes/unreleased/runtime-bug-fixes-455.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-455.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Defer a data source read whose `depends_on` names a module call with pending changes
+time: 2026-07-21T21:29:44Z
+custom:
+    Component: runtime
+    PR: "455"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -3401,11 +3401,13 @@ func (e *Engine) invokeDataSourceOnce(
 	}
 
 	depMarks := cty.ValueMarks{}
+	var depURNs []string
 	addURN := func(urn string) {
 		if urn == "" {
 			return
 		}
 		depMarks[eval.DepMark(urn)] = struct{}{}
+		depURNs = append(depURNs, urn)
 	}
 
 	// Check-rule references establish dependencies, as in TF; carry them on
@@ -3502,6 +3504,28 @@ func (e *Engine) invokeDataSourceOnce(
 		}
 		if e.cellPending(cell) {
 			dependsOnPending = true
+		}
+	}
+
+	// A data source carrying custom conditions widens the decision to its whole
+	// dependency set, direct and indirect: a condition can only be made to pass
+	// by an upstream change, so a pending resource reached through another data
+	// source counts too. Without conditions a `depends_on` naming a data source
+	// is no reason to wait — a read has no side effects of its own.
+	if len(ds.Preconditions) > 0 || len(ds.Postconditions) > 0 {
+		for _, dep := range ds.DependsOn {
+			val, diags := dep.TraverseAbs(hclCtx)
+			if diags.HasErrors() {
+				continue
+			}
+			for _, urn := range eval.CollectDepURNs(val) {
+				addURN(urn)
+			}
+		}
+		for _, urn := range depURNs {
+			if _, pending := e.pendingURNs.Get(urn); pending {
+				dependsOnPending = true
+			}
 		}
 	}
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -457,6 +457,13 @@ type Engine struct {
 	// here; catching those needs the engine's diff, not the outputs.
 	pendingURNs *util.SyncMap[string, struct{}]
 
+	// pendingModuleCalls holds the cells of the module calls that contain a
+	// pending resource, so `depends_on` naming a module call — which covers
+	// every resource the module contains — defers a read just as naming the
+	// resource itself does. A call is keyed by the block key it has in the
+	// calling scope, so every instance of an expanded call shares one entry.
+	pendingModuleCalls *util.SyncMap[expansionCell, struct{}]
+
 	// failedNodes tracks resource nodes that failed to register, keyed by instance key.
 	// Dependent nodes check this map and are skipped when a dependency failed.
 	failedNodes *util.SyncMap[string, error]
@@ -624,6 +631,7 @@ func NewEngine(ctx context.Context, config *ast.Config, opts *EngineOptions) (*E
 		expansions:              util.NewSyncMap[expansionCell, *graph.BlockExpansion](),
 		cellURNs:                newURNRegistry(),
 		pendingURNs:             util.NewSyncMap[string, struct{}](),
+		pendingModuleCalls:      util.NewSyncMap[expansionCell, struct{}](),
 		failedNodes:             util.NewSyncMap[string, error](),
 		alwaysRegisterProviders: opts.AlwaysRegisterProviders,
 		resolver: packages.NewResolver(
@@ -1716,6 +1724,9 @@ func (e *Engine) registerResourceInstanceInContext(
 
 	if !markedOutputs.IsWhollyKnown() {
 		e.pendingURNs.Set(string(urn), struct{}{})
+		for inst := modInst; inst != nil; inst = inst.Parent {
+			e.pendingModuleCalls.Set(moduleCallCell(inst), struct{}{})
+		}
 	}
 
 	var iOpts inheritableOpts
@@ -3485,11 +3496,12 @@ func (e *Engine) invokeDataSourceOnce(
 		if node.ModuleInfo != nil {
 			fullDepKey = node.ModuleInfo.Prefix() + depKey
 		}
-		for _, urn := range e.cellURNs.get(expansionCell{block: fullDepKey, mi: miPath}) {
+		cell := expansionCell{block: fullDepKey, mi: miPath}
+		for _, urn := range e.cellURNs.get(cell) {
 			addURN(urn)
-			if _, pending := e.pendingURNs.Get(urn); pending {
-				dependsOnPending = true
-			}
+		}
+		if e.cellPending(cell) {
+			dependsOnPending = true
 		}
 	}
 
@@ -3525,25 +3537,53 @@ func (e *Engine) invokeDataSourceOnce(
 // defers the reads inside it just as one written on the data block would.
 func (e *Engine) moduleDependsOnPending(mi *moduleInstance) bool {
 	for inst := mi; inst != nil; inst = inst.Parent {
-		// The targets are addressed from the calling module's scope.
-		parentMI := ""
-		if inst.Parent != nil {
-			parentMI = inst.Parent.Path.String()
-		}
 		for _, dep := range inst.ModuleInfo.Module.DependsOn {
 			depKey := graph.FormatTraversal(dep)
 			if depKey == "" {
 				continue
 			}
-			cell := expansionCell{block: inst.ModuleInfo.ParentPrefix() + depKey, mi: parentMI}
-			for _, urn := range e.cellURNs.get(cell) {
-				if _, pending := e.pendingURNs.Get(urn); pending {
-					return true
-				}
+			// The targets are addressed from the calling module's scope.
+			cell := expansionCell{block: inst.ModuleInfo.ParentPrefix() + depKey, mi: parentMIPath(inst)}
+			if e.cellPending(cell) {
+				return true
 			}
 		}
 	}
 	return false
+}
+
+// cellPending reports whether the block cell resolves to anything whose changes
+// have not been applied yet: a resource instance with unknowns in its outputs,
+// or a module call containing one.
+func (e *Engine) cellPending(cell expansionCell) bool {
+	if _, pending := e.pendingModuleCalls.Get(cell); pending {
+		return true
+	}
+	for _, urn := range e.cellURNs.get(cell) {
+		if _, pending := e.pendingURNs.Get(urn); pending {
+			return true
+		}
+	}
+	return false
+}
+
+// moduleCallCell is the cell of the module call inst instantiates, keyed as the
+// calling scope addresses it: every instance of an expanded call shares it,
+// matching how a `depends_on` entry naming the call covers the whole call.
+func moduleCallCell(inst *moduleInstance) expansionCell {
+	return expansionCell{
+		block: inst.ModuleInfo.ParentPrefix() + "module." + inst.ModuleInfo.ModuleName(),
+		mi:    parentMIPath(inst),
+	}
+}
+
+// parentMIPath is the instance path of the module instance enclosing inst, or
+// "" when inst was called from the root.
+func parentMIPath(inst *moduleInstance) string {
+	if inst.Parent == nil {
+		return ""
+	}
+	return inst.Parent.Path.String()
 }
 
 // processCall processes a call block (method invocation on a resource).

--- a/tests/tfcompat/l2_data_condition_transitive_defer_test.go
+++ b/tests/tfcompat/l2_data_condition_transitive_defer_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A data source carrying a pre- or postcondition weighs its whole ancestry,
+// not just the blocks its own `depends_on` names, when deciding whether to
+// defer its read: a condition can only be satisfied by whatever the pending
+// changes upstream produce. The read here reaches a pending resource through
+// another data source, so it belongs to apply.
+func TestL2DataConditionTransitiveDefer(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_condition_transitive_defer", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "pending", Factory: providers.PendingProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StagePreview},
+			{},
+		},
+	})
+}

--- a/tests/tfcompat/l2_data_depends_on_module_deferred_read_test.go
+++ b/tests/tfcompat/l2_data_depends_on_module_deferred_read_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A `depends_on` whose target is a module call reaches every resource inside
+// that module, so a root data source defers its read until the module's
+// pending resources are applied.
+func TestL2DataDependsOnModuleDeferredRead(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_depends_on_module_deferred_read", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "pending", Factory: providers.PendingProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StagePreview},
+			{},
+		},
+	})
+}

--- a/tests/tfcompat/l2_module_depends_on_module_deferred_read_test.go
+++ b/tests/tfcompat/l2_module_depends_on_module_deferred_read_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A module call's `depends_on` naming another module call defers the reads
+// inside it: the dependency covers every resource the named module contains.
+func TestL2ModuleDependsOnModuleDeferredRead(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_depends_on_module_deferred_read", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "pending", Factory: providers.PendingProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StagePreview},
+			{},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_data_condition_transitive_defer/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_condition_transitive_defer/main.tf
@@ -1,0 +1,32 @@
+# `a` defers its read because it `depends_on` a resource that is about to be
+# created. `b` only names `a`, and a `depends_on` edge onto a data source is
+# never on its own a reason to defer — a read has no side effects. But `b`
+# carries a custom condition, and a condition can only be made to pass by an
+# upstream change, so the deferral decision widens to `b`'s indirect
+# dependencies: `pending_thing.thing` sits behind `a`, so `b` defers too.
+resource "pending_thing" "thing" {
+  name = "widget"
+}
+
+data "pending_lookup" "a" {
+  name = "widget"
+
+  depends_on = [pending_thing.thing]
+}
+
+data "pending_lookup" "b" {
+  name = "widget"
+
+  depends_on = [data.pending_lookup.a]
+
+  lifecycle {
+    postcondition {
+      condition     = self.result != ""
+      error_message = "the lookup returned no result"
+    }
+  }
+}
+
+output "looked_up" {
+  value = data.pending_lookup.b.result
+}

--- a/tests/tfcompat/testdata/cases/l2_data_depends_on_module_deferred_read/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_depends_on_module_deferred_read/main.tf
@@ -1,0 +1,16 @@
+# A `depends_on` entry naming a module call covers every resource the module
+# contains, so the read waits for `module.maker`'s pending creation just as it
+# would for a resource written directly in the root.
+module "maker" {
+  source = "./modules/maker"
+}
+
+data "pending_lookup" "lookup" {
+  name = "widget"
+
+  depends_on = [module.maker]
+}
+
+output "looked_up" {
+  value = data.pending_lookup.lookup.result
+}

--- a/tests/tfcompat/testdata/cases/l2_data_depends_on_module_deferred_read/modules/maker/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_depends_on_module_deferred_read/modules/maker/main.tf
@@ -1,0 +1,3 @@
+resource "pending_thing" "thing" {
+  name = "widget"
+}

--- a/tests/tfcompat/testdata/cases/l2_module_depends_on_module_deferred_read/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_depends_on_module_deferred_read/main.tf
@@ -1,0 +1,16 @@
+# The reader's `depends_on` names another module call rather than a resource:
+# the dependency covers every resource `module.maker` contains, so the read
+# inside `module.reader` waits for the maker's pending creation.
+module "maker" {
+  source = "./modules/maker"
+}
+
+module "reader" {
+  source = "./modules/reader"
+
+  depends_on = [module.maker]
+}
+
+output "looked_up" {
+  value = module.reader.result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_depends_on_module_deferred_read/modules/maker/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_depends_on_module_deferred_read/modules/maker/main.tf
@@ -1,0 +1,3 @@
+resource "pending_thing" "thing" {
+  name = "widget"
+}

--- a/tests/tfcompat/testdata/cases/l2_module_depends_on_module_deferred_read/modules/reader/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_depends_on_module_deferred_read/modules/reader/main.tf
@@ -1,0 +1,7 @@
+data "pending_lookup" "lookup" {
+  name = "widget"
+}
+
+output "result" {
+  value = data.pending_lookup.lookup.result
+}


### PR DESCRIPTION
Stacked on https://github.com/pulumi-labs/pulumi-hcl/pull/454. Two further gaps in when a data source read is deferred to apply, both found by adversarially probing that PR and both verified against OpenTofu's `dependenciesHavePendingChanges` (`internal/tofu/node_resource_abstract_instance.go`).

**1. `depends_on` naming a module call.** A `depends_on` entry that names a module covers every resource that module contains, so a read gated on it must wait. The entry only ever resolved against resource cells, so it produced no URNs and nothing marked the read pending — the read ran during preview against state the module had not produced. Covers both a root data source with `depends_on = [module.maker]` and a module call whose `depends_on` names another module call.

**2. A conditioned read's indirect dependencies.** OpenTofu decides deferral from a data source's direct `depends_on` targets, except when the data source carries a precondition or postcondition — then it uses the full, transitive dependency set, because a condition can only be made to pass by an upstream change. Data-source-on-data-source edges are skipped either way, a read having no side effects of its own. A conditioned read gated on a data source that was itself deferred therefore ran during preview.

Each commit carries its own tfcompat case; both cases fail without the corresponding fix.