### PR TITLE
Enforce `prevent_destroy` from configuration; add `protect` to `pulumi` blocks

### DIFF
--- a/.changes/unreleased/runtime-Improvements-344.yaml
+++ b/.changes/unreleased/runtime-Improvements-344.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Add `protect` to resource and module `pulumi` blocks
+time: 2026-07-30T00:00:00Z
+custom:
+    Component: runtime
+    PR: "344"

--- a/.changes/unreleased/runtime-bug-fixes-344.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-344.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Enforce `lifecycle { prevent_destroy }` from current configuration, so removing the resource block destroys the instance in one apply
+time: 2026-07-30T00:00:00Z
+custom:
+    Component: runtime
+    PR: "344"

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-parent-inheritance/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-parent-inheritance/main.pp
@@ -22,8 +22,8 @@ resource "orphan1" "simple:index:Resource" {
 resource "parent2" "simple:index:Resource" {
   value = true
   options {
-    retainOnDelete = true
     protect        = true
+    retainOnDelete = true
   }
 }
 
@@ -38,8 +38,8 @@ resource "child3" "simple:index:Resource" {
   value = true
   options {
     parent         = parent2
-    retainOnDelete = false
     protect        = false
+    retainOnDelete = false
   }
 }
 

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-protect/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-protect/main.tf
@@ -8,15 +8,19 @@ terraform {
 }
 
 resource "simple_resource" "protected" {
+  pulumi {
+    protect = true
+  }
   lifecycle {
-    prevent_destroy       = true
     create_before_destroy = true
   }
   value = true
 }
 resource "simple_resource" "unprotected" {
+  pulumi {
+    protect = false
+  }
   lifecycle {
-    prevent_destroy       = false
     create_before_destroy = true
   }
   value = true

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-parent-inheritance/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-parent-inheritance/main.tf
@@ -34,10 +34,10 @@ resource "simple_resource" "orphan1" {
 }
 resource "simple_resource" "parent2" {
   pulumi {
+    protect          = true
     retain_on_delete = true
   }
   lifecycle {
-    prevent_destroy       = true
     create_before_destroy = true
   }
   value = true
@@ -54,10 +54,10 @@ resource "simple_resource" "child2" {
 resource "simple_resource" "child3" {
   pulumi {
     parent           = simple_resource.parent2
+    protect          = false
     retain_on_delete = false
   }
   lifecycle {
-    prevent_destroy       = false
     create_before_destroy = true
   }
   value = true

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-protect/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-protect/main.tf
@@ -8,15 +8,19 @@ terraform {
 }
 
 resource "simple_resource" "protected" {
+  pulumi {
+    protect = true
+  }
   lifecycle {
-    prevent_destroy       = true
     create_before_destroy = true
   }
   value = true
 }
 resource "simple_resource" "unprotected" {
+  pulumi {
+    protect = false
+  }
   lifecycle {
-    prevent_destroy       = false
     create_before_destroy = true
   }
   value = true

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-parent-inheritance/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-parent-inheritance/main.tf
@@ -34,10 +34,10 @@ resource "simple_resource" "orphan1" {
 }
 resource "simple_resource" "parent2" {
   pulumi {
+    protect          = true
     retain_on_delete = true
   }
   lifecycle {
-    prevent_destroy       = true
     create_before_destroy = true
   }
   value = true
@@ -54,10 +54,10 @@ resource "simple_resource" "child2" {
 resource "simple_resource" "child3" {
   pulumi {
     parent           = simple_resource.parent2
+    protect          = false
     retain_on_delete = false
   }
   lifecycle {
-    prevent_destroy       = false
     create_before_destroy = true
   }
   value = true

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -184,7 +184,7 @@ resource "aws_instance" "web" {
 | Attribute               | Type | Description                                                              |
 |-------------------------|------|--------------------------------------------------------------------------|
 | `create_before_destroy` | bool | When `true`, creates the replacement before destroying the old resource. |
-| `prevent_destroy`       | bool | Protect resource from accidental deletion (maps to Pulumi `protect`)     |
+| `prevent_destroy`       | bool | Refuse plans that would destroy this resource                            |
 | `ignore_changes`        | list | Property paths to exclude from diff detection                            |
 | `replace_triggered_by`  | list | Replace this resource when any referenced resource or attribute changes  |
 
@@ -328,6 +328,7 @@ resource "aws_instance" "web" {
     name                       = "web-primary"
     parent                     = module.my_component
     additional_secret_outputs  = ["password"]
+    protect                    = true
     retain_on_delete           = true
     deleted_with               = aws_vpc.main
     replace_on_changes         = ["ami"]
@@ -341,21 +342,22 @@ resource "aws_instance" "web" {
 }
 ```
 
-| Attribute                   | Type         | Description                                                  |
-|-----------------------------|--------------|--------------------------------------------------------------|
-| `name`                      | string       | Override the Pulumi logical name                             |
-| `parent`                    | reference    | Parent resource for component hierarchy                      |
-| `additional_secret_outputs` | list(string) | Output properties to encrypt in state                        |
-| `retain_on_delete`          | bool         | Keep the cloud resource when removed from the program        |
-| `deleted_with`              | reference    | Cascade deletion when the referenced resource is deleted     |
-| `replace_with`              | list         | Resources whose replacement triggers replacement of this one |
-| `hide_diffs`                | list(string) | Property paths whose diffs should not be displayed           |
-| `replace_on_changes`        | list(string) | Property paths that force replacement when changed           |
-| `import_id`                 | string       | Cloud resource ID to import                                  |
-| `aliases`                   | list         | Alternative names for this resource (used during renames)    |
-| `version`                   | string       | Provider plugin version                                      |
-| `plugin_download_url`       | string       | URL to download the provider plugin from                     |
-| `env_var_mappings`          | expression   | Environment variable remappings for the provider             |
+| Attribute                   | Type         | Description                                                                   |
+|-----------------------------|--------------|-------------------------------------------------------------------------------|
+| `name`                      | string       | Override the Pulumi logical name                                              |
+| `parent`                    | reference    | Parent resource for component hierarchy                                       |
+| `additional_secret_outputs` | list(string) | Output properties to encrypt in state                                         |
+| `protect`                   | bool         | Mark the resource protected in state; deleting it requires unprotecting first |
+| `retain_on_delete`          | bool         | Keep the cloud resource when removed from the program                         |
+| `deleted_with`              | reference    | Cascade deletion when the referenced resource is deleted                      |
+| `replace_with`              | list         | Resources whose replacement triggers replacement of this one                  |
+| `hide_diffs`                | list(string) | Property paths whose diffs should not be displayed                            |
+| `replace_on_changes`        | list(string) | Property paths that force replacement when changed                            |
+| `import_id`                 | string       | Cloud resource ID to import                                                   |
+| `aliases`                   | list         | Alternative names for this resource (used during renames)                     |
+| `version`                   | string       | Provider plugin version                                                       |
+| `plugin_download_url`       | string       | URL to download the provider plugin from                                      |
+| `env_var_mappings`          | expression   | Environment variable remappings for the provider                              |
 
 To trigger replacement when another resource or attribute changes, use the
 standard Terraform [`replace_triggered_by`](#lifecycle-block) lifecycle
@@ -578,7 +580,9 @@ Like resources, a module block accepts a nested `pulumi` block; its `name`
 attribute overrides the Pulumi logical name of each module instance
 (evaluated per instance, with `count.index`/`each.key` in scope). The
 overridden name also prefixes the derived names of everything inside the
-instance, and is visible to the module source as `pulumi.module.name`.
+instance, and is visible to the module source as `pulumi.module.name`. Its
+`protect` attribute marks each instance's component resource protected in
+state.
 
 ```hcl
 module "vpc" {
@@ -929,17 +933,17 @@ Differences from Terraform to be aware of:
 
 ### Feature Mappings
 
-| Terraform Feature       | Pulumi Equivalent      | Notes                                    |
-|-------------------------|------------------------|------------------------------------------|
-| `prevent_destroy`       | `protect`              | Same behavior                            |
-| `ignore_changes`        | `ignoreChanges`        | Same behavior                            |
-| `create_before_destroy` | `deleteBeforeReplace`  | Inverted; defaults to TF delete-first    |
-| `replace_triggered_by`  | `replacementTrigger`   | Replaces when a referenced value changes |
-| `moved` blocks          | `aliases`              | Renames without recreation               |
-| `import` blocks         | Import resource option | Imports existing resources               |
-| `timeouts`              | `customTimeouts`       | Same duration format                     |
-| Modules                 | Component resources    | All source types supported               |
-| Provisioners            | Command provider       | `local-exec`, `remote-exec`, `file`      |
+| Terraform Feature       | Pulumi Equivalent      | Notes                                     |
+|-------------------------|------------------------|-------------------------------------------|
+| `prevent_destroy`       | (native)               | Guard lifts when removed from the program |
+| `ignore_changes`        | `ignoreChanges`        | Same behavior                             |
+| `create_before_destroy` | `deleteBeforeReplace`  | Inverted; defaults to TF delete-first     |
+| `replace_triggered_by`  | `replacementTrigger`   | Replaces when a referenced value changes  |
+| `moved` blocks          | `aliases`              | Renames without recreation                |
+| `import` blocks         | Import resource option | Imports existing resources                |
+| `timeouts`              | `customTimeouts`       | Same duration format                      |
+| Modules                 | Component resources    | All source types supported                |
+| Provisioners            | Command provider       | `local-exec`, `remote-exec`, `file`       |
 
 ### Unsupported Features
 

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -1341,6 +1341,14 @@ func (g *generator) genResourceOptions(body *hclwrite.Body, r *pcl.Resource) hcl
 		g.genPropertyPathTraversalList(pulumiBody(), "additional_secret_outputs", opts.AdditionalSecretOutputs)
 	}
 
+	if opts.Protect != nil {
+		tokens, d := g.exprTokens(opts.Protect, schema.BoolType)
+		diags = append(diags, d...)
+		if !d.HasErrors() {
+			pulumiBody().SetAttributeRaw("protect", tokens)
+		}
+	}
+
 	if opts.RetainOnDelete != nil {
 		tokens, d := g.exprTokens(opts.RetainOnDelete, schema.BoolType)
 		diags = append(diags, d...)
@@ -1746,13 +1754,6 @@ func (g *generator) genLifecycleBlock(body *hclwrite.Body, opts *pcl.ResourceOpt
 	var attrs []attr
 
 	if opts != nil {
-		if opts.Protect != nil {
-			tokens, d := g.exprTokens(opts.Protect, schema.BoolType)
-			*diags = append(*diags, d...)
-			if !d.HasErrors() {
-				attrs = append(attrs, attr{"prevent_destroy", tokens})
-			}
-		}
 		if opts.IgnoreChanges != nil {
 			tokens, d := g.exprTokens(opts.IgnoreChanges, schema.AnyType)
 			*diags = append(*diags, d...)
@@ -1969,11 +1970,27 @@ func (g *generator) genModule(body *hclwrite.Body, c *pcl.Component) hcl.Diagnos
 		naming, d = g.genRange(block.Body(), c.Options.Range)
 		diags = append(diags, d...)
 	}
+	var pulumiBlockBody *hclwrite.Body
+	pulumiBody := func() *hclwrite.Body {
+		if pulumiBlockBody == nil {
+			pulumiBlockBody = block.Body().AppendNewBlock("pulumi", nil).Body()
+		}
+		return pulumiBlockBody
+	}
+
 	// Pin the component instances' names the same way ranged resources are
 	// pinned, so nested components keep the "<parent>-<child>" names the
 	// other languages produce.
 	if tokens := pinnedNameTokens(g.insideComponent, c.LogicalName(), naming); tokens != nil {
-		block.Body().AppendNewBlock("pulumi", nil).Body().SetAttributeRaw("name", tokens)
+		pulumiBody().SetAttributeRaw("name", tokens)
+	}
+
+	if c.Options != nil && c.Options.Protect != nil {
+		tokens, d := g.exprTokens(c.Options.Protect, schema.BoolType)
+		diags = append(diags, d...)
+		if !d.HasErrors() {
+			pulumiBody().SetAttributeRaw("protect", tokens)
+		}
 	}
 
 	for _, attr := range c.Inputs {

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -546,6 +546,7 @@ var resourceOptionHCLToPCL = map[string]string{
 	"import_id":                 "import",
 	"parent":                    "parent",
 	"plugin_download_url":       "pluginDownloadURL",
+	"protect":                   "protect",
 	"provider":                  "provider",
 	"providers":                 "providers",
 	"range":                     "range",

--- a/pkg/hcl/ast/module.go
+++ b/pkg/hcl/ast/module.go
@@ -73,6 +73,11 @@ type Module struct {
 	// calling scope, with count.index/each.key in scope.
 	PulumiName hcl.Expression
 
+	// Protect if true marks each instance's component resource protected in
+	// the engine's state. It is evaluated per instance in the calling scope,
+	// with count.index/each.key in scope.
+	Protect hcl.Expression
+
 	// DeclRange is the source range of the module block.
 	DeclRange hcl.Range
 }

--- a/pkg/hcl/ast/resource.go
+++ b/pkg/hcl/ast/resource.go
@@ -95,6 +95,12 @@ type Resource struct {
 	// secret. Each entry names a single top-level property.
 	AdditionalSecretOutputs []hcl.Traversal
 
+	// Protect if true marks the resource protected in the engine's state, so
+	// deleting it requires unprotecting first. Unlike lifecycle
+	// prevent_destroy, the guard persists in state after the resource leaves
+	// the program.
+	Protect hcl.Expression
+
 	// RetainOnDelete if true means the provider's Delete method will not be called for this resource.
 	RetainOnDelete hcl.Expression
 

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -926,6 +926,10 @@ func (p *Parser) parsePulumiResourceOptions(block *hcl.Block, resource *ast.Reso
 		}
 	}
 
+	if attr, ok := content.Attributes["protect"]; ok {
+		resource.Protect = attr.Expr
+	}
+
 	if attr, ok := content.Attributes["retain_on_delete"]; ok {
 		resource.RetainOnDelete = attr.Expr
 	}
@@ -1454,6 +1458,9 @@ func (p *Parser) parseModuleBlock(config *ast.Config, block *hcl.Block) hcl.Diag
 			diags = append(diags, optDiags...)
 			if attr, ok := optContent.Attributes["name"]; ok {
 				module.PulumiName = attr.Expr
+			}
+			if attr, ok := optContent.Attributes["protect"]; ok {
+				module.Protect = attr.Expr
 			}
 		}
 	}

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -209,6 +209,7 @@ var pulumiResourceOptionsSchema = &hcl.BodySchema{
 		{Name: "name"},
 		{Name: "additional_secret_outputs"},
 		{Name: "parent"},
+		{Name: "protect"},
 		{Name: "retain_on_delete"},
 		{Name: "deleted_with"},
 		{Name: "replace_with"},
@@ -303,6 +304,7 @@ var moduleSchema = &hcl.BodySchema{
 var pulumiModuleOptionsSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{Name: "name"},
+		{Name: "protect"},
 	},
 }
 

--- a/pkg/hcl/run/destroy_dispatch.go
+++ b/pkg/hcl/run/destroy_dispatch.go
@@ -130,7 +130,10 @@ func (e *Engine) registerDestroyDispatcher(ctx context.Context) {
 		return
 	}
 	if err := e.resmon.RegisterResourceHook(ctx, destroyProvisionerHook, e.dispatcher.dispatch, ResourceHookOptions{
-		OnDryRun: false, // TF doesn't run provisioners during plan.
+		// The prevent_destroy guard must refuse at plan time, so the hook
+		// fires during previews; provisioner entries gate themselves on the
+		// deployment's dry-run flag instead.
+		OnDryRun: true,
 	}); err != nil {
 		_ = e.resmon.LogWarning(ctx, fmt.Sprintf(
 			"registering the destroy-time provisioner hook: %v", err))
@@ -166,6 +169,14 @@ type blockEntry struct {
 	// parent-chain check — a gone module call's component type names its
 	// source, which is no longer in the configuration.
 	moduleTarget bool
+	// preventDestroy refuses the orphan's delete: the block is still in
+	// configuration with its lifecycle guard set (a count shrink or dropped
+	// for_each key), so its instances may not be destroyed.
+	preventDestroy bool
+	// guardErr is a prevent_destroy evaluation failure, surfaced when an
+	// orphan of this block is actually deleted: a guard that cannot be
+	// evaluated must refuse the delete, not silently allow it.
+	guardErr error
 }
 
 // urnTypes returns u's own type and the qualified-type chain contributed by
@@ -204,6 +215,16 @@ func (b *blockEntry) matches(args *ResourceHookArgs) bool {
 // error would make the resource undeletable.
 func (b *blockEntry) run(ctx context.Context, args *ResourceHookArgs) error {
 	name := strings.TrimPrefix(args.Name, b.prefix)
+	if b.guardErr != nil {
+		return b.guardErr
+	}
+	if b.preventDestroy {
+		return preventDestroyRefusal(name)
+	}
+	if b.dryRun {
+		// Provisioners never run during plan.
+		return nil
+	}
 	addr, err := modulepath.ParseAddress(name)
 	if err != nil {
 		return nil
@@ -314,7 +335,10 @@ func (e *Engine) recordBlockEntry(
 	ctx context.Context, res *ast.Resource, resSchema *schema.Resource,
 	evalCtx *eval.Context, parentURN urn.URN, modInst *moduleInstance,
 ) {
-	if e.resmon == nil || !hasDestroyProvisioners(res) {
+	// Per-instance symbols are rejected by evalPreventDestroy, so the block's
+	// module scope evaluates the guard the same way the live-instance path does.
+	guarded, guardErr := evalPreventDestroy(res, evalCtx.HCLContext())
+	if guardErr == nil && !guarded && !hasDestroyProvisioners(res) {
 		return
 	}
 
@@ -322,14 +346,16 @@ func (e *Engine) recordBlockEntry(
 	prefix := strings.TrimSuffix(probeName, "probe")
 
 	entry := &blockEntry{
-		resmon:    e.resmon,
-		dryRun:    e.dryRun,
-		res:       res,
-		resSchema: resSchema,
-		mapping:   e.resolver.ResourceBodyMapping(ctx, res.Type),
-		token:     resSchema.Token,
-		prefix:    prefix,
-		evalCtx:   evalCtx,
+		resmon:         e.resmon,
+		dryRun:         e.dryRun,
+		res:            res,
+		resSchema:      resSchema,
+		mapping:        e.resolver.ResourceBodyMapping(ctx, res.Type),
+		token:          resSchema.Token,
+		prefix:         prefix,
+		evalCtx:        evalCtx,
+		preventDestroy: guarded,
+		guardErr:       guardErr,
 	}
 	_, entry.parentChain = urnTypes(string(probeURN))
 	modConfig := modulepath.Root()

--- a/pkg/hcl/run/provisioner.go
+++ b/pkg/hcl/run/provisioner.go
@@ -31,17 +31,14 @@ import (
 	"github.com/pulumi-labs/pulumi-hcl/pkg/provisioner/runtime"
 )
 
-// bindProvisionerHooks binds AfterCreate (when=create) or BeforeDelete
-// (when=destroy). TF does not re-run provisioners on update — no AfterUpdate
-// binding. The HCL eval context is snapshotted now since the callback fires
-// asynchronously, after processing has moved past this resource.
+// bindGlobalHooks binds the instance's hook machinery.
 //
-// Destroy-time provisioners bind the constant [destroyProvisionerHook]: a
-// per-instance name recorded in state would be unregistered on a later run
-// that no longer declares the instance, bricking its delete. The runner is
-// keyed by a URN computed before registration, because a delete-before-replace
-// delete fires while RegisterResource is still blocked.
-func (e *Engine) bindProvisionerHooks(
+// The constant hook is used because a per-instance name recorded in state
+// would be unregistered on a later run that no longer declares the instance,
+// breaking its delete. The entry is keyed by a URN computed before
+// registration, because a delete-before-replace delete fires while
+// RegisterResource is still blocked.
+func (e *Engine) bindGlobalHooks(
 	ctx context.Context,
 	res *ast.Resource,
 	resSchema *schema.Resource,
@@ -51,12 +48,70 @@ func (e *Engine) bindProvisionerHooks(
 	opts *ResourceOptions,
 	resourceName string,
 ) error {
-	if len(res.Provisioners) == 0 {
+	if len(res.Provisioners) == 0 && !opts.PreventDestroy {
 		return nil
 	}
 	if opts.Hooks == nil {
 		opts.Hooks = &ResourceHookBinding{}
 	}
+
+	destroyProvisioners, err := e.bindProvisionerHooks(ctx, res, resSchema, mapping, instance, evalCtx, opts, resourceName)
+	if err != nil {
+		return err
+	}
+	guard := preventDestroyHook(opts, instance)
+	if guard == nil && destroyProvisioners == nil {
+		return nil
+	}
+
+	dryRun := e.dryRun
+	instanceURN, _ := e.resmon.ResolveURN(opts.Parent, resSchema.Token, resourceName)
+	e.dispatcher.putInstance(string(instanceURN),
+		func(hookCtx context.Context, args *ResourceHookArgs) error {
+			if guard != nil {
+				return guard(hookCtx, args)
+			}
+			if dryRun {
+				// Provisioners never run during plan.
+				return nil
+			}
+			if destroyProvisioners != nil {
+				return destroyProvisioners(hookCtx, args)
+			}
+			return nil
+		})
+	opts.Hooks.BeforeDelete = append(opts.Hooks.BeforeDelete, destroyProvisionerHook)
+	return nil
+}
+
+// preventDestroyHook returns the hook refusing this instance's delete, or nil
+// when the lifecycle guard is not set.
+func preventDestroyHook(opts *ResourceOptions, instance *graph.ExpandedResource) ResourceHookFunction {
+	if !opts.PreventDestroy {
+		return nil
+	}
+	addr := instance.Key.String()
+	return func(context.Context, *ResourceHookArgs) error {
+		return preventDestroyRefusal(addr)
+	}
+}
+
+// bindProvisionerHooks validates res's provisioners, registers and binds the
+// create-time (AfterCreate) hooks, and returns the destroy-time runner for
+// the dispatcher entry — nil when there are no destroy-time provisioners. TF
+// does not re-run provisioners on update — no AfterUpdate binding. The HCL
+// eval context is snapshotted now since the callbacks fire asynchronously,
+// after processing has moved past this resource.
+func (e *Engine) bindProvisionerHooks(
+	ctx context.Context,
+	res *ast.Resource,
+	resSchema *schema.Resource,
+	mapping *bridge.BodyMapping,
+	instance *graph.ExpandedResource,
+	evalCtx *eval.Context,
+	opts *ResourceOptions,
+	resourceName string,
+) (ResourceHookFunction, error) {
 	hclSnapshot := evalCtx.HCLContext()
 	dryRun := e.dryRun
 
@@ -89,7 +144,7 @@ func (e *Engine) bindProvisionerHooks(
 	for i, prov := range res.Provisioners {
 		prov, index := prov, i+1
 		if err := runtime.Validate(prov.Type); err != nil {
-			return fmt.Errorf("provisioner %d for %s: %w", index, instance.Key, err)
+			return nil, fmt.Errorf("provisioner %d for %s: %w", index, instance.Key, err)
 		}
 		if prov.When == "destroy" {
 			destroy = true
@@ -102,29 +157,25 @@ func (e *Engine) bindProvisionerHooks(
 		if err := e.resmon.RegisterResourceHook(ctx, hookName, callback, ResourceHookOptions{
 			OnDryRun: false, // TF doesn't run provisioners during plan.
 		}); err != nil {
-			return fmt.Errorf("registering provisioner hook: %w", err)
+			return nil, fmt.Errorf("registering provisioner hook: %w", err)
 		}
 		opts.Hooks.AfterCreate = append(opts.Hooks.AfterCreate, hookName)
 	}
 	if !destroy {
-		return nil
+		return nil, nil
 	}
 
-	instanceURN, _ := e.resmon.ResolveURN(opts.Parent, resSchema.Token, resourceName)
-	e.dispatcher.putInstance(string(instanceURN),
-		func(hookCtx context.Context, args *ResourceHookArgs) error {
-			for i, prov := range res.Provisioners {
-				if prov.When != "destroy" {
-					continue
-				}
-				if err := runOne(hookCtx, prov, i+1, args.OldOutputs, args.ID, args.URN); err != nil {
-					return err
-				}
+	return func(hookCtx context.Context, args *ResourceHookArgs) error {
+		for i, prov := range res.Provisioners {
+			if prov.When != "destroy" {
+				continue
 			}
-			return nil
-		})
-	opts.Hooks.BeforeDelete = append(opts.Hooks.BeforeDelete, destroyProvisionerHook)
-	return nil
+			if err := runOne(hookCtx, prov, i+1, args.OldOutputs, args.ID, args.URN); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, nil
 }
 
 // effectiveConnectionBody: provisioner-level overrides resource-level.

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2138,7 +2138,7 @@ func evalPreventDestroy(res *ast.Resource, hclCtx *hcl.EvalContext) (bool, error
 	for _, trav := range res.Lifecycle.PreventDestroy.Variables() {
 		if root := trav.RootName(); root == "count" || root == "each" {
 			return false, fmt.Errorf(
-				"Invalid reference in prevent_destroy on %q: the argument cannot refer to %s.*, "+
+				"invalid reference in prevent_destroy on %q: the argument cannot refer to %s.*, "+
 					"because it must be evaluable for instances that have already been removed from the configuration",
 				res.Type+"."+res.Name, root)
 		}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1629,7 +1629,7 @@ func (e *Engine) registerResourceInstanceInContext(
 		}
 	}
 
-	opts, err := e.buildResourceOptionsInContext(ctx, node, res, instance, evalCtx, parentURN, modInst, resourceMapping, resSchema.InputProperties, resSchema.Properties, resourceInputs)
+	opts, err := e.buildResourceOptions(ctx, node, res, instance, evalCtx, parentURN, modInst, resourceMapping, resSchema.InputProperties, resSchema.Properties, resourceInputs)
 	if err != nil {
 		return err
 	}
@@ -1705,8 +1705,8 @@ func (e *Engine) registerResourceInstanceInContext(
 		}
 	}
 
-	if len(res.Provisioners) > 0 {
-		if err := e.bindProvisionerHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName); err != nil {
+	if len(res.Provisioners) > 0 || opts.PreventDestroy {
+		if err := e.bindGlobalHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName); err != nil {
 			return err
 		}
 	}
@@ -1770,8 +1770,8 @@ func (e *Engine) registerResourceInstanceInContext(
 	return nil
 }
 
-// buildResourceOptionsInContext builds resource options using the provided eval context and parent URN.
-func (e *Engine) buildResourceOptionsInContext(
+// buildResourceOptions builds resource options using the provided eval context and parent URN.
+func (e *Engine) buildResourceOptions(
 	ctx context.Context, node *graph.Node, res *ast.Resource, instance *graph.ExpandedResource,
 	evalCtx *eval.Context, parentURN urn.URN,
 	modInst *moduleInstance, resourceMapping *bridge.BodyMapping,
@@ -1801,22 +1801,11 @@ func (e *Engine) buildResourceOptionsInContext(
 
 	// Handle lifecycle options
 	if res.Lifecycle != nil {
-		if res.Lifecycle.PreventDestroy != nil {
-			val, diags := res.Lifecycle.PreventDestroy.Value(hclCtx)
-			if diags.HasErrors() {
-				return nil, fmt.Errorf("evaluating prevent_destroy on %q: %s",
-					res.Type+"."+res.Name, diags.Error())
-			}
-			val, _ = val.Unmark()
-			val, err := ctyconvert.Convert(val, cty.Bool)
-			if err != nil {
-				return nil, fmt.Errorf("invalid prevent_destroy value on %q: %w",
-					res.Type+"."+res.Name, err)
-			}
-			if cty.True.RawEquals(val) {
-				opts.Protect = true
-			}
+		guarded, err := evalPreventDestroy(res, hclCtx)
+		if err != nil {
+			return nil, err
 		}
+		opts.PreventDestroy = guarded
 		// ignore_changes maps to ignoreChanges. The traversal names are TF
 		// (snake_case) attribute names; the Pulumi engine matches ignoreChanges
 		// paths against Pulumi (camelCase) property names, so they must be
@@ -1986,6 +1975,14 @@ func (e *Engine) buildResourceOptionsInContext(
 		}
 	}
 
+	if res.Protect != nil {
+		val, diags := res.Protect.Value(hclCtx)
+		val, _ = val.Unmark()
+		if !diags.HasErrors() && val.Type() == cty.Bool && !val.IsNull() && val.IsKnown() {
+			opts.Protect = val.True()
+		}
+	}
+
 	if res.RetainOnDelete != nil {
 		val, diags := res.RetainOnDelete.Value(hclCtx)
 		val, _ = val.Unmark()
@@ -2117,8 +2114,7 @@ func (e *Engine) buildResourceOptionsInContext(
 
 	if key, ok := graph.TraversalKey(node.Key.Module, res.ResourceParent); ok {
 		if parentOpts, ok := e.resourceInheritableOpts.Get(graph.InstanceKey{Node: key}); ok {
-			if (res.Lifecycle == nil || res.Lifecycle.PreventDestroy == nil) &&
-				parentOpts.Protect != nil && *parentOpts.Protect {
+			if res.Protect == nil && parentOpts.Protect != nil && *parentOpts.Protect {
 				opts.Protect = true
 			}
 			if res.RetainOnDelete == nil && parentOpts.RetainOnDelete != nil {
@@ -2128,6 +2124,46 @@ func (e *Engine) buildResourceOptionsInContext(
 	}
 
 	return opts, nil
+}
+
+// evalPreventDestroy evaluates res's lifecycle.prevent_destroy in hclCtx. An
+// unknown value (a computed reference during preview) counts as unset.
+// References to per-instance symbols are rejected statically: the guard must
+// be evaluable for instances that have already been removed from the
+// configuration, whose per-instance data is gone.
+func evalPreventDestroy(res *ast.Resource, hclCtx *hcl.EvalContext) (bool, error) {
+	if res.Lifecycle == nil || res.Lifecycle.PreventDestroy == nil {
+		return false, nil
+	}
+	for _, trav := range res.Lifecycle.PreventDestroy.Variables() {
+		if root := trav.RootName(); root == "count" || root == "each" {
+			return false, fmt.Errorf(
+				"Invalid reference in prevent_destroy on %q: the argument cannot refer to %s.*, "+
+					"because it must be evaluable for instances that have already been removed from the configuration",
+				res.Type+"."+res.Name, root)
+		}
+	}
+	val, diags := res.Lifecycle.PreventDestroy.Value(hclCtx)
+	if diags.HasErrors() {
+		return false, fmt.Errorf("evaluating prevent_destroy on %q: %s",
+			res.Type+"."+res.Name, diags.Error())
+	}
+	val, _ = val.Unmark()
+	val, err := ctyconvert.Convert(val, cty.Bool)
+	if err != nil {
+		return false, fmt.Errorf("invalid prevent_destroy value on %q: %w",
+			res.Type+"."+res.Name, err)
+	}
+
+	return val.True(), nil
+}
+
+// preventDestroyRefusal is returned from the destroy dispatcher for a guarded
+// instance; tfcompat tests compare the wording across runtimes.
+func preventDestroyRefusal(addr string) error {
+	return fmt.Errorf(
+		"resource instance %s has prevent_destroy set, but the plan calls for it to be destroyed. "+
+			"To proceed, disable prevent_destroy for this resource", addr)
 }
 
 // resolveMovedAliases finds the `moved` blocks that rename the resource instance
@@ -3140,6 +3176,12 @@ type ResourceOptions struct {
 	PluginDownloadURL       string
 	PackageRef              PackageRef
 	Hooks                   *ResourceHookBinding
+
+	// PreventDestroy is enforced by the destroy dispatcher hook, not the
+	// engine: the guard must be re-evaluated from current configuration on
+	// every run, while an engine option would persist in state. Never
+	// forwarded to RegisterResource.
+	PreventDestroy bool
 }
 
 // registerResource registers a resource with the Pulumi engine. tfType is the
@@ -3346,7 +3388,7 @@ func (e *Engine) invokeDataSourceOnce(
 
 	// depends_on marks the outputs with every registered instance URN of the
 	// target block, keyed or not — dependency metadata is resource-wide (see
-	// buildResourceOptionsInContext).
+	// buildResourceOptions).
 	dependsOnPending := e.moduleDependsOnPending(mi)
 	for _, dep := range ds.DependsOn {
 		block, ok := graph.TraversalKey(node.Key.Module, dep)
@@ -4053,6 +4095,14 @@ func (e *Engine) initModuleCallIn(
 		}
 		componentOpts := &ResourceOptions{Parent: parentURN}
 		componentOpts.Aliases = e.moduleComponentAliases(instPath)
+		if mod.Protect != nil {
+			hclCtx := parentEvalCtx.HCLContextWithIteration(index, eachKey, eachVal)
+			val, diags := mod.Protect.Value(hclCtx)
+			val, _ = val.Unmark()
+			if !diags.HasErrors() && val.Type() == cty.Bool && !val.IsNull() && val.IsKnown() {
+				componentOpts.Protect = val.True()
+			}
+		}
 		componentURN, _, _, err := e.registerComponentResource(ctx, componentType, instName, property.NewMap(inputs), componentOpts)
 		if err != nil {
 			return nil, fmt.Errorf("registering module component %s: %w", instPath.String(), err)
@@ -4316,6 +4366,7 @@ func (e *Engine) registerComponentResource(
 		Inputs:       inputs,
 		Dependencies: deps,
 		Parent:       opts.Parent,
+		Protect:      opts.Protect,
 	})
 	if err != nil {
 		return "", "", property.Map{}, err

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -979,10 +979,12 @@ resource "aws_instance" "web" {
 
 	req := mock.RegisteredResources[1]
 
-	// prevent_destroy maps to Protect
-	if !req.Protect {
-		t.Error("expected Protect=true from prevent_destroy")
-	}
+	// prevent_destroy binds the destroy dispatcher hook rather than the
+	// engine's Protect option, so the guard lifts when the block leaves the
+	// configuration.
+	assert.False(t, req.Protect)
+	require.NotNil(t, req.Hooks)
+	assert.Equal(t, []string{"pulumi-hcl:provisioner:before-delete"}, req.Hooks.BeforeDelete)
 
 	assert.Equal(t, []property.Glob{property.GlobFromSegments(property.NewSegment("tags"))}, req.IgnoreChanges)
 }
@@ -1044,7 +1046,10 @@ resource "aws_instance" "web" {
 		mock, err := runEngine(t, "var.flag")
 		require.NoError(t, err)
 		require.Len(t, mock.RegisteredResources, 2)
-		assert.True(t, mock.RegisteredResources[1].Protect)
+		req := mock.RegisteredResources[1]
+		assert.False(t, req.Protect)
+		require.NotNil(t, req.Hooks)
+		assert.Equal(t, []string{"pulumi-hcl:provisioner:before-delete"}, req.Hooks.BeforeDelete)
 	})
 
 	t.Run("negated variable", func(t *testing.T) {
@@ -1052,13 +1057,126 @@ resource "aws_instance" "web" {
 		mock, err := runEngine(t, "!var.flag")
 		require.NoError(t, err)
 		require.Len(t, mock.RegisteredResources, 2)
-		assert.False(t, mock.RegisteredResources[1].Protect)
+		req := mock.RegisteredResources[1]
+		assert.False(t, req.Protect)
+		assert.Nil(t, req.Hooks)
 	})
 
 	t.Run("invalid type", func(t *testing.T) {
 		t.Parallel()
 		_, err := runEngine(t, "[true]")
 		require.ErrorContains(t, err, `invalid prevent_destroy value on "aws_instance.web"`)
+	})
+
+	t.Run("per-instance reference", func(t *testing.T) {
+		t.Parallel()
+		_, err := runEngine(t, "count.index == 0")
+		require.ErrorContains(t, err, "Invalid reference in prevent_destroy")
+	})
+}
+
+// TestEngine_PulumiProtect verifies that a resource or module `pulumi {
+// protect = ... }` maps to the engine's Protect option.
+func TestEngine_PulumiProtect(t *testing.T) {
+	t.Parallel()
+
+	awsSchema := func(t *testing.T) schema.ReferenceLoader {
+		return schemaloader.New(t, schema.PackageSpec{
+			Name: "aws",
+			Resources: map[string]schema.ResourceSpec{
+				"aws:index:Instance": {
+					InputProperties: map[string]schema.PropertySpec{
+						"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"ami": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		})
+	}
+
+	t.Run("resource", func(t *testing.T) {
+		t.Parallel()
+		src := []byte(`
+resource "aws_instance" "web" {
+  ami = "ami-12345"
+
+  pulumi {
+    protect = true
+  }
+}
+`)
+		p := parser.NewParser()
+		config, diags := p.ParseSource("test.hcl", src)
+		require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+		mock := &testutil.MockResourceMonitor{}
+		engine := newTestEngine(t, config, &run.EngineOptions{
+			ModuleLoader:    testModuleLoader(t),
+			ProjectName:     "test-project",
+			StackName:       "dev",
+			ResourceMonitor: mock,
+			WorkDir:         t.TempDir(),
+			RootDir:         t.TempDir(),
+			SchemaLoader:    awsSchema(t),
+		})
+		require.NoError(t, engine.Run(t.Context()))
+
+		require.Len(t, mock.RegisteredResources, 2)
+		req := mock.RegisteredResources[1]
+		assert.True(t, req.Protect)
+		assert.Nil(t, req.Hooks)
+	})
+
+	t.Run("module", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		moduleDir := tmpDir + "/modules/child"
+		require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+		require.NoError(t, os.WriteFile(moduleDir+"/main.tf", []byte(`
+resource "aws_instance" "r" {
+  ami = "ami-r"
+}
+`), 0o644))
+		require.NoError(t, os.WriteFile(tmpDir+"/main.tf", []byte(`
+module "a" {
+  source = "./modules/child"
+
+  pulumi {
+    protect = true
+  }
+}
+`), 0o644))
+
+		p := parser.NewParser()
+		config, diags := p.ParseDirectory(tmpDir)
+		require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+		mock := &testutil.MockResourceMonitor{}
+		engine := newTestEngine(t, config, &run.EngineOptions{
+			ModuleLoader:    testLiveModuleLoader(t),
+			ProjectName:     "test-project",
+			StackName:       "dev",
+			ResourceMonitor: mock,
+			WorkDir:         tmpDir,
+			RootDir:         tmpDir,
+			SchemaLoader:    awsSchema(t),
+		})
+		require.NoError(t, engine.Run(t.Context()))
+
+		protects := map[string]bool{}
+		for _, req := range mock.RegisteredResources {
+			if req.Type != "pulumi:pulumi:Stack" {
+				protects[req.Type] = req.Protect
+			}
+		}
+		assert.Equal(t, map[string]bool{
+			"components:index:Child": true,
+			"aws:index:Instance":     false,
+		}, protects)
 	})
 }
 

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -1071,7 +1071,7 @@ resource "aws_instance" "web" {
 	t.Run("per-instance reference", func(t *testing.T) {
 		t.Parallel()
 		_, err := runEngine(t, "count.index == 0")
-		require.ErrorContains(t, err, "Invalid reference in prevent_destroy")
+		require.ErrorContains(t, err, "invalid reference in prevent_destroy")
 	})
 }
 

--- a/tests/tfcompat/l2_prevent_destroy_test.go
+++ b/tests/tfcompat/l2_prevent_destroy_test.go
@@ -15,32 +15,106 @@
 package tfcompat_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
 	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
-	"github.com/stretchr/testify/assert"
 )
 
+// preventDestroyErr is the plan-time refusal both runtimes must emit when a
+// prevent_destroy resource would be destroyed. Kept short of the full
+// sentence because tofu hard-wraps its diagnostics at a position that varies
+// with the resource address.
+const preventDestroyErr = "has prevent_destroy set"
+
+// TestL2PreventDestroyRemoved removes a guarded resource from configuration.
+// The guard is config-gated: removing the block removes the guard with it, so
+// a single apply destroys the orphaned instance and succeeds.
+func TestL2PreventDestroyRemoved(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_prevent_destroy_removed", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}
+
+// TestL2PreventDestroyReplace forces a replacement of a guarded resource. The
+// destroy half of the replacement is refused with the same diagnostic at both
+// plan and apply time.
+func TestL2PreventDestroyReplace(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_prevent_destroy_replace", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "replacer", Factory: providers.ReplacerProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{},
+			{Mode: tfcompat.StagePreview, ExpectErr: preventDestroyErr},
+			{ExpectErr: preventDestroyErr},
+		},
+	})
+}
+
+// TestL2PreventDestroyCount shrinks the count of a guarded resource. The
+// orphaned instance's block is still in configuration with the guard set, so
+// the apply is refused.
+func TestL2PreventDestroyCount(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_prevent_destroy_count", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{},
+			{ExpectErr: preventDestroyErr},
+		},
+	})
+}
+
+// TestL2PreventDestroyCountRef sets prevent_destroy from count.index. The
+// guard must be evaluable for instances whose per-instance data is gone, so
+// both runtimes reject the reference outright.
+func TestL2PreventDestroyCountRef(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_prevent_destroy_count_ref", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{ExpectErr: "Invalid reference in prevent_destroy"},
+		},
+	})
+}
+
+// TestL2PreventDestroyProvisioner destroys a guarded resource that also
+// carries a destroy-time provisioner. The guard blocks the plan before the
+// provisioner fires, so the marker file must not exist afterwards.
+func TestL2PreventDestroyProvisioner(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_prevent_destroy_provisioner", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{},
+			{Mode: tfcompat.StageDestroy, ExpectErr: preventDestroyErr},
+			{},
+		},
+	})
+}
+
+// TestL2PreventDestroy destroys a guarded resource: both runtimes refuse and
+// the instance survives.
 func TestL2PreventDestroy(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_prevent_destroy", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
-		AssertState: func(t *testing.T, resources []apitype.ResourceV3) {
-			var found *apitype.ResourceV3
-			for i, r := range resources {
-				if strings.HasSuffix(string(r.URN), "::protected") {
-					found = &resources[i]
-					break
-				}
-			}
-			if assert.NotNil(t, found, "simple_resource.protected not found in Pulumi state") {
-				assert.True(t, found.Protect, "expected Protect=true on simple_resource.protected; got %+v", found)
-			}
+		Stages: []tfcompat.Stage{
+			{},
+			{Mode: tfcompat.StageDestroy, ExpectErr: preventDestroyErr},
 		},
 	})
 }

--- a/tests/tfcompat/l2_prevent_destroy_test.go
+++ b/tests/tfcompat/l2_prevent_destroy_test.go
@@ -82,7 +82,9 @@ func TestL2PreventDestroyCountRef(t *testing.T) {
 			{Name: "simple", Factory: providers.SimpleProvider},
 		},
 		Stages: []tfcompat.Stage{
-			{ExpectErr: "Invalid reference in prevent_destroy"},
+			// Case-neutral so it matches tofu's capitalized diagnostic and the
+			// runtime's lowercase error.
+			{ExpectErr: "reference in prevent_destroy"},
 		},
 	})
 }

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_count/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_count/0/main.tf
@@ -1,0 +1,8 @@
+resource "simple_resource" "guarded" {
+  count     = 2
+  input_one = "n-${count.index}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_count/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_count/1/main.tf
@@ -1,0 +1,10 @@
+# Shrinking count orphans instance [1], but the block still carries the
+# guard, so the plan is refused.
+resource "simple_resource" "guarded" {
+  count     = 1
+  input_one = "n-${count.index}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_count_ref/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_count_ref/main.tf
@@ -1,0 +1,10 @@
+# prevent_destroy may not refer to per-instance symbols: the guard must be
+# evaluable for instances that have already been removed from configuration.
+resource "simple_resource" "guarded" {
+  count     = 2
+  input_one = "n-${count.index}"
+
+  lifecycle {
+    prevent_destroy = count.index == 0
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_provisioner/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_provisioner/0/main.tf
@@ -1,0 +1,14 @@
+# The marker lands under .terraform/ because that directory survives between
+# stages in each runtime's working directory.
+resource "simple_resource" "guarded" {
+  input_one = "hello"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "mkdir -p '${path.cwd}/.terraform' && touch '${path.cwd}/.terraform/pd-marker'"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_provisioner/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_provisioner/1/main.tf
@@ -1,0 +1,14 @@
+# Unchanged program; this stage runs a full destroy, which prevent_destroy
+# refuses before the destroy-time provisioner can fire.
+resource "simple_resource" "guarded" {
+  input_one = "hello"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "mkdir -p '${path.cwd}/.terraform' && touch '${path.cwd}/.terraform/pd-marker'"
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_provisioner/2/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_provisioner/2/main.tf
@@ -1,0 +1,18 @@
+# The blocked destroy must not have run the destroy-time provisioner; each
+# runtime checks its own working directory's marker.
+resource "simple_resource" "guarded" {
+  input_one = "hello"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "mkdir -p '${path.cwd}/.terraform' && touch '${path.cwd}/.terraform/pd-marker'"
+  }
+}
+
+output "provisioner_ran" {
+  value = fileexists("${path.cwd}/.terraform/pd-marker")
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_removed/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_removed/0/main.tf
@@ -1,0 +1,11 @@
+resource "simple_resource" "keep" {
+  input_one = "hello"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+output "result" {
+  value = simple_resource.keep.result
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_removed/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_removed/1/main.tf
@@ -1,0 +1,6 @@
+# The guarded resource is gone from configuration. prevent_destroy is
+# config-gated: removing the block removes the guard with it, so this single
+# apply destroys the orphaned instance and succeeds.
+output "done" {
+  value = "done"
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_replace/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_replace/0/main.tf
@@ -1,0 +1,11 @@
+resource "replacer_resource" "guarded" {
+  force = "a"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+output "result" {
+  value = replacer_resource.guarded.result
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_replace/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_replace/1/main.tf
@@ -1,0 +1,13 @@
+# `force` is ForceNew: this change plans a replacement, whose destroy half is
+# refused by prevent_destroy at plan time.
+resource "replacer_resource" "guarded" {
+  force = "b"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+output "result" {
+  value = replacer_resource.guarded.result
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_replace/2/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_replace/2/main.tf
@@ -1,0 +1,12 @@
+# Same replacement attempt as stage 1, driven through apply instead of plan.
+resource "replacer_resource" "guarded" {
+  force = "b"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+output "result" {
+  value = replacer_resource.guarded.result
+}


### PR DESCRIPTION
Switch Terraform's `prevent_destroy` from an analog to Pulumi's in-state `protect` resource option to a program hook enforced before-destroy hook. This allows removing a resource from state and then running `pulumi up`.

There is now a protect option in each resource's `pulumi` block to set the state level protect.

Closes https://github.com/pulumi-labs/pulumi-hcl/issues/344