### PR TITLE
Type graph node keys as (module path, element id)

### DIFF
--- a/pkg/hcl/graph/classification_test.go
+++ b/pkg/hcl/graph/classification_test.go
@@ -34,18 +34,21 @@ type blockDepsView struct {
 
 func depsView(t *testing.T, g *Graph, key string) blockDepsView {
 	t.Helper()
-	node, ok := g.seen[key]
+	node, ok := g.seen[nk(key)]
 	require.True(t, ok, "no node %q", key)
 	require.NotNil(t, node.n.Deps, "node %q has no classified deps", key)
 	bd := node.n.Deps
-	view := blockDepsView{Whole: slices.Clone(bd.Whole), Narrow: slices.Clone(bd.Narrow)}
+	view := blockDepsView{Narrow: slices.Clone(bd.Narrow)}
 	for _, n := range bd.Static {
-		view.Static = append(view.Static, g.keyByDagNode[n])
+		view.Static = append(view.Static, g.keyByDagNode[n].String())
+	}
+	for _, w := range bd.Whole {
+		view.Whole = append(view.Whole, w.String())
 	}
 	slices.Sort(view.Static)
 	slices.Sort(view.Whole)
 	slices.SortFunc(view.Narrow, func(a, b InstanceDep) int {
-		return cmp.Or(cmp.Compare(a.Key, b.Key), cmp.Compare(a.Suffix, b.Suffix))
+		return cmp.Or(cmp.Compare(a.Key.String(), b.Key.String()), cmp.Compare(a.Suffix, b.Suffix))
 	})
 	return view
 }
@@ -89,11 +92,11 @@ resource "order_resource" "dyn" {
 `)
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: "order_resource.a", Suffix: `["x"]`}},
+		Narrow: []InstanceDep{{Key: nk("order_resource.a"), Suffix: `["x"]`}},
 	}, depsView(t, g, "order_resource.b"))
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: "order_resource.a", Suffix: `[0]`}},
+		Narrow: []InstanceDep{{Key: nk("order_resource.a"), Suffix: `[0]`}},
 	}, depsView(t, g, "order_resource.c"))
 
 	assert.Equal(t, blockDepsView{
@@ -133,7 +136,7 @@ resource "order_resource" "d" {
 `)
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: "order_resource.a", Suffix: `["x"]`}},
+		Narrow: []InstanceDep{{Key: nk("order_resource.a"), Suffix: `["x"]`}},
 	}, depsView(t, g, "order_resource.b"))
 
 	assert.Equal(t, blockDepsView{
@@ -141,7 +144,7 @@ resource "order_resource" "d" {
 	}, depsView(t, g, "order_resource.c"))
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: "order_resource.a", Suffix: `["x"]`}},
+		Narrow: []InstanceDep{{Key: nk("order_resource.a"), Suffix: `["x"]`}},
 	}, depsView(t, g, "order_resource.d"))
 }
 
@@ -186,11 +189,11 @@ data "order_data" "narrow" {
 `)
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: "data.order_data.d", Suffix: `["x"]`}},
+		Narrow: []InstanceDep{{Key: nk("data.order_data.d"), Suffix: `["x"]`}},
 	}, depsView(t, g, "order_resource.b"))
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: "order_resource.a", Suffix: `["x"]`}},
+		Narrow: []InstanceDep{{Key: nk("order_resource.a"), Suffix: `["x"]`}},
 	}, depsView(t, g, "data.order_data.narrow"))
 }
 
@@ -224,7 +227,7 @@ module "m" {
 
 	assert.Equal(t, blockDepsView{
 		Static: []string{"module.m.__init__"},
-		Narrow: []InstanceDep{{Key: "module.m.order_resource.a", Suffix: `["x"]`}},
+		Narrow: []InstanceDep{{Key: nk("module.m.order_resource.a"), Suffix: `["x"]`}},
 	}, depsView(t, g, "module.m.order_resource.b"))
 }
 
@@ -258,7 +261,7 @@ module "m" {
 	require.NoError(t, err)
 	require.Empty(t, g.Validate())
 
-	assert.Equal(t, NodeTypeDataSource, g.seen["module.m.data.order_data.d"].n.Type)
+	assert.Equal(t, NodeTypeDataSource, g.seen[nk("module.m.data.order_data.d")].n.Type)
 	assert.Equal(t, blockDepsView{
 		Static: []string{"module.m.__init__"},
 		Whole:  []string{"module.m.data.order_data.d"},
@@ -289,12 +292,12 @@ resource "order_resource" "b" {
 `)
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: "order_resource.a", Suffix: `["x"]`}},
+		Narrow: []InstanceDep{{Key: nk("order_resource.a"), Suffix: `["x"]`}},
 	}, depsView(t, g, "local.picked"))
 
 	// No block-level edge from the resource to the local: the local's only
 	// build-time prerequisites are its static deps (none here).
-	local, ok := g.seen["local.picked"]
+	local, ok := g.seen[nk("local.picked")]
 	require.True(t, ok)
 	for pred := range g.dag.Predecessors(local.i) {
 		assert.NotEqual(t, "order_resource.a", g.keyByDagNode[pred])
@@ -323,9 +326,9 @@ resource "order_resource" "b" {
 }
 `)
 
-	assert.Equal(t, map[string]bool{
-		"order_resource.a": true,
-		"order_resource.b": true,
+	assert.Equal(t, map[NodeKey]bool{
+		nk("order_resource.a"): true,
+		nk("order_resource.b"): true,
 	}, g.ForcedCreateBeforeDestroy())
 }
 

--- a/pkg/hcl/graph/classification_test.go
+++ b/pkg/hcl/graph/classification_test.go
@@ -29,7 +29,7 @@ import (
 type blockDepsView struct {
 	Static []string
 	Whole  []string
-	Narrow []InstanceDep
+	Narrow []InstanceKey
 }
 
 func depsView(t *testing.T, g *Graph, key string) blockDepsView {
@@ -47,8 +47,8 @@ func depsView(t *testing.T, g *Graph, key string) blockDepsView {
 	}
 	slices.Sort(view.Static)
 	slices.Sort(view.Whole)
-	slices.SortFunc(view.Narrow, func(a, b InstanceDep) int {
-		return cmp.Or(cmp.Compare(a.Key.String(), b.Key.String()), cmp.Compare(a.Suffix, b.Suffix))
+	slices.SortFunc(view.Narrow, func(a, b InstanceKey) int {
+		return cmp.Or(cmp.Compare(a.Node.String(), b.Node.String()), cmp.Compare(a.Suffix, b.Suffix))
 	})
 	return view
 }
@@ -92,11 +92,11 @@ resource "order_resource" "dyn" {
 `)
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: nk("order_resource.a"), Suffix: `["x"]`}},
+		Narrow: []InstanceKey{{Node: nk("order_resource.a"), Suffix: `["x"]`}},
 	}, depsView(t, g, "order_resource.b"))
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: nk("order_resource.a"), Suffix: `[0]`}},
+		Narrow: []InstanceKey{{Node: nk("order_resource.a"), Suffix: `[0]`}},
 	}, depsView(t, g, "order_resource.c"))
 
 	assert.Equal(t, blockDepsView{
@@ -136,7 +136,7 @@ resource "order_resource" "d" {
 `)
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: nk("order_resource.a"), Suffix: `["x"]`}},
+		Narrow: []InstanceKey{{Node: nk("order_resource.a"), Suffix: `["x"]`}},
 	}, depsView(t, g, "order_resource.b"))
 
 	assert.Equal(t, blockDepsView{
@@ -144,7 +144,7 @@ resource "order_resource" "d" {
 	}, depsView(t, g, "order_resource.c"))
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: nk("order_resource.a"), Suffix: `["x"]`}},
+		Narrow: []InstanceKey{{Node: nk("order_resource.a"), Suffix: `["x"]`}},
 	}, depsView(t, g, "order_resource.d"))
 }
 
@@ -189,11 +189,11 @@ data "order_data" "narrow" {
 `)
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: nk("data.order_data.d"), Suffix: `["x"]`}},
+		Narrow: []InstanceKey{{Node: nk("data.order_data.d"), Suffix: `["x"]`}},
 	}, depsView(t, g, "order_resource.b"))
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: nk("order_resource.a"), Suffix: `["x"]`}},
+		Narrow: []InstanceKey{{Node: nk("order_resource.a"), Suffix: `["x"]`}},
 	}, depsView(t, g, "data.order_data.narrow"))
 }
 
@@ -227,7 +227,7 @@ module "m" {
 
 	assert.Equal(t, blockDepsView{
 		Static: []string{"module.m.__init__"},
-		Narrow: []InstanceDep{{Key: nk("module.m.order_resource.a"), Suffix: `["x"]`}},
+		Narrow: []InstanceKey{{Node: nk("module.m.order_resource.a"), Suffix: `["x"]`}},
 	}, depsView(t, g, "module.m.order_resource.b"))
 }
 
@@ -292,7 +292,7 @@ resource "order_resource" "b" {
 `)
 
 	assert.Equal(t, blockDepsView{
-		Narrow: []InstanceDep{{Key: nk("order_resource.a"), Suffix: `["x"]`}},
+		Narrow: []InstanceKey{{Node: nk("order_resource.a"), Suffix: `["x"]`}},
 	}, depsView(t, g, "local.picked"))
 
 	// No block-level edge from the resource to the local: the local's only

--- a/pkg/hcl/graph/default_provider_test.go
+++ b/pkg/hcl/graph/default_provider_test.go
@@ -204,7 +204,7 @@ module "mid" {
 	require.NoError(t, err)
 
 	assert.Empty(t, g.Validate())
-	assert.True(t, g.HasDependents("simple"))
+	assert.True(t, g.HasDependents(nk("simple")))
 }
 
 // TestPassThroughAliasedProviderMissingBlock covers a module call passing an
@@ -304,7 +304,7 @@ module "child" {
 	require.NoError(t, err)
 
 	assert.Empty(t, g.Validate())
-	assert.True(t, g.HasDependents("simple"))
+	assert.True(t, g.HasDependents(nk("simple")))
 
 	order := walkOrder(t, g)
 	assert.Less(t, indexOf(order, "simple"), indexOf(order, "module.child.simple_resource.r"))
@@ -359,7 +359,7 @@ module "child" {
 	require.NoError(t, err)
 
 	assert.Empty(t, g.Validate())
-	assert.True(t, g.HasDependents("simple"))
+	assert.True(t, g.HasDependents(nk("simple")))
 
 	order := walkOrder(t, g)
 	assert.Less(t, indexOf(order, "simple"), indexOf(order, "module.child.simple_resource.r"))

--- a/pkg/hcl/graph/expand.go
+++ b/pkg/hcl/graph/expand.go
@@ -22,11 +22,11 @@ import (
 
 // ExpandedResource represents a single instance of a resource after count/for_each expansion.
 type ExpandedResource struct {
-	// Key is the unique identifier for this instance (e.g., "aws_instance.web[0]" or "aws_instance.web[\"a\"]")
+	// Key is the rendered identifier for this instance (e.g., "aws_instance.web[0]" or "aws_instance.web[\"a\"]")
 	Key string
 
-	// OriginalKey is the key of the original resource before expansion
-	OriginalKey string
+	// Suffix is the instance-key suffix ("[0]", `["a"]`, or "" for a single instance)
+	Suffix string
 
 	// Index is the numeric index for count-based expansion (nil for for_each)
 	Index *int
@@ -53,118 +53,92 @@ type ExpandResult struct {
 // ResourceExpander handles count and for_each expansion.
 type ResourceExpander struct {
 	// countValues maps resource keys to their evaluated count values
-	countValues map[string]int
+	countValues map[NodeKey]int
 
 	// boolCountKeys tracks resources whose count is a bool (0 or 1, single-instance semantics)
-	boolCountKeys map[string]bool
+	boolCountKeys map[NodeKey]bool
 
 	// forEachValues maps resource keys to their evaluated for_each values
-	forEachValues map[string]map[string]cty.Value
+	forEachValues map[NodeKey]map[string]cty.Value
 }
 
 // NewResourceExpander creates a new resource expander.
 func NewResourceExpander() *ResourceExpander {
 	return &ResourceExpander{
-		countValues:   make(map[string]int),
-		boolCountKeys: make(map[string]bool),
-		forEachValues: make(map[string]map[string]cty.Value),
+		countValues:   make(map[NodeKey]int),
+		boolCountKeys: make(map[NodeKey]bool),
+		forEachValues: make(map[NodeKey]map[string]cty.Value),
 	}
 }
 
 // SetCount sets the evaluated count value for a resource.
-func (e *ResourceExpander) SetCount(key string, count int) {
+func (e *ResourceExpander) SetCount(key NodeKey, count int) {
 	e.countValues[key] = count
 }
 
 // SetBoolCount sets a bool-derived count for a resource (0 or 1).
 // When count > 0, produces a single instance with no numeric index suffix.
-func (e *ResourceExpander) SetBoolCount(key string, count int) {
+func (e *ResourceExpander) SetBoolCount(key NodeKey, count int) {
 	e.countValues[key] = count
 	e.boolCountKeys[key] = true
 }
 
 // SetForEach sets the evaluated for_each value for a resource.
-func (e *ResourceExpander) SetForEach(key string, values map[string]cty.Value) {
+func (e *ResourceExpander) SetForEach(key NodeKey, values map[string]cty.Value) {
 	e.forEachValues[key] = values
 }
 
 // Expand expands a resource node into its instances.
 func (e *ResourceExpander) Expand(node *Node) *ExpandResult {
+	single := &ExpandResult{
+		Instances: []*ExpandedResource{{Key: node.Key.String(), Node: node}},
+		IsSingle:  true,
+	}
+
 	// Check for count
 	if count, ok := e.countValues[node.Key]; ok {
 		if count == 0 {
-			return &ExpandResult{
-				Instances: nil,
-				IsSingle:  false,
-			}
+			return &ExpandResult{}
 		}
 
 		// Bool-derived counts produce a single instance without an index suffix.
 		if e.boolCountKeys[node.Key] {
-			return &ExpandResult{
-				Instances: []*ExpandedResource{{
-					Key:         node.Key,
-					OriginalKey: node.Key,
-					Node:        node,
-				}},
-				IsSingle: true,
-			}
+			return single
 		}
 
 		instances := make([]*ExpandedResource, count)
 		for i := range count {
 			idx := i
+			suffix := fmt.Sprintf("[%d]", i)
 			instances[i] = &ExpandedResource{
-				Key:         fmt.Sprintf("%s[%d]", node.Key, i),
-				OriginalKey: node.Key,
-				Index:       &idx,
-				Node:        node,
+				Key:    node.Key.String() + suffix,
+				Suffix: suffix,
+				Index:  &idx,
+				Node:   node,
 			}
 		}
-		return &ExpandResult{
-			Instances: instances,
-			IsSingle:  false,
-		}
+		return &ExpandResult{Instances: instances}
 	}
 
 	// Check for for_each
 	if forEachVals, ok := e.forEachValues[node.Key]; ok {
-		if len(forEachVals) == 0 {
-			return &ExpandResult{
-				Instances: nil,
-				IsSingle:  false,
-			}
-		}
-
 		instances := make([]*ExpandedResource, 0, len(forEachVals))
 		for k, v := range forEachVals {
 			key := cty.StringVal(k)
 			val := v
+			suffix := fmt.Sprintf("[%q]", k)
 			instances = append(instances, &ExpandedResource{
-				Key:         fmt.Sprintf("%s[%q]", node.Key, k),
-				OriginalKey: node.Key,
-				EachKey:     &key,
-				EachValue:   &val,
-				Node:        node,
+				Key:       node.Key.String() + suffix,
+				Suffix:    suffix,
+				EachKey:   &key,
+				EachValue: &val,
+				Node:      node,
 			})
 		}
-		return &ExpandResult{
-			Instances: instances,
-			IsSingle:  false,
-		}
+		return &ExpandResult{Instances: instances}
 	}
 
-	// Single instance
-	return &ExpandResult{
-		Instances: []*ExpandedResource{
-			{
-				Key:         node.Key,
-				OriginalKey: node.Key,
-				Node:        node,
-			},
-		},
-		IsSingle: true,
-	}
+	return single
 }
 
 // EachKeyString returns the for_each instance key as a plain string, or nil for

--- a/pkg/hcl/graph/expand.go
+++ b/pkg/hcl/graph/expand.go
@@ -20,13 +20,18 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// InstanceKey identifies one instance of a block: the block's node key plus
+// the instance suffix ("", "[0]", `["k"]`).
+type InstanceKey struct {
+	Node   NodeKey
+	Suffix string
+}
+
+func (k InstanceKey) String() string { return k.Node.String() + k.Suffix }
+
 // ExpandedResource represents a single instance of a resource after count/for_each expansion.
 type ExpandedResource struct {
-	// Key is the rendered identifier for this instance (e.g., "aws_instance.web[0]" or "aws_instance.web[\"a\"]")
-	Key string
-
-	// Suffix is the instance-key suffix ("[0]", `["a"]`, or "" for a single instance)
-	Suffix string
+	Key InstanceKey
 
 	// Index is the numeric index for count-based expansion (nil for for_each)
 	Index *int
@@ -91,7 +96,7 @@ func (e *ResourceExpander) SetForEach(key NodeKey, values map[string]cty.Value) 
 // Expand expands a resource node into its instances.
 func (e *ResourceExpander) Expand(node *Node) *ExpandResult {
 	single := &ExpandResult{
-		Instances: []*ExpandedResource{{Key: node.Key.String(), Node: node}},
+		Instances: []*ExpandedResource{{Key: InstanceKey{Node: node.Key}, Node: node}},
 		IsSingle:  true,
 	}
 
@@ -109,12 +114,10 @@ func (e *ResourceExpander) Expand(node *Node) *ExpandResult {
 		instances := make([]*ExpandedResource, count)
 		for i := range count {
 			idx := i
-			suffix := fmt.Sprintf("[%d]", i)
 			instances[i] = &ExpandedResource{
-				Key:    node.Key.String() + suffix,
-				Suffix: suffix,
-				Index:  &idx,
-				Node:   node,
+				Key:   InstanceKey{Node: node.Key, Suffix: fmt.Sprintf("[%d]", i)},
+				Index: &idx,
+				Node:  node,
 			}
 		}
 		return &ExpandResult{Instances: instances}
@@ -126,10 +129,8 @@ func (e *ResourceExpander) Expand(node *Node) *ExpandResult {
 		for k, v := range forEachVals {
 			key := cty.StringVal(k)
 			val := v
-			suffix := fmt.Sprintf("[%q]", k)
 			instances = append(instances, &ExpandedResource{
-				Key:       node.Key.String() + suffix,
-				Suffix:    suffix,
+				Key:       InstanceKey{Node: node.Key, Suffix: fmt.Sprintf("[%q]", k)},
 				EachKey:   &key,
 				EachValue: &val,
 				Node:      node,

--- a/pkg/hcl/graph/expansion.go
+++ b/pkg/hcl/graph/expansion.go
@@ -52,7 +52,7 @@ import (
 // expand exec, which the walker cannot start until wiring armed it.
 type BlockExpansion struct {
 	g         *Graph
-	key       string
+	key       NodeKey
 	expand    pdag.Node
 	armExpand pdag.Done
 	complete  pdag.Node
@@ -68,7 +68,7 @@ type BlockExpansion struct {
 // under "<key>!expand" so InjectAfter sees it; skeletons created mid-walk must
 // not touch the interning maps and stay anonymous. expandExec runs on the
 // expand node; finish is deferred around it.
-func (g *Graph) NewBlockExpansion(key string, static bool, expandExec func(context.Context) error) *BlockExpansion {
+func (g *Graph) NewBlockExpansion(key NodeKey, static bool, expandExec func(context.Context) error) *BlockExpansion {
 	b := &BlockExpansion{
 		g:     g,
 		key:   key,
@@ -79,7 +79,7 @@ func (g *Graph) NewBlockExpansion(key string, static bool, expandExec func(conte
 		return expandExec(ctx)
 	}
 	if static {
-		b.expand, b.armExpand = g.internExecNode(key+"!expand", exec)
+		b.expand, b.armExpand = g.internExecNode(NodeKey{Module: key.Module, ID: key.ID + "!expand"}, exec)
 	} else {
 		b.expand, b.armExpand = g.dag.NewNode(dagNode{exec: exec})
 	}
@@ -106,7 +106,7 @@ func (b *BlockExpansion) Complete() pdag.Node { return b.complete }
 // expansion runs — consumers wire during skeleton materialization, which
 // happens before Arm.
 func (b *BlockExpansion) Gate(suffix string) pdag.Node {
-	contract.Assertf(!b.expanded, "gate %q%s requested after expansion", b.key, suffix)
+	contract.Assertf(!b.expanded, "gate %q%s requested after expansion", b.key.String(), suffix)
 	if gate, ok := b.gates[suffix]; ok {
 		return gate
 	}

--- a/pkg/hcl/graph/expansion_test.go
+++ b/pkg/hcl/graph/expansion_test.go
@@ -68,7 +68,7 @@ func TestBlockExpansionGateRunsBeforeDelayedSibling(t *testing.T) {
 	narrowDone := make(chan struct{})
 
 	var b *BlockExpansion
-	b = g.NewBlockExpansion("order_resource.a", false, func(context.Context) error {
+	b = g.NewBlockExpansion(nk("order_resource.a"), false, func(context.Context) error {
 		if err := b.AddInstance(`["x"]`, record(log, "a-x")); err != nil {
 			return err
 		}
@@ -109,7 +109,7 @@ func TestBlockExpansionUnmatchedGateFallsBack(t *testing.T) {
 	log := &eventLog{}
 
 	var b *BlockExpansion
-	b = g.NewBlockExpansion("order_resource.a", false, func(context.Context) error {
+	b = g.NewBlockExpansion(nk("order_resource.a"), false, func(context.Context) error {
 		return b.AddInstance(`[0]`, record(log, "a-0"))
 	})
 
@@ -131,7 +131,7 @@ func TestBlockExpansionExpandErrorDoesNotHang(t *testing.T) {
 
 	expandErr := errors.New("count evaluation failed")
 	var b *BlockExpansion
-	b = g.NewBlockExpansion("order_resource.a", false, func(context.Context) error {
+	b = g.NewBlockExpansion(nk("order_resource.a"), false, func(context.Context) error {
 		if err := b.AddInstance(`[0]`, func(context.Context) error { return nil }); err != nil {
 			return err
 		}
@@ -154,11 +154,11 @@ func TestBlockExpansionStaticInterning(t *testing.T) {
 	t.Parallel()
 	g := NewGraph()
 
-	b := g.NewBlockExpansion("order_resource.a", true, func(context.Context) error { return nil })
+	b := g.NewBlockExpansion(nk("order_resource.a"), true, func(context.Context) error { return nil })
 	b.Arm()
 
-	interned, ok := g.seen["order_resource.a!expand"]
+	interned, ok := g.seen[nk("order_resource.a!expand")]
 	require.True(t, ok)
-	assert.Equal(t, &Node{Key: "order_resource.a!expand", Type: NodeTypeBuiltin}, interned.n)
+	assert.Equal(t, &Node{Key: nk("order_resource.a!expand"), Type: NodeTypeBuiltin}, interned.n)
 	assert.Empty(t, g.Validate())
 }

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -122,17 +122,35 @@ type NodeKey struct {
 
 func (k NodeKey) String() string { return ReferencePrefix(k.Module) + k.ID }
 
-// ResolveRef resolves a scope-relative reference string (as produced by
-// FormatTraversal) to a NodeKey. A reference has at most one leading
-// "module.<name>." hop; a bare "module.<name>" names the call's completion
-// node, which lives in scope itself.
-func ResolveRef(scope modulepath.Path, ref string) NodeKey {
-	if rest, ok := strings.CutPrefix(ref, "module."); ok {
-		if name, id, ok := strings.Cut(rest, "."); ok {
-			return NodeKey{Module: scope.Append(modulepath.NewStep(name)), ID: id}
+// TraversalKey resolves a reference traversal in the module at scope to its
+// node key; ok is false for non-referencing traversals. A `module.<name>`
+// reference names the call's completion node (which lives in scope itself);
+// `module.<name>.<output>` resolves into the child module.
+func TraversalKey(scope modulepath.Path, traversal hcl.Traversal) (NodeKey, bool) {
+	namespace, parts := eval.ParseTraversal(traversal)
+	switch namespace {
+	case "", "path", "terraform", "count", "each", "self", "pulumi":
+	case "data":
+		if len(parts) >= 2 {
+			return NodeKey{Module: scope, ID: "data." + parts[0] + "." + parts[1]}, true
+		}
+	case "module":
+		if len(parts) >= 1 {
+			if out := moduleOutputName(traversal); out != "" {
+				return NodeKey{Module: scope.Append(modulepath.NewStep(parts[0])), ID: "output." + out}, true
+			}
+			return NodeKey{Module: scope, ID: "module." + parts[0]}, true
+		}
+	case "call":
+		if len(parts) >= 2 {
+			return NodeKey{Module: scope, ID: "call." + parts[0] + "." + parts[1]}, true
+		}
+	default: // var, local, and resource references share one shape.
+		if len(parts) >= 1 {
+			return NodeKey{Module: scope, ID: namespace + "." + parts[0]}, true
 		}
 	}
-	return NodeKey{Module: scope, ID: ref}
+	return NodeKey{}, false
 }
 
 // Node represents a node in the dependency graph.
@@ -189,14 +207,7 @@ type Node struct {
 type BlockDeps struct {
 	Static []pdag.Node
 	Whole  []NodeKey
-	Narrow []InstanceDep
-}
-
-// InstanceDep names one instance of a same-scope resource/data block: the
-// block's node key plus the instance's key suffix (`[0]`, `["x"]`).
-type InstanceDep struct {
-	Key    NodeKey
-	Suffix string
+	Narrow []InstanceKey
 }
 
 // NodeType indicates what type of configuration element a node represents.
@@ -448,7 +459,7 @@ func (g *Graph) ForcedCreateBeforeDestroy() map[NodeKey]bool {
 				}
 			}
 			for _, narrow := range n.Deps.Narrow {
-				if in, ok := g.seen[narrow.Key]; ok {
+				if in, ok := g.seen[narrow.Node]; ok {
 					mark(in.i)
 				}
 			}
@@ -928,11 +939,10 @@ func packageNameFromResourceType(token string) string {
 func (g *Graph) traversalDepRefs(path modulepath.Path, traversals ...hcl.Traversal) []depRef {
 	var refs []depRef
 	for _, t := range traversals {
-		ref := FormatTraversal(t)
-		if ref == "" {
+		key, ok := TraversalKey(path, t)
+		if !ok {
 			continue
 		}
-		key := ResolveRef(path, ref)
 		g.recordRef(key, t.SourceRange())
 		refs = append(refs, depRef{key: key, traversal: t})
 	}
@@ -1010,7 +1020,7 @@ type depClassifier struct {
 	seen       map[pdag.Node]bool
 	staticSeen map[pdag.Node]bool
 	wholeSeen  map[NodeKey]bool
-	narrowSeen map[InstanceDep]bool
+	narrowSeen map[InstanceKey]bool
 }
 
 func (g *Graph) newDepClassifier(path modulepath.Path, blockEdges bool) *depClassifier {
@@ -1022,7 +1032,7 @@ func (g *Graph) newDepClassifier(path modulepath.Path, blockEdges bool) *depClas
 		seen:       make(map[pdag.Node]bool),
 		staticSeen: make(map[pdag.Node]bool),
 		wholeSeen:  make(map[NodeKey]bool),
-		narrowSeen: make(map[InstanceDep]bool),
+		narrowSeen: make(map[InstanceKey]bool),
 	}
 }
 
@@ -1067,7 +1077,7 @@ func (c *depClassifier) classify(refs []depRef) {
 // finish subsumes narrow entries under whole-block dependencies and returns
 // the classified deps with the node's edge set.
 func (c *depClassifier) finish() (*BlockDeps, []pdag.Node) {
-	c.bd.Narrow = slices.DeleteFunc(c.bd.Narrow, func(d InstanceDep) bool { return c.wholeSeen[d.Key] })
+	c.bd.Narrow = slices.DeleteFunc(c.bd.Narrow, func(d InstanceKey) bool { return c.wholeSeen[d.Node] })
 	if len(c.bd.Narrow) == 0 {
 		c.bd.Narrow = nil
 	}
@@ -1078,10 +1088,10 @@ func (c *depClassifier) finish() (*BlockDeps, []pdag.Node) {
 // scope at path (sameScope), and if so which instance it addresses: a
 // non-empty Suffix when the traversal indexes the block with a literal string
 // or whole-number key, "" for a whole-block reference.
-func (g *Graph) classifyDep(ref depRef, path modulepath.Path) (id InstanceDep, sameScope bool) {
+func (g *Graph) classifyDep(ref depRef, path modulepath.Path) (id InstanceKey, sameScope bool) {
 	scope := g.scopes[path]
 	if scope == nil || ref.traversal == nil || ref.key.Module != path {
-		return InstanceDep{}, false
+		return InstanceKey{}, false
 	}
 	// The index step follows the two naming steps (type.name), or three for
 	// data sources (data.type.name).
@@ -1090,12 +1100,12 @@ func (g *Graph) classifyDep(ref depRef, path modulepath.Path) (id InstanceDep, s
 	if isData {
 		idxPos = 3
 		if _, ok := scope.config.DataSources[blockKey]; !ok {
-			return InstanceDep{}, false
+			return InstanceKey{}, false
 		}
 	} else if _, ok := scope.config.Resources[ref.key.ID]; !ok {
-		return InstanceDep{}, false
+		return InstanceKey{}, false
 	}
-	return InstanceDep{Key: ref.key, Suffix: literalIndexSuffix(ref.traversal, idxPos)}, true
+	return InstanceKey{Node: ref.key, Suffix: literalIndexSuffix(ref.traversal, idxPos)}, true
 }
 
 // literalIndexSuffix returns the instance-key suffix (`[0]`, `["x"]`) when the
@@ -1349,50 +1359,6 @@ func (g *Graph) providerFunctionDep(path modulepath.Path, providerName string) (
 		}
 	}
 	return NodeKey{}, false
-}
-
-// FormatTraversal converts a traversal to a scope-relative dependency
-// reference string ("" for non-referencing traversals).
-func FormatTraversal(traversal hcl.Traversal) string {
-	if len(traversal) == 0 {
-		return ""
-	}
-
-	namespace, parts := eval.ParseTraversal(traversal)
-
-	switch namespace {
-	case "var", "local", "path", "terraform", "count", "each", "self", "pulumi":
-		// These are handled differently
-		if namespace == "local" && len(parts) >= 1 {
-			return "local." + parts[0]
-		}
-		if namespace == "var" && len(parts) >= 1 {
-			return "var." + parts[0]
-		}
-		return ""
-	case "data":
-		if len(parts) >= 2 {
-			return fmt.Sprintf("data.%s.%s", parts[0], parts[1])
-		}
-	case "module":
-		if len(parts) >= 1 {
-			if out := moduleOutputName(traversal); out != "" {
-				return fmt.Sprintf("module.%s.output.%s", parts[0], out)
-			}
-			return "module." + parts[0]
-		}
-	case "call":
-		if len(parts) >= 2 {
-			return fmt.Sprintf("call.%s.%s", parts[0], parts[1])
-		}
-	default:
-		// Resource reference
-		if len(parts) >= 1 {
-			return fmt.Sprintf("%s.%s", namespace, parts[0])
-		}
-	}
-
-	return ""
 }
 
 // moduleOutputName returns the output name from a `module.NAME[idx].OUTPUT`

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -68,14 +68,9 @@ func (m *ModuleInfo) ModuleName() string {
 	return last.Name()
 }
 
-// Prefix returns the string prefix used to disambiguate node keys
-// belonging to this module from the rest of the graph.
-func (m *ModuleInfo) Prefix() string { return ReferencePrefix(m.Path) }
-
 // ReferencePrefix renders path in the dependency-reference syntax used for
-// graph keys — "module.<name>.module.<name>." — matching how HCL traversals
-// reference module contents, so lookups by string concatenation hit the keys
-// the prefixed nodes were stored under. The root renders "". NOT
+// rendered node keys — "module.<name>.module.<name>." — matching how HCL
+// traversals reference module contents. The root renders "". NOT
 // collision-free ("a.module.b" collides with ["a", "b"]); use Path equality
 // when that matters.
 func ReferencePrefix(path modulepath.Path) string {
@@ -91,16 +86,6 @@ func ReferencePrefix(path modulepath.Path) string {
 		b.WriteByte('.')
 	}
 	return b.String()
-}
-
-// ParentPrefix returns the string prefix of the enclosing module, or "" if
-// this module is at the root of the configuration.
-func (m *ModuleInfo) ParentPrefix() string {
-	parent, _, ok := m.Path.Parent()
-	if !ok {
-		return ""
-	}
-	return ReferencePrefix(parent)
 }
 
 // ParentPath returns the path of the enclosing module, or modulepath.Root() if
@@ -126,10 +111,34 @@ type ModuleLoader interface {
 	LoadModule(source, version, workDir string) (*LoadedModule, error)
 }
 
+// NodeKey identifies a node: the static config path of its containing module
+// (always keyless) plus the element id in scope-relative reference syntax
+// (e.g. "var.x", "data.aws_ami.a", "module.<name>" for a completion node,
+// which lives in the parent module's scope).
+type NodeKey struct {
+	Module modulepath.Path
+	ID     string
+}
+
+func (k NodeKey) String() string { return ReferencePrefix(k.Module) + k.ID }
+
+// ResolveRef resolves a scope-relative reference string (as produced by
+// FormatTraversal) to a NodeKey. A reference has at most one leading
+// "module.<name>." hop; a bare "module.<name>" names the call's completion
+// node, which lives in scope itself.
+func ResolveRef(scope modulepath.Path, ref string) NodeKey {
+	if rest, ok := strings.CutPrefix(ref, "module."); ok {
+		if name, id, ok := strings.Cut(rest, "."); ok {
+			return NodeKey{Module: scope.Append(modulepath.NewStep(name)), ID: id}
+		}
+	}
+	return NodeKey{Module: scope, ID: ref}
+}
+
 // Node represents a node in the dependency graph.
 type Node struct {
-	// Key is the unique identifier for this node (e.g., "aws_instance.web" or "local.common_tags")
-	Key string
+	// Key is the unique identifier for this node
+	Key NodeKey
 
 	// Type indicates what kind of node this is
 	Type NodeType
@@ -179,14 +188,14 @@ type Node struct {
 // Whole binds to the target's completion, Narrow to the gate of one instance.
 type BlockDeps struct {
 	Static []pdag.Node
-	Whole  []string
+	Whole  []NodeKey
 	Narrow []InstanceDep
 }
 
 // InstanceDep names one instance of a same-scope resource/data block: the
 // block's node key plus the instance's key suffix (`[0]`, `["x"]`).
 type InstanceDep struct {
-	Key    string
+	Key    NodeKey
 	Suffix string
 }
 
@@ -239,22 +248,22 @@ func (t NodeType) String() string {
 
 // Graph represents a dependency graph of configuration elements.
 type Graph struct {
-	seen map[string]internedNode
+	seen map[NodeKey]internedNode
 	dag  *pdag.DAG[dagNode]
 
 	// references records the source location(s) at which each node key was
 	// referenced from a user-written traversal. Used by Validate to anchor
 	// errors about unknown nodes back at the offending source.
-	references map[string][]hcl.Range
+	references map[NodeKey][]hcl.Range
 
 	// keyByDagNode lets AddNode resolve each dependency's key so we can
 	// track dependent counts. pdag only exposes node indices, not the
 	// metadata we attached at creation time.
-	keyByDagNode map[pdag.Node]string
+	keyByDagNode map[pdag.Node]NodeKey
 
 	// dependents counts how many other nodes list a given key in their
 	// dependency list. Read by HasDependents at Walk time.
-	dependents map[string]int
+	dependents map[NodeKey]int
 
 	// moved holds the moved blocks of each module keyed by that module's path.
 	// A moved block's from/to addresses are relative to the module it is written
@@ -262,10 +271,10 @@ type Graph struct {
 	// module.
 	moved map[modulepath.Path][]*ast.Moved
 
-	// scopes maps a module's node-key prefix to its scope, so expression-level
-	// dependency extraction (which receives only the prefix) can resolve
-	// provider-defined function calls to the provider block they use.
-	scopes map[string]*moduleScope
+	// scopes maps a module's path to its scope, so expression-level dependency
+	// extraction can resolve provider-defined function calls to the provider
+	// block they use.
+	scopes map[modulepath.Path]*moduleScope
 
 	// missingProviders collects, keyed by provider address, the diagnostics
 	// for module-call `providers` entries that name a provider configuration
@@ -274,7 +283,7 @@ type Graph struct {
 }
 
 type dagNode struct {
-	key  string
+	key  NodeKey
 	exec func(context.Context) error
 }
 
@@ -286,13 +295,13 @@ type internedNode struct {
 // NewGraph creates a new empty graph.
 func NewGraph() *Graph {
 	return &Graph{
-		seen:         make(map[string]internedNode),
+		seen:         make(map[NodeKey]internedNode),
 		dag:          pdag.New[dagNode](),
-		references:   make(map[string][]hcl.Range),
-		keyByDagNode: make(map[pdag.Node]string),
-		dependents:   make(map[string]int),
+		references:   make(map[NodeKey][]hcl.Range),
+		keyByDagNode: make(map[pdag.Node]NodeKey),
+		dependents:   make(map[NodeKey]int),
 		moved:        make(map[modulepath.Path][]*ast.Moved),
-		scopes:       make(map[string]*moduleScope),
+		scopes:       make(map[modulepath.Path]*moduleScope),
 
 		missingProviders: make(map[string]*hcl.Diagnostic),
 	}
@@ -308,7 +317,7 @@ func (g *Graph) MovedBlocks(path modulepath.Path) []*ast.Moved {
 // recordRef records that key was referenced from the given source range.
 // Multiple references to the same key accumulate; this is used by Validate
 // to anchor errors about unknown nodes back to the offending source.
-func (g *Graph) recordRef(key string, rng hcl.Range) {
+func (g *Graph) recordRef(key NodeKey, rng hcl.Range) {
 	g.references[key] = append(g.references[key], rng)
 }
 
@@ -369,7 +378,7 @@ func (g *Graph) InjectAfter(f func(context.Context) error, match func(*Node) boo
 	return nil
 }
 
-func (g *Graph) newNode(key string) (*Node, pdag.Node) {
+func (g *Graph) newNode(key NodeKey) (*Node, pdag.Node) {
 	if n, ok := g.seen[key]; ok {
 		contract.Assertf(n.n.Key == key, "key should not be changed")
 		return n.n, n.i
@@ -406,8 +415,8 @@ func (g *Graph) AddNode(node *Node, deps []pdag.Node) error {
 // it declares create_before_destroy, or when a resource that transitively
 // depends on it does: the behaviour propagates to a resource's dependencies so
 // that every create in a replacement chain runs before any delete.
-func (g *Graph) ForcedCreateBeforeDestroy() map[string]bool {
-	forced := make(map[string]bool)
+func (g *Graph) ForcedCreateBeforeDestroy() map[NodeKey]bool {
+	forced := make(map[NodeKey]bool)
 	visited := make(map[pdag.Node]bool)
 
 	var mark func(node pdag.Node)
@@ -466,12 +475,12 @@ func declaresCreateBeforeDestroy(n *Node) bool {
 // HasDependents reports whether any other node in the graph lists `key` in
 // its dependency list. Used by the engine to skip work for nodes whose
 // output nothing consumes (e.g. unused `provider` blocks).
-func (g *Graph) HasDependents(key string) bool {
+func (g *Graph) HasDependents(key NodeKey) bool {
 	return g.dependents[key] > 0
 }
 
 // KeyNode returns the dag node interned under key.
-func (g *Graph) KeyNode(key string) (pdag.Node, bool) {
+func (g *Graph) KeyNode(key NodeKey) (pdag.Node, bool) {
 	n, ok := g.seen[key]
 	return n.i, ok
 }
@@ -487,7 +496,7 @@ func (g *Graph) ExpandableNodes() []*Node {
 			out = append(out, n.n)
 		}
 	}
-	slices.SortFunc(out, func(a, b *Node) int { return cmp.Compare(a.Key, b.Key) })
+	slices.SortFunc(out, func(a, b *Node) int { return cmp.Compare(a.Key.String(), b.Key.String()) })
 	return out
 }
 
@@ -495,21 +504,22 @@ func (g *Graph) ExpandableNodes() []*Node {
 // moduleLoader is required when config contains modules.
 func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir string) (*Graph, error) {
 	g := NewGraph()
-	g.moved[modulepath.Root()] = config.Moved
+	root := modulepath.Root()
+	g.moved[root] = config.Moved
 	rootScope := &moduleScope{config: config}
-	g.scopes[""] = rootScope
+	g.scopes[root] = rootScope
 
 	contract.AssertNoErrorf(errors.Join(
 		g.AddNode(&Node{
-			Key:  "pulumi.stack",
+			Key:  NodeKey{ID: "pulumi.stack"},
 			Type: NodeTypeBuiltin,
 		}, nil),
 		g.AddNode(&Node{
-			Key:  "pulumi.project",
+			Key:  NodeKey{ID: "pulumi.project"},
 			Type: NodeTypeBuiltin,
 		}, nil),
 		g.AddNode(&Node{
-			Key:  "pulumi.organization",
+			Key:  NodeKey{ID: "pulumi.organization"},
 			Type: NodeTypeBuiltin,
 		}, nil),
 	), "nodes without dependencies cannot error")
@@ -517,7 +527,7 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 	// Variable values come from outside, so a variable depends only on whatever
 	// its validation rules reference (e.g. another variable).
 	for name, v := range config.Variables {
-		if err := g.addVariableNodes("var."+name, v, nil, nil, ""); err != nil {
+		if err := g.addVariableNodes(NodeKey{ID: "var." + name}, v, nil, nil, root); err != nil {
 			return nil, err
 		}
 	}
@@ -528,9 +538,9 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 	// keep block-level edges — references through them widen across module
 	// instances.)
 	for name, local := range config.Locals {
-		bd, deps := g.localDeps(local, "")
+		bd, deps := g.localDeps(local, root)
 		err := g.AddNode(&Node{
-			Key:   "local." + name,
+			Key:   NodeKey{ID: "local." + name},
 			Type:  NodeTypeLocal,
 			Local: local,
 			Deps:  bd,
@@ -542,9 +552,10 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 
 	// Add provider nodes (must come before resources since resources can reference them)
 	for key, provider := range config.Providers {
-		deps := g.providerDeps(provider, key, "")
+		nodeKey := NodeKey{ID: key}
+		deps := g.providerDeps(provider, nodeKey, root)
 		err := g.AddNode(&Node{
-			Key:      key,
+			Key:      nodeKey,
 			Type:     NodeTypeProvider,
 			Provider: provider,
 		}, deps)
@@ -555,12 +566,12 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 
 	// Add resource nodes
 	for key, resource := range config.Resources {
-		bd, deps := g.resourceDeps(resource, "")
-		provDeps := g.defaultProviderDeps(resource, config, "")
+		bd, deps := g.resourceDeps(resource, root)
+		provDeps := g.defaultProviderDeps(resource, config, root)
 		bd.Static = append(bd.Static, provDeps...)
 		deps = append(deps, provDeps...)
 		err := g.AddNode(&Node{
-			Key:      key,
+			Key:      NodeKey{ID: key},
 			Type:     NodeTypeResource,
 			Resource: resource,
 			Deps:     bd,
@@ -572,12 +583,12 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 
 	// Add data source nodes
 	for key, dataSource := range config.DataSources {
-		bd, deps := g.resourceDeps(dataSource, "")
-		provDeps := g.defaultProviderDeps(dataSource, config, "")
+		bd, deps := g.resourceDeps(dataSource, root)
+		provDeps := g.defaultProviderDeps(dataSource, config, root)
 		bd.Static = append(bd.Static, provDeps...)
 		deps = append(deps, provDeps...)
 		err := g.AddNode(&Node{
-			Key:      "data." + key,
+			Key:      NodeKey{ID: "data." + key},
 			Type:     NodeTypeDataSource,
 			Resource: dataSource,
 			Deps:     bd,
@@ -589,20 +600,20 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 
 	// Inline module contents into the graph for fine-grained dependency tracking.
 	for name, module := range config.Modules {
-		if err := g.inlineModule(name, module, modulepath.Root(), moduleLoader, workDir, rootScope); err != nil {
+		if err := g.inlineModule(name, module, root, moduleLoader, workDir, rootScope); err != nil {
 			return nil, fmt.Errorf("inlining module %s: %w", name, err)
 		}
 	}
 
-	if err := g.addCallNodes(config, "", nil); err != nil {
+	if err := g.addCallNodes(config, root, nil); err != nil {
 		return nil, err
 	}
 
 	// Add output nodes
 	for name, output := range config.Outputs {
-		deps := g.outputDeps(output, "")
+		deps := g.outputDeps(output, root)
 		err := g.AddNode(&Node{
-			Key:    "output." + name,
+			Key:    NodeKey{ID: "output." + name},
 			Type:   NodeTypeOutput,
 			Output: output,
 		}, deps)
@@ -650,7 +661,7 @@ func (g *Graph) classifyPlanTimeReads() {
 // internExecNode creates an exec node interned under key (as a Builtin, so
 // pre-walk passes see it but Validate accepts it), leaving arming to the
 // caller.
-func (g *Graph) internExecNode(key string, exec func(context.Context) error) (pdag.Node, pdag.Done) {
+func (g *Graph) internExecNode(key NodeKey, exec func(context.Context) error) (pdag.Node, pdag.Done) {
 	i, done := g.dag.NewNode(dagNode{key: key, exec: exec})
 	g.seen[key] = internedNode{i: i, n: &Node{Key: key, Type: NodeTypeBuiltin}}
 	g.keyByDagNode[i] = key
@@ -660,7 +671,7 @@ func (g *Graph) internExecNode(key string, exec func(context.Context) error) (pd
 // NewJoinNode creates an armed no-op node interned under key, for the engine
 // to use as a synchronization point (edges added via Order).
 func (g *Graph) NewJoinNode(key string) pdag.Node {
-	i, done := g.internExecNode(key, func(context.Context) error { return nil })
+	i, done := g.internExecNode(NodeKey{ID: key}, func(context.Context) error { return nil })
 	done()
 	return i
 }
@@ -675,7 +686,7 @@ func (g *Graph) Order(from, to pdag.Node) error {
 // don't set `provider` explicitly. Without this the engine could process the
 // resource before the default provider finishes registering — the provider
 // block's config would then never make it into the resource.
-func (g *Graph) defaultProviderDeps(resource *ast.Resource, config *ast.Config, prefix string) []pdag.Node {
+func (g *Graph) defaultProviderDeps(resource *ast.Resource, config *ast.Config, path modulepath.Path) []pdag.Node {
 	if resource.Provider != nil {
 		return nil
 	}
@@ -686,21 +697,21 @@ func (g *Graph) defaultProviderDeps(resource *ast.Resource, config *ast.Config, 
 	if _, ok := config.Providers[pkgName]; !ok {
 		return nil
 	}
-	_, idx := g.newNode(prefix + pkgName)
+	_, idx := g.newNode(NodeKey{Module: path, ID: pkgName})
 	return []pdag.Node{idx}
 }
 
-// moduleScope is an ancestor module's node-key prefix and config, linked toward
-// the root via parent. Scopes are immutable once built and shared by reference.
-// mod and parentPrefix describe the module call that instantiated this scope
-// (nil/"" for the root), so pass-through provider references can resolve into
-// the parent scope.
+// moduleScope is an ancestor module's path and config, linked toward the root
+// via parent. Scopes are immutable once built and shared by reference. mod and
+// parentPath describe the module call that instantiated this scope (nil/root
+// for the root), so pass-through provider references can resolve into the
+// parent scope.
 type moduleScope struct {
-	prefix       string
-	config       *ast.Config
-	parent       *moduleScope
-	mod          *ast.Module
-	parentPrefix string
+	path       modulepath.Path
+	config     *ast.Config
+	parent     *moduleScope
+	mod        *ast.Module
+	parentPath modulepath.Path
 }
 
 // inheritedProviderDeps returns an edge to the nearest ancestor's default
@@ -772,12 +783,12 @@ func (g *Graph) resolvePassedProvider(
 		return nil
 	}
 	if _, ok := parent.config.Providers[parentKey]; ok {
-		_, idx := g.newNode(parent.prefix + parentKey)
+		_, idx := g.newNode(NodeKey{Module: parent.path, ID: parentKey})
 		return []pdag.Node{idx}
 	}
 	if parent.mod != nil {
 		if _, ok := parent.mod.Providers[parentKey]; ok {
-			_, idx := g.newNode(parent.prefix + parentKey)
+			_, idx := g.newNode(NodeKey{Module: parent.path, ID: parentKey})
 			return []pdag.Node{idx}
 		}
 	}
@@ -787,7 +798,7 @@ func (g *Graph) resolvePassedProvider(
 			return nil
 		}
 	}
-	addr := fmt.Sprintf("%sprovider[%q]", parent.prefix, ProviderFQN(childConfig.Terraform, strings.SplitN(childKey, ".", 2)[0]))
+	addr := fmt.Sprintf("%sprovider[%q]", ReferencePrefix(parent.path), ProviderFQN(childConfig.Terraform, strings.SplitN(childKey, ".", 2)[0]))
 	if aliased {
 		addr += "." + alias
 	}
@@ -866,12 +877,12 @@ func (g *Graph) defaultProviderNode(name string, s *moduleScope) []pdag.Node {
 	for ; s != nil; s = s.parent {
 		local := LocalProviderName(s.config.Terraform, fqn, name)
 		if _, ok := s.config.Providers[local]; ok {
-			_, idx := g.newNode(s.prefix + local)
+			_, idx := g.newNode(NodeKey{Module: s.path, ID: local})
 			return []pdag.Node{idx}
 		}
 		if s.mod != nil {
 			if _, ok := s.mod.Providers[local]; ok {
-				_, idx := g.newNode(s.prefix + local)
+				_, idx := g.newNode(NodeKey{Module: s.path, ID: local})
 				return []pdag.Node{idx}
 			}
 		}
@@ -912,38 +923,42 @@ func packageNameFromResourceType(token string) string {
 	return strings.SplitN(token, "_", 2)[0]
 }
 
-// resourceDeps extracts all dependencies from a resource, applying prefix to
-// resolved keys. It returns the block-level edge set for the node (unchanged
+// traversalDepRefs resolves reference traversals (depends_on and friends) to
+// depRefs, recording each reference; non-referencing traversals are skipped.
+func (g *Graph) traversalDepRefs(path modulepath.Path, traversals ...hcl.Traversal) []depRef {
+	var refs []depRef
+	for _, t := range traversals {
+		ref := FormatTraversal(t)
+		if ref == "" {
+			continue
+		}
+		key := ResolveRef(path, ref)
+		g.recordRef(key, t.SourceRange())
+		refs = append(refs, depRef{key: key, traversal: t})
+	}
+	return refs
+}
+
+// resourceDeps extracts all dependencies from a resource declared in the
+// module at path. It returns the block-level edge set for the node (unchanged
 // coarse semantics: cycle detection, Validate, and completion ordering all
 // stay block-granular) alongside the same dependencies in classified form for
 // the engine's expansion layer. References in the body, count/for_each, and
 // depends_on classify as whole-block or single-instance; every other
 // dependency kind (provider refs, ResourceParent, DeletedWith, ReplaceWith,
 // replace_triggered_by, aliases) stays static (block-granular).
-func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) (*BlockDeps, []pdag.Node) {
-	c := g.newDepClassifier(prefix, true)
-	addStatic, addStaticRefs, classify := c.addStatic, c.addStaticRefs, c.classify
+func (g *Graph) resourceDeps(resource *ast.Resource, path modulepath.Path) (*BlockDeps, []pdag.Node) {
+	c := g.newDepClassifier(path, true)
 
-	classify(g.exprDepRefs(resource.Count, prefix, nil))
-	classify(g.exprDepRefs(resource.ForEach, prefix, nil))
-	for _, traversal := range resource.DependsOn {
-		if dep := formatTraversal(traversal); dep != "" {
-			g.recordRef(prefix+dep, traversal.SourceRange())
-			classify([]depRef{{key: prefix + dep, traversal: traversal}})
-		}
-	}
+	c.classify(g.exprDepRefs(resource.Count, path, nil))
+	c.classify(g.exprDepRefs(resource.ForEach, path, nil))
+	c.classify(g.traversalDepRefs(path, resource.DependsOn...))
 	if resource.Config != nil {
-		classify(g.bodyDepRefs(resource.Config, prefix, nil))
+		c.classify(g.bodyDepRefs(resource.Config, path, nil))
 	}
 
-	if resource.ResourceParent != nil {
-		if dep := formatTraversal(resource.ResourceParent); dep != "" {
-			g.recordRef(prefix+dep, resource.ResourceParent.SourceRange())
-			_, idx := g.newNode(prefix + dep)
-			addStatic(idx)
-		}
-	}
-	addStaticRefs(g.exprDepRefs(resource.Provider, prefix, nil))
+	c.addStaticRefs(g.traversalDepRefs(path, resource.ResourceParent))
+	c.addStaticRefs(g.exprDepRefs(resource.Provider, path, nil))
 	// A bare `provider = name` reference (no alias) is a single-segment
 	// traversal, which exprDepRefs drops because it carries no attribute after
 	// the root. It names the default configuration, which resolves through
@@ -953,38 +968,20 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) (*BlockDeps,
 	// resolved by exprDepRefs above.
 	if resource.Provider != nil {
 		if vars := resource.Provider.Variables(); len(vars) == 1 && len(vars[0]) == 1 {
-			for _, dep := range g.defaultProviderNode(vars[0].RootName(), g.scopes[prefix]) {
-				addStatic(dep)
+			for _, dep := range g.defaultProviderNode(vars[0].RootName(), g.scopes[path]) {
+				c.addStatic(dep)
 			}
 		}
 	}
-	for _, traversal := range resource.Providers {
-		if dep := formatTraversal(traversal); dep != "" {
-			g.recordRef(prefix+dep, traversal.SourceRange())
-			_, idx := g.newNode(prefix + dep)
-			addStatic(idx)
-		}
-	}
-	if resource.DeletedWith != nil {
-		if dep := formatTraversal(resource.DeletedWith); dep != "" {
-			g.recordRef(prefix+dep, resource.DeletedWith.SourceRange())
-			_, idx := g.newNode(prefix + dep)
-			addStatic(idx)
-		}
-	}
-	for _, traversal := range resource.ReplaceWith {
-		if dep := formatTraversal(traversal); dep != "" {
-			g.recordRef(prefix+dep, traversal.SourceRange())
-			_, idx := g.newNode(prefix + dep)
-			addStatic(idx)
-		}
-	}
+	c.addStaticRefs(g.traversalDepRefs(path, resource.Providers...))
+	c.addStaticRefs(g.traversalDepRefs(path, resource.DeletedWith))
+	c.addStaticRefs(g.traversalDepRefs(path, resource.ReplaceWith...))
 	if resource.Lifecycle != nil {
 		for _, expr := range resource.Lifecycle.ReplaceTriggeredBy {
-			addStaticRefs(g.exprDepRefs(expr, prefix, nil))
+			c.addStaticRefs(g.exprDepRefs(expr, path, nil))
 		}
 	}
-	addStaticRefs(g.exprDepRefs(resource.Aliases, prefix, nil))
+	c.addStaticRefs(g.exprDepRefs(resource.Aliases, path, nil))
 
 	return c.finish()
 }
@@ -993,9 +990,9 @@ func (g *Graph) resourceDeps(resource *ast.Resource, prefix string) (*BlockDeps,
 // returned edge set omits same-scope resource/data blocks entirely: the
 // engine wires those at instance granularity (completion or gate), so the
 // local evaluates as soon as the instances it actually reads are available.
-func (g *Graph) localDeps(local *ast.Local, prefix string) (*BlockDeps, []pdag.Node) {
-	c := g.newDepClassifier(prefix, false)
-	c.classify(g.exprDepRefs(local.Value, prefix, nil))
+func (g *Graph) localDeps(local *ast.Local, path modulepath.Path) (*BlockDeps, []pdag.Node) {
+	c := g.newDepClassifier(path, false)
+	c.classify(g.exprDepRefs(local.Value, path, nil))
 	return c.finish()
 }
 
@@ -1007,24 +1004,24 @@ func (g *Graph) localDeps(local *ast.Local, prefix string) (*BlockDeps, []pdag.N
 // the local's evaluation).
 type depClassifier struct {
 	g          *Graph
-	prefix     string
+	path       modulepath.Path
 	blockEdges bool
 	bd         *BlockDeps
 	seen       map[pdag.Node]bool
 	staticSeen map[pdag.Node]bool
-	wholeSeen  map[string]bool
+	wholeSeen  map[NodeKey]bool
 	narrowSeen map[InstanceDep]bool
 }
 
-func (g *Graph) newDepClassifier(prefix string, blockEdges bool) *depClassifier {
+func (g *Graph) newDepClassifier(path modulepath.Path, blockEdges bool) *depClassifier {
 	return &depClassifier{
 		g:          g,
-		prefix:     prefix,
+		path:       path,
 		blockEdges: blockEdges,
 		bd:         &BlockDeps{},
 		seen:       make(map[pdag.Node]bool),
 		staticSeen: make(map[pdag.Node]bool),
-		wholeSeen:  make(map[string]bool),
+		wholeSeen:  make(map[NodeKey]bool),
 		narrowSeen: make(map[InstanceDep]bool),
 	}
 }
@@ -1047,7 +1044,7 @@ func (c *depClassifier) addStaticRefs(refs []depRef) {
 func (c *depClassifier) classify(refs []depRef) {
 	for _, ref := range refs {
 		_, n := c.g.newNode(ref.key)
-		id, sameScope := c.g.classifyDep(ref, c.prefix)
+		id, sameScope := c.g.classifyDep(ref, c.path)
 		if !sameScope {
 			c.addStatic(n)
 			continue
@@ -1078,25 +1075,24 @@ func (c *depClassifier) finish() (*BlockDeps, []pdag.Node) {
 }
 
 // classifyDep reports whether ref names a resource/data block declared in the
-// scope at prefix (sameScope), and if so which instance it addresses: a
+// scope at path (sameScope), and if so which instance it addresses: a
 // non-empty Suffix when the traversal indexes the block with a literal string
 // or whole-number key, "" for a whole-block reference.
-func (g *Graph) classifyDep(ref depRef, prefix string) (id InstanceDep, sameScope bool) {
-	scope := g.scopes[prefix]
-	if scope == nil || ref.traversal == nil {
+func (g *Graph) classifyDep(ref depRef, path modulepath.Path) (id InstanceDep, sameScope bool) {
+	scope := g.scopes[path]
+	if scope == nil || ref.traversal == nil || ref.key.Module != path {
 		return InstanceDep{}, false
 	}
-	base := strings.TrimPrefix(ref.key, prefix)
 	// The index step follows the two naming steps (type.name), or three for
 	// data sources (data.type.name).
 	idxPos := 2
-	blockKey, isData := strings.CutPrefix(base, "data.")
+	blockKey, isData := strings.CutPrefix(ref.key.ID, "data.")
 	if isData {
 		idxPos = 3
 		if _, ok := scope.config.DataSources[blockKey]; !ok {
 			return InstanceDep{}, false
 		}
-	} else if _, ok := scope.config.Resources[base]; !ok {
+	} else if _, ok := scope.config.Resources[ref.key.ID]; !ok {
 		return InstanceDep{}, false
 	}
 	return InstanceDep{Key: ref.key, Suffix: literalIndexSuffix(ref.traversal, idxPos)}, true
@@ -1127,16 +1123,16 @@ func literalIndexSuffix(t hcl.Traversal, idxPos int) string {
 	return ""
 }
 
-// providerDeps extracts all dependencies from a provider block, applying prefix
-// to resolved keys. key is the block's own node key: a provider config that
+// providerDeps extracts all dependencies from a provider block declared in the
+// module at path. key is the block's own node key: a provider config that
 // calls one of its own provider's functions would otherwise depend on itself.
-func (g *Graph) providerDeps(provider *ast.Provider, key, prefix string) []pdag.Node {
+func (g *Graph) providerDeps(provider *ast.Provider, key NodeKey, path modulepath.Path) []pdag.Node {
 	seen := make(map[pdag.Node]bool)
-	for _, dep := range g.exprDeps(provider.ForEach, prefix) {
+	for _, dep := range g.exprDeps(provider.ForEach, path) {
 		seen[dep] = true
 	}
 	if provider.Config != nil {
-		for _, dep := range g.bodyDeps(provider.Config, prefix, nil) {
+		for _, dep := range g.bodyDeps(provider.Config, path, nil) {
 			seen[dep] = true
 		}
 	}
@@ -1145,25 +1141,24 @@ func (g *Graph) providerDeps(provider *ast.Provider, key, prefix string) []pdag.
 	return slices.Collect(maps.Keys(seen))
 }
 
-// bodyDeps extracts dependencies from an HCL body, applying prefix to resolved keys.
-func (g *Graph) bodyDeps(body hcl.Body, prefix string, exclude map[string]bool) []pdag.Node {
-	return g.refsToNodes(g.bodyDepRefs(body, prefix, exclude))
+// bodyDeps extracts dependencies from an HCL body in the scope at path.
+func (g *Graph) bodyDeps(body hcl.Body, path modulepath.Path, exclude map[string]bool) []pdag.Node {
+	return g.refsToNodes(g.bodyDepRefs(body, path, exclude))
 }
 
-// bodyDepRefs extracts one depRef per referencing traversal in an HCL body,
-// applying prefix to resolved keys.
-func (g *Graph) bodyDepRefs(body hcl.Body, prefix string, exclude map[string]bool) []depRef {
+// bodyDepRefs extracts one depRef per referencing traversal in an HCL body.
+func (g *Graph) bodyDepRefs(body hcl.Body, path modulepath.Path, exclude map[string]bool) []depRef {
 	if eb, ok := body.(*ast.EscapedBody); ok {
 		// Scan the underlying bodies so the native-syntax walk below still
 		// sees dynamic and lifecycle blocks; the merged body hides them.
-		return append(g.bodyDepRefs(eb.Base, prefix, exclude), g.bodyDepRefs(eb.Escape, prefix, exclude)...)
+		return append(g.bodyDepRefs(eb.Base, path, exclude), g.bodyDepRefs(eb.Escape, path, exclude)...)
 	}
 
 	var refs []depRef
 
 	attrs, _ := body.JustAttributes()
 	for _, attr := range attrs {
-		refs = append(refs, g.exprDepRefs(attr.Expr, prefix, exclude)...)
+		refs = append(refs, g.exprDepRefs(attr.Expr, path, exclude)...)
 	}
 
 	if syntaxBody, ok := body.(*hclsyntax.Body); ok {
@@ -1178,7 +1173,7 @@ func (g *Graph) bodyDepRefs(body hcl.Body, prefix string, exclude map[string]boo
 				childExclude := make(map[string]bool, len(exclude)+1)
 				maps.Copy(childExclude, exclude)
 				childExclude[iterName] = true
-				refs = append(refs, g.bodyDepRefs(block.Body, prefix, childExclude)...)
+				refs = append(refs, g.bodyDepRefs(block.Body, path, childExclude)...)
 			} else if block.Type == "lifecycle" {
 				// lifecycle blocks contain ignore_changes which holds property
 				// paths (e.g. tags["env"]), not dependency references. We must
@@ -1187,14 +1182,14 @@ func (g *Graph) bodyDepRefs(body hcl.Body, prefix string, exclude map[string]boo
 					if attrName == "ignore_changes" {
 						continue
 					}
-					refs = append(refs, g.exprDepRefs(attr.Expr, prefix, exclude)...)
+					refs = append(refs, g.exprDepRefs(attr.Expr, path, exclude)...)
 				}
 				// Still recurse into nested blocks (precondition, postcondition).
 				for _, nested := range block.Body.Blocks {
-					refs = append(refs, g.bodyDepRefs(nested.Body, prefix, exclude)...)
+					refs = append(refs, g.bodyDepRefs(nested.Body, path, exclude)...)
 				}
 			} else {
-				refs = append(refs, g.bodyDepRefs(block.Body, prefix, exclude)...)
+				refs = append(refs, g.bodyDepRefs(block.Body, path, exclude)...)
 			}
 		}
 	}
@@ -1205,11 +1200,11 @@ func (g *Graph) bodyDepRefs(body hcl.Body, prefix string, exclude map[string]boo
 // outputDeps gathers an output node's dependencies: its value expression plus
 // the condition and error-message expressions of every precondition, so an
 // output is sequenced after everything its precondition references.
-func (g *Graph) outputDeps(output *ast.Output, prefix string) []pdag.Node {
-	deps := g.exprDeps(output.Value, prefix)
+func (g *Graph) outputDeps(output *ast.Output, path modulepath.Path) []pdag.Node {
+	deps := g.exprDeps(output.Value, path)
 	for _, rule := range output.Preconditions {
-		deps = append(deps, g.exprDeps(rule.Condition, prefix)...)
-		deps = append(deps, g.exprDeps(rule.ErrorMessage, prefix)...)
+		deps = append(deps, g.exprDeps(rule.Condition, path)...)
+		deps = append(deps, g.exprDeps(rule.ErrorMessage, path)...)
 	}
 	return deps
 }
@@ -1218,12 +1213,12 @@ func (g *Graph) outputDeps(output *ast.Output, prefix string) []pdag.Node {
 // `validation` rules — the condition and error-message expressions — minus a
 // self-reference to the variable being validated, which is always in scope and
 // would otherwise form a cycle.
-func (g *Graph) variableValidationDeps(v *ast.Variable, key, prefix string) []pdag.Node {
+func (g *Graph) variableValidationDeps(v *ast.Variable, key NodeKey, path modulepath.Path) []pdag.Node {
 	_, self := g.newNode(key)
 	var deps []pdag.Node
 	for _, rule := range v.Validations {
-		deps = append(deps, g.exprDeps(rule.Condition, prefix)...)
-		deps = append(deps, g.exprDeps(rule.ErrorMessage, prefix)...)
+		deps = append(deps, g.exprDeps(rule.Condition, path)...)
+		deps = append(deps, g.exprDeps(rule.ErrorMessage, path)...)
 	}
 	return slices.DeleteFunc(deps, func(n pdag.Node) bool { return n == self })
 }
@@ -1246,8 +1241,8 @@ const variableValueKeySuffix = "!value"
 // onto a NodeTypeVariableValidation node that owns the public key: consumers
 // wait for the checks, and the value itself is evaluated by an internal value
 // node that carries a copy of the declaration with the split rules removed.
-func (g *Graph) addVariableNodes(key string, v *ast.Variable, modInfo *ModuleInfo, valueDeps []pdag.Node, prefix string) error {
-	validationDeps := g.variableValidationDeps(v, key, prefix)
+func (g *Graph) addVariableNodes(key NodeKey, v *ast.Variable, modInfo *ModuleInfo, valueDeps []pdag.Node, path modulepath.Path) error {
+	validationDeps := g.variableValidationDeps(v, key, path)
 	if len(validationDeps) == 0 {
 		return g.AddNode(&Node{
 			Key:        key,
@@ -1259,7 +1254,7 @@ func (g *Graph) addVariableNodes(key string, v *ast.Variable, modInfo *ModuleInf
 
 	valueVar := *v
 	valueVar.Validations = nil
-	valueKey := key + variableValueKeySuffix
+	valueKey := NodeKey{Module: key.Module, ID: key.ID + variableValueKeySuffix}
 	if err := g.AddNode(&Node{
 		Key:        valueKey,
 		Type:       NodeTypeVariable,
@@ -1281,33 +1276,33 @@ func (g *Graph) addVariableNodes(key string, v *ast.Variable, modInfo *ModuleInf
 // resolved node key plus the raw traversal it came from (nil for
 // provider-function deps, which have no traversal).
 type depRef struct {
-	key       string
+	key       NodeKey
 	traversal hcl.Traversal
 }
 
-// exprDeps extracts all dependencies from an expression, applying prefix to resolved keys.
-func (g *Graph) exprDeps(expr hcl.Expression, prefix string) []pdag.Node {
-	return g.refsToNodes(g.exprDepRefs(expr, prefix, nil))
+// exprDeps extracts all dependencies from an expression in the scope at path.
+func (g *Graph) exprDeps(expr hcl.Expression, path modulepath.Path) []pdag.Node {
+	return g.refsToNodes(g.exprDepRefs(expr, path, nil))
 }
 
 // refsToNodes dedups refs by key and interns each as a graph node.
 func (g *Graph) refsToNodes(refs []depRef) []pdag.Node {
-	var deps []string
+	seen := make(map[NodeKey]bool, len(refs))
+	var result []pdag.Node
 	for _, ref := range refs {
-		addToSortedListAsSet(&deps, ref.key)
-	}
-	result := make([]pdag.Node, len(deps))
-	for i, dep := range deps {
-		_, n := g.newNode(dep)
-		result[i] = n
+		if seen[ref.key] {
+			continue
+		}
+		seen[ref.key] = true
+		_, n := g.newNode(ref.key)
+		result = append(result, n)
 	}
 	return result
 }
 
 // exprDepRefs extracts one depRef per referencing traversal (no dedup, so a
-// classifier can see each instance-keyed occurrence), applying prefix to
-// resolved keys.
-func (g *Graph) exprDepRefs(expr hcl.Expression, prefix string, exclude map[string]bool) []depRef {
+// classifier can see each instance-keyed occurrence) in the scope at path.
+func (g *Graph) exprDepRefs(expr hcl.Expression, path modulepath.Path, exclude map[string]bool) []depRef {
 	if expr == nil {
 		return nil
 	}
@@ -1315,57 +1310,18 @@ func (g *Graph) exprDepRefs(expr hcl.Expression, prefix string, exclude map[stri
 	var refs []depRef
 
 	for _, traversal := range expr.Variables() {
-		namespace, parts := eval.ParseTraversal(traversal)
-
+		namespace, _ := eval.ParseTraversal(traversal)
 		if exclude[namespace] {
 			continue
 		}
-
-		var dep string
-		switch namespace {
-		case "var":
-			if len(parts) >= 1 {
-				dep = fmt.Sprintf("%svar.%s", prefix, parts[0])
-			}
-		case "local":
-			if len(parts) >= 1 {
-				dep = fmt.Sprintf("%slocal.%s", prefix, parts[0])
-			}
-		case "path", "terraform", "count", "each", "self", "pulumi":
-			continue
-		case "data":
-			if len(parts) >= 2 {
-				dep = fmt.Sprintf("%sdata.%s.%s", prefix, parts[0], parts[1])
-			}
-		case "module":
-			if len(parts) >= 1 {
-				if out := moduleOutputName(traversal); out != "" {
-					dep = fmt.Sprintf("%smodule.%s.output.%s", prefix, parts[0], out)
-				} else {
-					dep = fmt.Sprintf("%smodule.%s", prefix, parts[0])
-				}
-			}
-		case "call":
-			if len(parts) >= 2 {
-				dep = fmt.Sprintf("%scall.%s.%s", prefix, parts[0], parts[1])
-			}
-		default:
-			if len(parts) >= 1 {
-				dep = fmt.Sprintf("%s%s.%s", prefix, namespace, parts[0])
-			}
-		}
-
-		if dep != "" {
-			g.recordRef(dep, traversal.SourceRange())
-			refs = append(refs, depRef{key: dep, traversal: traversal})
-		}
+		refs = append(refs, g.traversalDepRefs(path, traversal)...)
 	}
 
 	// A provider-defined function call routes through the provider block its
 	// namespace resolves to, so order the caller after that block the same way
 	// an implicit default-provider reference would.
 	for _, providerName := range ast.ProviderFunctionCallsInExpr(expr) {
-		if dep, ok := g.providerFunctionDep(prefix, providerName); ok {
+		if dep, ok := g.providerFunctionDep(path, providerName); ok {
 			refs = append(refs, depRef{key: dep})
 		}
 	}
@@ -1374,36 +1330,30 @@ func (g *Graph) exprDepRefs(expr hcl.Expression, prefix string, exclude map[stri
 }
 
 // providerFunctionDep resolves the provider block a provider-defined function
-// call in the scope identified by prefix routes through, mirroring the
-// runtime's resolution order: the instantiating module call's pass-through
-// providers, then the un-aliased provider block of the call's own module, then
-// those of its ancestors. ok is false when no block is declared anywhere — the
-// engine then falls back to the package's default provider, which needs no
-// ordering edge.
-func (g *Graph) providerFunctionDep(prefix, providerName string) (string, bool) {
-	for s := g.scopes[prefix]; s != nil; s = s.parent {
+// call in the scope at path routes through, mirroring the runtime's resolution
+// order: the instantiating module call's pass-through providers, then the
+// un-aliased provider block of the call's own module, then those of its
+// ancestors. ok is false when no block is declared anywhere — the engine then
+// falls back to the package's default provider, which needs no ordering edge.
+func (g *Graph) providerFunctionDep(path modulepath.Path, providerName string) (NodeKey, bool) {
+	for s := g.scopes[path]; s != nil; s = s.parent {
 		if s.mod != nil {
 			if passExpr, ok := s.mod.Providers[providerName]; ok {
 				if parentKey := providerExprKey(passExpr); parentKey != "" {
-					return s.parentPrefix + parentKey, true
+					return NodeKey{Module: s.parentPath, ID: parentKey}, true
 				}
 			}
 		}
 		if _, ok := s.config.Providers[providerName]; ok {
-			return s.prefix + providerName, true
+			return NodeKey{Module: s.path, ID: providerName}, true
 		}
 	}
-	return "", false
+	return NodeKey{}, false
 }
 
-// FormatTraversal converts a traversal to a dependency string.
-// This is exported for use by other packages.
+// FormatTraversal converts a traversal to a scope-relative dependency
+// reference string ("" for non-referencing traversals).
 func FormatTraversal(traversal hcl.Traversal) string {
-	return formatTraversal(traversal)
-}
-
-// formatTraversal converts a traversal to a dependency string.
-func formatTraversal(traversal hcl.Traversal) string {
 	if len(traversal) == 0 {
 		return ""
 	}
@@ -1471,18 +1421,18 @@ func (g *Graph) Validate() []error {
 	var errs []error
 
 	// Sort keys for deterministic error ordering.
-	keys := make([]string, 0, len(g.seen))
+	keys := make([]NodeKey, 0, len(g.seen))
 	for key, node := range g.seen {
 		if node.n.Type == NodeTypeUnknown {
 			keys = append(keys, key)
 		}
 	}
-	slices.Sort(keys)
+	slices.SortFunc(keys, func(a, b NodeKey) int { return cmp.Compare(a.String(), b.String()) })
 
 	for _, key := range keys {
 		diag := &hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  fmt.Sprintf("unknown node %q", key),
+			Summary:  fmt.Sprintf("unknown node %q", key.String()),
 		}
 		if refs := g.references[key]; len(refs) > 0 {
 			// Use the earliest reference (sorted by filename, then position)
@@ -1528,17 +1478,15 @@ func (g *Graph) inlineModule(
 	}
 
 	path := parentPath.Append(modulepath.NewStep(name))
-	prefix := ReferencePrefix(path)
-	parentPrefix := ReferencePrefix(parentPath)
 	g.moved[path] = loaded.Config.Moved
 	scope := &moduleScope{
-		prefix:       prefix,
-		config:       loaded.Config,
-		parent:       parent,
-		mod:          mod,
-		parentPrefix: parentPrefix,
+		path:       path,
+		config:     loaded.Config,
+		parent:     parent,
+		mod:        mod,
+		parentPath: parentPath,
 	}
-	g.scopes[prefix] = scope
+	g.scopes[path] = scope
 	modInfo := &ModuleInfo{
 		Path:             path,
 		Module:           mod,
@@ -1550,21 +1498,15 @@ func (g *Graph) inlineModule(
 	// Init node: depends on count/for_each/depends_on from parent scope,
 	// plus the parent module's init (so a nested module never initializes
 	// before its enclosing module's instance/eval-context is registered).
-	initKey := prefix + "__init__"
+	initKey := NodeKey{Module: path, ID: "__init__"}
 	var initDeps []pdag.Node
 	if !parentPath.IsRoot() {
-		_, parentInitIdx := g.newNode(parentPrefix + "__init__")
+		_, parentInitIdx := g.newNode(NodeKey{Module: parentPath, ID: "__init__"})
 		initDeps = append(initDeps, parentInitIdx)
 	}
-	initDeps = append(initDeps, g.exprDeps(mod.Count, parentPrefix)...)
-	initDeps = append(initDeps, g.exprDeps(mod.ForEach, parentPrefix)...)
-	for _, traversal := range mod.DependsOn {
-		if dep := formatTraversal(traversal); dep != "" {
-			g.recordRef(parentPrefix+dep, traversal.SourceRange())
-			_, idx := g.newNode(parentPrefix + dep)
-			initDeps = append(initDeps, idx)
-		}
-	}
+	initDeps = append(initDeps, g.exprDeps(mod.Count, parentPath)...)
+	initDeps = append(initDeps, g.exprDeps(mod.ForEach, parentPath)...)
+	initDeps = append(initDeps, g.refsToNodes(g.traversalDepRefs(parentPath, mod.DependsOn...))...)
 	if err := g.AddNode(&Node{
 		Key:        initKey,
 		Type:       NodeTypeModuleInit,
@@ -1581,19 +1523,19 @@ func (g *Graph) inlineModule(
 	for varName, v := range loaded.Config.Variables {
 		varDeps := []pdag.Node{initIdx}
 		if inputAttr, ok := moduleInputAttrs[varName]; ok {
-			varDeps = append(varDeps, g.exprDeps(inputAttr.Expr, parentPrefix)...)
+			varDeps = append(varDeps, g.exprDeps(inputAttr.Expr, parentPath)...)
 		}
-		if err := g.addVariableNodes(prefix+"var."+varName, v, modInfo, varDeps, prefix); err != nil {
+		if err := g.addVariableNodes(NodeKey{Module: path, ID: "var." + varName}, v, modInfo, varDeps, path); err != nil {
 			return err
 		}
 	}
 
 	// Locals
 	for localName, local := range loaded.Config.Locals {
-		deps := g.exprDeps(local.Value, prefix)
+		deps := g.exprDeps(local.Value, path)
 		deps = append(deps, initIdx)
 		if err := g.AddNode(&Node{
-			Key:        prefix + "local." + localName,
+			Key:        NodeKey{Module: path, ID: "local." + localName},
 			Type:       NodeTypeLocal,
 			Local:      local,
 			ModuleInfo: modInfo,
@@ -1604,10 +1546,11 @@ func (g *Graph) inlineModule(
 
 	// Providers
 	for key, provider := range loaded.Config.Providers {
-		deps := g.providerDeps(provider, prefix+key, prefix)
+		nodeKey := NodeKey{Module: path, ID: key}
+		deps := g.providerDeps(provider, nodeKey, path)
 		deps = append(deps, initIdx)
 		if err := g.AddNode(&Node{
-			Key:        prefix + key,
+			Key:        nodeKey,
 			Type:       NodeTypeProvider,
 			Provider:   provider,
 			ModuleInfo: modInfo,
@@ -1628,7 +1571,7 @@ func (g *Graph) inlineModule(
 	// anything in the child consumes it.
 	for localKey, passExpr := range mod.Providers {
 		deps := g.resolvePassedProvider(loaded.Config, localKey, passExpr, parent)
-		shadowKey := prefix + localKey
+		shadowKey := NodeKey{Module: path, ID: localKey}
 		if existing, ok := g.seen[shadowKey]; ok && existing.n.Type != NodeTypeUnknown {
 			continue
 		}
@@ -1643,8 +1586,8 @@ func (g *Graph) inlineModule(
 
 	// Resources
 	for key, resource := range loaded.Config.Resources {
-		bd, deps := g.resourceDeps(resource, prefix)
-		provDeps := g.defaultProviderDeps(resource, loaded.Config, prefix)
+		bd, deps := g.resourceDeps(resource, path)
+		provDeps := g.defaultProviderDeps(resource, loaded.Config, path)
 		passDeps := g.passThroughProviderDeps(resource, scope)
 		provDeps = append(provDeps, passDeps...)
 		if len(provDeps) == 0 {
@@ -1655,7 +1598,7 @@ func (g *Graph) inlineModule(
 		deps = append(deps, initIdx)
 		deps = append(deps, provDeps...)
 		if err := g.AddNode(&Node{
-			Key:        prefix + key,
+			Key:        NodeKey{Module: path, ID: key},
 			Type:       NodeTypeResource,
 			Resource:   resource,
 			ModuleInfo: modInfo,
@@ -1667,8 +1610,8 @@ func (g *Graph) inlineModule(
 
 	// Data sources
 	for key, ds := range loaded.Config.DataSources {
-		bd, deps := g.resourceDeps(ds, prefix)
-		provDeps := g.defaultProviderDeps(ds, loaded.Config, prefix)
+		bd, deps := g.resourceDeps(ds, path)
+		provDeps := g.defaultProviderDeps(ds, loaded.Config, path)
 		passDeps := g.passThroughProviderDeps(ds, scope)
 		provDeps = append(provDeps, passDeps...)
 		if len(provDeps) == 0 {
@@ -1679,7 +1622,7 @@ func (g *Graph) inlineModule(
 		deps = append(deps, initIdx)
 		deps = append(deps, provDeps...)
 		if err := g.AddNode(&Node{
-			Key:        prefix + "data." + key,
+			Key:        NodeKey{Module: path, ID: "data." + key},
 			Type:       NodeTypeDataSource,
 			Resource:   ds,
 			ModuleInfo: modInfo,
@@ -1691,10 +1634,10 @@ func (g *Graph) inlineModule(
 
 	// Outputs
 	for outputName, output := range loaded.Config.Outputs {
-		deps := g.outputDeps(output, prefix)
+		deps := g.outputDeps(output, path)
 		deps = append(deps, initIdx)
 		if err := g.AddNode(&Node{
-			Key:        prefix + "output." + outputName,
+			Key:        NodeKey{Module: path, ID: "output." + outputName},
 			Type:       NodeTypeOutput,
 			Output:     output,
 			ModuleInfo: modInfo,
@@ -1711,22 +1654,22 @@ func (g *Graph) inlineModule(
 	// contents, not only the resources that happen to feed an output. Node keys
 	// for the nested modules are forward references resolved once they are
 	// inlined below.
-	completionKey := parentPrefix + "module." + name
+	completionKey := NodeKey{Module: parentPath, ID: "module." + name}
 	completionDeps := []pdag.Node{initIdx}
 	for key := range loaded.Config.Resources {
-		_, idx := g.newNode(prefix + key)
+		_, idx := g.newNode(NodeKey{Module: path, ID: key})
 		completionDeps = append(completionDeps, idx)
 	}
 	for key := range loaded.Config.DataSources {
-		_, idx := g.newNode(prefix + "data." + key)
+		_, idx := g.newNode(NodeKey{Module: path, ID: "data." + key})
 		completionDeps = append(completionDeps, idx)
 	}
 	for outputName := range loaded.Config.Outputs {
-		_, idx := g.newNode(prefix + "output." + outputName)
+		_, idx := g.newNode(NodeKey{Module: path, ID: "output." + outputName})
 		completionDeps = append(completionDeps, idx)
 	}
 	for nestedName := range loaded.Config.Modules {
-		_, idx := g.newNode(prefix + "module." + nestedName)
+		_, idx := g.newNode(NodeKey{Module: path, ID: "module." + nestedName})
 		completionDeps = append(completionDeps, idx)
 	}
 	if err := g.AddNode(&Node{
@@ -1738,7 +1681,7 @@ func (g *Graph) inlineModule(
 		return err
 	}
 
-	if err := g.addCallNodes(loaded.Config, prefix, modInfo); err != nil {
+	if err := g.addCallNodes(loaded.Config, path, modInfo); err != nil {
 		return err
 	}
 
@@ -1752,24 +1695,24 @@ func (g *Graph) inlineModule(
 	return nil
 }
 
-// addCallNodes adds call nodes from config into the graph with the given prefix.
-func (g *Graph) addCallNodes(config *ast.Config, prefix string, modInfo *ModuleInfo) error {
+// addCallNodes adds call nodes from config into the graph in the scope at path.
+func (g *Graph) addCallNodes(config *ast.Config, path modulepath.Path, modInfo *ModuleInfo) error {
 	for key, call := range config.Calls {
-		callKey := prefix + "call." + key
+		callKey := NodeKey{Module: path, ID: "call." + key}
 		var deps []pdag.Node
 		for resKey, res := range config.Resources {
 			if res.Name == call.ResourceName {
-				_, idx := g.newNode(prefix + resKey)
+				_, idx := g.newNode(NodeKey{Module: path, ID: resKey})
 				deps = append(deps, idx)
 				break
 			}
 		}
 		if _, exists := config.Providers[call.ResourceName]; exists {
-			_, idx := g.newNode(prefix + call.ResourceName)
+			_, idx := g.newNode(NodeKey{Module: path, ID: call.ResourceName})
 			deps = append(deps, idx)
 		}
 		if call.Config != nil {
-			deps = append(deps, g.bodyDeps(call.Config, prefix, nil)...)
+			deps = append(deps, g.bodyDeps(call.Config, path, nil)...)
 		}
 		if err := g.AddNode(&Node{
 			Key:        callKey,
@@ -1781,11 +1724,4 @@ func (g *Graph) addCallNodes(config *ast.Config, prefix string, modInfo *ModuleI
 		}
 	}
 	return nil
-}
-
-func addToSortedListAsSet[S ~[]E, E cmp.Ordered](s *S, element E) {
-	idx, found := slices.BinarySearch(*s, element)
-	if !found {
-		*s = slices.Insert(*s, idx, element)
-	}
 }

--- a/pkg/hcl/graph/graph_test.go
+++ b/pkg/hcl/graph/graph_test.go
@@ -315,7 +315,7 @@ func TestResourceExpander(t *testing.T) {
 		if len(result.Instances) != 1 {
 			t.Errorf("Expected 1 instance, got %d", len(result.Instances))
 		}
-		if result.Instances[0].Key != "aws_instance.web" {
+		if result.Instances[0].Key.String() != "aws_instance.web" {
 			t.Errorf("Unexpected key: %s", result.Instances[0].Key)
 		}
 	})
@@ -333,7 +333,7 @@ func TestResourceExpander(t *testing.T) {
 		}
 		for i, inst := range result.Instances {
 			expectedKey := "aws_instance.web[" + string(rune('0'+i)) + "]"
-			if inst.Key != expectedKey {
+			if inst.Key.String() != expectedKey {
 				t.Errorf("Instance %d: expected key %s, got %s", i, expectedKey, inst.Key)
 			}
 			if inst.Index == nil || *inst.Index != i {

--- a/pkg/hcl/graph/graph_test.go
+++ b/pkg/hcl/graph/graph_test.go
@@ -58,7 +58,7 @@ output "instance_id" {
 	require.Len(t, nodes, 7, "4 explicit nodes + 3 builtins")
 
 	// Verify dependencies
-	localNode := g.seen["local.greeting"].n
+	localNode := g.seen[nk("local.greeting")].n
 	if localNode == nil {
 		t.Fatal("Expected local.greeting node")
 	}
@@ -66,7 +66,7 @@ output "instance_id" {
 	// Verify topological sort works
 	var sorted []string
 	err = g.dag.Walk(t.Context(), func(_ context.Context, n dagNode) error {
-		sorted = append(sorted, n.key)
+		sorted = append(sorted, n.key.String())
 		return nil
 	}, pdag.MaxProcs(1))
 	require.NoError(t, err)
@@ -121,8 +121,8 @@ output "gate" {
 	g, err := BuildFromConfig(config, nil, "")
 	require.NoError(t, err)
 
-	assert.Equal(t, NodeTypeVariableValidation, g.seen["var.gate"].n.Type)
-	assert.Equal(t, NodeTypeVariable, g.seen["var.gate!value"].n.Type)
+	assert.Equal(t, NodeTypeVariableValidation, g.seen[nk("var.gate")].n.Type)
+	assert.Equal(t, NodeTypeVariable, g.seen[nk("var.gate!value")].n.Type)
 
 	barrierKey := "barrier"
 	require.NoError(t, g.InjectAfter(func(context.Context) error { return nil }, func(n *Node) bool {
@@ -131,7 +131,7 @@ output "gate" {
 
 	var sorted []string
 	err = g.dag.Walk(t.Context(), func(_ context.Context, n dagNode) error {
-		key := n.key
+		key := n.key.String()
 		if n.exec != nil {
 			key = barrierKey
 		}
@@ -170,8 +170,8 @@ variable "name" {
 	g, err := BuildFromConfig(config, nil, "")
 	require.NoError(t, err)
 
-	assert.Equal(t, NodeTypeVariable, g.seen["var.name"].n.Type)
-	assert.NotContains(t, g.seen, "var.name!value")
+	assert.Equal(t, NodeTypeVariable, g.seen[nk("var.name")].n.Type)
+	assert.NotContains(t, g.seen, nk("var.name!value"))
 }
 
 func TestForcedCreateBeforeDestroy(t *testing.T) {
@@ -206,10 +206,10 @@ resource "aws_instance" "d" {
 	g, err := BuildFromConfig(config, nil, "")
 	require.NoError(t, err)
 
-	assert.Equal(t, map[string]bool{
-		"aws_instance.a": true,
-		"aws_instance.b": true,
-		"aws_instance.c": true,
+	assert.Equal(t, map[NodeKey]bool{
+		nk("aws_instance.a"): true,
+		nk("aws_instance.b"): true,
+		nk("aws_instance.c"): true,
 	}, g.ForcedCreateBeforeDestroy())
 }
 
@@ -242,9 +242,9 @@ resource "aws_instance" "user" {
 	g, err := BuildFromConfig(config, nil, "")
 	require.NoError(t, err)
 
-	assert.Equal(t, map[string]bool{
-		"aws_instance.dep":  true,
-		"aws_instance.user": true,
+	assert.Equal(t, map[NodeKey]bool{
+		nk("aws_instance.dep"):  true,
+		nk("aws_instance.user"): true,
 	}, g.ForcedCreateBeforeDestroy())
 }
 
@@ -253,8 +253,8 @@ func TestValidate(t *testing.T) {
 	g := NewGraph()
 
 	// Missing dependency
-	_, i := g.newNode("NonExistent")
-	err := g.AddNode(&Node{Key: "A", Type: NodeTypeLocal}, []pdag.Node{i})
+	_, i := g.newNode(nk("NonExistent"))
+	err := g.AddNode(&Node{Key: nk("A"), Type: NodeTypeLocal}, []pdag.Node{i})
 	require.NoError(t, err)
 
 	errors := g.Validate()
@@ -302,7 +302,7 @@ func TestResourceExpander(t *testing.T) {
 	t.Parallel()
 
 	node := &Node{
-		Key:  "aws_instance.web",
+		Key:  nk("aws_instance.web"),
 		Type: NodeTypeResource,
 	}
 
@@ -323,7 +323,7 @@ func TestResourceExpander(t *testing.T) {
 	t.Run("count expansion", func(t *testing.T) {
 		t.Parallel()
 		expander := NewResourceExpander()
-		expander.SetCount("aws_instance.web", 3)
+		expander.SetCount(nk("aws_instance.web"), 3)
 		result := expander.Expand(node)
 		if result.IsSingle {
 			t.Error("Should not be single instance")
@@ -345,8 +345,8 @@ func TestResourceExpander(t *testing.T) {
 	t.Run("count zero", func(t *testing.T) {
 		t.Parallel()
 		expander := NewResourceExpander()
-		expander.SetCount("aws_instance.zero", 0)
-		zeroNode := &Node{Key: "aws_instance.zero", Type: NodeTypeResource}
+		expander.SetCount(nk("aws_instance.zero"), 0)
+		zeroNode := &Node{Key: nk("aws_instance.zero"), Type: NodeTypeResource}
 		result := expander.Expand(zeroNode)
 		if result.IsSingle {
 			t.Error("Should not be single instance")
@@ -359,11 +359,11 @@ func TestResourceExpander(t *testing.T) {
 	t.Run("for_each expansion", func(t *testing.T) {
 		t.Parallel()
 		expander := NewResourceExpander()
-		expander.SetForEach("aws_instance.each", map[string]cty.Value{
+		expander.SetForEach(nk("aws_instance.each"), map[string]cty.Value{
 			"a": cty.StringVal("value_a"),
 			"b": cty.StringVal("value_b"),
 		})
-		eachNode := &Node{Key: "aws_instance.each", Type: NodeTypeResource}
+		eachNode := &Node{Key: nk("aws_instance.each"), Type: NodeTypeResource}
 		result := expander.Expand(eachNode)
 		if result.IsSingle {
 			t.Error("Should not be single instance")

--- a/pkg/hcl/graph/provider_functions_test.go
+++ b/pkg/hcl/graph/provider_functions_test.go
@@ -44,7 +44,7 @@ variable "name" {
 	g, err := BuildFromConfig(config, nil, "")
 	require.NoError(t, err)
 
-	assert.True(t, g.HasDependents("simple"))
+	assert.True(t, g.HasDependents(nk("simple")))
 	assert.Empty(t, g.Validate())
 
 	order := walkOrder(t, g)
@@ -74,8 +74,8 @@ variable "name" {
 	require.NoError(t, err)
 
 	assert.Empty(t, g.Validate())
-	assert.False(t, g.HasDependents("simple"))
-	_, ok := g.seen["simple"]
+	assert.False(t, g.HasDependents(nk("simple")))
+	_, ok := g.seen[nk("simple")]
 	assert.False(t, ok, "no node should be created for an undeclared provider")
 }
 
@@ -118,7 +118,7 @@ variable "name" {
 	g, err := BuildFromConfig(config, nil, "")
 	require.NoError(t, err)
 
-	assert.True(t, g.HasDependents("simple"))
+	assert.True(t, g.HasDependents(nk("simple")))
 	assert.Empty(t, g.Validate())
 
 	order := walkOrder(t, g)
@@ -178,7 +178,7 @@ module "child" {
 	require.NoError(t, err)
 
 	assert.Empty(t, g.Validate())
-	assert.True(t, g.HasDependents("simple"))
+	assert.True(t, g.HasDependents(nk("simple")))
 
 	order := walkOrder(t, g)
 	assert.Less(t, indexOf(order, "simple"), indexOf(order, "module.child.simple_thing.y"))
@@ -229,7 +229,7 @@ module "child" {
 	require.NoError(t, err)
 
 	assert.Empty(t, g.Validate())
-	assert.True(t, g.HasDependents("simple.aliased"))
+	assert.True(t, g.HasDependents(nk("simple.aliased")))
 
 	order := walkOrder(t, g)
 	assert.Less(t, indexOf(order, "simple.aliased"), indexOf(order, "module.child.simple_thing.y"))

--- a/pkg/hcl/graph/provisioner_reference_test.go
+++ b/pkg/hcl/graph/provisioner_reference_test.go
@@ -16,14 +16,35 @@ package graph
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/util/pdag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/parser"
 )
+
+// nk parses a rendered node key ("module.m.output.o") back into its typed
+// form, so tests can keep asserting against reference-syntax strings.
+func nk(s string) NodeKey {
+	p := modulepath.Root()
+	for {
+		rest, ok := strings.CutPrefix(s, "module.")
+		if !ok {
+			break
+		}
+		name, id, ok := strings.Cut(rest, ".")
+		if !ok {
+			break
+		}
+		p = p.Append(modulepath.NewStep(name))
+		s = id
+	}
+	return NodeKey{Module: p, ID: s}
+}
 
 // walkOrder returns the DAG node keys in the single-worker Walk visitation
 // order, so a test can assert that one node is scheduled before another.
@@ -31,7 +52,7 @@ func walkOrder(t *testing.T, g *Graph) []string {
 	t.Helper()
 	var order []string
 	err := g.dag.Walk(t.Context(), func(_ context.Context, n dagNode) error {
-		order = append(order, n.key)
+		order = append(order, n.key.String())
 		return nil
 	}, pdag.MaxProcs(1))
 	require.NoError(t, err)
@@ -68,7 +89,7 @@ resource "simple_resource" "dependent" {
 	g, err := BuildFromConfig(config, nil, "")
 	require.NoError(t, err)
 
-	assert.True(t, g.HasDependents("simple_resource.upstream"))
+	assert.True(t, g.HasDependents(nk("simple_resource.upstream")))
 
 	order := walkOrder(t, g)
 	assert.Less(t, indexOf(order, "simple_resource.upstream"),
@@ -101,5 +122,5 @@ resource "simple_resource" "dependent" {
 	g, err := BuildFromConfig(config, nil, "")
 	require.NoError(t, err)
 
-	assert.True(t, g.HasDependents("simple_resource.upstream"))
+	assert.True(t, g.HasDependents(nk("simple_resource.upstream")))
 }

--- a/pkg/hcl/run/cells.go
+++ b/pkg/hcl/run/cells.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/graph"
+	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -39,24 +40,24 @@ import (
 // is: create every cell of the scope, wire dependencies and gates, then arm —
 // so a gate is always created before its target's expansion runs.
 type expansionCell struct {
-	block graph.NodeKey // graph node key
-	mi    string        // module instance path, "" at the root
+	block graph.NodeKey
+	mi    modulepath.Path // module instance path
 }
 
 func cellKey(node *graph.Node, mi *moduleInstance) expansionCell {
 	c := expansionCell{block: node.Key}
 	if mi != nil {
-		c.mi = mi.Path.String()
+		c.mi = mi.Path
 	}
 	return c
 }
 
-// cell returns the expansion cell for a block within one module instance ("" =
-// root), erroring when materialization never created it.
-func (e *Engine) cell(block graph.NodeKey, mi string) (*graph.BlockExpansion, error) {
+// cell returns the expansion cell for a block within one module instance,
+// erroring when materialization never created it.
+func (e *Engine) cell(block graph.NodeKey, mi modulepath.Path) (*graph.BlockExpansion, error) {
 	b, ok := e.expansions.Get(expansionCell{block: block, mi: mi})
 	if !ok {
-		return nil, fmt.Errorf("no expansion cell for %q in module instance %q", block.String(), mi)
+		return nil, fmt.Errorf("no expansion cell for %q in module instance %q", block.String(), mi.String())
 	}
 	return b, nil
 }
@@ -165,7 +166,7 @@ func (e *Engine) wireRootLocals(g *graph.Graph, locals []*graph.Node) error {
 			return fmt.Errorf("no graph node for %q", node.Key.String())
 		}
 		for _, whole := range node.Deps.Whole {
-			target, err := e.cell(whole, "")
+			target, err := e.cell(whole, modulepath.Root())
 			if err != nil {
 				return err
 			}
@@ -174,7 +175,7 @@ func (e *Engine) wireRootLocals(g *graph.Graph, locals []*graph.Node) error {
 			}
 		}
 		for _, narrow := range node.Deps.Narrow {
-			target, err := e.cell(narrow.Key, "")
+			target, err := e.cell(narrow.Node, modulepath.Root())
 			if err != nil {
 				return err
 			}
@@ -262,7 +263,7 @@ func (e *Engine) wireCell(g *graph.Graph, node *graph.Node, mi *moduleInstance) 
 		}
 	}
 	for _, narrow := range node.Deps.Narrow {
-		target, err := e.cell(narrow.Key, key.mi)
+		target, err := e.cell(narrow.Node, key.mi)
 		if err != nil {
 			return err
 		}
@@ -408,7 +409,7 @@ func (e *Engine) expandResourceCell(
 
 	for _, instance := range result.Instances {
 		inst := instance
-		err := b.AddInstance(inst.Suffix, func(ctx context.Context) error {
+		err := b.AddInstance(inst.Key.Suffix, func(ctx context.Context) error {
 			if e.hasFailedDependency(res) {
 				e.failedNodes.Set(inst.Key, fmt.Errorf("skipped: dependency failed"))
 				return nil
@@ -488,7 +489,7 @@ func (e *Engine) expandDataCell(
 
 	for _, instance := range result.Instances {
 		inst := instance
-		err := b.AddInstance(inst.Suffix, func(ctx context.Context) error {
+		err := b.AddInstance(inst.Key.Suffix, func(ctx context.Context) error {
 			instCtx := evalCtx.WithIteration(inst.Index, inst.EachKey, inst.EachValue)
 			ctyOut, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, instCtx, mi)
 			if err != nil {

--- a/pkg/hcl/run/cells.go
+++ b/pkg/hcl/run/cells.go
@@ -39,8 +39,8 @@ import (
 // is: create every cell of the scope, wire dependencies and gates, then arm —
 // so a gate is always created before its target's expansion runs.
 type expansionCell struct {
-	block string // graph node key, module-prefixed
-	mi    string // module instance path, "" at the root
+	block graph.NodeKey // graph node key
+	mi    string        // module instance path, "" at the root
 }
 
 func cellKey(node *graph.Node, mi *moduleInstance) expansionCell {
@@ -53,10 +53,10 @@ func cellKey(node *graph.Node, mi *moduleInstance) expansionCell {
 
 // cell returns the expansion cell for a block within one module instance ("" =
 // root), erroring when materialization never created it.
-func (e *Engine) cell(block, mi string) (*graph.BlockExpansion, error) {
+func (e *Engine) cell(block graph.NodeKey, mi string) (*graph.BlockExpansion, error) {
 	b, ok := e.expansions.Get(expansionCell{block: block, mi: mi})
 	if !ok {
-		return nil, fmt.Errorf("no expansion cell for %q in module instance %q", block, mi)
+		return nil, fmt.Errorf("no expansion cell for %q in module instance %q", block.String(), mi)
 	}
 	return b, nil
 }
@@ -136,9 +136,9 @@ func (e *Engine) materializeRootCells(g *graph.Graph) error {
 		// classified the data source as deferred — so this cannot cycle with
 		// the barrier gating resource expansion.)
 		if node.Type == graph.NodeTypeDataSource && node.PlanTimeRead {
-			init, ok := g.KeyNode(node.ModuleInfo.Prefix() + "__init__")
+			init, ok := g.KeyNode(graph.NodeKey{Module: node.ModuleInfo.Path, ID: "__init__"})
 			if !ok {
-				return fmt.Errorf("no init node for module %q", node.ModuleInfo.Prefix())
+				return fmt.Errorf("no init node for module %q", graph.ReferencePrefix(node.ModuleInfo.Path))
 			}
 			if err := g.Order(init, e.planBarrier); err != nil {
 				return err
@@ -162,7 +162,7 @@ func (e *Engine) wireRootLocals(g *graph.Graph, locals []*graph.Node) error {
 	for _, node := range locals {
 		ln, ok := g.KeyNode(node.Key)
 		if !ok {
-			return fmt.Errorf("no graph node for %q", node.Key)
+			return fmt.Errorf("no graph node for %q", node.Key.String())
 		}
 		for _, whole := range node.Deps.Whole {
 			target, err := e.cell(whole, "")
@@ -192,7 +192,7 @@ func (e *Engine) wireRootLocals(g *graph.Graph, locals []*graph.Node) error {
 func (e *Engine) materializeModuleCells(modInfo *graph.ModuleInfo, instances []*moduleInstance) error {
 	var blocks []*graph.Node
 	for _, node := range e.graph.ExpandableNodes() {
-		if node.ModuleInfo != nil && node.ModuleInfo.Prefix() == modInfo.Prefix() {
+		if node.ModuleInfo != nil && node.ModuleInfo.Path == modInfo.Path {
 			blocks = append(blocks, node)
 		}
 	}
@@ -288,7 +288,7 @@ func (e *Engine) wireCell(g *graph.Graph, node *graph.Node, mi *moduleInstance) 
 
 	blockNode, ok := g.KeyNode(node.Key)
 	if !ok {
-		return fmt.Errorf("no graph node for %q", node.Key)
+		return fmt.Errorf("no graph node for %q", node.Key.String())
 	}
 	return b.CompleteBefore(blockNode)
 }
@@ -370,10 +370,7 @@ func (e *Engine) expandResourceCell(
 		return err
 	}
 
-	baseKey := node.Key
-	if node.ModuleInfo != nil {
-		baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix())
-	}
+	baseKey := node.Key.ID
 
 	// A count/for_each that reads values this operation has not yet produced
 	// cannot be expanded. During preview, register no instances and bind the
@@ -411,7 +408,7 @@ func (e *Engine) expandResourceCell(
 
 	for _, instance := range result.Instances {
 		inst := instance
-		err := b.AddInstance(strings.TrimPrefix(inst.Key, node.Key), func(ctx context.Context) error {
+		err := b.AddInstance(inst.Suffix, func(ctx context.Context) error {
 			if e.hasFailedDependency(res) {
 				e.failedNodes.Set(inst.Key, fmt.Errorf("skipped: dependency failed"))
 				return nil
@@ -449,11 +446,7 @@ func (e *Engine) expandDataCell(
 		return fmt.Errorf("resolving data source type %s: %w", ds.Type, err)
 	}
 
-	dsKey := node.Key
-	if node.ModuleInfo != nil {
-		dsKey = strings.TrimPrefix(dsKey, node.ModuleInfo.Prefix())
-	}
-	dsKey = strings.TrimPrefix(dsKey, "data.")
+	dsKey := strings.TrimPrefix(node.Key.ID, "data.")
 
 	if ds.Count == nil && ds.ForEach == nil {
 		return b.AddInstance("", func(ctx context.Context) error {
@@ -495,7 +488,7 @@ func (e *Engine) expandDataCell(
 
 	for _, instance := range result.Instances {
 		inst := instance
-		err := b.AddInstance(strings.TrimPrefix(inst.Key, node.Key), func(ctx context.Context) error {
+		err := b.AddInstance(inst.Suffix, func(ctx context.Context) error {
 			instCtx := evalCtx.WithIteration(inst.Index, inst.EachKey, inst.EachValue)
 			ctyOut, err := e.invokeDataSourceOnce(ctx, node, ds, funcSchema, instCtx, mi)
 			if err != nil {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -386,10 +386,10 @@ type Engine struct {
 	resmon ResourceMonitor
 
 	// resourceOutputs maps resource keys to their output values.
-	resourceOutputs *util.SyncMap[string, cty.Value]
+	resourceOutputs *util.SyncMap[graph.InstanceKey, cty.Value]
 
 	// resourceInheritableOpts maps resource keys to the options that children can inherit.
-	resourceInheritableOpts *util.SyncMap[string, inheritableOpts]
+	resourceInheritableOpts *util.SyncMap[graph.InstanceKey, inheritableOpts]
 
 	// defaultProviders maps a package name to the urn::id of its un-aliased
 	// `provider "<pkg>" {}` block. Resources whose package matches and that
@@ -474,7 +474,7 @@ type Engine struct {
 
 	// failedNodes tracks resource nodes that failed to register, keyed by instance key.
 	// Dependent nodes check this map and are skipped when a dependency failed.
-	failedNodes *util.SyncMap[string, error]
+	failedNodes *util.SyncMap[graph.InstanceKey, error]
 
 	// graph is the resolved dependency graph for the current run. Stored on
 	// the engine so processNode handlers can consult its topology (e.g.
@@ -630,8 +630,8 @@ func NewEngine(ctx context.Context, config *ast.Config, opts *EngineOptions) (*E
 		pkgLoader:               opts.SchemaLoader,
 		providerInfoSource:      opts.ProviderInfoSource,
 		resmon:                  opts.ResourceMonitor,
-		resourceOutputs:         util.NewSyncMap[string, cty.Value](),
-		resourceInheritableOpts: util.NewSyncMap[string, inheritableOpts](),
+		resourceOutputs:         util.NewSyncMap[graph.InstanceKey, cty.Value](),
+		resourceInheritableOpts: util.NewSyncMap[graph.InstanceKey, inheritableOpts](),
 		defaultProviders:        util.NewSyncMap[string, string](),
 		stackOutputs:            make(map[string]property.Value),
 		projectName:             opts.ProjectName,
@@ -651,7 +651,7 @@ func NewEngine(ctx context.Context, config *ast.Config, opts *EngineOptions) (*E
 		cellURNs:                newURNRegistry(),
 		pendingURNs:             util.NewSyncMap[string, struct{}](),
 		pendingModuleCalls:      util.NewSyncMap[expansionCell, struct{}](),
-		failedNodes:             util.NewSyncMap[string, error](),
+		failedNodes:             util.NewSyncMap[graph.InstanceKey, error](),
 		alwaysRegisterProviders: opts.AlwaysRegisterProviders,
 		resolver: packages.NewResolver(
 			opts.SchemaLoader, opts.ProviderInfoSource, opts.Packages, knownProviders(config.Terraform)),
@@ -1298,7 +1298,7 @@ func (e *Engine) inheritedDefaultProvider(modInfo *graph.ModuleInfo, name string
 			tfBlock = parentInfo.Terraform
 		}
 		local := graph.LocalProviderName(tfBlock, fqn, name)
-		if outputs, ok := e.resourceOutputs.Get(graph.ReferencePrefix(parent) + local); ok {
+		if outputs, ok := e.nodeOutputs(graph.NodeKey{Module: parent, ID: local}); ok {
 			if ref, err := providerRefFromCty(outputs); err == nil {
 				return ref
 			}
@@ -1510,9 +1510,9 @@ func (e *Engine) registerProviderInContext(
 	// into.
 	outputObj["urn"] = cty.StringVal(string(resp.URN))
 
-	outputsKey := node.Key.String()
+	outputsKey := graph.InstanceKey{Node: node.Key}
 	if inst != nil {
-		outputsKey = fmt.Sprintf("%s[%q]", node.Key, inst.key)
+		outputsKey.Suffix = fmt.Sprintf("[%q]", inst.key)
 	}
 	e.resourceOutputs.Set(outputsKey, cty.ObjectVal(outputObj).Mark(eval.DepMark(resp.URN)))
 
@@ -1774,22 +1774,19 @@ func (e *Engine) buildResourceOptionsInContext(
 	opts := &ResourceOptions{}
 	opts.Parent = parentURN
 
-	resPrefix := graph.ReferencePrefix(node.Key.Module)
-
 	// depends_on records every registered instance of the target block,
 	// keyed or not — dependency metadata is resource-wide (see urnRegistry).
 	// The registry lookup also covers expanded targets, whose instance
 	// outputs are not addressable by the block key.
-	miPath := ""
+	miPath := modulepath.Root()
 	if modInst != nil {
-		miPath = modInst.Path.String()
+		miPath = modInst.Path
 	}
 	for _, dep := range res.DependsOn {
-		depKey := graph.FormatTraversal(dep)
-		if depKey == "" {
+		block, ok := graph.TraversalKey(node.Key.Module, dep)
+		if !ok {
 			continue
 		}
-		block := graph.ResolveRef(node.Key.Module, depKey)
 		opts.DependsOn = append(opts.DependsOn, e.cellURNs.get(expansionCell{block: block, mi: miPath})...)
 	}
 
@@ -1849,13 +1846,10 @@ func (e *Engine) buildResourceOptionsInContext(
 	opts.DeleteBeforeReplaceDef = true
 	opts.DeleteBeforeReplace = !cbd
 
-	if res.ResourceParent != nil {
-		depKey := graph.FormatTraversal(res.ResourceParent)
-		if depKey != "" {
-			if outputs, ok := e.resourceOutputs.Get(resPrefix + depKey); ok {
-				if parentURN := ctyAsString(outputs.GetAttr("urn")); parentURN != "" {
-					opts.Parent = urn.URN(parentURN) // TODO: Don't look at attrs for this
-				}
+	if key, ok := graph.TraversalKey(node.Key.Module, res.ResourceParent); ok {
+		if outputs, ok := e.nodeOutputs(key); ok {
+			if parentURN := ctyAsString(outputs.GetAttr("urn")); parentURN != "" {
+				opts.Parent = urn.URN(parentURN) // TODO: Don't look at attrs for this
 			}
 		}
 	}
@@ -1870,14 +1864,13 @@ func (e *Engine) buildResourceOptionsInContext(
 		}
 	} else if modInfo != nil {
 		// Implicit default in a module: try a pass-through entry, then
-		// the in-module `provider "<pkg>" {}` block (registered earlier
-		// at key resPrefix+pkg in resourceOutputs), then an inherited
+		// the in-module `provider "<pkg>" {}` block, then an inherited
 		// ancestor default. If none exist, fall through to Pulumi's
 		// engine default.
 		pkg := packageNameFromResourceType(res.Type)
 		if ref := e.resolvePassThroughProvider(modInfo, pkg); ref != "" {
 			opts.Provider = ref
-		} else if outputs, ok := e.resourceOutputs.Get(resPrefix + pkg); ok {
+		} else if outputs, ok := e.nodeOutputs(graph.NodeKey{Module: node.Key.Module, ID: pkg}); ok {
 			if ref, err := providerRefFromCty(outputs); err == nil {
 				opts.Provider = ref
 			}
@@ -1891,15 +1884,15 @@ func (e *Engine) buildResourceOptionsInContext(
 	}
 
 	for _, traversal := range res.Providers {
-		providerKey := graph.FormatTraversal(traversal)
-		if providerKey == "" {
+		key, ok := graph.TraversalKey(node.Key.Module, traversal)
+		if !ok {
 			continue
 		}
-		if providerOutputs, ok := e.resourceOutputs.Get(resPrefix + providerKey); ok {
+		if providerOutputs, ok := e.nodeOutputs(key); ok {
 			urn := ctyAsString(providerOutputs.GetAttr("urn"))
 			id := ctyAsString(providerOutputs.GetAttr("id"))
 			if urn != "" && id != "" {
-				pkgName := packageNameFromResourceType(strings.SplitN(providerKey, ".", 2)[0])
+				pkgName := packageNameFromResourceType(strings.SplitN(key.ID, ".", 2)[0])
 				if opts.Providers == nil {
 					opts.Providers = make(map[string]string)
 				}
@@ -1995,23 +1988,20 @@ func (e *Engine) buildResourceOptionsInContext(
 		}
 	}
 
-	if res.DeletedWith != nil {
-		depKey := graph.FormatTraversal(res.DeletedWith)
-		if depKey != "" {
-			if outputs, ok := e.resourceOutputs.Get(resPrefix + depKey); ok {
-				if urn := ctyAsString(outputs.GetAttr("urn")); urn != "" {
-					opts.DeletedWith = urn
-				}
+	if key, ok := graph.TraversalKey(node.Key.Module, res.DeletedWith); ok {
+		if outputs, ok := e.nodeOutputs(key); ok {
+			if urn := ctyAsString(outputs.GetAttr("urn")); urn != "" {
+				opts.DeletedWith = urn
 			}
 		}
 	}
 
 	for _, ref := range res.ReplaceWith {
-		depKey := graph.FormatTraversal(ref)
-		if depKey == "" {
+		key, ok := graph.TraversalKey(node.Key.Module, ref)
+		if !ok {
 			continue
 		}
-		if outputs, ok := e.resourceOutputs.Get(resPrefix + depKey); ok {
+		if outputs, ok := e.nodeOutputs(key); ok {
 			if urn := ctyAsString(outputs.GetAttr("urn")); urn != "" {
 				opts.ReplaceWith = append(opts.ReplaceWith, urn)
 			}
@@ -2118,17 +2108,14 @@ func (e *Engine) buildResourceOptionsInContext(
 		}
 	}
 
-	if res.ResourceParent != nil {
-		depKey := graph.FormatTraversal(res.ResourceParent)
-		if depKey != "" {
-			if parentOpts, ok := e.resourceInheritableOpts.Get(resPrefix + depKey); ok {
-				if (res.Lifecycle == nil || res.Lifecycle.PreventDestroy == nil) &&
-					parentOpts.Protect != nil && *parentOpts.Protect {
-					opts.Protect = true
-				}
-				if res.RetainOnDelete == nil && parentOpts.RetainOnDelete != nil {
-					opts.RetainOnDelete = parentOpts.RetainOnDelete
-				}
+	if key, ok := graph.TraversalKey(node.Key.Module, res.ResourceParent); ok {
+		if parentOpts, ok := e.resourceInheritableOpts.Get(graph.InstanceKey{Node: key}); ok {
+			if (res.Lifecycle == nil || res.Lifecycle.PreventDestroy == nil) &&
+				parentOpts.Protect != nil && *parentOpts.Protect {
+				opts.Protect = true
+			}
+			if res.RetainOnDelete == nil && parentOpts.RetainOnDelete != nil {
+				opts.RetainOnDelete = parentOpts.RetainOnDelete
 			}
 		}
 	}
@@ -2892,15 +2879,19 @@ func knownProviders(tfBlock *ast.Terraform) []string {
 	return providers
 }
 
+// nodeOutputs returns the outputs of a block's single (suffixless) instance.
+func (e *Engine) nodeOutputs(key graph.NodeKey) (cty.Value, bool) {
+	return e.resourceOutputs.Get(graph.InstanceKey{Node: key})
+}
+
 // hasFailedDependency reports whether any dependency of res is in failedNodes.
 // When true, the resource should be skipped so that only genuinely independent
 // resources are registered with the engine.
 func (e *Engine) hasFailedDependency(res *ast.Resource) bool {
 	// Check explicit depends_on traversals.
 	for _, dep := range res.DependsOn {
-		depKey := graph.FormatTraversal(dep)
-		if depKey != "" {
-			if _, failed := e.failedNodes.Get(depKey); failed {
+		if key, ok := graph.TraversalKey(modulepath.Root(), dep); ok {
+			if _, failed := e.failedNodes.Get(graph.InstanceKey{Node: key}); failed {
 				return true
 			}
 		}
@@ -2912,7 +2903,7 @@ func (e *Engine) hasFailedDependency(res *ast.Resource) bool {
 		attrs, _ := res.Config.JustAttributes()
 		for _, attr := range attrs {
 			for _, depKey := range eval.NonRecoverableDependencies(attr.Expr) {
-				if _, failed := e.failedNodes.Get(depKey); failed {
+				if _, failed := e.failedNodes.Get(graph.InstanceKey{Node: graph.NodeKey{ID: depKey}}); failed {
 					return true
 				}
 			}
@@ -3378,9 +3369,9 @@ func (e *Engine) invokeDataSourceOnce(
 ) (cty.Value, error) {
 	hclCtx := evalCtx.HCLContext()
 
-	miPath := ""
+	miPath := modulepath.Root()
 	if mi != nil {
-		miPath = mi.Path.String()
+		miPath = mi.Path
 	}
 
 	// Failed preconditions prevent the read; unknown conditions defer.
@@ -3450,10 +3441,9 @@ func (e *Engine) invokeDataSourceOnce(
 		}
 	} else if node.ModuleInfo != nil {
 		pkg := packageNameFromResourceType(ds.Type)
-		resPrefix := graph.ReferencePrefix(node.ModuleInfo.Path)
 		if ref := e.resolvePassThroughProvider(node.ModuleInfo, pkg); ref != "" {
 			invokeReq.Provider = ref
-		} else if outputs, ok := e.resourceOutputs.Get(resPrefix + pkg); ok {
+		} else if outputs, ok := e.nodeOutputs(graph.NodeKey{Module: node.Key.Module, ID: pkg}); ok {
 			if ref, err := providerRefFromCty(outputs); err == nil {
 				invokeReq.Provider = ref
 			}
@@ -3478,11 +3468,11 @@ func (e *Engine) invokeDataSourceOnce(
 	// buildResourceOptionsInContext).
 	dependsOnPending := e.moduleDependsOnPending(mi)
 	for _, dep := range ds.DependsOn {
-		depKey := graph.FormatTraversal(dep)
-		if depKey == "" {
+		block, ok := graph.TraversalKey(node.Key.Module, dep)
+		if !ok {
 			continue
 		}
-		cell := expansionCell{block: graph.ResolveRef(node.Key.Module, depKey), mi: miPath}
+		cell := expansionCell{block: block, mi: miPath}
 		for _, urn := range e.cellURNs.get(cell) {
 			addURN(urn)
 		}
@@ -3546,12 +3536,12 @@ func (e *Engine) invokeDataSourceOnce(
 func (e *Engine) moduleDependsOnPending(mi *moduleInstance) bool {
 	for inst := mi; inst != nil; inst = inst.Parent {
 		for _, dep := range inst.ModuleInfo.Module.DependsOn {
-			depKey := graph.FormatTraversal(dep)
-			if depKey == "" {
+			// The targets are addressed from the calling module's scope.
+			block, ok := graph.TraversalKey(inst.ModuleInfo.ParentPath(), dep)
+			if !ok {
 				continue
 			}
-			// The targets are addressed from the calling module's scope.
-			cell := expansionCell{block: graph.ResolveRef(inst.ModuleInfo.ParentPath(), depKey), mi: parentMIPath(inst)}
+			cell := expansionCell{block: block, mi: parentMIPath(inst)}
 			if e.cellPending(cell) {
 				return true
 			}
@@ -3586,12 +3576,12 @@ func moduleCallCell(inst *moduleInstance) expansionCell {
 }
 
 // parentMIPath is the instance path of the module instance enclosing inst, or
-// "" when inst was called from the root.
-func parentMIPath(inst *moduleInstance) string {
+// the root when inst was called from the root.
+func parentMIPath(inst *moduleInstance) modulepath.Path {
 	if inst.Parent == nil {
-		return ""
+		return modulepath.Root()
 	}
-	return inst.Parent.Path.String()
+	return inst.Parent.Path
 }
 
 // processCall processes a call block (method invocation on a resource).
@@ -3666,7 +3656,7 @@ func (e *Engine) processCall(ctx context.Context, node *graph.Node) error {
 	}
 
 	// Look up resource outputs to get URN and ID
-	outputs, ok := e.resourceOutputs.Get(resKey)
+	outputs, ok := e.nodeOutputs(graph.NodeKey{ID: resKey})
 	if !ok {
 		return fmt.Errorf("resource %q outputs not found", resKey)
 	}
@@ -3840,7 +3830,7 @@ func (e *Engine) providerFunctionImpl(
 		if modInfo != nil {
 			if ref := e.resolvePassThroughProvider(modInfo, providerName); ref != "" {
 				req.Provider = ref
-			} else if outputs, ok := e.resourceOutputs.Get(graph.ReferencePrefix(modInfo.Path) + providerName); ok {
+			} else if outputs, ok := e.nodeOutputs(graph.NodeKey{Module: modInfo.Path, ID: providerName}); ok {
 				if ref, err := providerRefFromCty(outputs); err == nil {
 					req.Provider = ref
 				}
@@ -4658,7 +4648,7 @@ func (e *Engine) bindPreconditionHooks(
 	hclSnapshot := evalCtx.HCLContext()
 	hookName := fmt.Sprintf("%s.%s:precondition", res.Type, resourceName)
 	callback := func(_ context.Context, _ *ResourceHookArgs) error {
-		return evaluatePreconditions(res.Preconditions, hclSnapshot, instance.Key)
+		return evaluatePreconditions(res.Preconditions, hclSnapshot, instance.Key.String())
 	}
 	if err := e.resmon.RegisterResourceHook(ctx, hookName, callback, ResourceHookOptions{
 		OnDryRun: true,
@@ -4701,7 +4691,7 @@ func (e *Engine) bindPostconditionHooks(
 		// adapted the same way as on the registration path: property-level
 		// lowering here, wrapper unboxing after re-expansion.
 		outputs := lowerTerraformDataOutputs(res.Type, args.NewOutputs, opts)
-		return evaluatePostconditions(res.Postconditions, hclSnapshot, outputs, res.Type, resSchema, mapping, dryRun, instance.Key)
+		return evaluatePostconditions(res.Postconditions, hclSnapshot, outputs, res.Type, resSchema, mapping, dryRun, instance.Key.String())
 	}
 	if err := e.resmon.RegisterResourceHook(ctx, hookName, callback, ResourceHookOptions{
 		OnDryRun: true,

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -485,7 +485,7 @@ type Engine struct {
 	// forcedCBD holds the resource node keys that must be created before their
 	// prior instance is destroyed because they, or a resource depending on
 	// them, declared create_before_destroy. Computed once from the graph.
-	forcedCBD map[string]bool
+	forcedCBD map[graph.NodeKey]bool
 
 	// alwaysRegisterProviders forces every `provider` block to be registered
 	// as a resource even when nothing references it, bypassing Terraform's
@@ -1112,7 +1112,7 @@ func (e *Engine) processLocal(ctx context.Context, node *graph.Node) error {
 
 	if node.ModuleInfo != nil {
 		return e.forEachModuleInstance(node, func(inst *moduleInstance) error {
-			localName := strings.TrimPrefix(node.Key, node.ModuleInfo.Prefix()+"local.")
+			localName := strings.TrimPrefix(node.Key.ID, "local.")
 			val, diags := local.Value.Value(inst.EvalCtx.HCLContext())
 			if diags.HasErrors() {
 				return fmt.Errorf("evaluating local value %s: %s", localName, diags.Error())
@@ -1127,7 +1127,7 @@ func (e *Engine) processLocal(ctx context.Context, node *graph.Node) error {
 		return fmt.Errorf("evaluating local value: %s", diags.Error())
 	}
 
-	localName := node.Key[6:] // Remove "local." prefix
+	localName := node.Key.ID[6:] // Remove "local." prefix
 	e.evaluator.Context().SetLocal(localName, val)
 
 	return nil
@@ -1199,11 +1199,7 @@ func (e *Engine) registerProvider(
 	// An empty for_each still binds the provider address so a reference
 	// evaluates to an empty collection rather than "no such attribute".
 	if len(forEach) == 0 {
-		baseKey := node.Key
-		if node.ModuleInfo != nil {
-			baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix())
-		}
-		evalCtx.SetResource(baseKey, "", cty.EmptyObjectVal)
+		evalCtx.SetResource(node.Key.ID, "", cty.EmptyObjectVal)
 	}
 
 	return nil
@@ -1237,7 +1233,7 @@ func (e *Engine) resolvePassThroughProvider(modInfo *graph.ModuleInfo, localKey 
 // parentModuleInfo returns the ModuleInfo of the module call enclosing
 // modInfo, or nil when the parent is the root config (or has no instances).
 func (e *Engine) parentModuleInfo(modInfo *graph.ModuleInfo) *graph.ModuleInfo {
-	if modInfo.ParentPrefix() == "" {
+	if modInfo.ParentPath().IsRoot() {
 		return nil
 	}
 	insts, ok := e.moduleInstances.Get(modInfo.ParentPath())
@@ -1319,7 +1315,7 @@ func (e *Engine) inheritedDefaultProvider(modInfo *graph.ModuleInfo, name string
 // parentEvalContext returns the eval.Context of the enclosing module
 // instance (or the root context when modInfo's parent is root).
 func (e *Engine) parentEvalContext(modInfo *graph.ModuleInfo) *eval.Context {
-	if modInfo.ParentPrefix() == "" {
+	if modInfo.ParentPath().IsRoot() {
 		return e.evaluator.Context()
 	}
 	parentInsts, ok := e.moduleInstances.Get(modInfo.ParentPath())
@@ -1514,7 +1510,7 @@ func (e *Engine) registerProviderInContext(
 	// into.
 	outputObj["urn"] = cty.StringVal(string(resp.URN))
 
-	outputsKey := node.Key
+	outputsKey := node.Key.String()
 	if inst != nil {
 		outputsKey = fmt.Sprintf("%s[%q]", node.Key, inst.key)
 	}
@@ -1527,11 +1523,7 @@ func (e *Engine) registerProviderInContext(
 	}
 
 	markedProviderOutputs := cty.ObjectVal(outputObj).Mark(eval.DepMark(resp.URN))
-	bareKey := node.Key
-	if node.ModuleInfo != nil {
-		// Strip prefix for module-internal references
-		bareKey = strings.TrimPrefix(node.Key, node.ModuleInfo.Prefix())
-	}
+	bareKey := node.Key.ID
 	if inst != nil {
 		// Instances assemble into an object keyed by each.key, so
 		// `<name>.<alias>["key"]` selects one through ordinary indexing.
@@ -1759,23 +1751,13 @@ func (e *Engine) registerResourceInstanceInContext(
 	iOpts.RetainOnDelete = opts.RetainOnDelete
 	e.resourceInheritableOpts.Set(instance.Key, iOpts)
 
+	baseKey := node.Key.ID
 	if instance.Index != nil {
-		baseKey := instance.OriginalKey
-		if node.ModuleInfo != nil {
-			baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix())
-		}
 		evalCtx.SetCountResource(baseKey, *instance.Index, urn, markedOutputs)
 	} else if instance.EachKey != nil {
-		baseKey := instance.OriginalKey
-		if node.ModuleInfo != nil {
-			baseKey = strings.TrimPrefix(baseKey, node.ModuleInfo.Prefix())
-		}
 		evalCtx.SetEachResource(baseKey, instance.EachKey.AsString(), urn, markedOutputs)
-	} else if node.ModuleInfo != nil {
-		bareKey := strings.TrimPrefix(instance.Key, node.ModuleInfo.Prefix())
-		evalCtx.SetResource(bareKey, urn, markedOutputs)
 	} else {
-		evalCtx.SetResource(instance.Key, urn, markedOutputs)
+		evalCtx.SetResource(baseKey, urn, markedOutputs)
 	}
 
 	return nil
@@ -1792,10 +1774,7 @@ func (e *Engine) buildResourceOptionsInContext(
 	opts := &ResourceOptions{}
 	opts.Parent = parentURN
 
-	resPrefix := ""
-	if modInfo != nil {
-		resPrefix = modInfo.Prefix()
-	}
+	resPrefix := graph.ReferencePrefix(node.Key.Module)
 
 	// depends_on records every registered instance of the target block,
 	// keyed or not — dependency metadata is resource-wide (see urnRegistry).
@@ -1810,7 +1789,8 @@ func (e *Engine) buildResourceOptionsInContext(
 		if depKey == "" {
 			continue
 		}
-		opts.DependsOn = append(opts.DependsOn, e.cellURNs.get(expansionCell{block: resPrefix + depKey, mi: miPath})...)
+		block := graph.ResolveRef(node.Key.Module, depKey)
+		opts.DependsOn = append(opts.DependsOn, e.cellURNs.get(expansionCell{block: block, mi: miPath})...)
 	}
 
 	hclCtx := evalCtx.HCLContext()
@@ -1865,7 +1845,7 @@ func (e *Engine) buildResourceOptionsInContext(
 	// ordering even when it does not declare it (forcedCBD, computed from the
 	// graph). This keeps every create in a replacement chain ahead of the deletes.
 	cbd := res.Lifecycle != nil && res.Lifecycle.CreateBeforeDestroy != nil && *res.Lifecycle.CreateBeforeDestroy
-	cbd = cbd || e.forcedCBD[instance.OriginalKey]
+	cbd = cbd || e.forcedCBD[node.Key]
 	opts.DeleteBeforeReplaceDef = true
 	opts.DeleteBeforeReplace = !cbd
 
@@ -3404,7 +3384,7 @@ func (e *Engine) invokeDataSourceOnce(
 	}
 
 	// Failed preconditions prevent the read; unknown conditions defer.
-	if err := evaluatePreconditions(ds.Preconditions, hclCtx, node.Key); err != nil {
+	if err := evaluatePreconditions(ds.Preconditions, hclCtx, node.Key.String()); err != nil {
 		return cty.NilVal, err
 	}
 
@@ -3470,7 +3450,7 @@ func (e *Engine) invokeDataSourceOnce(
 		}
 	} else if node.ModuleInfo != nil {
 		pkg := packageNameFromResourceType(ds.Type)
-		resPrefix := node.ModuleInfo.Prefix()
+		resPrefix := graph.ReferencePrefix(node.ModuleInfo.Path)
 		if ref := e.resolvePassThroughProvider(node.ModuleInfo, pkg); ref != "" {
 			invokeReq.Provider = ref
 		} else if outputs, ok := e.resourceOutputs.Get(resPrefix + pkg); ok {
@@ -3502,11 +3482,7 @@ func (e *Engine) invokeDataSourceOnce(
 		if depKey == "" {
 			continue
 		}
-		fullDepKey := depKey
-		if node.ModuleInfo != nil {
-			fullDepKey = node.ModuleInfo.Prefix() + depKey
-		}
-		cell := expansionCell{block: fullDepKey, mi: miPath}
+		cell := expansionCell{block: graph.ResolveRef(node.Key.Module, depKey), mi: miPath}
 		for _, urn := range e.cellURNs.get(cell) {
 			addURN(urn)
 		}
@@ -3556,7 +3532,7 @@ func (e *Engine) invokeDataSourceOnce(
 		return cty.NilVal, fmt.Errorf("converting function outputs to HCL types: %w", err)
 	}
 
-	if err := evaluatePostconditionValues(ds.Postconditions, hclCtx, ctyOutputs, node.Key); err != nil {
+	if err := evaluatePostconditionValues(ds.Postconditions, hclCtx, ctyOutputs, node.Key.String()); err != nil {
 		return cty.NilVal, err
 	}
 
@@ -3575,7 +3551,7 @@ func (e *Engine) moduleDependsOnPending(mi *moduleInstance) bool {
 				continue
 			}
 			// The targets are addressed from the calling module's scope.
-			cell := expansionCell{block: inst.ModuleInfo.ParentPrefix() + depKey, mi: parentMIPath(inst)}
+			cell := expansionCell{block: graph.ResolveRef(inst.ModuleInfo.ParentPath(), depKey), mi: parentMIPath(inst)}
 			if e.cellPending(cell) {
 				return true
 			}
@@ -3604,7 +3580,7 @@ func (e *Engine) cellPending(cell expansionCell) bool {
 // matching how a `depends_on` entry naming the call covers the whole call.
 func moduleCallCell(inst *moduleInstance) expansionCell {
 	return expansionCell{
-		block: inst.ModuleInfo.ParentPrefix() + "module." + inst.ModuleInfo.ModuleName(),
+		block: graph.NodeKey{Module: inst.ModuleInfo.ParentPath(), ID: "module." + inst.ModuleInfo.ModuleName()},
 		mi:    parentMIPath(inst),
 	}
 }
@@ -3864,7 +3840,7 @@ func (e *Engine) providerFunctionImpl(
 		if modInfo != nil {
 			if ref := e.resolvePassThroughProvider(modInfo, providerName); ref != "" {
 				req.Provider = ref
-			} else if outputs, ok := e.resourceOutputs.Get(modInfo.Prefix() + providerName); ok {
+			} else if outputs, ok := e.resourceOutputs.Get(graph.ReferencePrefix(modInfo.Path) + providerName); ok {
 				if ref, err := providerRefFromCty(outputs); err == nil {
 					req.Provider = ref
 				}
@@ -4018,11 +3994,11 @@ func (a *moduleLoaderAdapter) LoadModule(source, version, workDir string) (*grap
 	}, nil
 }
 
-// forEachModuleInstance iterates over all instances of the module identified by node.ModuleInfo.Prefix().
+// forEachModuleInstance iterates over all instances of the module identified by node.ModuleInfo.Path.
 func (e *Engine) forEachModuleInstance(node *graph.Node, fn func(inst *moduleInstance) error) error {
 	instances, ok := e.moduleInstances.Get(node.ModuleInfo.Path)
 	if !ok {
-		return fmt.Errorf("no module instances for prefix %q", node.ModuleInfo.Prefix())
+		return fmt.Errorf("no module instances for prefix %q", graph.ReferencePrefix(node.ModuleInfo.Path))
 	}
 	for _, inst := range instances {
 		if err := fn(inst); err != nil {
@@ -4127,7 +4103,7 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 	// slice lets downstream per-instance work (vars, locals, nested modules,
 	// resources) loop zero times instead of falling back to the root context.
 	parents := []*moduleInstance{nil}
-	if modInfo.ParentPrefix() != "" {
+	if !modInfo.ParentPath().IsRoot() {
 		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPath())
 		if !ok || len(parentInstances) == 0 {
 			e.moduleInstances.Set(modInfo.Path, nil)
@@ -4297,7 +4273,7 @@ func (e *Engine) initModuleCallIn(
 func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error {
 	output := node.Output
 	modInfo := node.ModuleInfo
-	outputName := strings.TrimPrefix(node.Key, modInfo.Prefix()+"output.")
+	outputName := strings.TrimPrefix(node.Key.ID, "output.")
 
 	err := e.forEachModuleInstance(node, func(inst *moduleInstance) error {
 		if err := runOutputPreconditions(output, inst.EvalCtx.HCLContext(), outputName); err != nil {
@@ -4340,7 +4316,7 @@ func (e *Engine) processModuleOutput(_ context.Context, node *graph.Node) error 
 // enclosing instance sees only its own instances of the call.
 func (e *Engine) publishModuleValue(modInfo *graph.ModuleInfo, instances []*moduleInstance) {
 	parents := []*moduleInstance{nil}
-	if modInfo.ParentPrefix() != "" {
+	if !modInfo.ParentPath().IsRoot() {
 		parentInstances, ok := e.moduleInstances.Get(modInfo.ParentPath())
 		if !ok {
 			return
@@ -4413,7 +4389,7 @@ func (e *Engine) processModuleComplete(ctx context.Context, node *graph.Node) er
 
 	instances, ok := e.moduleInstances.Get(modInfo.Path)
 	if !ok {
-		return fmt.Errorf("no module instances for prefix %q", modInfo.Prefix())
+		return fmt.Errorf("no module instances for prefix %q", graph.ReferencePrefix(modInfo.Path))
 	}
 
 	// Register component outputs and collect per-instance output objects.
@@ -4928,7 +4904,7 @@ func (e *Engine) evaluateCheck(ctx context.Context, name string, check *ast.Chec
 // the expansion-cell machinery.
 func (e *Engine) readScopedDataSource(ctx context.Context, ds *ast.Resource, evalCtx *eval.Context) error {
 	node := &graph.Node{
-		Key:      "data." + ast.ResourceKey(ds.Type, ds.Name),
+		Key:      graph.NodeKey{ID: "data." + ast.ResourceKey(ds.Type, ds.Name)},
 		Type:     graph.NodeTypeDataSource,
 		Resource: ds,
 	}


### PR DESCRIPTION
Graph node keys were strings — `module.a.module.b.<element>` — assembled by prefix concatenation and taken apart with `TrimPrefix` wherever a consumer needed the element back. They are now

```go
type NodeKey struct {
    Module modulepath.Path // static config path of the containing module
    ID     string          // element id in reference syntax ("var.x", "aws_x.y", "data.aws_x.y", …)
}
```

- Every graph map (`seen`, `references`, `dependents`, `keyByDagNode`), the expander, `BlockDeps.Whole`, `InstanceDep.Key`, module scopes (now keyed by `modulepath.Path`), `forcedCBD`, and the engine's expansion cells key by the struct.
- Scope-relative reference strings resolve to a key in exactly one place (`ResolveRef`, handling the single module hop an HCL reference can make); the prefix-collision class between module encodings and element ids is gone by construction.
- `ExpandedResource` carries its instance-key `Suffix` explicitly; consumers stop deriving it by trimming.
- Deleted: the `prefix string` threading through every dep-collection helper, `ModuleInfo.Prefix`/`ParentPrefix`, `ExpandedResource.OriginalKey`, and the `TrimPrefix` surgeries in `pkg/hcl/run`.
- Strings survive only at real string boundaries: evaluator bindings, diagnostics, and instance identities render through `NodeKey.String`/`ReferencePrefix`, byte-identical to before.

**Net −97 lines.** No behavior change: full tfcompat suite (278), all unit suites (1263), and golangci-lint green. No changelog fragment — internal refactor.