### PR TITLE
Accept byte strings in the language host and component providers

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-268.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-268.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Support strings containing non-UTF8 bytes
+time: 2026-07-30T12:35:20.918723+02:00
+custom:
+    Component: runtime
+    PR: "268"

--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -144,8 +144,6 @@ var expectedFailures = map[string]string{
 		" is reserved as the namespace for resource method calls in HCL",
 	"l2-config-default-from-invoke": "HCL codegen does not support a config variable whose" +
 		" default is sourced from an invoke result",
-	"l2-raw-string-bytes": "cty strings are sequences of unicode characters, so the HCL" +
-		" runtime cannot carry non-UTF8 bytes in a string property",
 	"l3-component-invoke": "the HCL runtime does not parent invokes inside a component to" +
 		" the component, so the invoke does not inherit the component's explicit provider",
 }

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-raw-string-bytes/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-raw-string-bytes/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-raw-string-bytes
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-raw-string-bytes/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-raw-string-bytes/main.pp
@@ -1,0 +1,9 @@
+resource "source" "bytesource:index:Resource" {
+  base64 = "AGhlbGxvIID+/yB3b3JsZPAo"
+}
+
+resource "sink" "bytesink:index:Resource" {
+  bytes        = source.bytes
+  expectBase64 = source.base64
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-raw-string-bytes/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-raw-string-bytes/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-raw-string-bytes
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-raw-string-bytes/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-raw-string-bytes/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    bytesink = {
+      source  = "pulumi/bytesink"
+      version = "47.0.0"
+    }
+    bytesource = {
+      source  = "pulumi/bytesource"
+      version = "48.0.0"
+    }
+  }
+}
+
+resource "bytesource_resource" "source" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  base64 = "AGhlbGxvIID+/yB3b3JsZPAo"
+}
+resource "bytesink_resource" "sink" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  bytes         = bytesource_resource.source.bytes
+  expect_base64 = bytesource_resource.source.base64
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-raw-string-bytes/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-raw-string-bytes/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-raw-string-bytes
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-raw-string-bytes/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-raw-string-bytes/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    bytesink = {
+      source  = "pulumi/bytesink"
+      version = "47.0.0"
+    }
+    bytesource = {
+      source  = "pulumi/bytesource"
+      version = "48.0.0"
+    }
+  }
+}
+
+resource "bytesource_resource" "source" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  base64 = "AGhlbGxvIID+/yB3b3JsZPAo"
+}
+resource "bytesink_resource" "sink" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  bytes         = bytesource_resource.source.bytes
+  expect_base64 = bytesource_resource.source.base64
+}

--- a/cmd/pulumi-language-hcl/testdata/sdks/bytesink-47.0.0/hcl.sdk.json
+++ b/cmd/pulumi-language-hcl/testdata/sdks/bytesink-47.0.0/hcl.sdk.json
@@ -1,0 +1,9 @@
+{
+  "Name": "bytesink",
+  "Kind": "resource",
+  "Version": "47.0.0",
+  "PluginDownloadURL": "",
+  "Checksums": null,
+  "Parameterization": null,
+  "ExtensionParameterization": null
+}

--- a/cmd/pulumi-language-hcl/testdata/sdks/bytesource-48.0.0/hcl.sdk.json
+++ b/cmd/pulumi-language-hcl/testdata/sdks/bytesource-48.0.0/hcl.sdk.json
@@ -1,0 +1,9 @@
+{
+  "Name": "bytesource",
+  "Kind": "resource",
+  "Version": "48.0.0",
+  "PluginDownloadURL": "",
+  "Checksums": null,
+  "Parameterization": null,
+  "ExtensionParameterization": null
+}

--- a/pkg/server/construct_monitor_test.go
+++ b/pkg/server/construct_monitor_test.go
@@ -86,6 +86,7 @@ func TestConstructMonitorForwardsInvokeRouting(t *testing.T) {
 		PluginDownloadURL: "https://example.com/download",
 		PackageRef:        "package-ref-uuid",
 		AcceptResources:   true,
+		AcceptsByteString: true,
 	}, capture.invokeReq, protocmp.Transform()))
 }
 
@@ -107,9 +108,10 @@ func TestConstructMonitorForwardsCallRouting(t *testing.T) {
 	args, err := structpb.NewStruct(map[string]any{"name": "x"})
 	require.NoError(t, err)
 	assert.Empty(t, cmp.Diff(&pulumirpc.ResourceCallRequest{
-		Tok:        "aws:index:Module/getOutput",
-		Args:       args,
-		PackageRef: "package-ref-uuid",
+		Tok:               "aws:index:Module/getOutput",
+		Args:              args,
+		PackageRef:        "package-ref-uuid",
+		AcceptsByteString: true,
 	}, capture.callReq, protocmp.Transform()))
 }
 

--- a/pkg/server/hooks.go
+++ b/pkg/server/hooks.go
@@ -84,8 +84,9 @@ func (s *callbackServer) register(fn callbackFunction) (*pulumirpc.Callback, err
 	s.functions[token] = fn
 	s.mu.Unlock()
 	return &pulumirpc.Callback{
-		Token:  token,
-		Target: "127.0.0.1:" + strconv.Itoa(s.handle.Port),
+		Token:             token,
+		Target:            "127.0.0.1:" + strconv.Itoa(s.handle.Port),
+		AcceptsByteString: true,
 	}, nil
 }
 
@@ -116,6 +117,7 @@ var hookMarshalOptions = plugin.MarshalOptions{
 	KeepSecrets:      true,
 	KeepResources:    true,
 	KeepOutputValues: true,
+	KeepByteString:   true,
 }
 
 // lazyCallbackServer is a callback server created on first use and shared for

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -206,6 +206,15 @@ func (a moduleLoaderAdapter) LoadModule(
 	return m.Config, m.SourcePath, nil
 }
 
+func (p *HCLProvider) Handshake(
+	ctx context.Context, req *pulumirpc.ProviderHandshakeRequest,
+) (*pulumirpc.ProviderHandshakeResponse, error) {
+	return &pulumirpc.ProviderHandshakeResponse{
+		AcceptSecrets:     true,
+		AcceptsByteString: true,
+	}, nil
+}
+
 // Attach configures the provider with a host callback.
 func (p *HCLProvider) Attach(ctx context.Context, req *pulumirpc.PluginAttach) (*emptypb.Empty, error) {
 	conn, err := grpc.NewClient(
@@ -451,6 +460,7 @@ func constructMarshalOptions() plugin.MarshalOptions {
 		KeepSecrets:      true,
 		KeepResources:    true,
 		KeepOutputValues: true,
+		KeepByteString:   true,
 	}
 }
 
@@ -479,6 +489,7 @@ func (m *constructResourceMonitor) RegisterResource(
 			ReplaceWith:             m.replaceWith,
 			AcceptSecrets:           true,
 			AcceptResources:         true,
+			AcceptsByteString:       true,
 		}
 		if m.deleteBeforeReplace != nil {
 			registerReq.DeleteBeforeReplace = *m.deleteBeforeReplace
@@ -545,6 +556,7 @@ func (m *constructResourceMonitor) RegisterResource(
 		Hooks:               hooksToProto(req.Hooks),
 		AcceptSecrets:       true,
 		AcceptResources:     true,
+		AcceptsByteString:   true,
 	})
 	if err != nil {
 		return nil, err
@@ -569,8 +581,9 @@ func (m *constructResourceMonitor) ReadResource(
 	req run.ReadResourceRequest,
 ) (*run.ReadResourceResponse, error) {
 	properties, err := plugin.MarshalProperties(resource.ToResourcePropertyMap(req.Inputs), plugin.MarshalOptions{
-		KeepSecrets:   true,
-		KeepResources: true,
+		KeepSecrets:    true,
+		KeepResources:  true,
+		KeepByteString: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshaling inputs: %w", err)
@@ -595,14 +608,16 @@ func (m *constructResourceMonitor) ReadResource(
 		PackageRef:              string(req.PackageRef),
 		AcceptSecrets:           true,
 		AcceptResources:         true,
+		AcceptsByteString:       true,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	outputs, err := plugin.UnmarshalProperties(resp.Properties, plugin.MarshalOptions{
-		KeepSecrets:   true,
-		KeepResources: true,
+		KeepSecrets:    true,
+		KeepResources:  true,
+		KeepByteString: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unmarshaling outputs: %w", err)
@@ -660,6 +675,7 @@ func (m *constructResourceMonitor) Invoke(
 		PluginDownloadURL: req.PluginDownloadURL,
 		PackageRef:        string(req.PackageRef),
 		AcceptResources:   true,
+		AcceptsByteString: true,
 	})
 	if err != nil {
 		return nil, err
@@ -692,9 +708,10 @@ func (m *constructResourceMonitor) Call(
 	}
 
 	resp, err := m.client.Call(ctx, &pulumirpc.ResourceCallRequest{
-		Tok:        req.Token,
-		Args:       argsStruct,
-		PackageRef: string(req.PackageRef),
+		Tok:               req.Token,
+		Args:              argsStruct,
+		PackageRef:        string(req.PackageRef),
+		AcceptsByteString: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("calling method: %w", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1301,6 +1301,7 @@ func (r *resourceMonitorAdapter) RegisterResource(
 		Aliases:                    aliases,
 		AcceptSecrets:              true,
 		AcceptResources:            true,
+		AcceptsByteString:          true,
 		SupportsPartialValues:      true,
 		DeleteBeforeReplace:        req.DeleteBeforeReplace,
 		DeleteBeforeReplaceDefined: req.DeleteBeforeReplaceDef,
@@ -1381,6 +1382,7 @@ func (r *resourceMonitorAdapter) ReadResource(
 		AcceptSecrets:           true,
 		AdditionalSecretOutputs: req.AdditionalSecretOutputs,
 		AcceptResources:         true,
+		AcceptsByteString:       true,
 		PluginDownloadURL:       req.PluginDownloadURL,
 		PackageRef:              string(req.PackageRef),
 	})
@@ -1419,6 +1421,7 @@ func (r *resourceMonitorAdapter) Invoke(
 		Version:           req.Version,
 		PluginDownloadURL: req.PluginDownloadURL,
 		AcceptResources:   true,
+		AcceptsByteString: true,
 		PackageRef:        string(req.PackageRef),
 	}
 
@@ -1499,9 +1502,10 @@ func (r *resourceMonitorAdapter) Call(
 	}
 
 	resp, err := r.monitorClient.Call(ctx, &pulumirpc.ResourceCallRequest{
-		Tok:        req.Token,
-		Args:       argsStruct,
-		PackageRef: string(req.PackageRef),
+		Tok:               req.Token,
+		Args:              argsStruct,
+		PackageRef:        string(req.PackageRef),
+		AcceptsByteString: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("calling method: %w", err)
@@ -1555,9 +1559,10 @@ func (r *resourceMonitorAdapter) RegisterResourceHook(
 
 func (*resourceMonitorAdapter) pluginOptions() plugin.MarshalOptions {
 	return plugin.MarshalOptions{
-		KeepUnknowns:  true,
-		KeepSecrets:   true,
-		KeepResources: true,
+		KeepUnknowns:   true,
+		KeepSecrets:    true,
+		KeepResources:  true,
+		KeepByteString: true,
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/pulumi-labs/pulumi-hcl/issues/268.

pulumi v3.255.0 introduced an opt-in wire encoding for string properties containing bytes that are not valid UTF-8: such strings marshal as a ByteString special-sig object instead of dying on proto3's UTF-8 check (`grpc: error while marshaling: string field contains invalid UTF-8`). This PR opts pulumi-hcl in everywhere it speaks the resource protocol.

## Changes

- **Language host** (`resourceMonitorAdapter`): sets `accepts_byte_string` on RegisterResource, ReadResource, Invoke, and Call requests and marshals properties with `KeepByteString`, so raw bytes flow losslessly between the engine and the HCL program.
- **Component providers** (`constructResourceMonitor`, shared by the local-path MLC and the dynamic module provider): same treatment for the resources a module registers, plus `KeepByteString` on every marshal across the Construct boundary.
- **`HCLProvider.Handshake`**: byte-string support is negotiated only at handshake time, so the local-path component provider now implements it. Since the engine ignores the Configure response's accept flags once a handshake succeeds, the response also carries the previously negotiated `AcceptSecrets`.
- **Resource-hook callbacks** advertise `accepts_byte_string`, so the engine may pass raw bytes to hook arguments.

The HCL runtime itself already carries such strings byte-for-byte (cty strings pass invalid UTF-8 through unchanged), so with the protocol opt-in the `l2-raw-string-bytes` conformance test passes and leaves the expected-failures list; its snapshots are checked in.

## Known gap

The dynamic `hcl:index:Module` provider's own Construct boundary rides pulumi-go-provider, which cannot advertise `accepts_byte_string` yet. Child-resource registrations inside a module are covered by this PR, but module-level inputs/outputs crossing that boundary stay unsupported until pulumi-go-provider learns the flag.

## Testing

- `go test ./cmd/pulumi-language-hcl/ -run 'TestLanguage/l2-raw-string-bytes'` passes (accept + verify).
- `go test ./pkg/server/...` passes; the construct-monitor golden request tests were extended with the new flag.