### PR TITLE
Use `github.repository` instead of a hardcoded repo slug in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           warmdir="$(mktemp -d)"
           (cd "$warmdir" && go mod init warm &&
-            go get "github.com/pulumi-labs/pulumi-hcl/sdk/go@${VERSION}")
+            go get "github.com/${{ github.repository }}/sdk/go@${VERSION}")
 
   # Publish the TypeScript SDK to npm as @pulumi-labs/hcl.
   #
@@ -306,7 +306,7 @@ jobs:
         uses: pulumi/esc-action@v3
       - name: Dispatch a registry docs build
         run: |
-          base="https://raw.githubusercontent.com/pulumi-labs/pulumi-hcl/${SHA}/registry"
+          base="https://raw.githubusercontent.com/${{ github.repository }}/${SHA}/registry"
           jq -n \
             --arg schema "${base}/schema.json" \
             --arg index "${base}/_index.md" \


### PR DESCRIPTION
Replaces the two hardcoded `pulumi-labs/pulumi-hcl` repo slugs in `release.yml` with `${{ github.repository }}`:

- the `raw.githubusercontent.com` base URL used by the registry docs dispatch, and
- the `go get` path in the Go module proxy warm step.

This is prep for moving the repository to another organization: both references now track wherever the workflow runs, so they need no edit at transfer time. The warm step's path must match the `module` directive generated from `importBasePath` in `module_resource_schema.go`; those coincide in steady state, and the step is `continue-on-error`, so it is harmless during any window where they diverge and self-heals once `importBasePath` is updated to match the new slug.

No user-visible change, so no changelog fragment.