### PR TITLE
Split `ast.DataSource` from `ast.Resource`

### DIFF
--- a/.changes/unreleased/language-host-bug-fixes-471.yaml
+++ b/.changes/unreleased/language-host-bug-fixes-471.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Reject lifecycle arguments, provisioner/connection/timeouts blocks, and unsupported `pulumi` options on `data` blocks
+time: 2026-07-30T13:30:00Z
+custom:
+    Component: language-host
+    PR: "471"

--- a/pkg/hcl/ast/check.go
+++ b/pkg/hcl/ast/check.go
@@ -40,9 +40,8 @@ type Check struct {
 
 	// DataResource is the check's optional scoped data source, read fresh on
 	// every operation and visible only to this check's assertions. A check may
-	// declare at most one. It is modelled as a Resource with IsDataSource set,
-	// matching data sources elsewhere in the config.
-	DataResource *Resource
+	// declare at most one.
+	DataResource *DataSource
 
 	// DeclRange is the source range of the check block.
 	DeclRange hcl.Range

--- a/pkg/hcl/ast/config.go
+++ b/pkg/hcl/ast/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	Resources map[string]*Resource
 
 	// DataSources maps "type.name" to data source definition.
-	DataSources map[string]*Resource
+	DataSources map[string]*DataSource
 
 	// Outputs maps output name to output definition.
 	Outputs map[string]*Output
@@ -88,7 +88,7 @@ func NewConfig() *Config {
 		Variables:   make(map[string]*Variable),
 		Locals:      make(map[string]*Local),
 		Resources:   make(map[string]*Resource),
-		DataSources: make(map[string]*Resource),
+		DataSources: make(map[string]*DataSource),
 		Outputs:     make(map[string]*Output),
 		Modules:     make(map[string]*Module),
 		Calls:       make(map[string]*Call),

--- a/pkg/hcl/ast/datasource.go
+++ b/pkg/hcl/ast/datasource.go
@@ -1,0 +1,72 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import (
+	"github.com/hashicorp/hcl/v2"
+)
+
+// DataSource represents a data block in HCL. A data source is a provider
+// read: it holds no state, so the managed-resource surface — lifecycle
+// arguments, provisioners, connections, timeouts, and most pulumi options —
+// does not apply and is rejected at parse time.
+//
+// Terraform syntax:
+//
+//	data "aws_ami" "ubuntu" {
+//	  most_recent = true
+//	}
+type DataSource struct {
+	// Type is the data source type (e.g., "aws_ami").
+	Type string
+
+	// Name is the local name of the data source (e.g., "ubuntu").
+	Name string
+
+	// Config is the body containing data source attributes.
+	// This excludes meta-arguments which are parsed separately.
+	Config hcl.Body
+
+	// Count is the count meta-argument expression, if present.
+	Count hcl.Expression
+
+	// ForEach is the for_each meta-argument expression, if present.
+	ForEach hcl.Expression
+
+	// DependsOn contains explicit dependencies from the depends_on meta-argument.
+	DependsOn []hcl.Traversal
+
+	// Provider is the raw expression from the `provider` attribute, if specified.
+	// It is evaluated at runtime; the resulting value supplies the provider URN/ID.
+	Provider hcl.Expression
+
+	// Version is the version of the provider plugin to use for this data source.
+	Version hcl.Expression
+
+	// PluginDownloadURL is the URL from which the provider plugin should be downloaded.
+	PluginDownloadURL hcl.Expression
+
+	// Preconditions contains precondition checks (evaluated before the read).
+	Preconditions []*CheckRule
+
+	// Postconditions contains postcondition checks (evaluated after the read).
+	Postconditions []*CheckRule
+
+	// DeclRange is the source range of the entire data block.
+	DeclRange hcl.Range
+
+	// TypeRange is the source range of the data source type.
+	TypeRange hcl.Range
+}

--- a/pkg/hcl/ast/datasource.go
+++ b/pkg/hcl/ast/datasource.go
@@ -52,6 +52,11 @@ type DataSource struct {
 	// It is evaluated at runtime; the resulting value supplies the provider URN/ID.
 	Provider hcl.Expression
 
+	// ResourceParent is the parent resource reference, if specified. The read
+	// itself registers nothing, but the reference orders it and is emitted by
+	// PCL codegen for the invoke `parent` option.
+	ResourceParent hcl.Traversal
+
 	// Version is the version of the provider plugin to use for this data source.
 	Version hcl.Expression
 

--- a/pkg/hcl/ast/resource.go
+++ b/pkg/hcl/ast/resource.go
@@ -41,7 +41,8 @@ type Timeouts struct {
 	DeclRange hcl.Range
 }
 
-// Resource represents a resource or data block in HCL.
+// Resource represents a managed resource block in HCL; data blocks are
+// [DataSource].
 //
 // Terraform syntax:
 //
@@ -148,9 +149,6 @@ type Resource struct {
 
 	// TypeRange is the source range of the resource type.
 	TypeRange hcl.Range
-
-	// IsDataSource indicates if this is a data source (data block) vs managed resource.
-	IsDataSource bool
 }
 
 // Lifecycle contains lifecycle configuration for a resource.

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -1016,6 +1016,7 @@ func (g *Graph) dataSourceDeps(ds *ast.DataSource, path modulepath.Path) (*Block
 		c.classify(g.bodyDepRefs(ds.Config, path, nil))
 	}
 
+	c.addStaticRefs(g.traversalDepRefs(path, ds.ResourceParent))
 	g.classifyProviderRef(c, ds.Provider, path)
 
 	return c.finish()

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -165,8 +165,11 @@ type Node struct {
 	// Type indicates what kind of node this is
 	Type NodeType
 
-	// Resource is set for resource/data nodes
+	// Resource is set for resource nodes
 	Resource *ast.Resource
+
+	// DataSource is set for data-source nodes
+	DataSource *ast.DataSource
 
 	// Local is set for local value nodes
 	Local *ast.Local
@@ -590,7 +593,7 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 	// Add resource nodes
 	for key, resource := range config.Resources {
 		bd, deps := g.resourceDeps(resource, root)
-		provDeps := g.defaultProviderDeps(resource, config, root)
+		provDeps := g.defaultProviderDeps(resource.Provider, resource.Type, config, root)
 		bd.Static = append(bd.Static, provDeps...)
 		deps = append(deps, provDeps...)
 		err := g.AddNode(&Node{
@@ -606,15 +609,15 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 
 	// Add data source nodes
 	for key, dataSource := range config.DataSources {
-		bd, deps := g.resourceDeps(dataSource, root)
-		provDeps := g.defaultProviderDeps(dataSource, config, root)
+		bd, deps := g.dataSourceDeps(dataSource, root)
+		provDeps := g.defaultProviderDeps(dataSource.Provider, dataSource.Type, config, root)
 		bd.Static = append(bd.Static, provDeps...)
 		deps = append(deps, provDeps...)
 		err := g.AddNode(&Node{
-			Key:      NodeKey{ID: "data." + key},
-			Type:     NodeTypeDataSource,
-			Resource: dataSource,
-			Deps:     bd,
+			Key:        NodeKey{ID: "data." + key},
+			Type:       NodeTypeDataSource,
+			DataSource: dataSource,
+			Deps:       bd,
 		}, deps)
 		if err != nil {
 			return nil, err
@@ -713,11 +716,11 @@ func (g *Graph) Order(from, to pdag.Node) error {
 // don't set `provider` explicitly. Without this the engine could process the
 // resource before the default provider finishes registering — the provider
 // block's config would then never make it into the resource.
-func (g *Graph) defaultProviderDeps(resource *ast.Resource, config *ast.Config, path modulepath.Path) []pdag.Node {
-	if resource.Provider != nil {
+func (g *Graph) defaultProviderDeps(provider hcl.Expression, typ string, config *ast.Config, path modulepath.Path) []pdag.Node {
+	if provider != nil {
 		return nil
 	}
-	pkgName := packageNameFromResourceType(resource.Type)
+	pkgName := packageNameFromResourceType(typ)
 	if pkgName == "" {
 		return nil
 	}
@@ -745,11 +748,11 @@ type moduleScope struct {
 // `<pkg>` configuration (see defaultProviderNode) for an in-module
 // resource/data source with no `provider`, no own-module block, and no
 // pass-through, forcing that configuration to register before the resource.
-func (g *Graph) inheritedProviderDeps(resource *ast.Resource, parent *moduleScope) []pdag.Node {
-	if resource.Provider != nil {
+func (g *Graph) inheritedProviderDeps(provider hcl.Expression, typ string, parent *moduleScope) []pdag.Node {
+	if provider != nil {
 		return nil
 	}
-	pkgName := packageNameFromResourceType(resource.Type)
+	pkgName := packageNameFromResourceType(typ)
 	if pkgName == "" {
 		return nil
 	}
@@ -768,7 +771,7 @@ func (g *Graph) inheritedProviderDeps(resource *ast.Resource, parent *moduleScop
 // declare the provider in `required_providers`, which stands for the implicit
 // empty default configuration. Anything else is a missing provider, reported
 // by Validate.
-func (g *Graph) passThroughProviderDeps(resource *ast.Resource, scope *moduleScope) []pdag.Node {
+func (g *Graph) passThroughProviderDeps(provider hcl.Expression, typ string, scope *moduleScope) []pdag.Node {
 	mod := scope.mod
 	if mod == nil || len(mod.Providers) == 0 {
 		return nil
@@ -777,10 +780,10 @@ func (g *Graph) passThroughProviderDeps(resource *ast.Resource, scope *moduleSco
 	//   explicit `provider = simple.foo` → "simple.foo"
 	//   implicit default                  → "simple"
 	var key string
-	if resource.Provider != nil {
-		key = providerExprKey(resource.Provider)
+	if provider != nil {
+		key = providerExprKey(provider)
 	} else {
-		key = packageNameFromResourceType(resource.Type)
+		key = packageNameFromResourceType(typ)
 	}
 	if key == "" {
 		return nil
@@ -987,21 +990,7 @@ func (g *Graph) resourceDeps(resource *ast.Resource, path modulepath.Path) (*Blo
 	}
 
 	c.addStaticRefs(g.traversalDepRefs(path, resource.ResourceParent))
-	c.addStaticRefs(g.exprDepRefs(resource.Provider, path, nil))
-	// A bare `provider = name` reference (no alias) is a single-segment
-	// traversal, which exprDepRefs drops because it carries no attribute after
-	// the root. It names the default configuration, which resolves through
-	// inheritance and may be implicit, so order the resource after whichever
-	// node registers it (if any). Aliased (`name.alias`) and call-based
-	// (`call.x.y`) provider expressions have further segments and are already
-	// resolved by exprDepRefs above.
-	if resource.Provider != nil {
-		if vars := resource.Provider.Variables(); len(vars) == 1 && len(vars[0]) == 1 {
-			for _, dep := range g.defaultProviderNode(vars[0].RootName(), g.scopes[path]) {
-				c.addStatic(dep)
-			}
-		}
-	}
+	g.classifyProviderRef(c, resource.Provider, path)
 	c.addStaticRefs(g.traversalDepRefs(path, resource.Providers...))
 	c.addStaticRefs(g.traversalDepRefs(path, resource.DeletedWith))
 	c.addStaticRefs(g.traversalDepRefs(path, resource.ReplaceWith...))
@@ -1013,6 +1002,43 @@ func (g *Graph) resourceDeps(resource *ast.Resource, path modulepath.Path) (*Blo
 	c.addStaticRefs(g.exprDepRefs(resource.Aliases, path, nil))
 
 	return c.finish()
+}
+
+// dataSourceDeps classifies a data block's dependencies: its meta-arguments,
+// config body, and provider reference.
+func (g *Graph) dataSourceDeps(ds *ast.DataSource, path modulepath.Path) (*BlockDeps, []pdag.Node) {
+	c := g.newDepClassifier(path, true)
+
+	c.classify(g.exprDepRefs(ds.Count, path, nil))
+	c.classify(g.exprDepRefs(ds.ForEach, path, nil))
+	c.classify(g.traversalDepRefs(path, ds.DependsOn...))
+	if ds.Config != nil {
+		c.classify(g.bodyDepRefs(ds.Config, path, nil))
+	}
+
+	g.classifyProviderRef(c, ds.Provider, path)
+
+	return c.finish()
+}
+
+// classifyProviderRef adds the static dependencies of a block's `provider`
+// attribute. A bare `provider = name` reference (no alias) is a
+// single-segment traversal, which exprDepRefs drops because it carries no
+// attribute after the root. It names the default configuration, which
+// resolves through inheritance and may be implicit, so order the block after
+// whichever node registers it (if any). Aliased (`name.alias`) and call-based
+// (`call.x.y`) provider expressions have further segments and are resolved by
+// exprDepRefs.
+func (g *Graph) classifyProviderRef(c *depClassifier, provider hcl.Expression, path modulepath.Path) {
+	c.addStaticRefs(g.exprDepRefs(provider, path, nil))
+	if provider == nil {
+		return
+	}
+	if vars := provider.Variables(); len(vars) == 1 && len(vars[0]) == 1 {
+		for _, dep := range g.defaultProviderNode(vars[0].RootName(), g.scopes[path]) {
+			c.addStatic(dep)
+		}
+	}
 }
 
 // localDeps classifies a local value's dependencies. Unlike resourceDeps, the
@@ -1626,11 +1652,11 @@ func (g *Graph) inlineModule(
 	// Resources
 	for key, resource := range loaded.Config.Resources {
 		bd, deps := g.resourceDeps(resource, path)
-		provDeps := g.defaultProviderDeps(resource, loaded.Config, path)
-		passDeps := g.passThroughProviderDeps(resource, scope)
+		provDeps := g.defaultProviderDeps(resource.Provider, resource.Type, loaded.Config, path)
+		passDeps := g.passThroughProviderDeps(resource.Provider, resource.Type, scope)
 		provDeps = append(provDeps, passDeps...)
 		if len(provDeps) == 0 {
-			provDeps = g.inheritedProviderDeps(resource, parent)
+			provDeps = g.inheritedProviderDeps(resource.Provider, resource.Type, parent)
 		}
 		bd.Static = append(bd.Static, initIdx)
 		bd.Static = append(bd.Static, provDeps...)
@@ -1649,12 +1675,12 @@ func (g *Graph) inlineModule(
 
 	// Data sources
 	for key, ds := range loaded.Config.DataSources {
-		bd, deps := g.resourceDeps(ds, path)
-		provDeps := g.defaultProviderDeps(ds, loaded.Config, path)
-		passDeps := g.passThroughProviderDeps(ds, scope)
+		bd, deps := g.dataSourceDeps(ds, path)
+		provDeps := g.defaultProviderDeps(ds.Provider, ds.Type, loaded.Config, path)
+		passDeps := g.passThroughProviderDeps(ds.Provider, ds.Type, scope)
 		provDeps = append(provDeps, passDeps...)
 		if len(provDeps) == 0 {
-			provDeps = g.inheritedProviderDeps(ds, parent)
+			provDeps = g.inheritedProviderDeps(ds.Provider, ds.Type, parent)
 		}
 		bd.Static = append(bd.Static, initIdx)
 		bd.Static = append(bd.Static, provDeps...)
@@ -1663,7 +1689,7 @@ func (g *Graph) inlineModule(
 		if err := g.AddNode(&Node{
 			Key:        NodeKey{Module: path, ID: "data." + key},
 			Type:       NodeTypeDataSource,
-			Resource:   ds,
+			DataSource: ds,
 			ModuleInfo: modInfo,
 			Deps:       bd,
 		}, deps); err != nil {

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -748,6 +748,13 @@ func (p *Parser) decodeDataBlock(block *hcl.Block) (*ast.DataSource, hcl.Diagnos
 		case "pulumi":
 			optContent, optDiags := subBlock.Body.Content(pulumiDataOptionsSchema)
 			diags = append(diags, optDiags...)
+			if attr, ok := optContent.Attributes["parent"]; ok {
+				traversal, travDiags := hcl.AbsTraversalForExpr(attr.Expr)
+				diags = append(diags, travDiags...)
+				if traversal != nil {
+					ds.ResourceParent = traversal
+				}
+			}
 			if attr, ok := optContent.Attributes["version"]; ok {
 				ds.Version = attr.Expr
 			}

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -146,9 +146,9 @@ func (p *Parser) parseBlock(config *ast.Config, block *hcl.Block) hcl.Diagnostic
 	case "locals":
 		return p.parseLocalsBlock(config, block)
 	case "resource":
-		return p.parseResourceBlock(config, block, false)
+		return p.parseResourceBlock(config, block)
 	case "data":
-		return p.parseResourceBlock(config, block, true)
+		return p.parseDataBlock(config, block)
 	case "output":
 		return p.parseOutputBlock(config, block)
 	case "module":
@@ -660,38 +660,151 @@ func countForEachConflict(count, forEach hcl.Expression) *hcl.Diagnostic {
 	}
 }
 
-// parseResourceBlock parses a resource or data block and records it in the
-// config's Resources or DataSources map.
-func (p *Parser) parseResourceBlock(config *ast.Config, block *hcl.Block, isDataSource bool) hcl.Diagnostics {
+// parseResourceBlock parses a resource block and records it in the config's
+// Resources map.
+func (p *Parser) parseResourceBlock(config *ast.Config, block *hcl.Block) hcl.Diagnostics {
 	resourceType := block.Labels[0]
 	name := block.Labels[1]
 	key := ast.ResourceKey(resourceType, name)
 
-	targetMap := config.Resources
-	blockType := "resource"
-	if isDataSource {
-		targetMap = config.DataSources
-		blockType = "data source"
-	}
-
-	if _, exists := targetMap[key]; exists {
+	if _, exists := config.Resources[key]; exists {
 		return hcl.Diagnostics{{
 			Severity: hcl.DiagError,
-			Summary:  fmt.Sprintf("Duplicate %s", blockType),
-			Detail:   fmt.Sprintf("A %s %q %q was already declared.", blockType, resourceType, name),
+			Summary:  "Duplicate resource",
+			Detail:   fmt.Sprintf("A resource %q %q was already declared.", resourceType, name),
 			Subject:  &block.DefRange,
 		}}
 	}
 
-	resource, diags := p.decodeResourceBlock(block, isDataSource)
-	targetMap[key] = resource
+	resource, diags := p.decodeResourceBlock(block)
+	config.Resources[key] = resource
 	return diags
 }
 
-// decodeResourceBlock decodes a resource or data block body into a Resource
-// without recording it in the config, so callers that scope the block
-// elsewhere (e.g. a check's data source) can reuse the same decoding.
-func (p *Parser) decodeResourceBlock(block *hcl.Block, isDataSource bool) (*ast.Resource, hcl.Diagnostics) {
+// parseDataBlock parses a data block and records it in the config's
+// DataSources map.
+func (p *Parser) parseDataBlock(config *ast.Config, block *hcl.Block) hcl.Diagnostics {
+	dataType := block.Labels[0]
+	name := block.Labels[1]
+	key := ast.ResourceKey(dataType, name)
+
+	if _, exists := config.DataSources[key]; exists {
+		return hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Duplicate data source",
+			Detail:   fmt.Sprintf("A data source %q %q was already declared.", dataType, name),
+			Subject:  &block.DefRange,
+		}}
+	}
+
+	ds, diags := p.decodeDataBlock(block)
+	config.DataSources[key] = ds
+	return diags
+}
+
+// decodeDataBlock decodes a data block body into a DataSource without
+// recording it in the config, so callers that scope the block elsewhere
+// (e.g. a check's data source) can reuse the same decoding. A data source is
+// a provider read, so the managed-resource surface is rejected: lifecycle
+// arguments with a dedicated diagnostic, everything else by schema.
+func (p *Parser) decodeDataBlock(block *hcl.Block) (*ast.DataSource, hcl.Diagnostics) {
+	content, remain, diags := block.Body.PartialContent(dataBlockSchema)
+
+	config, escDiags := mergeEscapeBlock(remain, content.Blocks, "resource-type-specific", "data")
+	diags = append(diags, escDiags...)
+
+	ds := &ast.DataSource{
+		Type:      block.Labels[0],
+		Name:      block.Labels[1],
+		Config:    config,
+		DeclRange: block.DefRange,
+		TypeRange: block.LabelRanges[0],
+	}
+
+	if attr, ok := content.Attributes["count"]; ok {
+		ds.Count = attr.Expr
+	}
+
+	if attr, ok := content.Attributes["for_each"]; ok {
+		ds.ForEach = attr.Expr
+	}
+
+	if d := countForEachConflict(ds.Count, ds.ForEach); d != nil {
+		diags = append(diags, d)
+	}
+
+	if attr, ok := content.Attributes["depends_on"]; ok {
+		deps, depsDiags := decodeDependsOn(attr)
+		diags = append(diags, depsDiags...)
+		ds.DependsOn = append(ds.DependsOn, deps...)
+	}
+
+	if attr, ok := content.Attributes["provider"]; ok {
+		ds.Provider = attr.Expr
+	}
+
+	for _, subBlock := range content.Blocks {
+		switch subBlock.Type {
+		case "pulumi":
+			optContent, optDiags := subBlock.Body.Content(pulumiDataOptionsSchema)
+			diags = append(diags, optDiags...)
+			if attr, ok := optContent.Attributes["version"]; ok {
+				ds.Version = attr.Expr
+			}
+			if attr, ok := optContent.Attributes["plugin_download_url"]; ok {
+				ds.PluginDownloadURL = attr.Expr
+			}
+		case "lifecycle":
+			lcResult, lcDiags := p.parseLifecycleBlock(subBlock)
+			diags = append(diags, lcDiags...)
+			diags = append(diags, dataLifecycleArgDiags(lcResult.Lifecycle, subBlock)...)
+			ds.Preconditions = append(ds.Preconditions, lcResult.Preconditions...)
+			ds.Postconditions = append(ds.Postconditions, lcResult.Postconditions...)
+		case "connection", "provisioner", "timeouts":
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Unsupported block type",
+				Detail:   fmt.Sprintf("Blocks of type %q are not valid for data resources.", subBlock.Type),
+				Subject:  &subBlock.DefRange,
+			})
+		}
+	}
+
+	return ds, diags
+}
+
+// dataLifecycleArgDiags rejects every lifecycle argument on a data block;
+// only precondition/postcondition blocks apply to data resources.
+func dataLifecycleArgDiags(lc *ast.Lifecycle, block *hcl.Block) hcl.Diagnostics {
+	if lc == nil {
+		return nil
+	}
+	var diags hcl.Diagnostics
+	for _, arg := range []struct {
+		name string
+		set  bool
+	}{
+		{"create_before_destroy", lc.CreateBeforeDestroy != nil},
+		{"prevent_destroy", lc.PreventDestroy != nil},
+		{"ignore_changes", len(lc.IgnoreChanges) > 0 || lc.IgnoreAllChanges},
+		{"replace_triggered_by", len(lc.ReplaceTriggeredBy) > 0},
+	} {
+		if arg.set {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid data resource lifecycle argument",
+				Detail: fmt.Sprintf("The lifecycle argument %q is defined only for managed resources "+
+					"(\"resource\" blocks), and is not valid for data resources.", arg.name),
+				Subject: block.DefRange.Ptr(),
+			})
+		}
+	}
+	return diags
+}
+
+// decodeResourceBlock decodes a resource block body into a Resource without
+// recording it in the config.
+func (p *Parser) decodeResourceBlock(block *hcl.Block) (*ast.Resource, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 
 	resourceType := block.Labels[0]
@@ -700,20 +813,15 @@ func (p *Parser) decodeResourceBlock(block *hcl.Block, isDataSource bool) (*ast.
 	content, remain, contentDiags := block.Body.PartialContent(resourceSchema)
 	diags = append(diags, contentDiags...)
 
-	blockKind := "resource"
-	if isDataSource {
-		blockKind = "data"
-	}
-	config, escDiags := mergeEscapeBlock(remain, content.Blocks, "resource-type-specific", blockKind)
+	config, escDiags := mergeEscapeBlock(remain, content.Blocks, "resource-type-specific", "resource")
 	diags = append(diags, escDiags...)
 
 	resource := &ast.Resource{
-		Type:         resourceType,
-		Name:         name,
-		Config:       config,
-		DeclRange:    block.DefRange,
-		TypeRange:    block.LabelRanges[0],
-		IsDataSource: isDataSource,
+		Type:      resourceType,
+		Name:      name,
+		Config:    config,
+		DeclRange: block.DefRange,
+		TypeRange: block.LabelRanges[0],
 	}
 
 	// Parse meta-arguments
@@ -1222,7 +1330,7 @@ func (p *Parser) parseCheckBlock(config *ast.Config, block *hcl.Block) hcl.Diagn
 				})
 				continue
 			}
-			ds, dsDiags := p.decodeResourceBlock(subBlock, true)
+			ds, dsDiags := p.decodeDataBlock(subBlock)
 			diags = append(diags, dsDiags...)
 			check.DataResource = ds
 		}

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -1222,9 +1222,14 @@ data "simple_lookup" "d" {
 func TestParseDataPulumiOptions(t *testing.T) {
 	t.Parallel()
 	src := `
+resource "simple_resource" "r" {
+  input_one = "x"
+}
+
 data "simple_lookup" "d" {
   query = "x"
   pulumi {
+    parent              = simple_resource.r
     version             = "1.2.3"
     plugin_download_url = "https://example.com"
   }
@@ -1232,6 +1237,7 @@ data "simple_lookup" "d" {
 	cfg, diags := NewParser().ParseSource("test.hcl", []byte(src))
 	require.False(t, diags.HasErrors(), "unexpected parse errors: %v", diags)
 	ds := cfg.DataSources["simple_lookup.d"]
+	require.NotNil(t, ds.ResourceParent)
 	require.NotNil(t, ds.Version)
 	require.NotNil(t, ds.PluginDownloadURL)
 }

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -870,7 +870,6 @@ check "with_data" {
 	require.NotNil(t, check.DataResource)
 	assert.Equal(t, "http", check.DataResource.Type)
 	assert.Equal(t, "example", check.DataResource.Name)
-	assert.True(t, check.DataResource.IsDataSource)
 
 	// A check's scoped data source must not leak into the global data sources.
 	_, leaked := config.DataSources["http.example"]
@@ -1156,4 +1155,102 @@ func traversalStrings(traversals []hcl.Traversal) []string {
 		ret = append(ret, string(hclwrite.TokensForTraversal(t).Bytes()))
 	}
 	return ret
+}
+
+// TestParseDataRejectsLifecycleArgs: a data block's lifecycle carries only
+// conditions; every lifecycle argument is an error.
+func TestParseDataRejectsLifecycleArgs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		attr string
+	}{
+		{"create_before_destroy", "create_before_destroy = true"},
+		{"prevent_destroy", "prevent_destroy = true"},
+		{"ignore_changes", "ignore_changes = [query]"},
+		{"replace_triggered_by", "replace_triggered_by = [simple_resource.r]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			src := `
+data "simple_lookup" "d" {
+  query = "x"
+  lifecycle {
+    ` + tc.attr + `
+  }
+}`
+			_, diags := NewParser().ParseSource("test.hcl", []byte(src))
+			require.True(t, diags.HasErrors(), "expected parse errors, got %v", diags)
+			require.Equal(t, "Invalid data resource lifecycle argument", diags[0].Summary)
+		})
+	}
+}
+
+// TestParseDataRejectsResourceSurface: pulumi options outside the data
+// subset are schema-rejected, as are managed-resource blocks.
+func TestParseDataRejectsResourceSurface(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		body    string
+		summary string
+	}{
+		{"protect", "pulumi {\n  protect = true\n}", "Unsupported argument"},
+		{"retain_on_delete", "pulumi {\n  retain_on_delete = true\n}", "Unsupported argument"},
+		{"name", "pulumi {\n  name = \"n\"\n}", "Unsupported argument"},
+		{"provisioner", "provisioner \"local-exec\" {\n  command = \"true\"\n}", "Unsupported block type"},
+		{"connection", "connection {\n  host = \"h\"\n}", "Unsupported block type"},
+		{"timeouts", "timeouts {\n  read = \"1m\"\n}", "Unsupported block type"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			src := `
+data "simple_lookup" "d" {
+  query = "x"
+  ` + tc.body + `
+}`
+			_, diags := NewParser().ParseSource("test.hcl", []byte(src))
+			require.True(t, diags.HasErrors(), "expected parse errors, got %v", diags)
+			require.Equal(t, tc.summary, diags[0].Summary)
+		})
+	}
+}
+
+// TestParseDataPulumiOptions: the data subset of pulumi options parses.
+func TestParseDataPulumiOptions(t *testing.T) {
+	t.Parallel()
+	src := `
+data "simple_lookup" "d" {
+  query = "x"
+  pulumi {
+    version             = "1.2.3"
+    plugin_download_url = "https://example.com"
+  }
+}`
+	cfg, diags := NewParser().ParseSource("test.hcl", []byte(src))
+	require.False(t, diags.HasErrors(), "unexpected parse errors: %v", diags)
+	ds := cfg.DataSources["simple_lookup.d"]
+	require.NotNil(t, ds.Version)
+	require.NotNil(t, ds.PluginDownloadURL)
+}
+
+// TestParseDataLifecycleConditionsStillParse: precondition/postcondition
+// blocks remain valid inside a data block's lifecycle.
+func TestParseDataLifecycleConditionsStillParse(t *testing.T) {
+	t.Parallel()
+	src := `
+data "simple_lookup" "d" {
+  query = "x"
+  lifecycle {
+    precondition {
+      condition     = true
+      error_message = "never"
+    }
+  }
+}`
+	cfg, diags := NewParser().ParseSource("test.hcl", []byte(src))
+	require.False(t, diags.HasErrors(), "unexpected parse errors: %v", diags)
+	require.Len(t, cfg.DataSources["simple_lookup.d"].Preconditions, 1)
 }

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -145,7 +145,7 @@ var outputSchema = &hcl.BodySchema{
 	},
 }
 
-// resourceSchema defines the structure of a resource/data block. Only the
+// resourceSchema defines the structure of a resource block. Only the
 // Terraform-standard meta-arguments live at the top level; Pulumi-specific
 // options go in the nested `pulumi` block so they cannot collide with a
 // resource's own provider-specific attributes (which may be named e.g.
@@ -170,8 +170,39 @@ var resourceSchema = &hcl.BodySchema{
 	},
 }
 
+// dataBlockSchema defines the structure of a data block. Data sources are
+// provider reads: the managed-resource blocks (connection, provisioner,
+// timeouts) are listed only so the parser can reject them with a diagnostic
+// rather than passing them through as data source attributes.
+var dataBlockSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "count"},
+		{Name: "for_each"},
+		{Name: "depends_on"},
+		{Name: "provider"},
+	},
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "pulumi"},
+		{Type: "lifecycle"},
+		{Type: "connection"},
+		{Type: "provisioner", LabelNames: []string{"type"}},
+		{Type: "timeouts"},
+		{Type: "_"}, // meta-argument escaping block
+	},
+}
+
+// pulumiDataOptionsSchema defines the Pulumi-specific options allowed inside
+// a data block's nested `pulumi` block: only the options the invoke path
+// honors.
+var pulumiDataOptionsSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "version"},
+		{Name: "plugin_download_url"},
+	},
+}
+
 // pulumiResourceOptionsSchema defines the Pulumi-specific options allowed
-// inside a resource or data block's nested `pulumi` block.
+// inside a resource block's nested `pulumi` block.
 var pulumiResourceOptionsSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{Name: "name"},

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -196,6 +196,7 @@ var dataBlockSchema = &hcl.BodySchema{
 // honors.
 var pulumiDataOptionsSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
+		{Name: "parent"},
 		{Name: "version"},
 		{Name: "plugin_download_url"},
 	},

--- a/pkg/hcl/run/cells.go
+++ b/pkg/hcl/run/cells.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/hcl/v2"
+
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/graph"
 	"github.com/pulumi-labs/pulumi-hcl/pkg/hcl/modulepath"
@@ -312,12 +314,14 @@ type metaArgs struct {
 	unknownArg string
 }
 
-func evalMetaArgs(evalCtx *eval.Context, node *graph.Node, expander *graph.ResourceExpander) (metaArgs, error) {
-	res := node.Resource
+func evalMetaArgs(
+	evalCtx *eval.Context, node *graph.Node, expander *graph.ResourceExpander,
+	countExpr, forEachExpr hcl.Expression,
+) (metaArgs, error) {
 	tempEvaluator := eval.NewEvaluator(evalCtx)
 	var m metaArgs
-	if res.Count != nil {
-		count, isBool, unknown, deps, diags := tempEvaluator.EvaluateCount(res.Count)
+	if countExpr != nil {
+		count, isBool, unknown, deps, diags := tempEvaluator.EvaluateCount(countExpr)
 		if diags.HasErrors() {
 			return m, fmt.Errorf("evaluating count: %s", diags.Error())
 		}
@@ -331,8 +335,8 @@ func evalMetaArgs(evalCtx *eval.Context, node *graph.Node, expander *graph.Resou
 			expander.SetCount(node.Key, count)
 		}
 	}
-	if res.ForEach != nil {
-		forEach, unknown, deps, diags := tempEvaluator.EvaluateForEach(res.ForEach)
+	if forEachExpr != nil {
+		forEach, unknown, deps, diags := tempEvaluator.EvaluateForEach(forEachExpr)
 		if diags.HasErrors() {
 			return m, fmt.Errorf("evaluating for_each: %s", diags.Error())
 		}
@@ -366,7 +370,7 @@ func (e *Engine) expandResourceCell(
 	}
 
 	expander := graph.NewResourceExpander()
-	meta, err := evalMetaArgs(evalCtx, node, expander)
+	meta, err := evalMetaArgs(evalCtx, node, expander, res.Count, res.ForEach)
 	if err != nil {
 		return err
 	}
@@ -433,9 +437,9 @@ func (e *Engine) expandResourceCell(
 func (e *Engine) expandDataCell(
 	ctx context.Context, node *graph.Node, b *graph.BlockExpansion, mi *moduleInstance,
 ) error {
-	ds := node.Resource
+	ds := node.DataSource
 	if ds == nil {
-		return fmt.Errorf("data source node missing Resource field")
+		return fmt.Errorf("data source node missing DataSource field")
 	}
 	evalCtx, _, _ := cellEvalState(e, mi)
 
@@ -461,7 +465,7 @@ func (e *Engine) expandDataCell(
 	}
 
 	expander := graph.NewResourceExpander()
-	meta, err := evalMetaArgs(evalCtx, node, expander)
+	meta, err := evalMetaArgs(evalCtx, node, expander, ds.Count, ds.ForEach)
 	if err != nil {
 		return err
 	}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -3245,7 +3245,7 @@ func (e *Engine) readResource(
 // and explicit depends_on, so downstream reads of data.X.Y carry them
 // without a separate dependency map.
 func (e *Engine) invokeDataSourceOnce(
-	ctx context.Context, node *graph.Node, ds *ast.Resource, funcSchema *schema.Function,
+	ctx context.Context, node *graph.Node, ds *ast.DataSource, funcSchema *schema.Function,
 	evalCtx *eval.Context, mi *moduleInstance,
 ) (cty.Value, error) {
 	hclCtx := evalCtx.HCLContext()
@@ -4783,11 +4783,11 @@ func (e *Engine) evaluateCheck(ctx context.Context, name string, check *ast.Chec
 // it available as data.<type>.<name> within that context only. Scoped data
 // sources are single reads: they run after the walk, synchronously, outside
 // the expansion-cell machinery.
-func (e *Engine) readScopedDataSource(ctx context.Context, ds *ast.Resource, evalCtx *eval.Context) error {
+func (e *Engine) readScopedDataSource(ctx context.Context, ds *ast.DataSource, evalCtx *eval.Context) error {
 	node := &graph.Node{
-		Key:      graph.NodeKey{ID: "data." + ast.ResourceKey(ds.Type, ds.Name)},
-		Type:     graph.NodeTypeDataSource,
-		Resource: ds,
+		Key:        graph.NodeKey{ID: "data." + ast.ResourceKey(ds.Type, ds.Name)},
+		Type:       graph.NodeTypeDataSource,
+		DataSource: ds,
 	}
 	funcSchema, err := e.resolver.ResolveFunction(ctx, ds.Type)
 	if err != nil {

--- a/tests/tfcompat/l2_data_prevent_destroy_test.go
+++ b/tests/tfcompat/l2_data_prevent_destroy_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2DataPreventDestroy sets prevent_destroy on a data block. Lifecycle
+// arguments are defined only for managed resources, so both runtimes reject
+// the configuration.
+func TestL2DataPreventDestroy(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_prevent_destroy", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{ExpectErr: "Invalid data resource lifecycle argument"},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_data_prevent_destroy/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_prevent_destroy/main.tf
@@ -1,0 +1,9 @@
+# Lifecycle arguments are defined only for managed resources; a data block's
+# lifecycle carries only conditions.
+data "simple_lookup" "d" {
+  query = "x"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}


### PR DESCRIPTION
Data blocks previously parsed as `ast.Resource` with an `IsDataSource` flag, silently accepting the whole managed-resource surface: lifecycle arguments, `provisioner`/`connection`/`timeouts` blocks, and every `pulumi` option. A data source is a provider read with none of that machinery, so this PR gives it its own AST node, block schema, and decode path — invalid states become unrepresentable instead of conditionally rejected.

## Behavior changes (all rejections of previously silently-ignored config)

- Lifecycle **arguments** on data blocks (`prevent_destroy`, `create_before_destroy`, `ignore_changes`, `replace_triggered_by`) error with "Invalid data resource lifecycle argument", the upstream wording; `precondition`/`postcondition` blocks still work. Compared against tofu by the new `TestL2DataPreventDestroy` tfcompat test.
- `provisioner`, `connection`, and `timeouts` blocks on data blocks error ("Unsupported block type").
- The data `pulumi` block accepts only what the invoke path honors — `version` and `plugin_download_url`; anything else (`name`, `protect`, `retain_on_delete`, …) is schema-rejected ("Unsupported argument").

## Mechanics

- `ast.DataSource` (new) carries the data-block field set; `ast.Resource` drops `IsDataSource`; `Config.DataSources` and `Check.DataResource` are retyped.
- `graph.Node` gains a `DataSource` field; data nodes no longer populate `Resource`. The provider-dependency helpers (`defaultProviderDeps`, `passThroughProviderDeps`, `inheritedProviderDeps`) take the provider expression and type name directly so both node kinds share them, and `evalMetaArgs` takes the count/for_each expressions rather than reaching through `node.Resource`.
- `invokeDataSourceOnce`/`readScopedDataSource` take `*ast.DataSource`.
- Override files are unaffected: resource/data overrides merge at the raw-block level before decoding.

Groundwork for https://github.com/pulumi-labs/pulumi-hcl/pull/470, which will be rebased on top.