### PR TITLE
Use `PULUMI_BOT_TOKEN` instead of `RELEASE_TOKEN`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           pulumi-version: "latest"
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       - uses: opentofu/setup-opentofu@v2
       # terraform_remote_state lowers to the pulumi-terraform getLocalReference
       # invoke; the tfcompat harness disables plugin acquisition, so pre-install it.
@@ -150,7 +150,7 @@ jobs:
         with:
           pulumi-version: "latest"
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       - run: make bin/pulumi-resource-hcl
       - run: pulumi package gen-sdk ./bin/pulumi-resource-hcl
       - name: Build Go SDK

--- a/.github/workflows/maintain-release-pr.yml
+++ b/.github/workflows/maintain-release-pr.yml
@@ -34,7 +34,7 @@ jobs:
           # come from a user identity, not GITHUB_TOKEN. PRs/pushes authored by
           # GITHUB_TOKEN don't trigger pull_request workflows, which would leave
           # the release PR with no required-check coverage.
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - uses: jdx/mise-action@v4
 
       - name: Check for unreleased changes
@@ -71,7 +71,7 @@ jobs:
       - name: Open or refresh release PR
         if: steps.check.outputs.has-changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
           VERSION: ${{ steps.latest.outputs.version }}
           AUTO_MERGE: ${{ inputs.auto_merge }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,12 @@ jobs:
       registry-sha: ${{ steps.commit.outputs.registry-sha }}
     env:
       VERSION: ${{ needs.release.outputs.version }}
-      GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      GH_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: sdk-releases
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Read the Go toolchain from the released source
         run: |
           git fetch --depth 1 origin "refs/tags/${VERSION}"
@@ -82,7 +82,7 @@ jobs:
         with:
           pulumi-version: "latest"
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Check if the Go SDK tag already exists
         id: already-tagged
         run: |


### PR DESCRIPTION
The repository transfer to the `pulumi` organization invalidated the repo-scoped `RELEASE_TOKEN` PAT: the first post-merge run of `maintain-release-pr.yml` failed with a 403 pushing to the repo (https://github.com/pulumi/pulumi-hcl/issues/481), and `release.yml`'s sdk-releases push and `ci.yml` would fail the same way.

The `pulumi` org shares its org-level `PULUMI_BOT_TOKEN` secret with this repository (verified via the repo's organization-secrets listing), so this switches every `secrets.RELEASE_TOKEN` reference to `secrets.PULUMI_BOT_TOKEN`. The now-unused repo-level `RELEASE_TOKEN` secret can be deleted once this merges.

Fixes https://github.com/pulumi/pulumi-hcl/issues/481.

CI-only change, no changelog fragment.