### PR TITLE
Implement `provider::terraform::encode_tfvars`

### DIFF
--- a/.changes/unreleased/runtime-Improvements-191.yaml
+++ b/.changes/unreleased/runtime-Improvements-191.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Add `provider::terraform::encode_tfvars`
+time: 2026-07-31T10:23:52Z
+custom:
+    Component: runtime
+    PR: "191"

--- a/pkg/hcl/eval/terraform_provider_functions.go
+++ b/pkg/hcl/eval/terraform_provider_functions.go
@@ -16,7 +16,9 @@ package eval
 
 import (
 	"errors"
+	"fmt"
 
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
@@ -28,7 +30,8 @@ import (
 // from the eval function table instead of being projected into invokes.
 func TerraformProviderFunctions() map[string]function.Function {
 	return map[string]function.Function{
-		"encode_expr": encodeExprFunc,
+		"encode_expr":   encodeExprFunc,
+		"encode_tfvars": encodeTFVarsFunc,
 	}
 }
 
@@ -50,6 +53,41 @@ var encodeExprFunc = function.New(&function.Spec{
 		}
 		f := hclwrite.NewEmptyFile()
 		f.Body().AppendUnstructuredTokens(hclwrite.TokensForValue(v))
+		return cty.StringVal(string(f.Bytes())), nil
+	},
+})
+
+// encodeTFVarsFunc renders an object as .tfvars file text, one attribute per
+// key in cty's sorted iteration order. Only object types are accepted — maps
+// are rejected like any other non-object. A wholly unknown argument
+// short-circuits to an unknown result, while a known object with unknown
+// attribute values errors (matching the error text of the hclwrite panic this
+// causes upstream).
+var encodeTFVarsFunc = function.New(&function.Spec{
+	Params: []function.Parameter{{
+		Name: "input",
+		Type: cty.DynamicPseudoType,
+	}},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		v := args[0]
+		if !v.Type().IsObjectType() {
+			return cty.NullVal(cty.String), errors.New("invalid input: must be an object")
+		}
+		f := hclwrite.NewEmptyFile()
+		body := f.Body()
+		for it := v.ElementIterator(); it.Next(); {
+			key, val := it.Element()
+			name := key.AsString()
+			if !hclsyntax.ValidIdentifier(name) {
+				return cty.NullVal(cty.String),
+					fmt.Errorf("invalid input: object key: %s - must be a valid identifier", name)
+			}
+			if !val.IsWhollyKnown() {
+				return cty.NullVal(cty.String), errors.New("cannot produce tokens for unknown value")
+			}
+			body.SetAttributeValue(name, val)
+		}
 		return cty.StringVal(string(f.Bytes())), nil
 	},
 })

--- a/pkg/hcl/eval/terraform_provider_functions_test.go
+++ b/pkg/hcl/eval/terraform_provider_functions_test.go
@@ -114,3 +114,103 @@ func TestEncodeExpr(t *testing.T) {
 		})
 	}
 }
+
+// Expected strings and error texts match OpenTofu v1.12.3's encode_tfvars
+// byte for byte, including sorted keys and the trailing newline.
+func TestEncodeTFVars(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arg  cty.Value
+		want cty.Value
+	}{
+		{
+			name: "basic",
+			arg: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("bar"),
+				"baz": cty.NumberIntVal(1),
+			}),
+			want: cty.StringVal("baz = 1\nfoo = \"bar\"\n"),
+		},
+		{
+			name: "nested",
+			arg: cty.ObjectVal(map[string]cty.Value{
+				"list": cty.TupleVal([]cty.Value{cty.NumberIntVal(1), cty.StringVal("two"), cty.True}),
+				"obj":  cty.ObjectVal(map[string]cty.Value{"a": cty.NumberIntVal(1)}),
+			}),
+			want: cty.StringVal("list = [1, \"two\", true]\nobj = {\n  a = 1\n}\n"),
+		},
+		{
+			name: "empty object",
+			arg:  cty.EmptyObjectVal,
+			want: cty.StringVal(""),
+		},
+		{
+			name: "wholly unknown defers",
+			arg:  cty.UnknownVal(cty.EmptyObject),
+			want: cty.UnknownVal(cty.String),
+		},
+		{
+			name: "sensitive attribute marks result",
+			arg: cty.ObjectVal(map[string]cty.Value{
+				"pw": cty.StringVal("secret").Mark(SensitiveMark),
+			}),
+			want: cty.StringVal("pw = \"secret\"\n").Mark(SensitiveMark),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := encodeTFVarsFunc.Call([]cty.Value{tt.arg})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	errTests := []struct {
+		name    string
+		arg     cty.Value
+		wantErr string
+	}{
+		{
+			name:    "null",
+			arg:     cty.NullVal(cty.DynamicPseudoType),
+			wantErr: "argument must not be null",
+		},
+		{
+			name:    "tuple",
+			arg:     cty.TupleVal([]cty.Value{cty.NumberIntVal(1), cty.NumberIntVal(2)}),
+			wantErr: "invalid input: must be an object",
+		},
+		{
+			name:    "string",
+			arg:     cty.StringVal("hello"),
+			wantErr: "invalid input: must be an object",
+		},
+		{
+			name:    "map",
+			arg:     cty.MapVal(map[string]cty.Value{"a": cty.StringVal("x")}),
+			wantErr: "invalid input: must be an object",
+		},
+		{
+			name:    "invalid identifier key",
+			arg:     cty.ObjectVal(map[string]cty.Value{"not valid!": cty.NumberIntVal(1)}),
+			wantErr: "invalid input: object key: not valid! - must be a valid identifier",
+		},
+		{
+			name: "unknown attribute value",
+			arg: cty.ObjectVal(map[string]cty.Value{
+				"v": cty.UnknownVal(cty.String),
+			}),
+			wantErr: "cannot produce tokens for unknown value",
+		},
+	}
+	for _, tt := range errTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := encodeTFVarsFunc.Call([]cty.Value{tt.arg})
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/tests/tfcompat/l2_encode_tfvars_test.go
+++ b/tests/tfcompat/l2_encode_tfvars_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL2EncodeTfvars covers the builtin `terraform` provider's
+// provider::terraform::encode_tfvars function
+// (https://github.com/pulumi-labs/pulumi-hcl/issues/191): both runtimes must
+// render objects — literals and resource outputs alike — as identical .tfvars
+// text, with no plugin to install.
+func TestL2EncodeTfvars(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_encode_tfvars", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_encode_tfvars/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_encode_tfvars/main.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_providers {
+    terraform = {
+      source = "terraform.io/builtin/terraform"
+    }
+  }
+}
+
+resource "terraform_data" "obj" {
+  input = {
+    a = 1
+    b = "two"
+  }
+}
+
+# The builtin `terraform` provider ships no installable plugin, so
+# provider::terraform::encode_tfvars must be implemented internally by both
+# runtimes. It renders an object as .tfvars file text, keys sorted, with a
+# trailing newline.
+output "basic" {
+  value = provider::terraform::encode_tfvars({ foo = "bar", baz = 1 })
+}
+
+output "nested" {
+  value = provider::terraform::encode_tfvars({
+    list = [1, "two", true]
+    obj  = { a = 1 }
+  })
+}
+
+output "empty" {
+  value = provider::terraform::encode_tfvars({})
+}
+
+# An object flowing out of a resource must encode identically too. It is
+# wholly unknown at plan time, so the call has to defer to apply rather than
+# fail. (Only *wholly* unknown arguments defer: an object literal wrapping the
+# unknown reference is a known object with unknown parts, which errors.)
+output "unknown_at_plan" {
+  value = provider::terraform::encode_tfvars(terraform_data.obj.output)
+}
+
+# Sensitive marks pass through: the result is sensitive, and the encoded text
+# is the unmarked content.
+output "sens" {
+  value     = provider::terraform::encode_tfvars({ pw = sensitive("secret") })
+  sensitive = true
+}
+
+output "is_sensitive" {
+  value = issensitive(provider::terraform::encode_tfvars({ pw = sensitive("secret") }))
+}


### PR DESCRIPTION
Implements `provider::terraform::encode_tfvars` for the builtin `terraform` provider (closes https://github.com/pulumi-labs/pulumi-hcl/issues/191; follow-up to https://github.com/pulumi-labs/pulumi-hcl/pull/474, which added the in-process function table this slots into).

Behavior pinned against OpenTofu v1.12.3, byte for byte:

- `encode_tfvars({ foo = "bar", baz = 1 })` → `"baz = 1\nfoo = \"bar\"\n"` — keys sorted, trailing newline; `{}` → `""`.
- Only object types are accepted: tuples, strings, and — notably — maps (`tomap(...)`) all fail with `invalid input: must be an object`.
- Keys must be valid HCL identifiers (`invalid input: object key: <key> - must be a valid identifier`).
- A wholly unknown argument (e.g. a `terraform_data` output at plan time) defers to an unknown result. A *known* object containing unknown attribute values makes OpenTofu's implementation panic inside `hclwrite` (caught by cty as `panic in function implementation: cannot produce tokens for unknown value`); this implementation errors cleanly with the same `cannot produce tokens for unknown value` text instead of panicking.
- Sensitive marks pass through: the result is sensitive, the encoded text is the unmarked content.

Coverage: `TestL2EncodeTfvars` (tfcompat, added failing in the first commit — literal objects, an unknown-at-plan resource output, and sensitivity pins) and a unit test asserting exact output strings and error texts.