### PR TITLE
Render the .NET package icon as a real PNG before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,12 @@ jobs:
           git fetch --depth 1 origin "refs/tags/${VERSION}"
           git show "FETCH_HEAD:README.md" > sdk/go/README.md
           git show "FETCH_HEAD:LICENSE" > sdk/go/LICENSE
+      - name: Render the .NET package icon as a real PNG
+        if: steps.already-tagged.outputs.exists == 'false'
+        run: |
+          sudo apt-get update && sudo apt-get install -y librsvg2-bin
+          git show "FETCH_HEAD:assets/logo.svg" |
+            rsvg-convert --width 128 --keep-aspect-ratio --output sdk/dotnet/logo.png
       - name: Assemble the registry payload
         if: steps.already-tagged.outputs.exists == 'false'
         run: |


### PR DESCRIPTION
The provider schema's `logoUrl` points at `assets/logo.svg` so the Pulumi registry serves the vector logo, but `pulumi package gen-sdk` downloads whatever that URL returns and saves the bytes verbatim as `sdk/dotnet/logo.png`, wiring it in as the NuGet `<PackageIcon>`. nuget.org validates package icons and only accepts real PNG/JPG, so the retried .NET publish from https://github.com/pulumi/pulumi-hcl/issues/482 failed with:

```
error: Response status code does not indicate success: 400 (Unsupported icon image format. Only PNG and JPG images are supported.).
```

This adds a step to `publish-go-sdk` that re-renders the icon from the released tag with `rsvg-convert` (128px wide, aspect ratio preserved — the logo's viewBox is 445×265, so forcing 128×128 would stretch it) before the regenerated SDKs are committed to `sdk-releases`. The registry keeps serving the SVG; only the NuGet package embeds the raster copy.

This mirrors what pulumi-command does for the same problem (https://github.com/pulumi/pulumi-command/issues/243), except the PNG is rendered in CI from the SVG instead of committing a pre-rendered copy, keeping the SVG the single source of truth.

The step runs inside the `publish-go-sdk` job (which checks out `sdk-releases`, not master), so the SVG is read from the released tag via the `FETCH_HEAD` the preceding README/LICENSE step already fetched. It takes effect on the next release that regenerates the SDKs — which is also the first release that will actually push `Pulumi.Hcl` to NuGet, since the stale branch's `Pulumi.Labs.Hcl` never made it past validation.