### PR TITLE
Disable `wait_for_ci` for codecov notifications

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,7 @@
 codecov:
   notify:
     manual_trigger: true
+    wait_for_ci: false
 
 coverage:
   status:


### PR DESCRIPTION
Follow-up to https://github.com/pulumi/pulumi-hcl/pull/484: no codecov status ever posted on its final commits, despite `send-notifications` being accepted twice and Codecov's API showing the commit fully processed (`state: complete`, 78.24%).

Cause: `codecov.notify.wait_for_ci` defaults to `true`, so Codecov holds the notification until all CI on the commit completes — but the send now comes from the `codecov-notify` job, so at send time the run is by definition still in progress, and with `manual_trigger` the held notification is never retried. The statuses that did appear during #484's iteration were sends that raced a run reaching a terminal state (cancelled/failed).

With `manual_trigger` the notify job already controls the timing (`needs: test`), so `wait_for_ci` adds nothing here. This PR's own run is the test: `codecov/project` and `codecov/patch` should post shortly after `ci / codecov-notify` completes.

CI-only change, no changelog fragment.