### PR TITLE
Implement `provider::terraform::encode_expr`

### DIFF
--- a/.changes/unreleased/runtime-Improvements-193.yaml
+++ b/.changes/unreleased/runtime-Improvements-193.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Add `provider::terraform::encode_expr`
+time: 2026-07-31T10:11:41Z
+custom:
+    Component: runtime
+    PR: "193"

--- a/pkg/hcl/eval/terraform_provider_functions.go
+++ b/pkg/hcl/eval/terraform_provider_functions.go
@@ -1,0 +1,55 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eval
+
+import (
+	"errors"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// TerraformProviderFunctions returns the builtin `terraform` provider's
+// provider-defined functions, keyed by TF function name. The provider ships no
+// installable plugin, so these are implemented in-process and served straight
+// from the eval function table instead of being projected into invokes.
+func TerraformProviderFunctions() map[string]function.Function {
+	return map[string]function.Function{
+		"encode_expr": encodeExprFunc,
+	}
+}
+
+// encodeExprFunc renders an arbitrary value as HCL expression source text. A
+// wholly unknown argument short-circuits to an unknown result before Impl runs
+// (AllowUnknown is false), while a known composite with unknown parts reaches
+// Impl and errors. Sensitive marks are stripped from the argument and
+// reapplied to the result by the function machinery.
+var encodeExprFunc = function.New(&function.Spec{
+	Params: []function.Parameter{{
+		Name: "expr",
+		Type: cty.DynamicPseudoType,
+	}},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		v := args[0]
+		if !v.IsWhollyKnown() {
+			return cty.NullVal(cty.String), errors.New("input is not wholly known")
+		}
+		f := hclwrite.NewEmptyFile()
+		f.Body().AppendUnstructuredTokens(hclwrite.TokensForValue(v))
+		return cty.StringVal(string(f.Bytes())), nil
+	},
+})

--- a/pkg/hcl/eval/terraform_provider_functions_test.go
+++ b/pkg/hcl/eval/terraform_provider_functions_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eval
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Expected strings match OpenTofu v1.12.3's encode_expr output byte for byte,
+// including hclwrite's attribute alignment and nested-object indentation.
+func TestEncodeExpr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arg  cty.Value
+		want cty.Value
+	}{
+		{
+			name: "list",
+			arg:  cty.TupleVal([]cty.Value{cty.NumberIntVal(1), cty.NumberIntVal(2)}),
+			want: cty.StringVal("[1, 2]"),
+		},
+		{
+			name: "string",
+			arg:  cty.StringVal("hello"),
+			want: cty.StringVal(`"hello"`),
+		},
+		{
+			name: "object",
+			arg: cty.ObjectVal(map[string]cty.Value{
+				"name": cty.StringVal("alice"),
+				"tags": cty.TupleVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+				"n":    cty.NumberIntVal(3),
+			}),
+			want: cty.StringVal("{\n  n    = 3\n  name = \"alice\"\n  tags = [\"a\", \"b\"]\n}"),
+		},
+		{
+			name: "nested",
+			arg: cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{"a": cty.NumberIntVal(1)}),
+				cty.ObjectVal(map[string]cty.Value{"a": cty.NumberIntVal(2)}),
+			}),
+			want: cty.StringVal("[{\n  a = 1\n  }, {\n  a = 2\n}]"),
+		},
+		{
+			name: "wholly unknown defers",
+			arg:  cty.UnknownVal(cty.String),
+			want: cty.UnknownVal(cty.String),
+		},
+		{
+			name: "sensitive mark passes through",
+			arg:  cty.StringVal("secret").Mark(SensitiveMark),
+			want: cty.StringVal(`"secret"`).Mark(SensitiveMark),
+		},
+		{
+			name: "nested sensitive mark passes through",
+			arg: cty.ObjectVal(map[string]cty.Value{
+				"pw":    cty.StringVal("secret").Mark(SensitiveMark),
+				"plain": cty.NumberIntVal(1),
+			}),
+			want: cty.StringVal("{\n  plain = 1\n  pw    = \"secret\"\n}").Mark(SensitiveMark),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := encodeExprFunc.Call([]cty.Value{tt.arg})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	errTests := []struct {
+		name    string
+		arg     cty.Value
+		wantErr string
+	}{
+		{
+			name:    "null",
+			arg:     cty.NullVal(cty.DynamicPseudoType),
+			wantErr: "argument must not be null",
+		},
+		{
+			name: "partially unknown",
+			arg: cty.ObjectVal(map[string]cty.Value{
+				"known":   cty.NumberIntVal(1),
+				"unknown": cty.UnknownVal(cty.String),
+			}),
+			wantErr: "input is not wholly known",
+		},
+	}
+	for _, tt := range errTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := encodeExprFunc.Call([]cty.Value{tt.arg})
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/pkg/hcl/packages/builtins.go
+++ b/pkg/hcl/packages/builtins.go
@@ -14,9 +14,19 @@
 
 package packages
 
-import "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+import (
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
 
 const (
+	// TerraformProviderSource is the source address of the builtin `terraform`
+	// provider. Declaring it in required_providers is what brings its
+	// provider-defined functions (provider::<local>::encode_expr, ...) into
+	// scope; the provider itself ships no installable plugin.
+	TerraformProviderSource = "terraform.io/builtin/terraform"
+
 	// TerraformDataType is Terraform's builtin `terraform_data` managed
 	// resource. Its provider (`terraform`) ships no installable plugin;
 	// Terraform/OpenTofu implement it internally.
@@ -33,6 +43,12 @@ const (
 	LocalReferenceToken  = "terraform:state:getLocalReference"
 	RemoteReferenceToken = "terraform:state:getRemoteReference"
 )
+
+// IsTerraformProviderSource reports whether a required_providers source
+// address names the builtin terraform provider.
+func IsTerraformProviderSource(source string) bool {
+	return strings.EqualFold(source, TerraformProviderSource)
+}
 
 // TerraformDataSchema is the synthetic schema terraform_data resolves to, so it
 // flows through the generic registration path like any other resource. It is

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -3711,6 +3711,14 @@ func (e *Engine) providerFunctionTable(
 
 	table := map[string]function.Function{}
 	for providerName := range referenced {
+		if config.Terraform != nil {
+			if req, ok := config.Terraform.RequiredProviders[providerName]; ok && packages.IsTerraformProviderSource(req.Source) {
+				for tfName, fn := range eval.TerraformProviderFunctions() {
+					table[ast.ProviderFunctionName(providerName, tfName)] = fn
+				}
+				continue
+			}
+		}
 		fns, err := e.resolver.ProviderFunctions(ctx, providerPackageName(config.Terraform, providerName))
 		if err != nil {
 			if lenient {

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -275,6 +275,14 @@ func seedProviderFunctions(
 
 	table := map[string]function.Function{}
 	for providerName := range referenced {
+		if config.Terraform != nil {
+			if req, ok := config.Terraform.RequiredProviders[providerName]; ok && packages.IsTerraformProviderSource(req.Source) {
+				for tfName, fn := range eval.TerraformProviderFunctions() {
+					table[ast.ProviderFunctionName(providerName, tfName)] = fn
+				}
+				continue
+			}
+		}
 		fns, err := resolver.ProviderFunctions(ctx, providerName)
 		if err != nil {
 			if lenient {

--- a/tests/tfcompat/l2_encode_expr_test.go
+++ b/tests/tfcompat/l2_encode_expr_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2EncodeExpr covers the builtin `terraform` provider's
+// provider::terraform::encode_expr function
+// (https://github.com/pulumi-labs/pulumi-hcl/issues/193): both runtimes must
+// render values — literals and data-source outputs alike — as identical HCL
+// expression text, with no plugin to install.
+func TestL2EncodeExpr(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_encode_expr", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_encode_expr/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_encode_expr/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    terraform = {
+      source = "terraform.io/builtin/terraform"
+    }
+  }
+}
+
+data "simple_lookup" "d" {
+  query = "q"
+}
+
+# The builtin `terraform` provider ships no installable plugin, so
+# provider::terraform::encode_expr must be implemented internally by both
+# runtimes. It renders any value as HCL expression source text.
+output "list" {
+  value = provider::terraform::encode_expr([1, 2])
+}
+
+output "string" {
+  value = provider::terraform::encode_expr("hello")
+}
+
+output "object" {
+  value = provider::terraform::encode_expr({
+    name = "alice"
+    tags = ["a", "b"]
+    n    = 3
+  })
+}
+
+output "nested" {
+  value = provider::terraform::encode_expr([{ a = 1 }, { a = 2 }])
+}
+
+# A value flowing out of a data source read must encode identically too. It is
+# unknown at plan time, so the call has to defer to apply rather than fail.
+# (The argument must be *wholly* unknown: encode_expr rejects composites that
+# mix known and unknown parts, so no literal may wrap the data reference.)
+output "data_attr" {
+  value = provider::terraform::encode_expr(data.simple_lookup.d.prefix_result)
+}

--- a/tests/tfcompat/testdata/cases/l2_encode_expr/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_encode_expr/main.tf
@@ -40,3 +40,23 @@ output "nested" {
 output "data_attr" {
   value = provider::terraform::encode_expr(data.simple_lookup.d.prefix_result)
 }
+
+# Sensitive marks pass through: the result is sensitive, and the encoded text
+# is the unmarked content — both for a wholly sensitive argument and for a
+# composite with a sensitive part.
+output "sens" {
+  value     = provider::terraform::encode_expr(sensitive("secret"))
+  sensitive = true
+}
+
+output "sens_inner" {
+  value = provider::terraform::encode_expr({
+    pw    = sensitive("secret")
+    plain = 1
+  })
+  sensitive = true
+}
+
+output "is_sensitive" {
+  value = issensitive(provider::terraform::encode_expr(sensitive("secret")))
+}


### PR DESCRIPTION
Implements `provider::terraform::encode_expr` for the builtin `terraform` provider, which ships no installable plugin (closes https://github.com/pulumi-labs/pulumi-hcl/issues/193; follow-up to https://github.com/pulumi-labs/pulumi-hcl/pull/187).

The function lives in `pkg/hcl/eval` as a plain cty function mirroring OpenTofu's `encodeExprFunc` (`hclwrite.TokensForValue`). Both provider-function table builders — the runtime engine's and the binder's type-inference seeding — serve these local functions for any `required_providers` entry whose source is `terraform.io/builtin/terraform`, instead of resolving through the package loader (which previously found the pulumi-terraform package, whose invokes are all single-bag, yielding an empty function namespace).

Behavior pinned against OpenTofu v1.12.3, byte for byte:

- `encode_expr([1, 2])` → `"[1, 2]"`, including hclwrite's attribute alignment and nested-object indentation quirks.
- A wholly unknown argument (e.g. an unread data-source attribute at plan time) defers to an unknown result; a *known* composite containing unknown parts fails with `input is not wholly known`.
- `null` is rejected by the parameter spec (`argument must not be null`).
- Sensitive marks pass through: the result is sensitive, the encoded text is the unmarked content.

Coverage: `TestL2EncodeExpr` (tfcompat, added failing in the first commit — simple literals, a data-source output, and the sensitivity pins) and a unit test asserting exact output strings.