### PR TITLE
Eagerly reject an unknown provisioner type

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-459.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-459.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Reject an unknown `provisioner` type at preview instead of at apply
+time: 2026-07-27T12:39:44Z
+custom:
+    Component: runtime
+    PR: "459"

--- a/pkg/hcl/run/provisioner.go
+++ b/pkg/hcl/run/provisioner.go
@@ -56,6 +56,9 @@ func (e *Engine) bindProvisionerHooks(
 
 	for i, prov := range res.Provisioners {
 		prov, index := prov, i+1
+		if err := runtime.Validate(prov.Type); err != nil {
+			return fmt.Errorf("provisioner %d for %s: %w", index, instance.Key, err)
+		}
 		spec := &runtime.Spec{
 			Type:   prov.Type,
 			Config: prov.Config,

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -2600,6 +2600,56 @@ resource "aws_instance" "web" {
 	assert.Equal(t, "First\nSecond\n", string(got))
 }
 
+// An unknown provisioner type is rejected when its hook is bound, before the
+// resource is registered — not when the hook would first run at apply.
+func TestEngine_UnknownProvisionerType(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "aws_instance" "web" {
+  ami = "ami-12345"
+
+  provisioner "habitat" {
+    command = "echo hi"
+  }
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "aws",
+			Resources: map[string]schema.ResourceSpec{
+				"aws:index:Instance": {
+					InputProperties: map[string]schema.PropertySpec{
+						"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	err := engine.Run(t.Context())
+	require.ErrorContains(t, err, `unsupported provisioner type: "habitat"`)
+	require.False(t, hasRegisteredResource(mock, "aws:index:Instance"),
+		"resource must not be registered when a provisioner type is unknown")
+}
+
 // TestEngine_ProvisionerReference covers a provisioner whose command
 // interpolates another resource's outputs: the referent must be created
 // first, and its created value must reach the command.

--- a/pkg/provisioner/runtime/runtime.go
+++ b/pkg/provisioner/runtime/runtime.go
@@ -30,15 +30,23 @@ type Spec struct {
 	Conn   hcl.Body // nil for local-exec
 }
 
-func Run(ctx context.Context, spec *Spec, hclCtx *hcl.EvalContext) error {
-	switch spec.Type {
-	case "local-exec":
-		return runLocalExec(ctx, spec, hclCtx)
-	case "remote-exec":
-		return runRemoteExec(ctx, spec, hclCtx)
-	case "file":
-		return runFile(ctx, spec, hclCtx)
-	default:
-		return fmt.Errorf("unsupported provisioner type: %q", spec.Type)
+var runners = map[string]func(context.Context, *Spec, *hcl.EvalContext) error{
+	"local-exec":  runLocalExec,
+	"remote-exec": runRemoteExec,
+	"file":        runFile,
+}
+
+// Validate rejects provisioner types this package cannot run.
+func Validate(typ string) error {
+	if _, ok := runners[typ]; !ok {
+		return fmt.Errorf("unsupported provisioner type: %q", typ)
 	}
+	return nil
+}
+
+func Run(ctx context.Context, spec *Spec, hclCtx *hcl.EvalContext) error {
+	if err := Validate(spec.Type); err != nil {
+		return err
+	}
+	return runners[spec.Type](ctx, spec, hclCtx)
 }


### PR DESCRIPTION
An unknown provisioner type (e.g. `provisioner "habitat"`) previously surfaced only when the hook fired at apply time. It is now rejected while provisioner hooks are bound during resource registration, so preview fails before the resource is registered.

The runtime's dispatch switch became a `runners` map with an exported `runtime.Validate`, keeping the supported-type list in one place; `Run` still checks it. This matches OpenTofu, which rejects an unknown provisioner at plan/validate (`unavailable provisioner "habitat"`) rather than at apply.