### PR TITLE
Support `removed` blocks with `lifecycle { destroy = true }`

### DIFF
--- a/.changes/unreleased/runtime-Improvements-458.yaml
+++ b/.changes/unreleased/runtime-Improvements-458.yaml
@@ -1,5 +1,5 @@
 kind: Improvements
-body: Support `removed` blocks with `lifecycle { destroy = true }`, re-running the destroy-time provisioners the removed resource declared
+body: Support `removed` blocks with `lifecycle { destroy = true }`, running the block's destroy-time provisioners when the resource is deleted
 time: 2026-07-27T15:00:00Z
 custom:
     Component: runtime

--- a/.changes/unreleased/runtime-Improvements-458.yaml
+++ b/.changes/unreleased/runtime-Improvements-458.yaml
@@ -1,5 +1,5 @@
 kind: Improvements
-body: Support `removed` blocks with `lifecycle { destroy = true }`, running the block's destroy-time provisioners when the resource is deleted
+body: Support `removed` blocks with `lifecycle { destroy = true }` in root and child modules, running the block's destroy-time provisioners when the resource is deleted
 time: 2026-07-27T15:00:00Z
 custom:
     Component: runtime

--- a/.changes/unreleased/runtime-Improvements-458.yaml
+++ b/.changes/unreleased/runtime-Improvements-458.yaml
@@ -1,5 +1,5 @@
 kind: Improvements
-body: Support `removed` blocks with `lifecycle { destroy = true }`, including destroy-time provisioners
+body: Support `removed` blocks with `lifecycle { destroy = true }`, re-running the destroy-time provisioners the removed resource declared
 time: 2026-07-27T15:00:00Z
 custom:
     Component: runtime

--- a/.changes/unreleased/runtime-Improvements-458.yaml
+++ b/.changes/unreleased/runtime-Improvements-458.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Support `removed` blocks with `lifecycle { destroy = true }`, including destroy-time provisioners
+time: 2026-07-27T15:00:00Z
+custom:
+    Component: runtime
+    PR: "458"

--- a/pkg/hcl/ast/config.go
+++ b/pkg/hcl/ast/config.go
@@ -54,6 +54,9 @@ type Config struct {
 	// Moved contains moved blocks for resource renaming.
 	Moved []*Moved
 
+	// Removed contains removed blocks for resource deletion.
+	Removed []*Removed
+
 	// Imports contains import blocks for importing existing resources.
 	Imports []*Import
 

--- a/pkg/hcl/ast/removed.go
+++ b/pkg/hcl/ast/removed.go
@@ -34,8 +34,9 @@ import (
 // destroyed by the Pulumi engine on its own, while destroy = false (forget)
 // has no engine mapping and parses with an error diagnostic.
 type Removed struct {
-	// From is the address of the removed resource or module.
-	From hcl.Traversal
+	// From is the address of the removed resource or module. It carries no
+	// instance keys; a removed block applies to every instance.
+	From TargetAddr
 
 	// Destroy reports whether the block declares lifecycle { destroy = true }.
 	// A false value (explicit, or from an omitted lifecycle block) is

--- a/pkg/hcl/ast/removed.go
+++ b/pkg/hcl/ast/removed.go
@@ -1,0 +1,51 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import (
+	"github.com/hashicorp/hcl/v2"
+)
+
+// Removed represents a removed block: the resource or module at From has been
+// deleted from the configuration and its remote objects should be destroyed.
+//
+// Terraform syntax:
+//
+//	removed {
+//	  from = aws_instance.example
+//	  lifecycle {
+//	    destroy = true
+//	  }
+//	}
+//
+// Only destroy = true is supported: a resource absent from the program is
+// destroyed by the Pulumi engine on its own, while destroy = false (forget)
+// has no engine mapping and parses with an error diagnostic.
+type Removed struct {
+	// From is the address of the removed resource or module.
+	From hcl.Traversal
+
+	// Destroy reports whether the block declares lifecycle { destroy = true }.
+	// A false value (explicit, or from an omitted lifecycle block) is
+	// unsupported and carries an error diagnostic.
+	Destroy bool
+
+	// Provisioners holds destroy-time provisioners to run when the removed
+	// resource is deleted. Only when = destroy provisioners are allowed.
+	Provisioners []*Provisioner
+
+	// DeclRange is the source range of the removed block.
+	DeclRange hcl.Range
+}

--- a/pkg/hcl/ast/target_addr.go
+++ b/pkg/hcl/ast/target_addr.go
@@ -1,0 +1,160 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import (
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
+)
+
+// TargetAddr is a parsed `moved`, `import`, or `removed` block address:
+// optional module-call steps followed by an optional resource. A
+// whole-module-call address (e.g. `module.a`) has an empty Type.
+type TargetAddr struct {
+	// Modules holds the module-call steps, outermost first.
+	Modules []modulepath.Step
+	// Type is the resource type, or "" for a whole-module-call address.
+	Type string
+	// Name is the resource name.
+	Name string
+	// KeyIndex is the count instance key, if the address is keyed by count.
+	KeyIndex *int
+	// KeyEach is the for_each instance key, if the address is keyed by
+	// for_each.
+	KeyEach *string
+}
+
+// Keyed reports whether the address names a specific count/for_each instance.
+func (a TargetAddr) Keyed() bool { return a.KeyIndex != nil || a.KeyEach != nil }
+
+// String renders the address in Terraform form, e.g.
+// module.a.simple_resource.b.
+func (a TargetAddr) String() string {
+	var parts []string
+	for _, s := range a.Modules {
+		parts = append(parts, "module", s.LogicalName())
+	}
+	if a.Type != "" {
+		parts = append(parts, a.Type, a.Name)
+	}
+	return strings.Join(parts, ".")
+}
+
+// ParseTargetAddr decodes an address traversal into its module-call steps and
+// (optional) resource. It returns false for a traversal it cannot model.
+func ParseTargetAddr(t hcl.Traversal) (TargetAddr, bool) {
+	var a TargetAddr
+	head := func(step hcl.Traverser) (string, bool) {
+		switch s := step.(type) {
+		case hcl.TraverseRoot:
+			return s.Name, true
+		case hcl.TraverseAttr:
+			return s.Name, true
+		}
+		return "", false
+	}
+	i := 0
+	for i < len(t) {
+		name, ok := head(t[i])
+		if !ok || name != "module" {
+			break
+		}
+		i++
+		if i >= len(t) {
+			return a, false
+		}
+		modName, ok := head(t[i])
+		if !ok {
+			return a, false
+		}
+		i++
+		step := modulepath.NewStep(modName)
+		if i < len(t) {
+			if idx, ok := t[i].(hcl.TraverseIndex); ok {
+				keyed, ok := moduleStepFor(modName, idx.Key)
+				if !ok {
+					return a, false
+				}
+				step = keyed
+				i++
+			}
+		}
+		a.Modules = append(a.Modules, step)
+	}
+	if i >= len(t) {
+		// Whole-module-call address (no trailing resource).
+		return a, len(a.Modules) > 0
+	}
+	typ, ok := head(t[i])
+	if !ok {
+		return a, false
+	}
+	i++
+	if i >= len(t) {
+		return a, false
+	}
+	name, ok := head(t[i])
+	if !ok {
+		return a, false
+	}
+	i++
+	a.Type, a.Name = typ, name
+	if i < len(t) {
+		if idx, ok := t[i].(hcl.TraverseIndex); ok {
+			a.KeyIndex, a.KeyEach = instanceKeyFromCty(idx.Key)
+			i++
+		}
+	}
+	return a, i == len(t)
+}
+
+// instanceKeyFromCty decodes an instance-key value into its typed components:
+// a count index for a number, a for_each key for a string. Both are nil for
+// any other type, which the caller treats as an unkeyed address.
+func instanceKeyFromCty(v cty.Value) (index *int, eachKey *string) {
+	switch v.Type() {
+	case cty.Number:
+		iv, _ := v.AsBigFloat().Int64()
+		n := int(iv)
+		return &n, nil
+	case cty.String:
+		s := v.AsString()
+		return nil, &s
+	default:
+		return nil, nil
+	}
+}
+
+// moduleStepFor builds a module-call path step for `module.<name>[<key>]`,
+// decoding the count index or for_each key. It returns false for a key that
+// is neither a non-negative integer nor a string.
+func moduleStepFor(name string, key cty.Value) (modulepath.Step, bool) {
+	switch key.Type() {
+	case cty.Number:
+		iv, _ := key.AsBigFloat().Int64()
+		if iv < 0 {
+			return modulepath.Step{}, false
+		}
+		return modulepath.NewIndexedStep(name, int(iv)), true
+	case cty.String:
+		return modulepath.NewKeyedStep(name, key.AsString()), true
+	default:
+		return modulepath.Step{}, false
+	}
+}

--- a/pkg/hcl/ast/target_addr.go
+++ b/pkg/hcl/ast/target_addr.go
@@ -27,8 +27,9 @@ import (
 // optional module-call steps followed by an optional resource. A
 // whole-module-call address (e.g. `module.a`) has an empty Type.
 type TargetAddr struct {
-	// Modules holds the module-call steps, outermost first.
-	Modules []modulepath.Step
+	// Module is the path of enclosing module calls; the root path for a
+	// top-level address.
+	Module modulepath.Path
 	// Type is the resource type, or "" for a whole-module-call address.
 	Type string
 	// Name is the resource name.
@@ -47,7 +48,7 @@ func (a TargetAddr) Keyed() bool { return a.KeyIndex != nil || a.KeyEach != nil 
 // module.a.simple_resource.b.
 func (a TargetAddr) String() string {
 	var parts []string
-	for _, s := range a.Modules {
+	for s := range a.Module.Steps {
 		parts = append(parts, "module", s.LogicalName())
 	}
 	if a.Type != "" {
@@ -95,11 +96,11 @@ func ParseTargetAddr(t hcl.Traversal) (TargetAddr, bool) {
 				i++
 			}
 		}
-		a.Modules = append(a.Modules, step)
+		a.Module = a.Module.Append(step)
 	}
 	if i >= len(t) {
 		// Whole-module-call address (no trailing resource).
-		return a, len(a.Modules) > 0
+		return a, !a.Module.IsRoot()
 	}
 	typ, ok := head(t[i])
 	if !ok {

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -1451,6 +1451,9 @@ func (g *Graph) inlineModule(
 	}
 
 	path := parentPath.Append(modulepath.NewStep(name))
+	if len(loaded.Config.Removed) > 0 {
+		return fmt.Errorf("module %s: removed blocks inside child modules are not yet supported", name)
+	}
 	g.moved[path] = loaded.Config.Moved
 	scope := &moduleScope{
 		path:       path,

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -286,11 +286,8 @@ type Graph struct {
 	// module.
 	moved map[modulepath.Path][]*ast.Moved
 
-	// removed holds every removed block in the module tree with its address
-	// rewritten to be root-relative: a child-declared block's relative "from"
-	// gains the declaring module's path as a module.name prefix during
-	// inlining. A removed address inside a child module can only be checked
-	// against that module's configuration once it is loaded for inlining.
+	// removed holds every removed block in the module tree, child-declared
+	// addresses rewritten to be root-relative during inlining.
 	removed []*ast.Removed
 
 	// scopes maps a module's path to its scope, so expression-level dependency
@@ -1496,9 +1493,9 @@ func absoluteTraversal(path modulepath.Path, from hcl.Traversal) hcl.Traversal {
 }
 
 // checkDuplicateRemovedProvisioners rejects two provisioner-carrying removed
-// blocks for one root-relative address. The parser catches the same-config
-// case; declarations from different modules only meet here. Two provisioner
-// sets for one orphan would be ambiguous at destroy time.
+// blocks for one root-relative address: two provisioner sets for one orphan
+// would be ambiguous at destroy time. Declarations from different modules
+// only meet here; the parser catches the same-config case.
 func checkDuplicateRemovedProvisioners(removed []*ast.Removed) error {
 	withProvisioners := map[string]hcl.Range{}
 	for _, rem := range removed {
@@ -1562,9 +1559,8 @@ func (g *Graph) inlineModule(
 	if err := checkRemovedStillExists(g.removed, path, loaded.Config); err != nil {
 		return err
 	}
-	// A child-declared removed address is relative to its module; rewrite it
-	// to root-relative before nested modules (whose configs the address may
-	// target) inline below.
+	// Rewrite child-declared removed addresses to root-relative before the
+	// nested modules they may target inline below.
 	for _, rem := range loaded.Config.Removed {
 		abs := *rem
 		abs.From = absoluteTraversal(path, rem.From)

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -286,6 +286,12 @@ type Graph struct {
 	// module.
 	moved map[modulepath.Path][]*ast.Moved
 
+	// removed holds the root configuration's removed blocks (child modules
+	// cannot declare them). A removed address inside a child module can only
+	// be checked against that module's configuration once it is loaded for
+	// inlining.
+	removed []*ast.Removed
+
 	// scopes maps a module's path to its scope, so expression-level dependency
 	// extraction can resolve provider-defined function calls to the provider
 	// block they use.
@@ -521,6 +527,7 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 	g := NewGraph()
 	root := modulepath.Root()
 	g.moved[root] = config.Moved
+	g.removed = config.Removed
 	rootScope := &moduleScope{config: config}
 	g.scopes[root] = rootScope
 
@@ -1428,6 +1435,54 @@ func (g *Graph) Validate() []error {
 	return errs
 }
 
+// checkRemovedStillExists reports a removed block whose module-prefixed
+// address is still declared by the child module being inlined at path,
+// mirroring the parse-time check for root addresses. A target nested deeper
+// than this module is checked when its own module is inlined; a target whose
+// module is gone is never reached, which is exactly a valid removal.
+func checkRemovedStillExists(removed []*ast.Removed, path modulepath.Path, config *ast.Config) error {
+	var pathNames []string
+	for s := range path.Steps {
+		pathNames = append(pathNames, s.Name())
+	}
+	for _, rem := range removed {
+		// A valid removed address is module.name pairs then an optional
+		// type.name tail (the parser rejects other shapes).
+		names := traversalNames(rem.From)
+		var chain, rest []string
+		for rest = names; len(rest) >= 2 && rest[0] == "module"; rest = rest[2:] {
+			chain = append(chain, rest[1])
+		}
+		if !slices.Equal(chain, pathNames) {
+			continue
+		}
+		addr := strings.Join(names, ".")
+		if len(rest) == 0 {
+			return fmt.Errorf("removed block for %s: this module block still exists in the configuration", addr)
+		}
+		if _, exists := config.Resources[ast.ResourceKey(rest[0], rest[1])]; exists {
+			return fmt.Errorf("removed block for %s: this resource block still exists in the configuration", addr)
+		}
+	}
+	return nil
+}
+
+// traversalNames flattens a traversal's root and attribute steps into their
+// names, e.g. module.child.simple_resource.a -> ["module", "child",
+// "simple_resource", "a"].
+func traversalNames(traversal hcl.Traversal) []string {
+	names := make([]string, 0, len(traversal))
+	for _, step := range traversal {
+		switch s := step.(type) {
+		case hcl.TraverseRoot:
+			names = append(names, s.Name)
+		case hcl.TraverseAttr:
+			names = append(names, s.Name)
+		}
+	}
+	return names
+}
+
 // rangeLess orders ranges by filename, then start line, then start column.
 func rangeLess(a, b hcl.Range) bool {
 	if a.Filename != b.Filename {
@@ -1453,6 +1508,9 @@ func (g *Graph) inlineModule(
 	path := parentPath.Append(modulepath.NewStep(name))
 	if len(loaded.Config.Removed) > 0 {
 		return fmt.Errorf("module %s: removed blocks inside child modules are not yet supported", name)
+	}
+	if err := checkRemovedStillExists(g.removed, path, loaded.Config); err != nil {
+		return err
 	}
 	g.moved[path] = loaded.Config.Moved
 	scope := &moduleScope{

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -526,6 +526,9 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 	root := modulepath.Root()
 	g.moved[root] = config.Moved
 	g.removed = slices.Clone(config.Removed)
+	if err := checkRemovedStillExists(g.removed, root, config); err != nil {
+		return nil, err
+	}
 	rootScope := &moduleScope{config: config}
 	g.scopes[root] = rootScope
 
@@ -1437,72 +1440,36 @@ func (g *Graph) Validate() []error {
 	return errs
 }
 
-// checkRemovedStillExists reports a removed block whose module-prefixed
-// address is still declared by the child module being inlined at path,
-// mirroring the parse-time check for root addresses. A target nested deeper
-// than this module is checked when its own module is inlined; a target whose
+// checkRemovedStillExists reports a removed block whose root-relative address
+// is still declared by the configuration at path. A target nested deeper than
+// this module is checked when its own module is inlined; a target whose
 // module is gone is never reached, which is exactly a valid removal.
 func checkRemovedStillExists(removed []*ast.Removed, path modulepath.Path, config *ast.Config) error {
-	var pathNames []string
-	for s := range path.Steps {
-		pathNames = append(pathNames, s.Name())
-	}
+	pathSteps := slices.Collect(path.Steps)
 	for _, rem := range removed {
-		// A valid removed address is module.name pairs then an optional
-		// type.name tail (the parser rejects other shapes).
-		names := traversalNames(rem.From)
-		var chain, rest []string
-		for rest = names; len(rest) >= 2 && rest[0] == "module"; rest = rest[2:] {
-			chain = append(chain, rest[1])
-		}
-		if !slices.Equal(chain, pathNames) {
+		if !slices.Equal(rem.From.Modules, pathSteps) {
 			continue
 		}
-		addr := strings.Join(names, ".")
-		if len(rest) == 0 {
-			return fmt.Errorf("removed block for %s: this module block still exists in the configuration", addr)
+		if rem.From.Type == "" {
+			return fmt.Errorf("removed block for %s: this module block still exists in the configuration", rem.From)
 		}
-		if _, exists := config.Resources[ast.ResourceKey(rest[0], rest[1])]; exists {
-			return fmt.Errorf("removed block for %s: this resource block still exists in the configuration", addr)
+		if _, exists := config.Resources[ast.ResourceKey(rem.From.Type, rem.From.Name)]; exists {
+			return fmt.Errorf("removed block for %s: this resource block still exists in the configuration", rem.From)
 		}
 	}
 	return nil
 }
 
-// absoluteTraversal prefixes a module-relative address with module.name pairs
-// for each step of path, yielding the root-relative form of the address.
-func absoluteTraversal(path modulepath.Path, from hcl.Traversal) hcl.Traversal {
-	rng := from.SourceRange()
-	abs := make(hcl.Traversal, 0, 2*path.Len()+len(from))
-	for s := range path.Steps {
-		abs = append(abs,
-			hcl.TraverseAttr{Name: "module", SrcRange: rng},
-			hcl.TraverseAttr{Name: s.Name(), SrcRange: rng})
-	}
-	for _, step := range from {
-		if root, ok := step.(hcl.TraverseRoot); ok {
-			abs = append(abs, hcl.TraverseAttr{Name: root.Name, SrcRange: root.SrcRange})
-		} else {
-			abs = append(abs, step)
-		}
-	}
-	if attr, ok := abs[0].(hcl.TraverseAttr); ok {
-		abs[0] = hcl.TraverseRoot{Name: attr.Name, SrcRange: attr.SrcRange}
-	}
-	return abs
-}
-
 // checkDuplicateRemovedProvisioners rejects two provisioner-carrying removed
 // blocks for one root-relative address: two provisioner sets for one orphan
-// would be ambiguous at destroy time. Declarations from different modules
-// only meet here; the parser catches the same-config case.
+// would be ambiguous at destroy time.
 func checkDuplicateRemovedProvisioners(removed []*ast.Removed) error {
 	withProvisioners := map[string]hcl.Range{}
 	for _, rem := range removed {
 		if len(rem.Provisioners) == 0 {
 			continue
 		}
-		addr := strings.Join(traversalNames(rem.From), ".")
+		addr := rem.From.String()
 		if prev, ok := withProvisioners[addr]; ok {
 			return fmt.Errorf(
 				"duplicate removed block for %s: a removed block with provisioners for this address was already declared at %s; declare all of the address's provisioners in one removed block",
@@ -1516,22 +1483,6 @@ func checkDuplicateRemovedProvisioners(removed []*ast.Removed) error {
 // Removed returns every removed block in the module tree, with child-declared
 // addresses rewritten to be root-relative.
 func (g *Graph) Removed() []*ast.Removed { return g.removed }
-
-// traversalNames flattens a traversal's root and attribute steps into their
-// names, e.g. module.child.simple_resource.a -> ["module", "child",
-// "simple_resource", "a"].
-func traversalNames(traversal hcl.Traversal) []string {
-	names := make([]string, 0, len(traversal))
-	for _, step := range traversal {
-		switch s := step.(type) {
-		case hcl.TraverseRoot:
-			names = append(names, s.Name)
-		case hcl.TraverseAttr:
-			names = append(names, s.Name)
-		}
-	}
-	return names
-}
 
 // rangeLess orders ranges by filename, then start line, then start column.
 func rangeLess(a, b hcl.Range) bool {
@@ -1556,15 +1507,16 @@ func (g *Graph) inlineModule(
 	}
 
 	path := parentPath.Append(modulepath.NewStep(name))
-	if err := checkRemovedStillExists(g.removed, path, loaded.Config); err != nil {
-		return err
-	}
-	// Rewrite child-declared removed addresses to root-relative before the
-	// nested modules they may target inline below.
+	// Rewrite child-declared removed addresses to root-relative before
+	// validating, so the child's own declarations are checked against its
+	// configuration along with any ancestor's.
 	for _, rem := range loaded.Config.Removed {
 		abs := *rem
-		abs.From = absoluteTraversal(path, rem.From)
+		abs.From.Modules = append(slices.Collect(path.Steps), rem.From.Modules...)
 		g.removed = append(g.removed, &abs)
+	}
+	if err := checkRemovedStillExists(g.removed, path, loaded.Config); err != nil {
+		return err
 	}
 	g.moved[path] = loaded.Config.Moved
 	scope := &moduleScope{

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -286,10 +286,11 @@ type Graph struct {
 	// module.
 	moved map[modulepath.Path][]*ast.Moved
 
-	// removed holds the root configuration's removed blocks (child modules
-	// cannot declare them). A removed address inside a child module can only
-	// be checked against that module's configuration once it is loaded for
-	// inlining.
+	// removed holds every removed block in the module tree with its address
+	// rewritten to be root-relative: a child-declared block's relative "from"
+	// gains the declaring module's path as a module.name prefix during
+	// inlining. A removed address inside a child module can only be checked
+	// against that module's configuration once it is loaded for inlining.
 	removed []*ast.Removed
 
 	// scopes maps a module's path to its scope, so expression-level dependency
@@ -527,7 +528,7 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 	g := NewGraph()
 	root := modulepath.Root()
 	g.moved[root] = config.Moved
-	g.removed = config.Removed
+	g.removed = slices.Clone(config.Removed)
 	rootScope := &moduleScope{config: config}
 	g.scopes[root] = rootScope
 
@@ -625,6 +626,10 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 		if err := g.inlineModule(name, module, root, moduleLoader, workDir, rootScope); err != nil {
 			return nil, fmt.Errorf("inlining module %s: %w", name, err)
 		}
+	}
+
+	if err := checkDuplicateRemovedProvisioners(g.removed); err != nil {
+		return nil, err
 	}
 
 	if err := g.addCallNodes(config, root, nil); err != nil {
@@ -1467,6 +1472,54 @@ func checkRemovedStillExists(removed []*ast.Removed, path modulepath.Path, confi
 	return nil
 }
 
+// absoluteTraversal prefixes a module-relative address with module.name pairs
+// for each step of path, yielding the root-relative form of the address.
+func absoluteTraversal(path modulepath.Path, from hcl.Traversal) hcl.Traversal {
+	rng := from.SourceRange()
+	abs := make(hcl.Traversal, 0, 2*path.Len()+len(from))
+	for s := range path.Steps {
+		abs = append(abs,
+			hcl.TraverseAttr{Name: "module", SrcRange: rng},
+			hcl.TraverseAttr{Name: s.Name(), SrcRange: rng})
+	}
+	for _, step := range from {
+		if root, ok := step.(hcl.TraverseRoot); ok {
+			abs = append(abs, hcl.TraverseAttr{Name: root.Name, SrcRange: root.SrcRange})
+		} else {
+			abs = append(abs, step)
+		}
+	}
+	if attr, ok := abs[0].(hcl.TraverseAttr); ok {
+		abs[0] = hcl.TraverseRoot{Name: attr.Name, SrcRange: attr.SrcRange}
+	}
+	return abs
+}
+
+// checkDuplicateRemovedProvisioners rejects two provisioner-carrying removed
+// blocks for one root-relative address. The parser catches the same-config
+// case; declarations from different modules only meet here. Two provisioner
+// sets for one orphan would be ambiguous at destroy time.
+func checkDuplicateRemovedProvisioners(removed []*ast.Removed) error {
+	withProvisioners := map[string]hcl.Range{}
+	for _, rem := range removed {
+		if len(rem.Provisioners) == 0 {
+			continue
+		}
+		addr := strings.Join(traversalNames(rem.From), ".")
+		if prev, ok := withProvisioners[addr]; ok {
+			return fmt.Errorf(
+				"duplicate removed block for %s: a removed block with provisioners for this address was already declared at %s; declare all of the address's provisioners in one removed block",
+				addr, prev)
+		}
+		withProvisioners[addr] = rem.DeclRange
+	}
+	return nil
+}
+
+// Removed returns every removed block in the module tree, with child-declared
+// addresses rewritten to be root-relative.
+func (g *Graph) Removed() []*ast.Removed { return g.removed }
+
 // traversalNames flattens a traversal's root and attribute steps into their
 // names, e.g. module.child.simple_resource.a -> ["module", "child",
 // "simple_resource", "a"].
@@ -1506,11 +1559,16 @@ func (g *Graph) inlineModule(
 	}
 
 	path := parentPath.Append(modulepath.NewStep(name))
-	if len(loaded.Config.Removed) > 0 {
-		return fmt.Errorf("module %s: removed blocks inside child modules are not yet supported", name)
-	}
 	if err := checkRemovedStillExists(g.removed, path, loaded.Config); err != nil {
 		return err
+	}
+	// A child-declared removed address is relative to its module; rewrite it
+	// to root-relative before nested modules (whose configs the address may
+	// target) inline below.
+	for _, rem := range loaded.Config.Removed {
+		abs := *rem
+		abs.From = absoluteTraversal(path, rem.From)
+		g.removed = append(g.removed, &abs)
 	}
 	g.moved[path] = loaded.Config.Moved
 	scope := &moduleScope{

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -1445,9 +1445,8 @@ func (g *Graph) Validate() []error {
 // this module is checked when its own module is inlined; a target whose
 // module is gone is never reached, which is exactly a valid removal.
 func checkRemovedStillExists(removed []*ast.Removed, path modulepath.Path, config *ast.Config) error {
-	pathSteps := slices.Collect(path.Steps)
 	for _, rem := range removed {
-		if !slices.Equal(rem.From.Modules, pathSteps) {
+		if rem.From.Module != path {
 			continue
 		}
 		if rem.From.Type == "" {
@@ -1512,7 +1511,7 @@ func (g *Graph) inlineModule(
 	// configuration along with any ancestor's.
 	for _, rem := range loaded.Config.Removed {
 		abs := *rem
-		abs.From.Modules = append(slices.Collect(path.Steps), rem.From.Modules...)
+		abs.From.Module = path.Join(rem.From.Module)
 		g.removed = append(g.removed, &abs)
 	}
 	if err := checkRemovedStillExists(g.removed, path, loaded.Config); err != nil {

--- a/pkg/hcl/graph/removed_test.go
+++ b/pkg/hcl/graph/removed_test.go
@@ -65,6 +65,127 @@ resource "simple_resource" "b" {}
 	assert.NoError(t, err)
 }
 
+// A child module's removed block inlines with its relative address rewritten
+// to be root-relative, provisioners intact.
+func TestRemovedDeclaredInChildModule(t *testing.T) {
+	t.Parallel()
+
+	rootConfig, diags := parser.NewParser().ParseSource("root.hcl", []byte(`
+module "m" {
+  source = "./child"
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	childConfig, diags := parser.NewParser().ParseSource("child.hcl", []byte(`
+removed {
+  from = simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+  provisioner "local-exec" {
+    when    = destroy
+    command = "true"
+  }
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	g, err := BuildFromConfig(rootConfig, fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: childConfig, SourcePath: "./child"},
+	}}, "")
+	require.NoError(t, err)
+
+	require.Len(t, g.Removed(), 1)
+	assert.Equal(t, []string{"module", "m", "simple_resource", "a"}, traversalNames(g.Removed()[0].From))
+	assert.True(t, g.Removed()[0].Destroy)
+	require.Len(t, g.Removed()[0].Provisioners, 1)
+}
+
+// A child module's removed block targeting its own nested module errors when
+// the grandchild config still declares the target.
+func TestRemovedDeclaredInChildModuleNestedStillExists(t *testing.T) {
+	t.Parallel()
+
+	rootConfig, diags := parser.NewParser().ParseSource("root.hcl", []byte(`
+module "m" {
+  source = "./child"
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	childConfig, diags := parser.NewParser().ParseSource("child.hcl", []byte(`
+module "n" {
+  source = "./grand"
+}
+
+removed {
+  from = module.n.simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	grandConfig, diags := parser.NewParser().ParseSource("grand.hcl", []byte(`
+resource "simple_resource" "a" {}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	_, err := BuildFromConfig(rootConfig, fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: childConfig, SourcePath: "./child"},
+		"./grand": {Config: grandConfig, SourcePath: "./grand"},
+	}}, "")
+	assert.EqualError(t, err,
+		"inlining module m: inlining nested module n: removed block for module.m.module.n.simple_resource.a: this resource block still exists in the configuration")
+}
+
+// Provisioner-carrying removed blocks for one address declared in two
+// different configurations are rejected: two provisioner sets for one orphan
+// would be ambiguous at destroy time.
+func TestRemovedDuplicateProvisionersAcrossConfigs(t *testing.T) {
+	t.Parallel()
+
+	rootConfig, diags := parser.NewParser().ParseSource("root.hcl", []byte(`
+module "m" {
+  source = "./child"
+}
+
+removed {
+  from = module.m.simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+  provisioner "local-exec" {
+    when    = destroy
+    command = "true"
+  }
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	childConfig, diags := parser.NewParser().ParseSource("child.hcl", []byte(`
+removed {
+  from = simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+  provisioner "local-exec" {
+    when    = destroy
+    command = "false"
+  }
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	_, err := BuildFromConfig(rootConfig, fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: childConfig, SourcePath: "./child"},
+	}}, "")
+	assert.EqualError(t, err,
+		"duplicate removed block for module.m.simple_resource.a: a removed block with provisioners for this address was already declared at root.hcl:6,1-8; declare all of the address's provisioners in one removed block")
+}
+
 // A removed block targeting a nested module errors when that module is still
 // declared; the depth-one case is already rejected at parse time.
 func TestRemovedNestedModuleStillExists(t *testing.T) {

--- a/pkg/hcl/graph/removed_test.go
+++ b/pkg/hcl/graph/removed_test.go
@@ -17,6 +17,8 @@ package graph
 import (
 	"testing"
 
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -97,9 +99,93 @@ removed {
 	require.NoError(t, err)
 
 	require.Len(t, g.Removed(), 1)
-	assert.Equal(t, []string{"module", "m", "simple_resource", "a"}, traversalNames(g.Removed()[0].From))
+	assert.Equal(t, ast.TargetAddr{
+		Modules: []modulepath.Step{modulepath.NewStep("m")},
+		Type:    "simple_resource",
+		Name:    "a",
+	}, g.Removed()[0].From)
 	assert.True(t, g.Removed()[0].Destroy)
 	require.Len(t, g.Removed()[0].Provisioners, 1)
+}
+
+// A removed block whose root-level target is still declared errors at graph
+// build.
+func TestRemovedRootTargetStillExists(t *testing.T) {
+	t.Parallel()
+
+	resourceConfig, diags := parser.NewParser().ParseSource("root.hcl", []byte(`
+resource "simple_resource" "a" {}
+
+removed {
+  from = simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	_, err := BuildFromConfig(resourceConfig, fakeModuleLoader{}, "")
+	assert.EqualError(t, err,
+		"removed block for simple_resource.a: this resource block still exists in the configuration")
+
+	moduleConfig, diags := parser.NewParser().ParseSource("root.hcl", []byte(`
+module "child" {
+  source = "./child"
+}
+
+removed {
+  from = module.child
+  lifecycle {
+    destroy = true
+  }
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	childConfig, diags := parser.NewParser().ParseSource("child.hcl", []byte(``))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	_, err = BuildFromConfig(moduleConfig, fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: childConfig, SourcePath: "./child"},
+	}}, "")
+	assert.EqualError(t, err,
+		"inlining module child: removed block for module.child: this module block still exists in the configuration")
+}
+
+// Two provisioner-carrying removed blocks for one address in one
+// configuration are rejected at graph build.
+func TestRemovedDuplicateProvisionersSameConfig(t *testing.T) {
+	t.Parallel()
+
+	config, diags := parser.NewParser().ParseSource("root.hcl", []byte(`
+removed {
+  from = simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+  provisioner "local-exec" {
+    when    = destroy
+    command = "true"
+  }
+}
+
+removed {
+  from = simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+  provisioner "local-exec" {
+    when    = destroy
+    command = "false"
+  }
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	_, err := BuildFromConfig(config, fakeModuleLoader{}, "")
+	assert.EqualError(t, err,
+		"duplicate removed block for simple_resource.a: a removed block with provisioners for this address was already declared at root.hcl:2,1-8; declare all of the address's provisioners in one removed block")
 }
 
 // A child module's removed block targeting its own nested module errors when

--- a/pkg/hcl/graph/removed_test.go
+++ b/pkg/hcl/graph/removed_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A removed block targeting a resource inside a child module errors during
+// inlining when the child still declares that resource, and builds cleanly
+// once the resource is gone.
+func TestRemovedResourceInModule(t *testing.T) {
+	t.Parallel()
+
+	rootSrc := []byte(`
+module "m" {
+  source = "./child"
+}
+
+removed {
+  from = module.m.simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+}
+`)
+	rootConfig, diags := parser.NewParser().ParseSource("root.hcl", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	stillExists, diags := parser.NewParser().ParseSource("child.hcl", []byte(`
+resource "simple_resource" "a" {}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	_, err := BuildFromConfig(rootConfig, fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: stillExists, SourcePath: "./child"},
+	}}, "")
+	assert.EqualError(t, err,
+		"inlining module m: removed block for module.m.simple_resource.a: this resource block still exists in the configuration")
+
+	gone, diags := parser.NewParser().ParseSource("child.hcl", []byte(`
+resource "simple_resource" "b" {}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	_, err = BuildFromConfig(rootConfig, fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: gone, SourcePath: "./child"},
+	}}, "")
+	assert.NoError(t, err)
+}
+
+// A removed block targeting a nested module errors when that module is still
+// declared; the depth-one case is already rejected at parse time.
+func TestRemovedNestedModuleStillExists(t *testing.T) {
+	t.Parallel()
+
+	rootSrc := []byte(`
+module "m" {
+  source = "./child"
+}
+
+removed {
+  from = module.m.module.n
+  lifecycle {
+    destroy = true
+  }
+}
+`)
+	rootConfig, diags := parser.NewParser().ParseSource("root.hcl", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	childConfig, diags := parser.NewParser().ParseSource("child.hcl", []byte(`
+module "n" {
+  source = "./grand"
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	grandConfig, diags := parser.NewParser().ParseSource("grand.hcl", []byte(`
+resource "simple_resource" "a" {}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	_, err := BuildFromConfig(rootConfig, fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: childConfig, SourcePath: "./child"},
+		"./grand": {Config: grandConfig, SourcePath: "./grand"},
+	}}, "")
+	assert.EqualError(t, err,
+		"inlining module m: inlining nested module n: removed block for module.m.module.n: this module block still exists in the configuration")
+}

--- a/pkg/hcl/graph/removed_test.go
+++ b/pkg/hcl/graph/removed_test.go
@@ -100,9 +100,9 @@ removed {
 
 	require.Len(t, g.Removed(), 1)
 	assert.Equal(t, ast.TargetAddr{
-		Modules: []modulepath.Step{modulepath.NewStep("m")},
-		Type:    "simple_resource",
-		Name:    "a",
+		Module: modulepath.Root().Append(modulepath.NewStep("m")),
+		Type:   "simple_resource",
+		Name:   "a",
 	}, g.Removed()[0].From)
 	assert.True(t, g.Removed()[0].Destroy)
 	require.Len(t, g.Removed()[0].Provisioners, 1)

--- a/pkg/hcl/modulepath/modulepath.go
+++ b/pkg/hcl/modulepath/modulepath.go
@@ -172,6 +172,9 @@ func (p Path) Len() int {
 // IsRoot reports whether p has zero steps.
 func (p Path) IsRoot() bool { return p == Path{} }
 
+// Join returns p followed by all of q's steps.
+func (p Path) Join(q Path) Path { return Path{repr: p.repr + q.repr} }
+
 // Append returns a new Path with s added to the end. p is not mutated.
 func (p Path) Append(s Step) Path {
 	var b strings.Builder

--- a/pkg/hcl/parser/README.md
+++ b/pkg/hcl/parser/README.md
@@ -1,0 +1,18 @@
+# parser
+
+Parses HCL source into the `ast` package's types.
+
+## Conventions
+
+- Decode scalar attributes (strings, bools, numbers) with
+  `gohcl.DecodeExpression(attr.Expr, nil, &target)` rather than hand-rolling
+  `attr.Expr.Value(nil)` plus a type check. It converts the way upstream's
+  decoders do (e.g. a string `"true"` satisfies a bool argument), so manual
+  strictness is a parity bug, not a safeguard. Addresses are the exception:
+  they are traversals, not evaluable expressions — use
+  `hcl.AbsTraversalForExpr`, then `ast.ParseTargetAddr` for
+  moved/import/removed-style targets.
+- The parser validates shape (what a block may contain), not cross-block
+  semantics. Checks that need the whole configuration or the module tree —
+  address-still-declared, cross-block duplicates — belong in `graph`, which
+  sees the merged, root-relative view.

--- a/pkg/hcl/parser/override.go
+++ b/pkg/hcl/parser/override.go
@@ -65,7 +65,7 @@ func applyOverrides(primary, override []*hcl.Block) (blocks, deferred []*hcl.Blo
 		case "locals", "terraform":
 			deferred = append(deferred, block)
 			continue
-		case "moved", "import":
+		case "moved", "import", "removed":
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  fmt.Sprintf("Cannot override %q blocks", block.Type),

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -1565,10 +1565,11 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 
 // validateRemovedBlocks checks that no removed block targets a resource or
 // module that is still declared in the same configuration, and that at most
-// one removed block per address carries provisioners (their hook names are
-// positional, so a second set cannot be registered). Addresses inside child
-// modules (module.x.type.name) are checked later, during module inlining,
-// because child module configurations are not loaded at parse time.
+// one removed block per address carries provisioners (two provisioner sets
+// for one address would be ambiguous at destroy time). Addresses inside
+// child modules (module.x.type.name) are checked later, during module
+// inlining, because child module configurations are not loaded at parse
+// time.
 func validateRemovedBlocks(config *ast.Config) hcl.Diagnostics {
 	var diags hcl.Diagnostics
 	withProvisioners := map[string]hcl.Range{}

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -1540,20 +1540,11 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 		})
 	}
 
-	if len(removed.Provisioners) > 0 && len(names) > 0 && names[0] == "module" {
-		if len(names) == 2 {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Invalid removed block",
-				Detail:   "Removed blocks containing provisioners can only target resources, not modules.",
-				Subject:  &block.DefRange,
-			})
-			return diags
-		}
+	if len(removed.Provisioners) > 0 && len(names) == 2 && names[0] == "module" {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  "Unsupported removed block",
-			Detail:   "Provisioners in removed blocks targeting resources inside modules are not yet supported.",
+			Summary:  "Invalid removed block",
+			Detail:   "Removed blocks containing provisioners can only target resources, not modules.",
 			Subject:  &block.DefRange,
 		})
 		return diags

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -129,7 +129,6 @@ func (p *Parser) parseFiles(primary, override map[string]*hcl.File) (*ast.Config
 		diags = append(diags, p.mergeParsedOverride(config, block)...)
 	}
 	config.ProviderFunctionCalls = slices.Sorted(maps.Keys(calls))
-	diags = append(diags, validateRemovedBlocks(config)...)
 
 	config.Diagnostics = diags
 	return config, diags
@@ -1425,7 +1424,6 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 		DeclRange: block.DefRange,
 	}
 
-	var names []string
 	if attr, ok := content.Attributes["from"]; ok {
 		traversal, travDiags := hcl.AbsTraversalForExpr(attr.Expr)
 		diags = append(diags, travDiags...)
@@ -1440,9 +1438,8 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 				return diags
 			}
 		}
-		names = traversalNames(traversal)
-		if len(names) > 0 {
-			if names[0] == "data" {
+		if len(traversal) > 0 {
+			if traversal.RootName() == "data" {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid \"from\" address",
@@ -1451,14 +1448,8 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 				})
 				return diags
 			}
-			// After stripping module.name prefixes, a valid address is either
-			// empty (a module address) or exactly type.name (a resource
-			// address).
-			rest := names
-			for len(rest) >= 2 && rest[0] == "module" {
-				rest = rest[2:]
-			}
-			if len(names) < 2 || (len(rest) != 0 && len(rest) != 2) {
+			addr, ok := ast.ParseTargetAddr(traversal)
+			if !ok {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid \"from\" address",
@@ -1467,8 +1458,8 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 				})
 				return diags
 			}
+			removed.From = addr
 		}
-		removed.From = traversal
 	}
 
 	destroy := false
@@ -1490,20 +1481,7 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 			lcContent, lcDiags := sub.Body.Content(removedLifecycleSchema)
 			diags = append(diags, lcDiags...)
 			if attr, ok := lcContent.Attributes["destroy"]; ok {
-				val, valDiags := attr.Expr.Value(nil)
-				diags = append(diags, valDiags...)
-				if !valDiags.HasErrors() {
-					if val.Type() != cty.Bool {
-						diags = append(diags, &hcl.Diagnostic{
-							Severity: hcl.DiagError,
-							Summary:  "Invalid \"destroy\" value",
-							Detail:   "The \"destroy\" argument must be a boolean constant.",
-							Subject:  attr.Expr.Range().Ptr(),
-						})
-						continue
-					}
-					destroy = val.True()
-				}
+				diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &destroy)...)
 			}
 		case "provisioner":
 			prov, provDiags := p.parseProvisionerBlock(sub)
@@ -1540,7 +1518,7 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 		})
 	}
 
-	if len(removed.Provisioners) > 0 && len(names) == 2 && names[0] == "module" {
+	if len(removed.Provisioners) > 0 && removed.From.Type == "" {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Invalid removed block",
@@ -1552,80 +1530,6 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 
 	config.Removed = append(config.Removed, removed)
 	return diags
-}
-
-// validateRemovedBlocks checks that no removed block targets a resource or
-// module that is still declared in the same configuration, and that at most
-// one removed block per address carries provisioners (two provisioner sets
-// for one address would be ambiguous at destroy time). Addresses inside
-// child modules (module.x.type.name) are checked later, during module
-// inlining, because child module configurations are not loaded at parse
-// time.
-func validateRemovedBlocks(config *ast.Config) hcl.Diagnostics {
-	var diags hcl.Diagnostics
-	withProvisioners := map[string]hcl.Range{}
-	for _, removed := range config.Removed {
-		names := traversalNames(removed.From)
-		if len(removed.Provisioners) > 0 {
-			addr := strings.Join(names, ".")
-			if prev, ok := withProvisioners[addr]; ok {
-				diags = append(diags, &hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Duplicate removed block",
-					Detail: fmt.Sprintf(
-						"A removed block with provisioners for %s was already declared at %s; declare all of the address's provisioners in one removed block.",
-						addr, prev,
-					),
-					Subject: &removed.DeclRange,
-				})
-			} else {
-				withProvisioners[addr] = removed.DeclRange
-			}
-		}
-		switch {
-		case len(names) == 2 && names[0] == "module":
-			if _, ok := config.Modules[names[1]]; ok {
-				diags = append(diags, &hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Removed module block still exists",
-					Detail: fmt.Sprintf(
-						"This removed block declares a removal of module.%s, but this module block still exists in the configuration. Please remove the module block.",
-						names[1],
-					),
-					Subject: &removed.DeclRange,
-				})
-			}
-		case len(names) == 2:
-			key := ast.ResourceKey(names[0], names[1])
-			if _, ok := config.Resources[key]; ok {
-				diags = append(diags, &hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  "Removed resource block still exists",
-					Detail: fmt.Sprintf(
-						"This removed block declares a removal of %s, but this resource block still exists in the configuration. Please remove the resource block.",
-						key,
-					),
-					Subject: &removed.DeclRange,
-				})
-			}
-		}
-	}
-	return diags
-}
-
-// traversalNames flattens a traversal's root and attribute steps into their
-// names, e.g. simple_resource.a -> ["simple_resource", "a"].
-func traversalNames(traversal hcl.Traversal) []string {
-	names := make([]string, 0, len(traversal))
-	for _, step := range traversal {
-		switch s := step.(type) {
-		case hcl.TraverseRoot:
-			names = append(names, s.Name)
-		case hcl.TraverseAttr:
-			names = append(names, s.Name)
-		}
-	}
-	return names
 }
 
 // parseCallBlock parses a call block.

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -129,6 +129,7 @@ func (p *Parser) parseFiles(primary, override map[string]*hcl.File) (*ast.Config
 		diags = append(diags, p.mergeParsedOverride(config, block)...)
 	}
 	config.ProviderFunctionCalls = slices.Sorted(maps.Keys(calls))
+	diags = append(diags, validateRemovedBlocks(config)...)
 
 	config.Diagnostics = diags
 	return config, diags
@@ -155,6 +156,8 @@ func (p *Parser) parseBlock(config *ast.Config, block *hcl.Block) hcl.Diagnostic
 		return p.parseModuleBlock(config, block)
 	case "moved":
 		return p.parseMovedBlock(config, block)
+	case "removed":
+		return p.parseRemovedBlock(config, block)
 	case "import":
 		return p.parseImportBlock(config, block)
 	case "check":
@@ -1408,6 +1411,216 @@ func (p *Parser) parseMovedBlock(config *ast.Config, block *hcl.Block) hcl.Diagn
 
 	config.Moved = append(config.Moved, moved)
 	return diags
+}
+
+// parseRemovedBlock parses a removed block. Only destroy = true is supported:
+// forgetting a resource (destroy = false, or an omitted lifecycle block) means
+// dropping it from state without destroying it, which has no Pulumi engine
+// mapping, so those forms are rejected rather than silently destroying or
+// retaining the resource.
+func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Diagnostics {
+	content, diags := block.Body.Content(removedSchema)
+
+	removed := &ast.Removed{
+		DeclRange: block.DefRange,
+	}
+
+	isModuleAddr := false
+	if attr, ok := content.Attributes["from"]; ok {
+		traversal, travDiags := hcl.AbsTraversalForExpr(attr.Expr)
+		diags = append(diags, travDiags...)
+		for _, step := range traversal {
+			if _, isIndex := step.(hcl.TraverseIndex); isIndex {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Resource instance keys not allowed",
+					Detail:   "A removed block's \"from\" address must not include instance keys; the block applies to every instance of the resource.",
+					Subject:  attr.Expr.Range().Ptr(),
+				})
+				return diags
+			}
+		}
+		if len(traversal) > 0 {
+			if root, ok := traversal[0].(hcl.TraverseRoot); ok {
+				switch root.Name {
+				case "data":
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid \"from\" address",
+						Detail:   "Data sources are not tracked in state, so they cannot be used in a removed block; delete the data block instead.",
+						Subject:  attr.Expr.Range().Ptr(),
+					})
+					return diags
+				case "module":
+					isModuleAddr = len(traversal) == 2
+				}
+			}
+			// After stripping module.name prefixes, a valid address is either
+			// empty (a module address) or exactly type.name (a resource
+			// address).
+			rest := traversalNames(traversal)
+			for len(rest) >= 2 && rest[0] == "module" {
+				rest = rest[2:]
+			}
+			if len(traversal) < 2 || (len(rest) != 0 && len(rest) != 2) {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid \"from\" address",
+					Detail:   "A removed block's \"from\" address must be a resource address (type.name) or a module address (module.name).",
+					Subject:  attr.Expr.Range().Ptr(),
+				})
+				return diags
+			}
+		}
+		removed.From = traversal
+	}
+
+	destroy := false
+	var seenLifecycle *hcl.Block
+	for _, sub := range content.Blocks {
+		switch sub.Type {
+		case "lifecycle":
+			if seenLifecycle != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Duplicate lifecycle block",
+					Detail:   fmt.Sprintf("The removed block already has a lifecycle block at %s.", seenLifecycle.DefRange),
+					Subject:  &sub.DefRange,
+				})
+				continue
+			}
+			seenLifecycle = sub
+
+			lcContent, lcDiags := sub.Body.Content(removedLifecycleSchema)
+			diags = append(diags, lcDiags...)
+			if attr, ok := lcContent.Attributes["destroy"]; ok {
+				val, valDiags := attr.Expr.Value(nil)
+				diags = append(diags, valDiags...)
+				if !valDiags.HasErrors() {
+					if val.Type() != cty.Bool {
+						diags = append(diags, &hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "Invalid \"destroy\" value",
+							Detail:   "The \"destroy\" argument must be a boolean constant.",
+							Subject:  attr.Expr.Range().Ptr(),
+						})
+						continue
+					}
+					destroy = val.True()
+				}
+			}
+		case "provisioner":
+			prov, provDiags := p.parseProvisionerBlock(sub)
+			diags = append(diags, provDiags...)
+			if prov == nil {
+				continue
+			}
+			if prov.When != "destroy" {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid \"removed.provisioner\" block",
+					Detail:   "Removed blocks can only contain destroy provisioners; \"when = destroy\" is required.",
+					Subject:  &sub.DefRange,
+				})
+				continue
+			}
+			removed.Provisioners = append(removed.Provisioners, prov)
+		}
+	}
+
+	if diags.HasErrors() {
+		return diags
+	}
+
+	removed.Destroy = destroy
+	if !removed.Destroy {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unsupported removed block",
+			Detail: "Removing a resource from state without destroying it is not supported; " +
+				"set `lifecycle { destroy = true }` to destroy the resource, or run " +
+				"`pulumi state delete <urn>` to remove it from state.",
+			Subject: &block.DefRange,
+		})
+	}
+
+	if len(removed.Provisioners) > 0 {
+		if isModuleAddr {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid removed block",
+				Detail:   "Removed blocks containing provisioners can only target resources, not modules.",
+				Subject:  &block.DefRange,
+			})
+			return diags
+		}
+		if root, ok := removed.From[0].(hcl.TraverseRoot); ok && root.Name == "module" {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Unsupported removed block",
+				Detail:   "Provisioners in removed blocks targeting resources inside modules are not yet supported.",
+				Subject:  &block.DefRange,
+			})
+			return diags
+		}
+	}
+
+	config.Removed = append(config.Removed, removed)
+	return diags
+}
+
+// validateRemovedBlocks checks that no removed block targets a resource or
+// module that is still declared in the same configuration. Addresses inside
+// child modules (module.x.type.name) cannot be checked here because child
+// module configurations are not loaded at parse time.
+func validateRemovedBlocks(config *ast.Config) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+	for _, removed := range config.Removed {
+		names := traversalNames(removed.From)
+		switch {
+		case len(names) == 2 && names[0] == "module":
+			if _, ok := config.Modules[names[1]]; ok {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Removed module block still exists",
+					Detail: fmt.Sprintf(
+						"This removed block declares a removal of module.%s, but this module block still exists in the configuration. Please remove the module block.",
+						names[1],
+					),
+					Subject: &removed.DeclRange,
+				})
+			}
+		case len(names) == 2:
+			key := ast.ResourceKey(names[0], names[1])
+			if _, ok := config.Resources[key]; ok {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Removed resource block still exists",
+					Detail: fmt.Sprintf(
+						"This removed block declares a removal of %s, but this resource block still exists in the configuration. Please remove the resource block.",
+						key,
+					),
+					Subject: &removed.DeclRange,
+				})
+			}
+		}
+	}
+	return diags
+}
+
+// traversalNames flattens a traversal's root and attribute steps into their
+// names, e.g. simple_resource.a -> ["simple_resource", "a"].
+func traversalNames(traversal hcl.Traversal) []string {
+	names := make([]string, 0, len(traversal))
+	for _, step := range traversal {
+		switch s := step.(type) {
+		case hcl.TraverseRoot:
+			names = append(names, s.Name)
+		case hcl.TraverseAttr:
+			names = append(names, s.Name)
+		}
+	}
+	return names
 }
 
 // parseCallBlock parses a call block.

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -1425,7 +1425,7 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 		DeclRange: block.DefRange,
 	}
 
-	isModuleAddr := false
+	var names []string
 	if attr, ok := content.Attributes["from"]; ok {
 		traversal, travDiags := hcl.AbsTraversalForExpr(attr.Expr)
 		diags = append(diags, travDiags...)
@@ -1440,29 +1440,25 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 				return diags
 			}
 		}
-		if len(traversal) > 0 {
-			if root, ok := traversal[0].(hcl.TraverseRoot); ok {
-				switch root.Name {
-				case "data":
-					diags = append(diags, &hcl.Diagnostic{
-						Severity: hcl.DiagError,
-						Summary:  "Invalid \"from\" address",
-						Detail:   "Data sources are not tracked in state, so they cannot be used in a removed block; delete the data block instead.",
-						Subject:  attr.Expr.Range().Ptr(),
-					})
-					return diags
-				case "module":
-					isModuleAddr = len(traversal) == 2
-				}
+		names = traversalNames(traversal)
+		if len(names) > 0 {
+			if names[0] == "data" {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid \"from\" address",
+					Detail:   "Data sources are not tracked in state, so they cannot be used in a removed block; delete the data block instead.",
+					Subject:  attr.Expr.Range().Ptr(),
+				})
+				return diags
 			}
 			// After stripping module.name prefixes, a valid address is either
 			// empty (a module address) or exactly type.name (a resource
 			// address).
-			rest := traversalNames(traversal)
+			rest := names
 			for len(rest) >= 2 && rest[0] == "module" {
 				rest = rest[2:]
 			}
-			if len(traversal) < 2 || (len(rest) != 0 && len(rest) != 2) {
+			if len(names) < 2 || (len(rest) != 0 && len(rest) != 2) {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "Invalid \"from\" address",
@@ -1544,8 +1540,8 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 		})
 	}
 
-	if len(removed.Provisioners) > 0 {
-		if isModuleAddr {
+	if len(removed.Provisioners) > 0 && len(names) > 0 && names[0] == "module" {
+		if len(names) == 2 {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Invalid removed block",
@@ -1554,15 +1550,13 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 			})
 			return diags
 		}
-		if root, ok := removed.From[0].(hcl.TraverseRoot); ok && root.Name == "module" {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Unsupported removed block",
-				Detail:   "Provisioners in removed blocks targeting resources inside modules are not yet supported.",
-				Subject:  &block.DefRange,
-			})
-			return diags
-		}
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unsupported removed block",
+			Detail:   "Provisioners in removed blocks targeting resources inside modules are not yet supported.",
+			Subject:  &block.DefRange,
+		})
+		return diags
 	}
 
 	config.Removed = append(config.Removed, removed)
@@ -1570,13 +1564,32 @@ func (p *Parser) parseRemovedBlock(config *ast.Config, block *hcl.Block) hcl.Dia
 }
 
 // validateRemovedBlocks checks that no removed block targets a resource or
-// module that is still declared in the same configuration. Addresses inside
-// child modules (module.x.type.name) cannot be checked here because child
-// module configurations are not loaded at parse time.
+// module that is still declared in the same configuration, and that at most
+// one removed block per address carries provisioners (their hook names are
+// positional, so a second set cannot be registered). Addresses inside child
+// modules (module.x.type.name) are checked later, during module inlining,
+// because child module configurations are not loaded at parse time.
 func validateRemovedBlocks(config *ast.Config) hcl.Diagnostics {
 	var diags hcl.Diagnostics
+	withProvisioners := map[string]hcl.Range{}
 	for _, removed := range config.Removed {
 		names := traversalNames(removed.From)
+		if len(removed.Provisioners) > 0 {
+			addr := strings.Join(names, ".")
+			if prev, ok := withProvisioners[addr]; ok {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Duplicate removed block",
+					Detail: fmt.Sprintf(
+						"A removed block with provisioners for %s was already declared at %s; declare all of the address's provisioners in one removed block.",
+						addr, prev,
+					),
+					Subject: &removed.DeclRange,
+				})
+			} else {
+				withProvisioners[addr] = removed.DeclRange
+			}
+		}
 		switch {
 		case len(names) == 2 && names[0] == "module":
 			if _, ok := config.Modules[names[1]]; ok {

--- a/pkg/hcl/parser/removed_test.go
+++ b/pkg/hcl/parser/removed_test.go
@@ -1,0 +1,249 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRemovedBlock(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+removed {
+  from = simple_resource.a
+
+  lifecycle {
+    destroy = true
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "true"
+  }
+}
+
+removed {
+  from = module.gone
+
+  lifecycle {
+    destroy = true
+  }
+}
+`)
+
+	config, diags := NewParser().ParseSource("main.tf", src)
+	require.False(t, diags.HasErrors(), "diags: %v", diags)
+	require.Len(t, config.Removed, 2)
+
+	assert.Equal(t, []string{"simple_resource", "a"}, traversalNames(config.Removed[0].From))
+	assert.True(t, config.Removed[0].Destroy)
+	require.Len(t, config.Removed[0].Provisioners, 1)
+	assert.Equal(t, "local-exec", config.Removed[0].Provisioners[0].Type)
+	assert.Equal(t, "destroy", config.Removed[0].Provisioners[0].When)
+
+	assert.Equal(t, []string{"module", "gone"}, traversalNames(config.Removed[1].From))
+	assert.True(t, config.Removed[1].Destroy)
+	assert.Empty(t, config.Removed[1].Provisioners)
+}
+
+// destroy = false is unsupported but still parses: the block lands in the AST
+// with Destroy false and the failure is an error diagnostic, not a dropped
+// block.
+func TestParseRemovedBlockDestroyFalse(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+removed {
+  from = simple_resource.a
+
+  lifecycle {
+    destroy = false
+  }
+}
+`)
+
+	config, diags := NewParser().ParseSource("main.tf", src)
+	require.Len(t, diags, 1)
+	assert.Equal(t, "Unsupported removed block", diags[0].Summary)
+	require.Len(t, config.Removed, 1)
+	assert.False(t, config.Removed[0].Destroy)
+}
+
+func TestParseRemovedBlockErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		src         string
+		wantSummary string
+	}{
+		{
+			name: "destroy false",
+			src: `
+removed {
+  from = simple_resource.a
+  lifecycle {
+    destroy = false
+  }
+}`,
+			wantSummary: "Unsupported removed block",
+		},
+		{
+			name: "lifecycle omitted",
+			src: `
+removed {
+  from = simple_resource.a
+}`,
+			wantSummary: "Unsupported removed block",
+		},
+		{
+			name: "instance key",
+			src: `
+removed {
+  from = simple_resource.a[0]
+  lifecycle {
+    destroy = true
+  }
+}`,
+			wantSummary: "Resource instance keys not allowed",
+		},
+		{
+			name: "data source address",
+			src: `
+removed {
+  from = data.simple_data.a
+  lifecycle {
+    destroy = true
+  }
+}`,
+			wantSummary: "Invalid \"from\" address",
+		},
+		{
+			name: "bare name address",
+			src: `
+removed {
+  from = foo
+  lifecycle {
+    destroy = true
+  }
+}`,
+			wantSummary: "Invalid \"from\" address",
+		},
+		{
+			name: "too many address parts",
+			src: `
+removed {
+  from = simple_resource.a.b
+  lifecycle {
+    destroy = true
+  }
+}`,
+			wantSummary: "Invalid \"from\" address",
+		},
+		{
+			name: "incomplete module-prefixed address",
+			src: `
+removed {
+  from = module.child.simple_resource
+  lifecycle {
+    destroy = true
+  }
+}`,
+			wantSummary: "Invalid \"from\" address",
+		},
+		{
+			name: "create provisioner",
+			src: `
+removed {
+  from = simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+  provisioner "local-exec" {
+    command = "true"
+  }
+}`,
+			wantSummary: "Invalid \"removed.provisioner\" block",
+		},
+		{
+			name: "module address with provisioner",
+			src: `
+removed {
+  from = module.gone
+  lifecycle {
+    destroy = true
+  }
+  provisioner "local-exec" {
+    when    = destroy
+    command = "true"
+  }
+}`,
+			wantSummary: "Invalid removed block",
+		},
+		{
+			name: "module-prefixed resource with provisioner",
+			src: `
+removed {
+  from = module.child.simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+  provisioner "local-exec" {
+    when    = destroy
+    command = "true"
+  }
+}`,
+			wantSummary: "Unsupported removed block",
+		},
+		{
+			name: "resource still declared",
+			src: `
+resource "simple_resource" "a" {}
+
+removed {
+  from = simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+}`,
+			wantSummary: "Removed resource block still exists",
+		},
+		{
+			name: "module still declared",
+			src: `
+module "child" {
+  source = "./child"
+}
+
+removed {
+  from = module.child
+  lifecycle {
+    destroy = true
+  }
+}`,
+			wantSummary: "Removed module block still exists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, diags := NewParser().ParseSource("main.tf", []byte(tt.src))
+			require.Len(t, diags, 1)
+			assert.Equal(t, tt.wantSummary, diags[0].Summary)
+		})
+	}
+}

--- a/pkg/hcl/parser/removed_test.go
+++ b/pkg/hcl/parser/removed_test.go
@@ -59,7 +59,7 @@ removed {
 	assert.Equal(t, "local-exec", config.Removed[0].Provisioners[0].Type)
 	assert.Equal(t, "destroy", config.Removed[0].Provisioners[0].When)
 
-	assert.Equal(t, ast.TargetAddr{Modules: []modulepath.Step{modulepath.NewStep("gone")}}, config.Removed[1].From)
+	assert.Equal(t, ast.TargetAddr{Module: modulepath.Root().Append(modulepath.NewStep("gone"))}, config.Removed[1].From)
 	assert.True(t, config.Removed[1].Destroy)
 	assert.Empty(t, config.Removed[1].Provisioners)
 }
@@ -106,9 +106,9 @@ removed {
 	require.False(t, diags.HasErrors(), "diags: %v", diags)
 	require.Len(t, config.Removed, 1)
 	assert.Equal(t, ast.TargetAddr{
-		Modules: []modulepath.Step{modulepath.NewStep("child")},
-		Type:    "simple_resource",
-		Name:    "a",
+		Module: modulepath.Root().Append(modulepath.NewStep("child")),
+		Type:   "simple_resource",
+		Name:   "a",
 	}, config.Removed[0].From)
 	require.Len(t, config.Removed[0].Provisioners, 1)
 }

--- a/pkg/hcl/parser/removed_test.go
+++ b/pkg/hcl/parser/removed_test.go
@@ -209,6 +209,32 @@ removed {
 			wantSummary: "Unsupported removed block",
 		},
 		{
+			name: "duplicate provisioner-carrying blocks",
+			src: `
+removed {
+  from = simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+  provisioner "local-exec" {
+    when    = destroy
+    command = "true"
+  }
+}
+
+removed {
+  from = simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+  provisioner "local-exec" {
+    when    = destroy
+    command = "false"
+  }
+}`,
+			wantSummary: "Duplicate removed block",
+		},
+		{
 			name: "resource still declared",
 			src: `
 resource "simple_resource" "a" {}
@@ -246,4 +272,46 @@ removed {
 			assert.Equal(t, tt.wantSummary, diags[0].Summary)
 		})
 	}
+}
+
+// Duplicate removed blocks without provisioners are legal, matching OpenTofu.
+func TestParseRemovedBlockDuplicateWithoutProvisioners(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+removed {
+  from = simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+}
+
+removed {
+  from = simple_resource.a
+  lifecycle {
+    destroy = true
+  }
+}
+`)
+
+	config, diags := NewParser().ParseSource("main.tf", src)
+	require.False(t, diags.HasErrors(), "diags: %v", diags)
+	assert.Len(t, config.Removed, 2)
+}
+
+func TestRemovedBlockInOverrideFileRejected(t *testing.T) {
+	t.Parallel()
+
+	_, diags := parseDir(t, map[string]string{
+		"main.tf": `resource "simple_resource" "r" { input_one = "base" }`,
+		"override.tf": `
+removed {
+  from = simple_resource.gone
+  lifecycle {
+    destroy = true
+  }
+}`,
+	})
+
+	require.Len(t, diags, 1)
+	assert.Equal(t, `Cannot override "removed" blocks`, diags[0].Summary)
 }

--- a/pkg/hcl/parser/removed_test.go
+++ b/pkg/hcl/parser/removed_test.go
@@ -61,6 +61,31 @@ removed {
 	assert.Empty(t, config.Removed[1].Provisioners)
 }
 
+// A provisioner-carrying removed block may target a resource inside a module.
+func TestParseRemovedBlockModulePrefixedProvisioner(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+removed {
+  from = module.child.simple_resource.a
+
+  lifecycle {
+    destroy = true
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "true"
+  }
+}
+`)
+
+	config, diags := NewParser().ParseSource("main.tf", src)
+	require.False(t, diags.HasErrors(), "diags: %v", diags)
+	require.Len(t, config.Removed, 1)
+	assert.Equal(t, []string{"module", "child", "simple_resource", "a"}, traversalNames(config.Removed[0].From))
+	require.Len(t, config.Removed[0].Provisioners, 1)
+}
+
 // destroy = false is unsupported but still parses: the block lands in the AST
 // with Destroy false and the failure is an error diagnostic, not a dropped
 // block.
@@ -192,21 +217,6 @@ removed {
   }
 }`,
 			wantSummary: "Invalid removed block",
-		},
-		{
-			name: "module-prefixed resource with provisioner",
-			src: `
-removed {
-  from = module.child.simple_resource.a
-  lifecycle {
-    destroy = true
-  }
-  provisioner "local-exec" {
-    when    = destroy
-    command = "true"
-  }
-}`,
-			wantSummary: "Unsupported removed block",
 		},
 		{
 			name: "duplicate provisioner-carrying blocks",

--- a/pkg/hcl/parser/removed_test.go
+++ b/pkg/hcl/parser/removed_test.go
@@ -19,6 +19,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
 )
 
 func TestParseRemovedBlock(t *testing.T) {
@@ -50,15 +53,35 @@ removed {
 	require.False(t, diags.HasErrors(), "diags: %v", diags)
 	require.Len(t, config.Removed, 2)
 
-	assert.Equal(t, []string{"simple_resource", "a"}, traversalNames(config.Removed[0].From))
+	assert.Equal(t, ast.TargetAddr{Type: "simple_resource", Name: "a"}, config.Removed[0].From)
 	assert.True(t, config.Removed[0].Destroy)
 	require.Len(t, config.Removed[0].Provisioners, 1)
 	assert.Equal(t, "local-exec", config.Removed[0].Provisioners[0].Type)
 	assert.Equal(t, "destroy", config.Removed[0].Provisioners[0].When)
 
-	assert.Equal(t, []string{"module", "gone"}, traversalNames(config.Removed[1].From))
+	assert.Equal(t, ast.TargetAddr{Modules: []modulepath.Step{modulepath.NewStep("gone")}}, config.Removed[1].From)
 	assert.True(t, config.Removed[1].Destroy)
 	assert.Empty(t, config.Removed[1].Provisioners)
+}
+
+// The destroy argument converts like any other decoded attribute, so a
+// string boolean is accepted.
+func TestParseRemovedBlockDestroyStringBool(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+removed {
+  from = simple_resource.a
+
+  lifecycle {
+    destroy = "true"
+  }
+}
+`)
+
+	config, diags := NewParser().ParseSource("main.tf", src)
+	require.False(t, diags.HasErrors(), "diags: %v", diags)
+	require.Len(t, config.Removed, 1)
+	assert.True(t, config.Removed[0].Destroy)
 }
 
 // A provisioner-carrying removed block may target a resource inside a module.
@@ -82,7 +105,11 @@ removed {
 	config, diags := NewParser().ParseSource("main.tf", src)
 	require.False(t, diags.HasErrors(), "diags: %v", diags)
 	require.Len(t, config.Removed, 1)
-	assert.Equal(t, []string{"module", "child", "simple_resource", "a"}, traversalNames(config.Removed[0].From))
+	assert.Equal(t, ast.TargetAddr{
+		Modules: []modulepath.Step{modulepath.NewStep("child")},
+		Type:    "simple_resource",
+		Name:    "a",
+	}, config.Removed[0].From)
 	require.Len(t, config.Removed[0].Provisioners, 1)
 }
 
@@ -219,10 +246,10 @@ removed {
 			wantSummary: "Invalid removed block",
 		},
 		{
-			name: "duplicate provisioner-carrying blocks",
+			name: "nested module address with provisioner",
 			src: `
 removed {
-  from = simple_resource.a
+  from = module.gone.module.deeper
   lifecycle {
     destroy = true
   }
@@ -230,47 +257,8 @@ removed {
     when    = destroy
     command = "true"
   }
-}
-
-removed {
-  from = simple_resource.a
-  lifecycle {
-    destroy = true
-  }
-  provisioner "local-exec" {
-    when    = destroy
-    command = "false"
-  }
 }`,
-			wantSummary: "Duplicate removed block",
-		},
-		{
-			name: "resource still declared",
-			src: `
-resource "simple_resource" "a" {}
-
-removed {
-  from = simple_resource.a
-  lifecycle {
-    destroy = true
-  }
-}`,
-			wantSummary: "Removed resource block still exists",
-		},
-		{
-			name: "module still declared",
-			src: `
-module "child" {
-  source = "./child"
-}
-
-removed {
-  from = module.child
-  lifecycle {
-    destroy = true
-  }
-}`,
-			wantSummary: "Removed module block still exists",
+			wantSummary: "Invalid removed block",
 		},
 	}
 

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -31,6 +31,7 @@ var rootSchema = &hcl.BodySchema{
 		{Type: "output", LabelNames: []string{"name"}},
 		{Type: "module", LabelNames: []string{"name"}},
 		{Type: "moved"},
+		{Type: "removed"},
 		{Type: "import"},
 		{Type: "check", LabelNames: []string{"name"}},
 		{Type: "call", LabelNames: []string{"resource", "method"}},
@@ -296,6 +297,25 @@ var movedSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{Name: "from", Required: true},
 		{Name: "to", Required: true},
+	},
+}
+
+// removedSchema defines the structure of a removed block.
+var removedSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "from", Required: true},
+	},
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "lifecycle"},
+		{Type: "provisioner", LabelNames: []string{"type"}},
+	},
+}
+
+// removedLifecycleSchema defines the structure of a removed block's lifecycle
+// block.
+var removedLifecycleSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "destroy"},
 	},
 }
 

--- a/pkg/hcl/run/destroy_dispatch.go
+++ b/pkg/hcl/run/destroy_dispatch.go
@@ -162,11 +162,9 @@ type blockEntry struct {
 	// overridden: a live `pulumi { name = ... }` override makes the derived
 	// name shape non-invertible, so the entry never matches by shape.
 	overridden bool
-	// moduleTarget: the address descends into modules. The orphan's
-	// parent-type chain is unknowable then — a module component's type names
-	// its source, and a removed module call's source is gone from config — so
-	// matching skips the chain check and relies on the token and the
-	// module-qualified name shape.
+	// moduleTarget: the address descends into modules, so matching skips the
+	// parent-chain check — a gone module call's component type names its
+	// source, which is no longer in the configuration.
 	moduleTarget bool
 }
 

--- a/pkg/hcl/run/destroy_dispatch.go
+++ b/pkg/hcl/run/destroy_dispatch.go
@@ -162,6 +162,12 @@ type blockEntry struct {
 	// overridden: a live `pulumi { name = ... }` override makes the derived
 	// name shape non-invertible, so the entry never matches by shape.
 	overridden bool
+	// moduleTarget: the address descends into modules. The orphan's
+	// parent-type chain is unknowable then — a module component's type names
+	// its source, and a removed module call's source is gone from config — so
+	// matching skips the chain check and relies on the token and the
+	// module-qualified name shape.
+	moduleTarget bool
 }
 
 // urnTypes returns u's own type and the qualified-type chain contributed by
@@ -176,7 +182,7 @@ func (b *blockEntry) matches(args *ResourceHookArgs) bool {
 		return false
 	}
 	typ, parentChain := urnTypes(args.URN)
-	if typ != b.token || parentChain != b.parentChain {
+	if typ != b.token || (!b.moduleTarget && parentChain != b.parentChain) {
 		return false
 	}
 	name := args.Name

--- a/pkg/hcl/run/removed.go
+++ b/pkg/hcl/run/removed.go
@@ -17,31 +17,36 @@ package run
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
 )
 
 // recordRemovedBlockEntries records a destroy-dispatcher entry for each
-// removed block that carries provisioners. The engine destroys a resource
-// absent from the program on its own and invokes the constant
-// [destroyProvisionerHook] recorded in its state; the dispatcher matches the
-// orphan to the removed block by config address (see [DestroyDispatcher]) and
-// runs the block's provisioners, instance keys included. A resource whose
-// state never recorded the hook — it had no destroy-time provisioners when
-// last registered — deletes without running the removed block's provisioners.
+// removed block that carries provisioners, from the graph's merged list:
+// every block in the module tree, child-declared addresses rewritten to be
+// root-relative. The engine destroys a resource absent from the program on
+// its own and invokes the constant [destroyProvisionerHook] recorded in its
+// state; the dispatcher matches the orphan to the removed block by config
+// address (see [DestroyDispatcher]) and runs the block's provisioners,
+// instance keys included. A resource whose state never recorded the hook —
+// it had no destroy-time provisioners when last registered — deletes without
+// running the removed block's provisioners.
 func (e *Engine) recordRemovedBlockEntries(ctx context.Context) error {
 	if e.resmon == nil {
 		return nil
 	}
-	for _, rem := range e.config.Removed {
+	for _, rem := range e.graph.Removed() {
 		// A destroy = false block already carries a parse-time error
 		// diagnostic; its provisioners must not run.
 		if !rem.Destroy || len(rem.Provisioners) == 0 {
 			continue
 		}
-		typ, name, err := removedResourceAddr(rem.From)
+		module, typ, name, err := removedResourceAddr(rem.From)
 		if err != nil {
 			return err
 		}
@@ -55,21 +60,57 @@ func (e *Engine) recordRemovedBlockEntries(ctx context.Context) error {
 			Provisioners: rem.Provisioners,
 			DeclRange:    rem.DeclRange,
 		}
-		e.recordBlockEntry(ctx, res, resSchema, e.evaluator.Context(), e.stackURN, nil)
+		e.recordRemovedEntry(ctx, res, resSchema, module)
 	}
 	return nil
 }
 
-// removedResourceAddr splits a removed block's "from" traversal into resource
-// type and name. The parser has already rejected the address shapes that
-// cannot carry provisioners (modules, instance keys, data sources).
-func removedResourceAddr(from hcl.Traversal) (typ, name string, err error) {
-	if len(from) == 2 {
-		root, rootOK := from[0].(hcl.TraverseRoot)
-		attr, attrOK := from[1].(hcl.TraverseAttr)
-		if rootOK && attrOK {
-			return root.Name, attr.Name, nil
+// recordRemovedEntry records the dispatch entry for a removed block's
+// resource address. Unlike a live block's entry it carries no module instance
+// scope — a module-qualified orphan evaluates its provisioners in TF's
+// destroy scope (self, count.index, each.key, path.*, terraform.*), which is
+// also all TF allows a removed block's provisioners to reference.
+func (e *Engine) recordRemovedEntry(
+	ctx context.Context, res *ast.Resource, resSchema *schema.Resource, module modulepath.Path,
+) {
+	probeURN, probeName := e.resmon.ResolveURN(e.stackURN, resSchema.Token, "probe")
+	entry := &blockEntry{
+		resmon:       e.resmon,
+		dryRun:       e.dryRun,
+		res:          res,
+		resSchema:    resSchema,
+		mapping:      e.resolver.ResourceBodyMapping(ctx, res.Type),
+		token:        resSchema.Token,
+		prefix:       strings.TrimSuffix(probeName, "probe"),
+		evalCtx:      e.evaluator.Context(),
+		config:       modulepath.NewAddress(module, modulepath.NewStep(res.Name)),
+		moduleTarget: !module.IsRoot(),
+	}
+	_, entry.parentChain = urnTypes(string(probeURN))
+	e.dispatcher.putBlock(entry)
+}
+
+// removedResourceAddr splits a removed block's root-relative "from" traversal
+// into the enclosing module config path and the resource type and name. The
+// parser has already rejected the address shapes that cannot carry
+// provisioners (whole modules, instance keys, data sources).
+func removedResourceAddr(from hcl.Traversal) (module modulepath.Path, typ, name string, err error) {
+	var names []string
+	for _, step := range from {
+		switch s := step.(type) {
+		case hcl.TraverseRoot:
+			names = append(names, s.Name)
+		case hcl.TraverseAttr:
+			names = append(names, s.Name)
 		}
 	}
-	return "", "", fmt.Errorf("removed block: expected a root resource address (type.name)")
+	module = modulepath.Root()
+	for len(names) >= 2 && names[0] == "module" {
+		module = module.Append(modulepath.NewStep(names[1]))
+		names = names[2:]
+	}
+	if len(names) != 2 {
+		return module, "", "", fmt.Errorf("removed block: expected a resource address (type.name)")
+	}
+	return module, names[0], names[1], nil
 }

--- a/pkg/hcl/run/removed.go
+++ b/pkg/hcl/run/removed.go
@@ -20,33 +20,21 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 
-	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
-	"github.com/pulumi-labs/pulumi-hcl/pkg/provisioner/runtime"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 )
 
-// registerRemovedProvisionerHooks registers the destroy-time provisioners
-// declared in removed blocks. The engine destroys a resource absent from the
-// program on its own; what it cannot do alone is resolve the BeforeDelete
-// hook names recorded in the resource's state — every recorded name must be
-// registered in this run's hook registry or the delete fails. Each
-// removed-block provisioner is therefore registered under the name the
-// resource bound while it was still declared:
-// "<type>.<name>:provisioner:<i>" (see bindProvisionerHooks).
-//
-// ponytail: names are matched by position — provisioner i in the removed
-// block must have been provisioner i on the resource, which holds when the
-// resource's provisioners were all destroy-time and moved over in order. A
-// resource that mixed create and destroy provisioners records shifted
-// indexes and needs state-aware naming to line up; its delete fails loudly
-// with "hook not registered". Instance-keyed names (count/for_each), custom
-// names (pulumi { name = ... }), and addresses renamed by a moved block are
-// similarly out of reach. The converse is silent: a provisioner the resource
-// never bound registers a hook no state entry references, so the engine
-// never invokes it — a provisioner first introduced in the removed block
-// does not run.
-func (e *Engine) registerRemovedProvisionerHooks(ctx context.Context) error {
-	hclSnapshot := e.evaluator.Context().HCLContext()
-	dryRun := e.dryRun
+// recordRemovedBlockEntries records a destroy-dispatcher entry for each
+// removed block that carries provisioners. The engine destroys a resource
+// absent from the program on its own and invokes the constant
+// [destroyProvisionerHook] recorded in its state; the dispatcher matches the
+// orphan to the removed block by config address (see [DestroyDispatcher]) and
+// runs the block's provisioners, instance keys included. A resource whose
+// state never recorded the hook — it had no destroy-time provisioners when
+// last registered — deletes without running the removed block's provisioners.
+func (e *Engine) recordRemovedBlockEntries(ctx context.Context) error {
+	if e.resmon == nil {
+		return nil
+	}
 	for _, rem := range e.config.Removed {
 		// A destroy = false block already carries a parse-time error
 		// diagnostic; its provisioners must not run.
@@ -61,51 +49,13 @@ func (e *Engine) registerRemovedProvisionerHooks(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("removed block for %s.%s: resolving resource type: %w", typ, name, err)
 		}
-		mapping := e.resolver.ResourceBodyMapping(ctx, typ)
-
-		for i, prov := range rem.Provisioners {
-			prov, index := prov, i+1
-			spec := &runtime.Spec{
-				Type:   prov.Type,
-				Config: prov.Config,
-			}
-			if prov.Connection != nil {
-				spec.Conn = prov.Connection.Config
-			}
-			onFailureContinue := prov.OnFailure == "continue"
-			hookName := fmt.Sprintf("%s.%s:provisioner:%d", typ, name, i)
-			errLabel := fmt.Sprintf("removed %s.%s", typ, name)
-
-			callback := func(hookCtx context.Context, args *ResourceHookArgs) error {
-				outputs := args.OldOutputs
-				// terraform_data's output mirrors input
-				// (lowerTerraformDataOutputs); its triggers_replace echo needs
-				// the registration-time trigger tuple, which a removed
-				// resource no longer has, so a reference to it fails to
-				// evaluate rather than reporting a fabricated value.
-				if typ == packages.TerraformDataType {
-					outputs = outputs.Set("output", outputs.Get("input"))
-				}
-				selfCtx, err := selfBoundEvalCtx(hclSnapshot, outputs, args.ID, args.URN, typ, resSchema, mapping, dryRun)
-				if err != nil {
-					return fmt.Errorf("provisioner %d for %s: %w", index, errLabel, err)
-				}
-				if runErr := runtime.Run(hookCtx, spec, selfCtx); runErr != nil {
-					if onFailureContinue {
-						return nil
-					}
-					return fmt.Errorf("provisioner %d (%s) for %s: %w",
-						index, prov.Type, errLabel, runErr)
-				}
-				return nil
-			}
-
-			if err := e.resmon.RegisterResourceHook(ctx, hookName, callback, ResourceHookOptions{
-				OnDryRun: false, // TF doesn't run provisioners during plan.
-			}); err != nil {
-				return fmt.Errorf("registering removed-block provisioner hook: %w", err)
-			}
+		res := &ast.Resource{
+			Type:         typ,
+			Name:         name,
+			Provisioners: rem.Provisioners,
+			DeclRange:    rem.DeclRange,
 		}
+		e.recordBlockEntry(ctx, res, resSchema, e.evaluator.Context(), e.stackURN, nil)
 	}
 	return nil
 }

--- a/pkg/hcl/run/removed.go
+++ b/pkg/hcl/run/removed.go
@@ -43,10 +43,6 @@ func (e *Engine) recordRemovedBlockEntries(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("removed block for %s: resolving resource type: %w", rem.From, err)
 		}
-		module := modulepath.Root()
-		for _, s := range rem.From.Modules {
-			module = module.Append(s)
-		}
 		res := &ast.Resource{
 			Type:         rem.From.Type,
 			Name:         rem.From.Name,
@@ -63,8 +59,8 @@ func (e *Engine) recordRemovedBlockEntries(ctx context.Context) error {
 			token:        resSchema.Token,
 			prefix:       strings.TrimSuffix(probeName, "probe"),
 			evalCtx:      e.evaluator.Context(),
-			config:       modulepath.NewAddress(module, modulepath.NewStep(rem.From.Name)),
-			moduleTarget: !module.IsRoot(),
+			config:       modulepath.NewAddress(rem.From.Module, modulepath.NewStep(rem.From.Name)),
+			moduleTarget: !rem.From.Module.IsRoot(),
 		}
 		_, entry.parentChain = urnTypes(string(probeURN))
 		e.dispatcher.putBlock(entry)

--- a/pkg/hcl/run/removed.go
+++ b/pkg/hcl/run/removed.go
@@ -19,9 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/hcl/v2"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
 )
@@ -42,68 +39,35 @@ func (e *Engine) recordRemovedBlockEntries(ctx context.Context) error {
 		if !rem.Destroy || len(rem.Provisioners) == 0 {
 			continue
 		}
-		module, typ, name, err := removedResourceAddr(rem.From)
+		resSchema, err := e.resolver.ResolveResource(ctx, rem.From.Type)
 		if err != nil {
-			return err
+			return fmt.Errorf("removed block for %s: resolving resource type: %w", rem.From, err)
 		}
-		resSchema, err := e.resolver.ResolveResource(ctx, typ)
-		if err != nil {
-			return fmt.Errorf("removed block for %s.%s: resolving resource type: %w", typ, name, err)
+		module := modulepath.Root()
+		for _, s := range rem.From.Modules {
+			module = module.Append(s)
 		}
 		res := &ast.Resource{
-			Type:         typ,
-			Name:         name,
+			Type:         rem.From.Type,
+			Name:         rem.From.Name,
 			Provisioners: rem.Provisioners,
 			DeclRange:    rem.DeclRange,
 		}
-		e.recordRemovedEntry(ctx, res, resSchema, module)
+		probeURN, probeName := e.resmon.ResolveURN(e.stackURN, resSchema.Token, "probe")
+		entry := &blockEntry{
+			resmon:       e.resmon,
+			dryRun:       e.dryRun,
+			res:          res,
+			resSchema:    resSchema,
+			mapping:      e.resolver.ResourceBodyMapping(ctx, rem.From.Type),
+			token:        resSchema.Token,
+			prefix:       strings.TrimSuffix(probeName, "probe"),
+			evalCtx:      e.evaluator.Context(),
+			config:       modulepath.NewAddress(module, modulepath.NewStep(rem.From.Name)),
+			moduleTarget: !module.IsRoot(),
+		}
+		_, entry.parentChain = urnTypes(string(probeURN))
+		e.dispatcher.putBlock(entry)
 	}
 	return nil
-}
-
-// recordRemovedEntry records the dispatch entry for a removed block's
-// resource address. The entry carries no module instance scope: a
-// module-qualified orphan evaluates its provisioners in the strict destroy
-// scope (self, count.index, each.key, path.*, terraform.*).
-func (e *Engine) recordRemovedEntry(
-	ctx context.Context, res *ast.Resource, resSchema *schema.Resource, module modulepath.Path,
-) {
-	probeURN, probeName := e.resmon.ResolveURN(e.stackURN, resSchema.Token, "probe")
-	entry := &blockEntry{
-		resmon:       e.resmon,
-		dryRun:       e.dryRun,
-		res:          res,
-		resSchema:    resSchema,
-		mapping:      e.resolver.ResourceBodyMapping(ctx, res.Type),
-		token:        resSchema.Token,
-		prefix:       strings.TrimSuffix(probeName, "probe"),
-		evalCtx:      e.evaluator.Context(),
-		config:       modulepath.NewAddress(module, modulepath.NewStep(res.Name)),
-		moduleTarget: !module.IsRoot(),
-	}
-	_, entry.parentChain = urnTypes(string(probeURN))
-	e.dispatcher.putBlock(entry)
-}
-
-// removedResourceAddr splits a removed block's root-relative "from" traversal
-// into the enclosing module config path and the resource type and name.
-func removedResourceAddr(from hcl.Traversal) (module modulepath.Path, typ, name string, err error) {
-	var names []string
-	for _, step := range from {
-		switch s := step.(type) {
-		case hcl.TraverseRoot:
-			names = append(names, s.Name)
-		case hcl.TraverseAttr:
-			names = append(names, s.Name)
-		}
-	}
-	module = modulepath.Root()
-	for len(names) >= 2 && names[0] == "module" {
-		module = module.Append(modulepath.NewStep(names[1]))
-		names = names[2:]
-	}
-	if len(names) != 2 {
-		return module, "", "", fmt.Errorf("removed block: expected a resource address (type.name)")
-	}
-	return module, names[0], names[1], nil
 }

--- a/pkg/hcl/run/removed.go
+++ b/pkg/hcl/run/removed.go
@@ -1,0 +1,121 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/packages"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/provisioner/runtime"
+)
+
+// registerRemovedProvisionerHooks registers the destroy-time provisioners
+// declared in removed blocks. The engine destroys a resource absent from the
+// program on its own; what it cannot do alone is resolve the BeforeDelete
+// hook names recorded in the resource's state — every recorded name must be
+// registered in this run's hook registry or the delete fails. Each
+// removed-block provisioner is therefore registered under the name the
+// resource bound while it was still declared:
+// "<type>.<name>:provisioner:<i>" (see bindProvisionerHooks).
+//
+// ponytail: names are matched by position — provisioner i in the removed
+// block must have been provisioner i on the resource, which holds when the
+// resource's provisioners were all destroy-time and moved over in order. A
+// resource that mixed create and destroy provisioners records shifted
+// indexes and needs state-aware naming to line up; its delete fails loudly
+// with "hook not registered". Instance-keyed names (count/for_each) are
+// similarly out of reach.
+func (e *Engine) registerRemovedProvisionerHooks(ctx context.Context) error {
+	for _, rem := range e.config.Removed {
+		// A destroy = false block already carries a parse-time error
+		// diagnostic; its provisioners must not run.
+		if !rem.Destroy || len(rem.Provisioners) == 0 {
+			continue
+		}
+		typ, name, err := removedResourceAddr(rem.From)
+		if err != nil {
+			return err
+		}
+		resSchema, err := e.resolver.ResolveResource(ctx, typ)
+		if err != nil {
+			return fmt.Errorf("removed block for %s.%s: resolving resource type: %w", typ, name, err)
+		}
+		mapping := e.resolver.ResourceBodyMapping(ctx, typ)
+		hclSnapshot := e.evaluator.Context().HCLContext()
+		dryRun := e.dryRun
+
+		for i, prov := range rem.Provisioners {
+			prov, index := prov, i+1
+			spec := &runtime.Spec{
+				Type:   prov.Type,
+				Config: prov.Config,
+			}
+			if prov.Connection != nil {
+				spec.Conn = prov.Connection.Config
+			}
+			onFailureContinue := prov.OnFailure == "continue"
+			hookName := fmt.Sprintf("%s.%s:provisioner:%d", typ, name, i)
+			errLabel := fmt.Sprintf("removed %s.%s", typ, name)
+
+			callback := func(hookCtx context.Context, args *ResourceHookArgs) error {
+				outputs := args.OldOutputs
+				// terraform_data's output mirrors input
+				// (lowerTerraformDataOutputs); its triggers_replace echo needs
+				// the registration-time trigger tuple, which a removed
+				// resource no longer has, so a reference to it fails to
+				// evaluate rather than reporting a fabricated value.
+				if typ == packages.TerraformDataType {
+					outputs = outputs.Set("output", outputs.Get("input"))
+				}
+				selfCtx, err := selfBoundEvalCtx(hclSnapshot, outputs, args.ID, args.URN, typ, resSchema, mapping, dryRun)
+				if err != nil {
+					return fmt.Errorf("provisioner %d for %s: %w", index, errLabel, err)
+				}
+				if runErr := runtime.Run(hookCtx, spec, selfCtx); runErr != nil {
+					if onFailureContinue {
+						return nil
+					}
+					return fmt.Errorf("provisioner %d (%s) for %s: %w",
+						index, prov.Type, errLabel, runErr)
+				}
+				return nil
+			}
+
+			if err := e.resmon.RegisterResourceHook(ctx, hookName, callback, ResourceHookOptions{
+				OnDryRun: false, // TF doesn't run provisioners during plan.
+			}); err != nil {
+				return fmt.Errorf("registering removed-block provisioner hook: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// removedResourceAddr splits a removed block's "from" traversal into resource
+// type and name. The parser has already rejected the address shapes that
+// cannot carry provisioners (modules, instance keys, data sources).
+func removedResourceAddr(from hcl.Traversal) (typ, name string, err error) {
+	if len(from) == 2 {
+		root, rootOK := from[0].(hcl.TraverseRoot)
+		attr, attrOK := from[1].(hcl.TraverseAttr)
+		if rootOK && attrOK {
+			return root.Name, attr.Name, nil
+		}
+	}
+	return "", "", fmt.Errorf("removed block: expected a root resource address (type.name)")
+}

--- a/pkg/hcl/run/removed.go
+++ b/pkg/hcl/run/removed.go
@@ -38,9 +38,15 @@ import (
 // resource's provisioners were all destroy-time and moved over in order. A
 // resource that mixed create and destroy provisioners records shifted
 // indexes and needs state-aware naming to line up; its delete fails loudly
-// with "hook not registered". Instance-keyed names (count/for_each) are
-// similarly out of reach.
+// with "hook not registered". Instance-keyed names (count/for_each), custom
+// names (pulumi { name = ... }), and addresses renamed by a moved block are
+// similarly out of reach. The converse is silent: a provisioner the resource
+// never bound registers a hook no state entry references, so the engine
+// never invokes it — a provisioner first introduced in the removed block
+// does not run.
 func (e *Engine) registerRemovedProvisionerHooks(ctx context.Context) error {
+	hclSnapshot := e.evaluator.Context().HCLContext()
+	dryRun := e.dryRun
 	for _, rem := range e.config.Removed {
 		// A destroy = false block already carries a parse-time error
 		// diagnostic; its provisioners must not run.
@@ -56,8 +62,6 @@ func (e *Engine) registerRemovedProvisionerHooks(ctx context.Context) error {
 			return fmt.Errorf("removed block for %s.%s: resolving resource type: %w", typ, name, err)
 		}
 		mapping := e.resolver.ResourceBodyMapping(ctx, typ)
-		hclSnapshot := e.evaluator.Context().HCLContext()
-		dryRun := e.dryRun
 
 		for i, prov := range rem.Provisioners {
 			prov, index := prov, i+1

--- a/pkg/hcl/run/removed.go
+++ b/pkg/hcl/run/removed.go
@@ -27,15 +27,11 @@ import (
 )
 
 // recordRemovedBlockEntries records a destroy-dispatcher entry for each
-// removed block that carries provisioners, from the graph's merged list:
-// every block in the module tree, child-declared addresses rewritten to be
-// root-relative. The engine destroys a resource absent from the program on
-// its own and invokes the constant [destroyProvisionerHook] recorded in its
-// state; the dispatcher matches the orphan to the removed block by config
-// address (see [DestroyDispatcher]) and runs the block's provisioners,
-// instance keys included. A resource whose state never recorded the hook —
-// it had no destroy-time provisioners when last registered — deletes without
-// running the removed block's provisioners.
+// removed block in the module tree that carries provisioners, so the
+// provisioners run when the engine deletes the orphaned instances. A resource
+// whose state never recorded [destroyProvisionerHook] — it had no
+// destroy-time provisioners when last registered — deletes without running
+// the removed block's provisioners.
 func (e *Engine) recordRemovedBlockEntries(ctx context.Context) error {
 	if e.resmon == nil {
 		return nil
@@ -66,10 +62,9 @@ func (e *Engine) recordRemovedBlockEntries(ctx context.Context) error {
 }
 
 // recordRemovedEntry records the dispatch entry for a removed block's
-// resource address. Unlike a live block's entry it carries no module instance
-// scope — a module-qualified orphan evaluates its provisioners in TF's
-// destroy scope (self, count.index, each.key, path.*, terraform.*), which is
-// also all TF allows a removed block's provisioners to reference.
+// resource address. The entry carries no module instance scope: a
+// module-qualified orphan evaluates its provisioners in the strict destroy
+// scope (self, count.index, each.key, path.*, terraform.*).
 func (e *Engine) recordRemovedEntry(
 	ctx context.Context, res *ast.Resource, resSchema *schema.Resource, module modulepath.Path,
 ) {
@@ -91,9 +86,7 @@ func (e *Engine) recordRemovedEntry(
 }
 
 // removedResourceAddr splits a removed block's root-relative "from" traversal
-// into the enclosing module config path and the resource type and name. The
-// parser has already rejected the address shapes that cannot carry
-// provisioners (whole modules, instance keys, data sources).
+// into the enclosing module config path and the resource type and name.
 func removedResourceAddr(from hcl.Traversal) (module modulepath.Path, typ, name string, err error) {
 	var names []string
 	for _, step := range from {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2129,124 +2129,6 @@ func (e *Engine) buildResourceOptionsInContext(
 	return opts, nil
 }
 
-// targetAddr is a parsed `moved` or `import` block address: optional
-// module-call steps followed by an optional resource. A whole-module-call
-// address (e.g. `module.a`) has an empty Type.
-type targetAddr struct {
-	modules  []modulepath.Step // module-call steps, outermost first
-	Type     string            // resource type, or "" for a whole-module-call address
-	Name     string            // resource name
-	keyIndex *int              // count instance key, if the address is keyed by count
-	keyEach  *string           // for_each instance key, if the address is keyed by for_each
-}
-
-// keyed reports whether the address names a specific count/for_each instance.
-func (a targetAddr) keyed() bool { return a.keyIndex != nil || a.keyEach != nil }
-
-// parseTargetAddr decodes a `moved` or `import` address traversal into its
-// module-call steps and (optional) resource. It returns false for a traversal
-// it cannot model.
-func parseTargetAddr(t hcl.Traversal) (targetAddr, bool) {
-	var a targetAddr
-	head := func(step hcl.Traverser) (string, bool) {
-		switch s := step.(type) {
-		case hcl.TraverseRoot:
-			return s.Name, true
-		case hcl.TraverseAttr:
-			return s.Name, true
-		}
-		return "", false
-	}
-	i := 0
-	for i < len(t) {
-		name, ok := head(t[i])
-		if !ok || name != "module" {
-			break
-		}
-		i++
-		if i >= len(t) {
-			return a, false
-		}
-		modName, ok := head(t[i])
-		if !ok {
-			return a, false
-		}
-		i++
-		step := modulepath.NewStep(modName)
-		if i < len(t) {
-			if idx, ok := t[i].(hcl.TraverseIndex); ok {
-				keyed, ok := moduleStepFor(modName, idx.Key)
-				if !ok {
-					return a, false
-				}
-				step = keyed
-				i++
-			}
-		}
-		a.modules = append(a.modules, step)
-	}
-	if i >= len(t) {
-		// Whole-module-call address (no trailing resource).
-		return a, len(a.modules) > 0
-	}
-	typ, ok := head(t[i])
-	if !ok {
-		return a, false
-	}
-	i++
-	if i >= len(t) {
-		return a, false
-	}
-	name, ok := head(t[i])
-	if !ok {
-		return a, false
-	}
-	i++
-	a.Type, a.Name = typ, name
-	if i < len(t) {
-		if idx, ok := t[i].(hcl.TraverseIndex); ok {
-			a.keyIndex, a.keyEach = instanceKeyFromCty(idx.Key)
-			i++
-		}
-	}
-	return a, i == len(t)
-}
-
-// instanceKeyFromCty decodes an instance-key value into its typed components: a
-// count index for a number, a for_each key for a string. Both are nil for any
-// other type, which the caller treats as an unkeyed address.
-func instanceKeyFromCty(v cty.Value) (index *int, eachKey *string) {
-	switch v.Type() {
-	case cty.Number:
-		iv, _ := v.AsBigFloat().Int64()
-		n := int(iv)
-		return &n, nil
-	case cty.String:
-		s := v.AsString()
-		return nil, &s
-	default:
-		return nil, nil
-	}
-}
-
-// moduleStepFor builds a module-call path step for `module.<name>[<key>]`,
-// decoding the count index or for_each key. It returns false for a key that is
-// neither a non-negative integer nor a string.
-func moduleStepFor(name string, key cty.Value) (modulepath.Step, bool) {
-	switch key.Type() {
-	case cty.Number:
-		iv, _ := key.AsBigFloat().Int64()
-		if iv < 0 {
-			return modulepath.Step{}, false
-		}
-		return modulepath.NewIndexedStep(name, int(iv)), true
-	case cty.String:
-		return modulepath.NewKeyedStep(name, key.AsString()), true
-	default:
-		return modulepath.Step{}, false
-	}
-}
-
 // resolveMovedAliases finds the `moved` blocks that rename the resource instance
 // being registered and returns the aliases recording its prior addresses, so a
 // rename is treated as a move rather than a replacement.
@@ -2306,19 +2188,19 @@ func (e *Engine) resolveMovedAliases(
 		work = work[1:]
 		for _, scope := range ancestorPaths(cur.path) {
 			for _, moved := range e.graph.MovedBlocks(scope) {
-				to, ok := parseTargetAddr(moved.To)
+				to, ok := ast.ParseTargetAddr(moved.To)
 				if !ok || to.Type == "" { // skip whole-module-call moves
 					continue
 				}
-				toPath := appendModuleSteps(scope, to.modules)
+				toPath := appendModuleSteps(scope, to.Modules)
 				if toPath != cur.path || to.Type != cur.typ || to.Name != cur.name {
 					continue
 				}
-				from, ok := parseTargetAddr(moved.From)
+				from, ok := ast.ParseTargetAddr(moved.From)
 				if !ok || from.Type == "" {
 					continue
 				}
-				fromPath := appendModuleSteps(scope, from.modules)
+				fromPath := appendModuleSteps(scope, from.Modules)
 
 				// Determine the prior instance key. A keyed endpoint on either side
 				// makes this an instance move taking the prior key from `from` (an
@@ -2328,16 +2210,16 @@ func (e *Engine) resolveMovedAliases(
 				var priorIdx *int
 				var priorEach *string
 				switch {
-				case to.keyed():
-					if !instanceKeysEqual(cur.index, cur.eachKey, to.keyIndex, to.keyEach) {
+				case to.Keyed():
+					if !instanceKeysEqual(cur.index, cur.eachKey, to.KeyIndex, to.KeyEach) {
 						continue
 					}
-					priorIdx, priorEach = from.keyIndex, from.keyEach
-				case from.keyed():
+					priorIdx, priorEach = from.KeyIndex, from.KeyEach
+				case from.Keyed():
 					if cur.index != nil || cur.eachKey != nil {
 						continue
 					}
-					priorIdx, priorEach = from.keyIndex, from.keyEach
+					priorIdx, priorEach = from.KeyIndex, from.KeyEach
 				default:
 					priorIdx, priorEach = cur.index, cur.eachKey
 				}
@@ -2437,20 +2319,20 @@ func (e *Engine) oldModulePaths(path modulepath.Path) []modulepath.Path {
 func (e *Engine) priorModulePath(path modulepath.Path) (_ modulepath.Path, ok bool) {
 	for _, scope := range ancestorPaths(path) {
 		for _, moved := range e.graph.MovedBlocks(scope) {
-			to, ok := parseTargetAddr(moved.To)
-			if !ok || to.Type != "" || len(to.modules) == 0 {
+			to, ok := ast.ParseTargetAddr(moved.To)
+			if !ok || to.Type != "" || len(to.Modules) == 0 {
 				continue // not a whole-module-call address
 			}
-			from, ok := parseTargetAddr(moved.From)
-			if !ok || from.Type != "" || len(from.modules) == 0 {
+			from, ok := ast.ParseTargetAddr(moved.From)
+			if !ok || from.Type != "" || len(from.Modules) == 0 {
 				continue
 			}
-			toPath := appendModuleSteps(scope, to.modules)
+			toPath := appendModuleSteps(scope, to.Modules)
 			suffix, ok := stripModulePrefix(path, toPath)
 			if !ok {
 				continue
 			}
-			fromPath := appendModuleSteps(scope, from.modules)
+			fromPath := appendModuleSteps(scope, from.Modules)
 			for _, s := range suffix {
 				fromPath = fromPath.Append(s)
 			}
@@ -2657,15 +2539,15 @@ func (e *Engine) matchImport(
 	if diags.HasErrors() {
 		return "", false, diags
 	}
-	to, ok := parseTargetAddr(traversal)
+	to, ok := ast.ParseTargetAddr(traversal)
 	if !ok || to.Type != res.Type || to.Name != res.Name {
 		return "", false, nil
 	}
-	if appendModuleSteps(modulepath.Root(), to.modules) != resPath {
+	if appendModuleSteps(modulepath.Root(), to.Modules) != resPath {
 		return "", false, nil
 	}
-	if to.keyed() || index != nil || eachKey != nil {
-		if !instanceKeysEqual(index, eachKey, to.keyIndex, to.keyEach) {
+	if to.Keyed() || index != nil || eachKey != nil {
+		if !instanceKeysEqual(index, eachKey, to.KeyIndex, to.KeyEach) {
 			return "", false, nil
 		}
 	}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2192,7 +2192,7 @@ func (e *Engine) resolveMovedAliases(
 				if !ok || to.Type == "" { // skip whole-module-call moves
 					continue
 				}
-				toPath := appendModuleSteps(scope, to.Modules)
+				toPath := scope.Join(to.Module)
 				if toPath != cur.path || to.Type != cur.typ || to.Name != cur.name {
 					continue
 				}
@@ -2200,7 +2200,7 @@ func (e *Engine) resolveMovedAliases(
 				if !ok || from.Type == "" {
 					continue
 				}
-				fromPath := appendModuleSteps(scope, from.Modules)
+				fromPath := scope.Join(from.Module)
 
 				// Determine the prior instance key. A keyed endpoint on either side
 				// makes this an instance move taking the prior key from `from` (an
@@ -2320,19 +2320,19 @@ func (e *Engine) priorModulePath(path modulepath.Path) (_ modulepath.Path, ok bo
 	for _, scope := range ancestorPaths(path) {
 		for _, moved := range e.graph.MovedBlocks(scope) {
 			to, ok := ast.ParseTargetAddr(moved.To)
-			if !ok || to.Type != "" || len(to.Modules) == 0 {
+			if !ok || to.Type != "" || to.Module.IsRoot() {
 				continue // not a whole-module-call address
 			}
 			from, ok := ast.ParseTargetAddr(moved.From)
-			if !ok || from.Type != "" || len(from.Modules) == 0 {
+			if !ok || from.Type != "" || from.Module.IsRoot() {
 				continue
 			}
-			toPath := appendModuleSteps(scope, to.Modules)
+			toPath := scope.Join(to.Module)
 			suffix, ok := stripModulePrefix(path, toPath)
 			if !ok {
 				continue
 			}
-			fromPath := appendModuleSteps(scope, from.Modules)
+			fromPath := scope.Join(from.Module)
 			for _, s := range suffix {
 				fromPath = fromPath.Append(s)
 			}
@@ -2428,14 +2428,6 @@ func ancestorPaths(p modulepath.Path) []modulepath.Path {
 	}
 	slices.Reverse(chain)
 	return chain
-}
-
-// appendModuleSteps extends base by the module-call steps of a moved address.
-func appendModuleSteps(base modulepath.Path, steps []modulepath.Step) modulepath.Path {
-	for _, s := range steps {
-		base = base.Append(s)
-	}
-	return base
 }
 
 // instanceKeysEqual reports whether two resource instance keys name the same
@@ -2543,7 +2535,7 @@ func (e *Engine) matchImport(
 	if !ok || to.Type != res.Type || to.Name != res.Name {
 		return "", false, nil
 	}
-	if appendModuleSteps(modulepath.Root(), to.Modules) != resPath {
+	if to.Module != resPath {
 		return "", false, nil
 	}
 	if to.Keyed() || index != nil || eachKey != nil {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -719,6 +719,12 @@ func (e *Engine) Run(ctx context.Context) error {
 		return err
 	}
 
+	// The engine deletes removed-block resources after the program exits;
+	// their destroy-time provisioners must be in the hook registry by then.
+	if err := e.registerRemovedProvisionerHooks(ctx); err != nil {
+		return err
+	}
+
 	// Collect errors from resources that failed to register but were not fatal
 	// (i.e., we continued processing to allow independent resources to proceed).
 	nodeErrs := slices.Collect(e.failedNodes.Values())

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -720,8 +720,8 @@ func (e *Engine) Run(ctx context.Context) error {
 	}
 
 	// The engine deletes removed-block resources after the program exits;
-	// their destroy-time provisioners must be in the hook registry by then.
-	if err := e.registerRemovedProvisionerHooks(ctx); err != nil {
+	// their dispatcher entries must be recorded by then.
+	if err := e.recordRemovedBlockEntries(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/server/removed_requirements_test.go
+++ b/pkg/server/removed_requirements_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
+)
+
+// A configuration whose only mention of a provider is a removed block still
+// requires that provider: the block's provisioners resolve the removed
+// resource's schema at run time.
+func TestCollectRequirementsRemovedBlock(t *testing.T) {
+	t.Parallel()
+
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(`
+removed {
+  from = simple_resource.a
+
+  lifecycle {
+    destroy = true
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "true"
+  }
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	tf, pulumiPkgs, aliases := collectRequirements(t.Context(), nil, config, "")
+	assert.Equal(t, []string{"hashicorp/simple"}, slices.Sorted(maps.Keys(tf)))
+	assert.Equal(t, map[string]*ast.RequiredProvider{"simple": nil}, aliases)
+	assert.Empty(t, pulumiPkgs)
+}

--- a/pkg/server/removed_requirements_test.go
+++ b/pkg/server/removed_requirements_test.go
@@ -53,3 +53,31 @@ removed {
 	assert.Equal(t, map[string]*ast.RequiredProvider{"simple": nil}, aliases)
 	assert.Empty(t, pulumiPkgs)
 }
+
+// A removed block whose target sits under a gone module call is the config's
+// only mention of the provider; the module-prefixed address still yields the
+// requirement.
+func TestCollectRequirementsRemovedBlockModulePrefixed(t *testing.T) {
+	t.Parallel()
+
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(`
+removed {
+  from = module.gone.simple_resource.a
+
+  lifecycle {
+    destroy = true
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "true"
+  }
+}
+`))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	tf, pulumiPkgs, aliases := collectRequirements(t.Context(), nil, config, "")
+	assert.Equal(t, []string{"hashicorp/simple"}, slices.Sorted(maps.Keys(tf)))
+	assert.Equal(t, map[string]*ast.RequiredProvider{"simple": nil}, aliases)
+	assert.Empty(t, pulumiPkgs)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/codegen"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/bridge"
@@ -492,9 +493,23 @@ func collectRequirementsRec(
 	}
 	// A removed block's provisioners resolve the removed resource's schema at
 	// run time, so its provider is required even with no resource block left.
+	// A module-prefixed target may name a module call that is itself gone, so
+	// the type falls back to this config's provider names.
 	for _, rem := range config.Removed {
-		if len(rem.From) == 2 && rem.From.RootName() != "module" {
-			addType(rem.From.RootName())
+		names := make([]string, 0, len(rem.From))
+		for _, step := range rem.From {
+			switch s := step.(type) {
+			case hcl.TraverseRoot:
+				names = append(names, s.Name)
+			case hcl.TraverseAttr:
+				names = append(names, s.Name)
+			}
+		}
+		for len(names) >= 2 && names[0] == "module" {
+			names = names[2:]
+		}
+		if len(names) == 2 {
+			addType(names[0])
 		}
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/codegen"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/bridge"
@@ -496,20 +495,8 @@ func collectRequirementsRec(
 	// A module-prefixed target may name a module call that is itself gone, so
 	// the type falls back to this config's provider names.
 	for _, rem := range config.Removed {
-		names := make([]string, 0, len(rem.From))
-		for _, step := range rem.From {
-			switch s := step.(type) {
-			case hcl.TraverseRoot:
-				names = append(names, s.Name)
-			case hcl.TraverseAttr:
-				names = append(names, s.Name)
-			}
-		}
-		for len(names) >= 2 && names[0] == "module" {
-			names = names[2:]
-		}
-		if len(names) == 2 {
-			addType(names[0])
+		if rem.From.Type != "" {
+			addType(rem.From.Type)
 		}
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -490,6 +490,13 @@ func collectRequirementsRec(
 			pulumi[run.TerraformStatePackage] = run.TerraformStatePackageVersion
 		}
 	}
+	// A removed block's provisioners resolve the removed resource's schema at
+	// run time, so its provider is required even with no resource block left.
+	for _, rem := range config.Removed {
+		if len(rem.From) == 2 && rem.From.RootName() != "module" {
+			addType(rem.From.RootName())
+		}
+	}
 
 	if loader == nil {
 		return

--- a/tests/tfcompat/l2_removed_module_test.go
+++ b/tests/tfcompat/l2_removed_module_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// Removed blocks for resources inside modules, in every declaration shape:
+// the child module declares the removal of its own resource, the root
+// declares a module-prefixed removal into a still-live module, and the root
+// declares a removal under a module call that is itself gone. Stage 2's
+// outputs read the marker each removed block's destroy-time provisioner
+// touched in stage 1.
+func TestL2RemovedModule(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_removed_module", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{}, {}, {}},
+	})
+}

--- a/tests/tfcompat/l2_removed_test.go
+++ b/tests/tfcompat/l2_removed_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A resource with a destroy-time provisioner and one without are both deleted
+// via removed blocks with destroy = true. The provisioner moves into the
+// removed block along with the resource's removal and must still run at
+// destroy: stage 2's output reads the marker file it touched in each
+// runtime's own working directory.
+func TestL2Removed(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_removed", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{{}, {}, {}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_removed/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_removed/0/main.tf
@@ -1,0 +1,14 @@
+# The marker lands under .terraform/ because that directory survives between
+# stages in both runtimes' working directories.
+resource "simple_resource" "a" {
+  input_one = "plain-a"
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "mkdir -p '${path.cwd}/.terraform' && touch '${path.cwd}/.terraform/removed-marker'"
+  }
+}
+
+resource "simple_resource" "b" {
+  input_one = "plain-b"
+}

--- a/tests/tfcompat/testdata/cases/l2_removed/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_removed/1/main.tf
@@ -1,0 +1,20 @@
+removed {
+  from = simple_resource.a
+
+  lifecycle {
+    destroy = true
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "mkdir -p '${path.cwd}/.terraform' && touch '${path.cwd}/.terraform/removed-marker'"
+  }
+}
+
+removed {
+  from = simple_resource.b
+
+  lifecycle {
+    destroy = true
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_removed/2/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_removed/2/main.tf
@@ -1,0 +1,5 @@
+# True only if the removed block's destroy-time provisioner ran in stage 1;
+# each runtime checks its own working directory's marker.
+output "provisioner_ran" {
+  value = fileexists("${path.cwd}/.terraform/removed-marker")
+}

--- a/tests/tfcompat/testdata/cases/l2_removed_module/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_removed_module/0/main.tf
@@ -1,0 +1,7 @@
+module "m" {
+  source = "./mod"
+}
+
+module "n" {
+  source = "./modn"
+}

--- a/tests/tfcompat/testdata/cases/l2_removed_module/0/mod/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_removed_module/0/mod/main.tf
@@ -1,0 +1,19 @@
+# The markers land under .terraform/ because that directory survives between
+# stages in both runtimes' working directories.
+resource "simple_resource" "a" {
+  input_one = "child-a"
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "mkdir -p '${path.cwd}/.terraform' && touch '${path.cwd}/.terraform/removed-marker-child'"
+  }
+}
+
+resource "simple_resource" "b" {
+  input_one = "child-b"
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "mkdir -p '${path.cwd}/.terraform' && touch '${path.cwd}/.terraform/removed-marker-root'"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_removed_module/0/modn/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_removed_module/0/modn/main.tf
@@ -1,0 +1,8 @@
+resource "simple_resource" "c" {
+  input_one = "gone-c"
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "mkdir -p '${path.cwd}/.terraform' && touch '${path.cwd}/.terraform/removed-marker-gone'"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_removed_module/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_removed_module/1/main.tf
@@ -1,0 +1,31 @@
+module "m" {
+  source = "./mod"
+}
+
+# The declaring module (m) still exists but no longer declares the resource.
+removed {
+  from = module.m.simple_resource.b
+
+  lifecycle {
+    destroy = true
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "mkdir -p '${path.cwd}/.terraform' && touch '${path.cwd}/.terraform/removed-marker-root'"
+  }
+}
+
+# The whole module call (n) is gone along with the resource.
+removed {
+  from = module.n.simple_resource.c
+
+  lifecycle {
+    destroy = true
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "mkdir -p '${path.cwd}/.terraform' && touch '${path.cwd}/.terraform/removed-marker-gone'"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_removed_module/1/mod/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_removed_module/1/mod/main.tf
@@ -1,0 +1,14 @@
+# The child module declares the removal of its own resource; the address is
+# relative to this module.
+removed {
+  from = simple_resource.a
+
+  lifecycle {
+    destroy = true
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "mkdir -p '${path.cwd}/.terraform' && touch '${path.cwd}/.terraform/removed-marker-child'"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_removed_module/2/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_removed_module/2/main.tf
@@ -1,0 +1,17 @@
+module "m" {
+  source = "./mod"
+}
+
+# True only if the matching removed block's destroy-time provisioner ran in
+# stage 1; each runtime checks its own working directory's markers.
+output "child_declared_ran" {
+  value = fileexists("${path.cwd}/.terraform/removed-marker-child")
+}
+
+output "root_declared_ran" {
+  value = fileexists("${path.cwd}/.terraform/removed-marker-root")
+}
+
+output "gone_module_ran" {
+  value = fileexists("${path.cwd}/.terraform/removed-marker-gone")
+}

--- a/tests/tfcompat/testdata/cases/l2_removed_module/2/mod/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_removed_module/2/mod/main.tf
@@ -1,0 +1,1 @@
+# Intentionally empty: the module's resources were removed in earlier stages.


### PR DESCRIPTION
Related to https://github.com/pulumi-labs/pulumi-hcl/issues/340 (does not close it: the forget case, `destroy = false`, remains unsupported — it now fails with a clear diagnostic instead of the generic unsupported-block error).

## What

Parses `removed` blocks into the AST and supports the `lifecycle { destroy = true }` form, running the block's destroy-time provisioners when the engine deletes the removed resource. Removed blocks work throughout the module tree: declared in child modules (with module-relative addresses), declared at the root targeting resources inside modules, and targeting resources under a module call that is itself gone from the configuration.

- The parser validates the `from` address: resource or module addresses only, no instance keys, no data sources, no malformed shapes (`foo`, `type.name.extra`, incomplete module-prefixed addresses). A removed block whose target is still declared is an error — checked at parse time for same-config addresses and during module inlining for module-prefixed ones, matching OpenTofu (verified against 1.12.3).
- Child-declared removed addresses are rewritten to be root-relative during module inlining, so still-exists validation walks the module tree uniformly at any nesting depth.
- Removed blocks in override files are rejected, matching OpenTofu.
- Duplicate removed blocks for one address are legal (OpenTofu allows them), except when two of them carry provisioners — two provisioner sets for one address would be ambiguous at destroy time, so that errors: at parse time within one configuration, at graph build across configurations (e.g. root and child both declaring provisioners for one address; OpenTofu silently runs only the root's, which looks more like an accident of evaluation order than a contract).
- Provisioner-carrying removed blocks may target resources inside modules; whole-module targets cannot carry provisioners, matching OpenTofu's error.
- Forgetting a resource (`destroy = false` or an omitted `lifecycle` block) has no Pulumi engine mapping; those forms parse with an error diagnostic pointing at `pulumi state delete` as the escape hatch.
- Provisioner execution rides the constant destroy-dispatcher hook from https://github.com/pulumi-labs/pulumi-hcl/pull/462: each provisioner-carrying removed block records a dispatcher block entry synthesized from its root-relative address, and the dispatcher matches the orphaned instances by config address — `count`/`for_each` instance keys, mixed create/destroy provisioner histories, and moved-then-removed addresses all resolve through the same matching the live-block orphan path uses. A module-qualified entry matches without pinning the parent component-type chain: a gone module call's component type names its source, which is no longer knowable, so matching relies on the resource token and the module-qualified name shape (ambiguous matches warn and no-op, as elsewhere in the dispatcher).
- Module-qualified removed provisioners evaluate in the strict destroy scope (`self`, `count.index`, `each.key`, `path.*`, `terraform.*`) — which is also everything OpenTofu allows a removed block's provisioners to reference.
- A configuration whose only mention of a provider is a removed block still requires that provider: removed resource types participate in provider package discovery, at every module level.

## Known limitations

- The engine only invokes the destroy hook recorded in the resource's state. A resource that declared no destroy-time provisioners when last registered never recorded the constant hook, so provisioners first introduced in its removed block do not run (OpenTofu runs whatever the current removed block declares). A resource that had any destroy-time provisioner runs the removed block's current set.
- OpenTofu restricts destroy provisioners to `self`/`count.index`/`each.key` references; pulumi-hcl deliberately allows broader references on the existing resource path (see `TestEngine_ProvisionerRefDependencies`), so root-level removed blocks inherit that pre-existing divergence rather than enforcing the restriction inconsistently. Follow-up material.

## Review

Adversarially reviewed by codex (OpenAI) in two rounds; round 2 concluded with agreement on all dispositions — findings 4, 5, 7, 8 fixed (verified empirically against `tofu` 1.12.3), the rest documented or deferred with concurrence. The subsequent rebase onto the destroy dispatcher (#462) retired the positional hook-naming limitations that round flagged (mixed indexes, `count`/`for_each`, moved addresses), and a follow-up commit removed the child-module limitations (child-declared removed blocks and provisioners targeting module resources), each shape verified against `tofu` 1.12.3 before implementation.

## Testing

- `pkg/hcl/parser`: unit tests for parsing, the `destroy = false` diagnostic, all rejected address/provisioner shapes, override-file rejection, and duplicate handling.
- `pkg/hcl/graph`: module-inlining still-exists validation at every depth, child-declared address rewriting, and cross-configuration duplicate rejection.
- `pkg/server`: provider discovery from removed blocks, including module-prefixed targets.
- `tests/tfcompat/TestL2Removed`: a three-stage compat case — create two resources (one with a destroy-time provisioner), remove both via `removed` blocks, then read a marker file the provisioner touched to prove it ran at destroy in both runtimes.
- `tests/tfcompat/TestL2RemovedModule`: the module shapes in one three-stage case — a child module removing its own resource, the root removing a resource inside a live module, and the root removing a resource under a deleted module call — each proving its destroy-time provisioner ran via a marker file, in both runtimes.
