### PR TITLE
Render module addresses in Terraform syntax

### DIFF
--- a/.changes/unreleased/runtime-Improvements-464.yaml
+++ b/.changes/unreleased/runtime-Improvements-464.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Render module addresses in diagnostics in Terraform syntax
+time: 2026-07-27T16:41:38Z
+custom:
+    Component: runtime
+    PR: "464"

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -68,14 +68,14 @@ func (m *ModuleInfo) ModuleName() string {
 	return last.Name()
 }
 
-// ReferencePrefix renders path in the dependency-reference syntax used for
-// rendered node keys — "module.<name>.module.<name>." — matching how HCL
-// traversals reference module contents. The root renders "". NOT
-// collision-free ("a.module.b" collides with ["a", "b"]); use Path equality
-// when that matters.
-func ReferencePrefix(path modulepath.Path) string {
+// ModuleAddress renders path in Terraform address syntax —
+// "module.<name>[key].module.<name>" — for diagnostics. The root renders "".
+func ModuleAddress(path modulepath.Path) string {
 	var b strings.Builder
 	for s := range path.Steps {
+		if b.Len() > 0 {
+			b.WriteByte('.')
+		}
 		b.WriteString("module.")
 		b.WriteString(s.Name())
 		if idx, ok := s.Index(); ok {
@@ -83,7 +83,6 @@ func ReferencePrefix(path modulepath.Path) string {
 		} else if key, ok := s.Key(); ok {
 			fmt.Fprintf(&b, "[%q]", key)
 		}
-		b.WriteByte('.')
 	}
 	return b.String()
 }
@@ -120,7 +119,12 @@ type NodeKey struct {
 	ID     string
 }
 
-func (k NodeKey) String() string { return ReferencePrefix(k.Module) + k.ID }
+func (k NodeKey) String() string {
+	if k.Module.IsRoot() {
+		return k.ID
+	}
+	return ModuleAddress(k.Module) + "." + k.ID
+}
 
 // TraversalKey resolves a reference traversal in the module at scope to its
 // node key; ok is false for non-referencing traversals. A `module.<name>`
@@ -809,7 +813,10 @@ func (g *Graph) resolvePassedProvider(
 			return nil
 		}
 	}
-	addr := fmt.Sprintf("%sprovider[%q]", ReferencePrefix(parent.path), ProviderFQN(childConfig.Terraform, strings.SplitN(childKey, ".", 2)[0]))
+	addr := NodeKey{
+		Module: parent.path,
+		ID:     fmt.Sprintf("provider[%q]", ProviderFQN(childConfig.Terraform, strings.SplitN(childKey, ".", 2)[0])),
+	}.String()
 	if aliased {
 		addr += "." + alias
 	}

--- a/pkg/hcl/graph/graph_test.go
+++ b/pkg/hcl/graph/graph_test.go
@@ -384,29 +384,21 @@ func TestResourceExpander(t *testing.T) {
 	})
 }
 
-func TestReferencePrefix(t *testing.T) {
+func TestModuleAddress(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "", ReferencePrefix(modulepath.Root()))
+	assert.Equal(t, "", ModuleAddress(modulepath.Root()))
 
 	p := modulepath.Root().Append(modulepath.NewStep("a"))
-	assert.Equal(t, "module.a.", ReferencePrefix(p))
+	assert.Equal(t, "module.a", ModuleAddress(p))
 
 	keyed := modulepath.Root().
 		Append(modulepath.NewIndexedStep("a", 2)).
 		Append(modulepath.NewKeyedStep("b", "k"))
-	assert.Equal(t, `module.a[2].module.b["k"].`, ReferencePrefix(keyed))
-}
+	assert.Equal(t, `module.a[2].module.b["k"]`, ModuleAddress(keyed))
 
-func TestReferencePrefix_DistinguishesDottedLabels(t *testing.T) {
-	t.Parallel()
-
-	// "a.b" / "c" must produce a different prefix than "a" / "b.c".
-	p1 := modulepath.Root().
-		Append(modulepath.NewStep("a.b")).
-		Append(modulepath.NewStep("c"))
-	p2 := modulepath.Root().
-		Append(modulepath.NewStep("a")).
-		Append(modulepath.NewStep("b.c"))
-	assert.NotEqual(t, ReferencePrefix(p1), ReferencePrefix(p2))
+	assert.Equal(t, "module.a.aws_instance.web",
+		NodeKey{Module: p, ID: "aws_instance.web"}.String())
+	assert.Equal(t, "aws_instance.web",
+		NodeKey{ID: "aws_instance.web"}.String())
 }

--- a/pkg/hcl/run/cells.go
+++ b/pkg/hcl/run/cells.go
@@ -139,7 +139,7 @@ func (e *Engine) materializeRootCells(g *graph.Graph) error {
 		if node.Type == graph.NodeTypeDataSource && node.PlanTimeRead {
 			init, ok := g.KeyNode(graph.NodeKey{Module: node.ModuleInfo.Path, ID: "__init__"})
 			if !ok {
-				return fmt.Errorf("no init node for module %q", graph.ReferencePrefix(node.ModuleInfo.Path))
+				return fmt.Errorf("no init node for module %q", graph.ModuleAddress(node.ModuleInfo.Path))
 			}
 			if err := g.Order(init, e.planBarrier); err != nil {
 				return err

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -3988,7 +3988,7 @@ func (a *moduleLoaderAdapter) LoadModule(source, version, workDir string) (*grap
 func (e *Engine) forEachModuleInstance(node *graph.Node, fn func(inst *moduleInstance) error) error {
 	instances, ok := e.moduleInstances.Get(node.ModuleInfo.Path)
 	if !ok {
-		return fmt.Errorf("no module instances for prefix %q", graph.ReferencePrefix(node.ModuleInfo.Path))
+		return fmt.Errorf("no module instances for %q", graph.ModuleAddress(node.ModuleInfo.Path))
 	}
 	for _, inst := range instances {
 		if err := fn(inst); err != nil {
@@ -4379,7 +4379,7 @@ func (e *Engine) processModuleComplete(ctx context.Context, node *graph.Node) er
 
 	instances, ok := e.moduleInstances.Get(modInfo.Path)
 	if !ok {
-		return fmt.Errorf("no module instances for prefix %q", graph.ReferencePrefix(modInfo.Path))
+		return fmt.Errorf("no module instances for %q", graph.ModuleAddress(modInfo.Path))
 	}
 
 	// Register component outputs and collect per-instance output objects.
@@ -4847,7 +4847,7 @@ func (e *Engine) evaluateChecks(ctx context.Context) error {
 	})
 	for _, inst := range instances {
 		errs = append(errs, e.evaluateConfigChecks(
-			ctx, graph.ReferencePrefix(inst.Path)+".", inst.Config, inst.EvalCtx))
+			ctx, graph.ModuleAddress(inst.Path)+".", inst.Config, inst.EvalCtx))
 	}
 	return errors.Join(errs...)
 }


### PR DESCRIPTION
With graph keys fully typed (https://github.com/pulumi-labs/pulumi-hcl/pull/463), nothing keys on rendered addresses anymore — rendering is purely diagnostic. `ReferencePrefix` (trailing-dot reference-prefix syntax, with a documented collision caveat) becomes `ModuleAddress`: Terraform address syntax, `module.a[2].module.b["k"]`, no trailing dot, no caveat to document.

`NodeKey.String()` composes it and its output is unchanged for every node key. The user-visible deltas are three diagnostic cleanups:

- `no module instances for prefix "module.a."` → `no module instances for "module.a"`
- `no init node for module "module.a."` → `…"module.a"`
- check names in child modules lose a doubled dot: `module.a..my_check` → `module.a.my_check`

The missing-provider diagnostic address now renders through `NodeKey.String()` (same output, one implementation).

Full tfcompat suite (278), all unit suites, cmd tests, and lint green; no goldens referenced the old artifact strings.