### PR TITLE
Implement `provider::terraform::decode_tfvars`

### DIFF
--- a/.changes/unreleased/runtime-Improvements-190.yaml
+++ b/.changes/unreleased/runtime-Improvements-190.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Add `provider::terraform::decode_tfvars`
+time: 2026-07-31T10:32:16Z
+custom:
+    Component: runtime
+    PR: "190"

--- a/pkg/hcl/eval/terraform_provider_functions.go
+++ b/pkg/hcl/eval/terraform_provider_functions.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
@@ -30,6 +31,7 @@ import (
 // from the eval function table instead of being projected into invokes.
 func TerraformProviderFunctions() map[string]function.Function {
 	return map[string]function.Function{
+		"decode_tfvars": decodeTFVarsFunc,
 		"encode_expr":   encodeExprFunc,
 		"encode_tfvars": encodeTFVarsFunc,
 	}
@@ -56,6 +58,45 @@ var encodeExprFunc = function.New(&function.Spec{
 		return cty.StringVal(string(f.Bytes())), nil
 	},
 })
+
+// decodeTFVarsFunc parses .tfvars file text into an object. Attribute
+// expressions are evaluated with no eval context, so constants (including
+// operators) evaluate while variable references and function calls error.
+// Every failure — parse errors, blocks, duplicate or non-attribute content —
+// wraps errFailedToDecode with the HCL diagnostics joined on. The content is
+// parsed at position 0,0 so diagnostic positions match upstream's.
+var decodeTFVarsFunc = function.New(&function.Spec{
+	Params: []function.Parameter{{
+		Name: "content",
+		Type: cty.String,
+	}},
+	Type: function.StaticReturnType(cty.DynamicPseudoType),
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		f, diag := hclsyntax.ParseConfig([]byte(args[0].AsString()), "", hcl.Pos{Line: 0, Column: 0})
+		if f == nil || diag.HasErrors() {
+			return cty.NullVal(cty.DynamicPseudoType), wrapDiagErrors(errFailedToDecode, diag)
+		}
+		attrs, diag := f.Body.JustAttributes()
+		if attrs == nil || diag.HasErrors() {
+			return cty.NullVal(cty.DynamicPseudoType), wrapDiagErrors(errFailedToDecode, diag)
+		}
+		vals := make(map[string]cty.Value, len(attrs))
+		for name, attr := range attrs {
+			val, diag := attr.Expr.Value(nil)
+			if diag.HasErrors() {
+				return cty.NullVal(cty.DynamicPseudoType), wrapDiagErrors(errFailedToDecode, diag)
+			}
+			vals[name] = val
+		}
+		return cty.ObjectVal(vals), nil
+	},
+})
+
+var errFailedToDecode = errors.New("failed to decode tfvars content")
+
+func wrapDiagErrors(m error, diag hcl.Diagnostics) error {
+	return errors.Join(append([]error{m}, diag.Errs()...)...)
+}
 
 // encodeTFVarsFunc renders an object as .tfvars file text, one attribute per
 // key in cty's sorted iteration order. Only object types are accepted — maps

--- a/pkg/hcl/eval/terraform_provider_functions_test.go
+++ b/pkg/hcl/eval/terraform_provider_functions_test.go
@@ -214,3 +214,106 @@ func TestEncodeTFVars(t *testing.T) {
 		})
 	}
 }
+
+// Expected values and error texts match OpenTofu v1.12.3's decode_tfvars,
+// including the 0-based diagnostic positions from parsing at position 0,0.
+func TestDecodeTFVars(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		arg  cty.Value
+		want cty.Value
+	}{
+		{
+			name: "basic",
+			arg:  cty.StringVal("foo = \"bar\"\nbaz = 1\n"),
+			want: cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.StringVal("bar"),
+				"baz": cty.NumberIntVal(1),
+			}),
+		},
+		{
+			name: "nested",
+			arg:  cty.StringVal("list = [1, \"two\", true]\nobj = {\n  a = 1\n}\n"),
+			want: cty.ObjectVal(map[string]cty.Value{
+				"list": cty.TupleVal([]cty.Value{cty.NumberIntVal(1), cty.StringVal("two"), cty.True}),
+				"obj":  cty.ObjectVal(map[string]cty.Value{"a": cty.NumberIntVal(1)}),
+			}),
+		},
+		{
+			name: "empty",
+			arg:  cty.StringVal(""),
+			want: cty.EmptyObjectVal,
+		},
+		{
+			name: "constant expressions evaluate",
+			arg:  cty.StringVal("sum = 1 + 2"),
+			want: cty.ObjectVal(map[string]cty.Value{"sum": cty.NumberIntVal(3)}),
+		},
+		{
+			name: "unknown defers",
+			arg:  cty.UnknownVal(cty.String),
+			want: cty.DynamicVal,
+		},
+		{
+			name: "sensitive input marks result",
+			arg:  cty.StringVal("a = 1").Mark(SensitiveMark),
+			want: cty.ObjectVal(map[string]cty.Value{"a": cty.NumberIntVal(1)}).Mark(SensitiveMark),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := decodeTFVarsFunc.Call([]cty.Value{tt.arg})
+			require.NoError(t, err)
+			// Parsed numbers differ from NumberIntVal in big.Float
+			// representation, so compare with cty's own equality.
+			assert.True(t, tt.want.RawEquals(got), "got %#v, want %#v", got, tt.want)
+		})
+	}
+
+	errTests := []struct {
+		name    string
+		arg     cty.Value
+		wantErr string
+	}{
+		{
+			name:    "null",
+			arg:     cty.NullVal(cty.String),
+			wantErr: "argument must not be null",
+		},
+		{
+			name:    "syntax error",
+			arg:     cty.StringVal("not valid {{{"),
+			wantErr: "failed to decode tfvars content",
+		},
+		{
+			name:    "variable reference",
+			arg:     cty.StringVal("a = var.x"),
+			wantErr: "failed to decode tfvars content\n:0,4-7: Variables not allowed; Variables may not be used here.",
+		},
+		{
+			name:    "function call",
+			arg:     cty.StringVal(`a = upper("x")`),
+			wantErr: "failed to decode tfvars content",
+		},
+		{
+			name:    "block",
+			arg:     cty.StringVal("block \"x\" {\n}\n"),
+			wantErr: "failed to decode tfvars content",
+		},
+		{
+			name:    "duplicate attribute",
+			arg:     cty.StringVal("a = 1\na = 2"),
+			wantErr: "failed to decode tfvars content",
+		},
+	}
+	for _, tt := range errTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := decodeTFVarsFunc.Call([]cty.Value{tt.arg})
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/tests/tfcompat/l2_decode_tfvars_test.go
+++ b/tests/tfcompat/l2_decode_tfvars_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi-labs/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL2DecodeTfvars covers the builtin `terraform` provider's
+// provider::terraform::decode_tfvars function
+// (https://github.com/pulumi-labs/pulumi-hcl/issues/190): both runtimes must
+// parse .tfvars text — literal and resource-produced alike — into identical
+// objects, with no plugin to install.
+func TestL2DecodeTfvars(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_decode_tfvars", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_decode_tfvars/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_decode_tfvars/main.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_providers {
+    terraform = {
+      source = "terraform.io/builtin/terraform"
+    }
+  }
+}
+
+resource "terraform_data" "content" {
+  input = "x = 1\ny = \"two\"\n"
+}
+
+# The builtin `terraform` provider ships no installable plugin, so
+# provider::terraform::decode_tfvars must be implemented internally by both
+# runtimes. It parses .tfvars text into an object.
+output "basic" {
+  value = provider::terraform::decode_tfvars("foo = \"bar\"\nbaz = 1\n")
+}
+
+output "nested" {
+  value = provider::terraform::decode_tfvars("list = [1, \"two\", true]\nobj = {\n  a = 1\n}\n")
+}
+
+output "empty" {
+  value = provider::terraform::decode_tfvars("")
+}
+
+# Constant expressions evaluate; only variables and function calls are
+# rejected (the content is evaluated with no eval context).
+output "exprs" {
+  value = provider::terraform::decode_tfvars("sum = 1 + 2")
+}
+
+output "roundtrip" {
+  value = provider::terraform::decode_tfvars(provider::terraform::encode_tfvars({ a = 1, b = "x" }))
+}
+
+# Content flowing out of a resource is unknown at plan time, so the call has
+# to defer to apply rather than fail.
+output "unknown_at_plan" {
+  value = provider::terraform::decode_tfvars(terraform_data.content.output)
+}
+
+# A sensitive input marks the whole decoded object sensitive.
+output "sens" {
+  value     = provider::terraform::decode_tfvars(sensitive("a = 1"))
+  sensitive = true
+}
+
+output "is_sensitive" {
+  value = issensitive(provider::terraform::decode_tfvars(sensitive("a = 1")))
+}


### PR DESCRIPTION
Implements `provider::terraform::decode_tfvars`, the last of the builtin `terraform` provider's three functions (closes https://github.com/pulumi-labs/pulumi-hcl/issues/190). Follow-up to https://github.com/pulumi-labs/pulumi-hcl/pull/475.

Behavior pinned against OpenTofu v1.12.3:

- `decode_tfvars("foo = \"bar\"\nbaz = 1\n")` → `{ foo = "bar", baz = 1 }`; `""` → `{}`; round-trips with `encode_tfvars`.
- The content is evaluated with no eval context, so constant expressions evaluate (`"sum = 1 + 2"` → `{ sum = 3 }`) while variable references and function calls fail.
- Every failure — syntax errors, blocks, duplicate attributes, non-constant expressions — wraps `failed to decode tfvars content` with the HCL diagnostics joined on, parsed at position 0,0 so even the quirky 0-based diagnostic positions (`:0,4-7: Variables not allowed; ...`) match upstream byte for byte.
- An unknown argument (e.g. a resource output at plan time) defers to an unknown result; a sensitive argument marks the whole decoded object sensitive.

Coverage: `TestL2DecodeTfvars` (tfcompat, added failing in the first commit — literals, an `encode_tfvars` round trip, unknown-at-plan resource content, and sensitivity pins) and a unit test asserting exact values and error texts.