### PR TITLE
Remove the `prevent_destroy` -> `protect` special-casing from the converter

### DIFF
--- a/.changes/unreleased/converter-bug-fixes-477.yaml
+++ b/.changes/unreleased/converter-bug-fixes-477.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Stop converting `lifecycle.prevent_destroy` to the `protect` resource option
+time: 2026-07-31T12:51:09.27111+02:00
+custom:
+    Component: converter
+    PR: "477"

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -800,8 +800,6 @@ func (ft *fileTransformer) emitFile(
 				case "lifecycle":
 					for _, attr := range sortedAttributes(subBlock.Body.Attributes) {
 						switch attr.Name {
-						case "prevent_destroy":
-							opts = append(opts, optEntry{"protect", ft.transformExpr(attr.Expr)})
 						case "ignore_changes":
 							opts = append(opts, optEntry{"ignoreChanges", ft.transformPropertyPathList(attr.Expr, res.InputProperties)})
 						case "create_before_destroy":

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -390,11 +390,6 @@ resource "test_item" "inbound" {
 	assert.Equal(t, expected, string(out.Bytes()))
 }
 
-// TestEjectPreventDestroyUnsupported locks in that `lifecycle.prevent_destroy`
-// no longer converts to the `protect` resource option: since the runtime
-// enforces prevent_destroy as a before-destroy guard rather than state-level
-// protect, the converter has no PCL equivalent and must report it as
-// unsupported.
 func TestEjectPreventDestroyUnsupported(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -390,6 +390,51 @@ resource "test_item" "inbound" {
 	assert.Equal(t, expected, string(out.Bytes()))
 }
 
+// TestEjectPreventDestroyUnsupported locks in that `lifecycle.prevent_destroy`
+// no longer converts to the `protect` resource option: since the runtime
+// enforces prevent_destroy as a before-destroy guard rather than state-level
+// protect, the converter has no PCL equivalent and must report it as
+// unsupported.
+func TestEjectPreventDestroyUnsupported(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Item": {
+				InputProperties: map[string]schema.PropertySpec{
+					"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+		},
+	}
+	loader := schemaloader.New(t, testSchema)
+
+	src := []byte(`terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+resource "test_item" "guarded" {
+  value = "hello"
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+`)
+
+	out := hclwrite.NewEmptyFile()
+	diags := transformSingleFile(t, src, "main.tf", out.Body(), loader, nil)
+	require.True(t, diags.HasErrors())
+	assert.Contains(t, diags.Error(), `lifecycle attribute "prevent_destroy" is not supported`)
+	assert.NotContains(t, string(out.Bytes()), "protect")
+}
+
 // TestEjectInvokeInListComprehension feeds in the HCL shape produced by the
 // codegen when a PCL invoke inside a list comprehension is hoisted: a data
 // block with for_each over the comprehension's collection, plus a

--- a/pkg/hcl/ast/resource.go
+++ b/pkg/hcl/ast/resource.go
@@ -167,7 +167,8 @@ type Lifecycle struct {
 	CreateBeforeDestroy *bool
 
 	// PreventDestroy indicates whether destruction of the resource should be prevented.
-	// In Pulumi, this maps to the "protect" resource option.
+	// Enforced by the runtime as a before-destroy guard; unlike the "protect"
+	// resource option, it does not persist in state.
 	// The expression is evaluated at runtime, so it may reference variables,
 	// locals, or other resources. nil means not explicitly set (may inherit
 	// from parent).


### PR DESCRIPTION
#470 means we no longer need to support `prevent_destroy` in the converter, so we can remove the special case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)