### PR TITLE
`terraform_data` -> `Stash`

### DIFF
--- a/.changes/unreleased/converter-Improvements-491.yaml
+++ b/.changes/unreleased/converter-Improvements-491.yaml
@@ -1,5 +1,5 @@
 kind: Improvements
-body: '`pulumi import --from hcl` imports `terraform_data` resources as the engine-builtin Stash, with their values supplied from the state'
+body: '`pulumi import --from hcl` imports `terraform_data` resources as a `Stash`, with their values supplied from the state'
 time: 2026-08-02T20:05:56.824643+02:00
 custom:
     Component: converter

--- a/.changes/unreleased/converter-Improvements-491.yaml
+++ b/.changes/unreleased/converter-Improvements-491.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: '`pulumi import --from hcl` imports `terraform_data` resources as the engine-builtin Stash, with their values supplied from the state'
+time: 2026-08-02T20:05:56.824643+02:00
+custom:
+    Component: converter
+    PR: "491"

--- a/pkg/converter/convert_state.go
+++ b/pkg/converter/convert_state.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/bridge"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/modulepath"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/packages"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/transform"
 	"github.com/pulumi/pulumi-hcl/pkg/util/encryption"
 	"github.com/pulumi/pulumi-hcl/vendored/addrs"
@@ -127,6 +128,13 @@ func convertTFState(
 	for res := range managedResources(state, warn) {
 		provider := res.ProviderConfig.Provider.Type
 		tfType := res.Addr.Resource.Type
+		// terraform_data is OpenTofu's builtin: no plugin, no bridge mapping.
+		// It imports as the engine-builtin Stash, the resource the runtime
+		// lowers it onto.
+		if tfType == packages.TerraformDataType {
+			resources = append(resources, stashImports(res, warn)...)
+			continue
+		}
 		info, err := providerInfoSource.GetProviderInfo(ctx, provider, nil)
 		if err != nil || info == nil {
 			warn("Failed to resolve provider", fmt.Sprintf(
@@ -270,16 +278,7 @@ func translateInstanceValues(
 	if err != nil {
 		return nil, nil, fmt.Errorf("decoding attributes: %w", err)
 	}
-	// Re-mark the state's dynamically-sensitive paths (e.g. TF's sensitive())
-	// with the evaluator's mark; the codec turns marks into secrets.
-	// Schema-declared sensitivity is applied by the codec itself.
-	if len(current.AttrSensitivePaths) > 0 {
-		pvms := make([]cty.PathValueMarks, len(current.AttrSensitivePaths))
-		for i, p := range current.AttrSensitivePaths {
-			pvms[i] = cty.PathValueMarks{Path: p.Path, Marks: cty.NewValueMarks(eval.SensitiveMark)}
-		}
-		val = val.MarkWithPaths(pvms)
-	}
+	val = markSensitivePaths(val, current.AttrSensitivePaths)
 
 	m, err := transform.CtyToResourceOutputs(val, res, bridge.ResourceBodyMapping(info, tfType))
 	if err != nil {
@@ -296,6 +295,108 @@ func translateInstanceValues(
 		}
 	}
 	outs["id"] = resource.NewStringProperty(id)
+	return outs, ins, nil
+}
+
+// markSensitivePaths re-marks the state's dynamically-sensitive paths (e.g.
+// TF's sensitive()) with the evaluator's mark; the transform codec turns marks
+// into secrets. Schema-declared sensitivity is applied by the codec itself.
+func markSensitivePaths(val cty.Value, paths []cty.PathValueMarks) cty.Value {
+	if len(paths) == 0 {
+		return val
+	}
+	pvms := make([]cty.PathValueMarks, len(paths))
+	for i, p := range paths {
+		pvms[i] = cty.PathValueMarks{Path: p.Path, Marks: cty.NewValueMarks(eval.SensitiveMark)}
+	}
+	return val.MarkWithPaths(pvms)
+}
+
+// terraformDataStateType is terraform_data's object type in state attributes;
+// decoding against it lets ctyjson consume the dynamic attributes' type
+// annotations natively.
+var terraformDataStateType = cty.Object(map[string]cty.Type{
+	"id":               cty.String,
+	"input":            cty.DynamicPseudoType,
+	"output":           cty.DynamicPseudoType,
+	"triggers_replace": cty.DynamicPseudoType,
+})
+
+// stashImports emits one Stash import per terraform_data instance. Inputs and
+// Outputs reproduce what the runtime registers: {type, value} wrappers for
+// non-null values, an explicit null input otherwise. triggers_replace is not
+// emitted — Stash rejects it as an input and an import cannot carry the
+// engine's replacement trigger; the trigger records on the first up, which the
+// engine forgives without a replace. An untranslatable instance is skipped
+// outright: with no plugin behind Stash, an id-only import could only fail.
+func stashImports(res *states.Resource, warn func(summary, detail string)) []plugin.ResourceImport {
+	var imports []plugin.ResourceImport
+	for _, key := range sortedInstanceKeys(res) {
+		current := res.Instances[key].Current
+		if current == nil {
+			continue
+		}
+		id, ok := importID(current)
+		if !ok {
+			warn("Skipped resource without id", fmt.Sprintf(
+				"an instance of %s has no string `id` attribute to import by", res.Addr))
+			continue
+		}
+		outs, ins, err := stashValues(current)
+		if err != nil {
+			warn("Skipped terraform_data resource", fmt.Sprintf(
+				"an instance of %s cannot be translated: %v", res.Addr, err))
+			continue
+		}
+		imports = append(imports, plugin.ResourceImport{
+			Type:    packages.StashToken,
+			Name:    resourceName(res.Addr.Resource.Name, key),
+			ID:      id,
+			Inputs:  ins,
+			Outputs: outs,
+		})
+	}
+	return imports
+}
+
+// stashValues translates a terraform_data instance's attributes into Stash's
+// property surface.
+func stashValues(current *states.ResourceInstanceObjectSrc) (outs, ins resource.PropertyMap, err error) {
+	if current.AttrsJSON == nil {
+		return nil, nil, errors.New("pre-0.12 flatmap attributes are not translatable")
+	}
+	val, err := ctyjson.Unmarshal(current.AttrsJSON, terraformDataStateType)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decoding attributes: %w", err)
+	}
+	val = markSensitivePaths(val, current.AttrSensitivePaths)
+
+	m, err := transform.CtyToResourceOutputs(val, packages.TerraformDataSchema(), nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("translating attributes: %w", err)
+	}
+	wrap := func(name string) (resource.PropertyValue, error) {
+		v := m.Get(name)
+		if v.IsNull() {
+			return resource.NewNullProperty(), nil
+		}
+		src, _ := val.GetAttr(name).Unmark()
+		wrapped, err := packages.WrapTerraformDataValue(src.Type(), v)
+		if err != nil {
+			return resource.PropertyValue{}, fmt.Errorf("%s: %w", name, err)
+		}
+		return resource.ToResourcePropertyValue(wrapped), nil
+	}
+	input, err := wrap("input")
+	if err != nil {
+		return nil, nil, err
+	}
+	output, err := wrap("output")
+	if err != nil {
+		return nil, nil, err
+	}
+	ins = resource.PropertyMap{"input": input}
+	outs = resource.PropertyMap{"input": input, "output": output}
 	return outs, ins, nil
 }
 

--- a/pkg/converter/convert_state.go
+++ b/pkg/converter/convert_state.go
@@ -128,9 +128,6 @@ func convertTFState(
 	for res := range managedResources(state, warn) {
 		provider := res.ProviderConfig.Provider.Type
 		tfType := res.Addr.Resource.Type
-		// terraform_data is OpenTofu's builtin: no plugin, no bridge mapping.
-		// It imports as the engine-builtin Stash, the resource the runtime
-		// lowers it onto.
 		if tfType == packages.TerraformDataType {
 			resources = append(resources, stashImports(res, warn)...)
 			continue

--- a/pkg/converter/convert_state.go
+++ b/pkg/converter/convert_state.go
@@ -128,23 +128,25 @@ func convertTFState(
 	for res := range managedResources(state, warn) {
 		provider := res.ProviderConfig.Provider.Type
 		tfType := res.Addr.Resource.Type
-		if tfType == packages.TerraformDataType {
-			resources = append(resources, stashImports(res, warn)...)
-			continue
+		stash := tfType == packages.TerraformDataType
+		token := packages.StashToken
+		var info *tfbridge.ProviderInfo
+		if !stash {
+			var err error
+			info, err = providerInfoSource.GetProviderInfo(ctx, provider, nil)
+			if err != nil || info == nil {
+				warn("Failed to resolve provider", fmt.Sprintf(
+					"could not resolve bridge mapping for provider %q: %v", provider, err))
+				continue
+			}
+			resInfo, ok := info.Resources[tfType]
+			if !ok || resInfo == nil || resInfo.Tok == "" {
+				warn("Failed to resolve resource type", fmt.Sprintf(
+					"provider %q has no mapping for TF type %q", provider, tfType))
+				continue
+			}
+			token = resInfo.Tok.String()
 		}
-		info, err := providerInfoSource.GetProviderInfo(ctx, provider, nil)
-		if err != nil || info == nil {
-			warn("Failed to resolve provider", fmt.Sprintf(
-				"could not resolve bridge mapping for provider %q: %v", provider, err))
-			continue
-		}
-		resInfo, ok := info.Resources[tfType]
-		if !ok || resInfo == nil || resInfo.Tok == "" {
-			warn("Failed to resolve resource type", fmt.Sprintf(
-				"provider %q has no mapping for TF type %q", provider, tfType))
-			continue
-		}
-		token := resInfo.Tok.String()
 
 		for _, key := range sortedInstanceKeys(res) {
 			current := res.Instances[key].Current
@@ -157,8 +159,15 @@ func convertTFState(
 					"an instance of %s has no string `id` attribute to import by", res.Addr))
 				continue
 			}
-			outs, ins, err := translateInstanceValues(ctx, loader, info, token, tfType, id, current)
-			if err != nil {
+			var outs, ins resource.PropertyMap
+			var err error
+			if stash {
+				if outs, ins, err = stashValues(current); err != nil {
+					warn("Skipped terraform_data resource", fmt.Sprintf(
+						"an instance of %s cannot be translated: %v", res.Addr, err))
+					continue
+				}
+			} else if outs, ins, err = translateInstanceValues(ctx, loader, info, token, tfType, id, current); err != nil {
 				warn("Importing without values", fmt.Sprintf(
 					"an instance of %s imports by id only: %v", res.Addr, err))
 			}
@@ -319,45 +328,15 @@ var terraformDataStateType = cty.Object(map[string]cty.Type{
 	"triggers_replace": cty.DynamicPseudoType,
 })
 
-// stashImports emits one Stash import per terraform_data instance. Inputs and
-// Outputs reproduce what the runtime registers: {type, value} wrappers for
-// non-null values, an explicit null input otherwise. triggers_replace is not
-// emitted — Stash rejects it as an input and an import cannot carry the
-// engine's replacement trigger; the trigger records on the first up, which the
-// engine forgives without a replace. An untranslatable instance is skipped
-// outright: with no plugin behind Stash, an id-only import could only fail.
-func stashImports(res *states.Resource, warn func(summary, detail string)) []plugin.ResourceImport {
-	var imports []plugin.ResourceImport
-	for _, key := range sortedInstanceKeys(res) {
-		current := res.Instances[key].Current
-		if current == nil {
-			continue
-		}
-		id, ok := importID(current)
-		if !ok {
-			warn("Skipped resource without id", fmt.Sprintf(
-				"an instance of %s has no string `id` attribute to import by", res.Addr))
-			continue
-		}
-		outs, ins, err := stashValues(current)
-		if err != nil {
-			warn("Skipped terraform_data resource", fmt.Sprintf(
-				"an instance of %s cannot be translated: %v", res.Addr, err))
-			continue
-		}
-		imports = append(imports, plugin.ResourceImport{
-			Type:    packages.StashToken,
-			Name:    resourceName(res.Addr.Resource.Name, key),
-			ID:      id,
-			Inputs:  ins,
-			Outputs: outs,
-		})
-	}
-	return imports
-}
-
 // stashValues translates a terraform_data instance's attributes into Stash's
-// property surface.
+// property surface — the resource the runtime lowers terraform_data onto,
+// served by the engine's builtin provider. Inputs and Outputs reproduce what
+// the runtime registers: {type, value} wrappers for non-null values, an
+// explicit null input otherwise. triggers_replace is not emitted — Stash
+// rejects it as an input and an import cannot carry the engine's replacement
+// trigger; the trigger records on the first up, which the engine forgives
+// without a replace. An untranslatable instance is skipped outright: with no
+// plugin behind Stash, an id-only import could only fail.
 func stashValues(current *states.ResourceInstanceObjectSrc) (outs, ins resource.PropertyMap, err error) {
 	if current.AttrsJSON == nil {
 		return nil, nil, errors.New("pre-0.12 flatmap attributes are not translatable")
@@ -372,28 +351,17 @@ func stashValues(current *states.ResourceInstanceObjectSrc) (outs, ins resource.
 	if err != nil {
 		return nil, nil, fmt.Errorf("translating attributes: %w", err)
 	}
-	wrap := func(name string) (resource.PropertyValue, error) {
+	wrap := func(name string) resource.PropertyValue {
 		v := m.Get(name)
 		if v.IsNull() {
-			return resource.NewNullProperty(), nil
+			return resource.NewNullProperty()
 		}
 		src, _ := val.GetAttr(name).Unmark()
-		wrapped, err := packages.WrapTerraformDataValue(src.Type(), v)
-		if err != nil {
-			return resource.PropertyValue{}, fmt.Errorf("%s: %w", name, err)
-		}
-		return resource.ToResourcePropertyValue(wrapped), nil
+		return resource.ToResourcePropertyValue(packages.WrapTerraformDataValue(src.Type(), v))
 	}
-	input, err := wrap("input")
-	if err != nil {
-		return nil, nil, err
-	}
-	output, err := wrap("output")
-	if err != nil {
-		return nil, nil, err
-	}
+	input := wrap("input")
 	ins = resource.PropertyMap{"input": input}
-	outs = resource.PropertyMap{"input": input, "output": output}
+	outs = resource.PropertyMap{"input": input, "output": wrap("output")}
 	return outs, ins, nil
 }
 

--- a/pkg/converter/convert_state_test.go
+++ b/pkg/converter/convert_state_test.go
@@ -375,6 +375,68 @@ func TestConvertTFState_SuppliesValues(t *testing.T) {
 
 // TestConvertTFState_ValueFallbacks pins the degradations: instances whose
 // values cannot be translated still import by id, with a warning.
+// TestConvertTFState_TerraformData pins the builtin's import shape: Stash
+// imports carrying the runtime's {type, value} wrapper encoding, an explicit
+// null input when absent, and no triggers_replace (the engine's replacement
+// trigger records on the first up).
+func TestConvertTFState_TerraformData(t *testing.T) {
+	t.Parallel()
+
+	state := parseState(t, `{
+		"resources": [
+			{
+				"mode": "managed", "type": "terraform_data", "name": "d",
+				"provider": "provider[\"terraform.io/builtin/terraform\"]",
+				"instances": [ {
+					"attributes": {
+						"id": "aaaa-bbbb",
+						"input": {"value": ["x", "y"], "type": ["set", "string"]},
+						"output": {"value": ["x", "y"], "type": ["set", "string"]},
+						"triggers_replace": {"value": "v1", "type": "string"}
+					}
+				} ]
+			},
+			{
+				"mode": "managed", "type": "terraform_data", "name": "trigger_only",
+				"provider": "provider[\"terraform.io/builtin/terraform\"]",
+				"instances": [ {
+					"attributes": {
+						"id": "cccc-dddd",
+						"input": null,
+						"output": null,
+						"triggers_replace": {"value": "v2", "type": "string"}
+					}
+				} ]
+			}
+		]
+	}`)
+
+	resp := convertTFState(t.Context(), fakeInfoSource{}, nil, state)
+	require.Empty(t, resp.Diagnostics)
+	require.Len(t, resp.Resources, 2)
+
+	got := resp.Resources[0]
+	assert.Equal(t, "pulumi:index:Stash", got.Type)
+	assert.Equal(t, "d", got.Name)
+	assert.Equal(t, "aaaa-bbbb", got.ID)
+	assert.Empty(t, got.Version)
+	assert.Nil(t, got.Parameterization, "the engine's builtin provider serves Stash; no plugin identity")
+	wrapped := resource.NewObjectProperty(resource.PropertyMap{
+		"type": resource.NewStringProperty(`["set","string"]`),
+		"value": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("x"), resource.NewStringProperty("y"),
+		}),
+	})
+	assert.Equal(t, resource.PropertyMap{"input": wrapped}, got.Inputs,
+		"the cty type survives in the wrapper; triggers_replace is not an input")
+	assert.Equal(t, resource.PropertyMap{"input": wrapped, "output": wrapped}, got.Outputs)
+
+	trigger := resp.Resources[1]
+	assert.Equal(t, "cccc-dddd", trigger.ID)
+	assert.Equal(t, resource.PropertyMap{"input": resource.NewNullProperty()}, trigger.Inputs,
+		"an absent input imports as the explicit null the runtime registers")
+}
+
 func TestConvertTFState_ValueFallbacks(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/converter/convert_state_test.go
+++ b/pkg/converter/convert_state_test.go
@@ -373,8 +373,6 @@ func TestConvertTFState_SuppliesValues(t *testing.T) {
 	assert.NotContains(t, ins, resource.PropertyKey("id"))
 }
 
-// TestConvertTFState_ValueFallbacks pins the degradations: instances whose
-// values cannot be translated still import by id, with a warning.
 // TestConvertTFState_TerraformData pins the builtin's import shape: Stash
 // imports carrying the runtime's {type, value} wrapper encoding, an explicit
 // null input when absent, and no triggers_replace (the engine's replacement
@@ -437,6 +435,8 @@ func TestConvertTFState_TerraformData(t *testing.T) {
 		"an absent input imports as the explicit null the runtime registers")
 }
 
+// TestConvertTFState_ValueFallbacks pins the degradations: instances whose
+// values cannot be translated still import by id, with a warning.
 func TestConvertTFState_ValueFallbacks(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/hcl/packages/builtins.go
+++ b/pkg/hcl/packages/builtins.go
@@ -18,6 +18,9 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 const (
@@ -79,6 +82,30 @@ func TerraformDataSchema() *schema.Resource {
 			anyProp("input"), anyProp("output"), anyProp("triggers_replace"),
 		},
 	}
+}
+
+// terraform_data's attributes are dynamically typed, and the Pulumi property
+// encoding cannot represent every cty type: a set flattens to an ordered array
+// that would re-expand as a tuple. Each value is therefore boxed as a
+// {type, value} wrapper object — persisting the cty type through the engine
+// and its state alongside the value, the way OpenTofu stores dynamic
+// attributes.
+const (
+	TerraformDataTypeKey  = "type"
+	TerraformDataValueKey = "value"
+)
+
+// WrapTerraformDataValue boxes a terraform_data value of the given cty type as
+// a {type, value} wrapper.
+func WrapTerraformDataValue(t cty.Type, v property.Value) (property.Value, error) {
+	typeJSON, err := ctyjson.MarshalType(t)
+	if err != nil {
+		return property.Value{}, err
+	}
+	return property.New(map[string]property.Value{
+		TerraformDataTypeKey:  property.New(string(typeJSON)),
+		TerraformDataValueKey: v,
+	}), nil
 }
 
 // TerraformRemoteStateSchema is the synthetic schema terraform_remote_state

--- a/pkg/hcl/packages/builtins.go
+++ b/pkg/hcl/packages/builtins.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
@@ -97,15 +98,13 @@ const (
 
 // WrapTerraformDataValue boxes a terraform_data value of the given cty type as
 // a {type, value} wrapper.
-func WrapTerraformDataValue(t cty.Type, v property.Value) (property.Value, error) {
+func WrapTerraformDataValue(t cty.Type, v property.Value) property.Value {
 	typeJSON, err := ctyjson.MarshalType(t)
-	if err != nil {
-		return property.Value{}, err
-	}
+	contract.AssertNoErrorf(err, "marshaling cty type for the terraform_data wrapper")
 	return property.New(map[string]property.Value{
 		TerraformDataTypeKey:  property.New(string(typeJSON)),
 		TerraformDataValueKey: v,
-	}), nil
+	})
 }
 
 // TerraformRemoteStateSchema is the synthetic schema terraform_remote_state

--- a/pkg/hcl/run/terraform_data.go
+++ b/pkg/hcl/run/terraform_data.go
@@ -120,20 +120,10 @@ func lowerTerraformDataOutputs(resType string, outputs property.Map, opts *Resou
 	return outputs.Set("triggers_replace", opts.ReplacementTrigger.AsArray().Get(0))
 }
 
-// terraform_data's attributes are dynamically typed, and the Pulumi property
-// encoding cannot represent every cty type: a set flattens to an ordered array
-// that would re-expand as a tuple. Each evaluated input is therefore boxed as
-// a {type, value} wrapper object before registration — persisting the cty type
-// through the engine and its state alongside the value, the way OpenTofu
-// stores dynamic attributes — and unboxed wherever outputs re-expand to cty,
-// including from prior state (e.g. a destroy-time provisioner's self).
-const (
-	tdataTypeKey  = "type"
-	tdataValueKey = "value"
-)
-
 // wrapTerraformDataInputs boxes terraform_data's evaluated inputs as
-// {type, value} wrappers. It is a no-op for every other type.
+// {type, value} wrappers (see packages.WrapTerraformDataValue), unboxed
+// wherever outputs re-expand to cty, including from prior state (e.g. a
+// destroy-time provisioner's self). It is a no-op for every other type.
 func wrapTerraformDataInputs(resType string, inputs property.Map, evaluated map[string]cty.Value) property.Map {
 	if resType != packages.TerraformDataType {
 		return inputs
@@ -147,14 +137,11 @@ func wrapTerraformDataInputs(resType string, inputs property.Map, evaluated map[
 		if !ok {
 			continue
 		}
-		typeJSON, err := ctyjson.MarshalType(src.Type())
+		wrapped, err := packages.WrapTerraformDataValue(src.Type(), v)
 		if err != nil {
 			continue
 		}
-		inputs = inputs.Set(name, property.New(map[string]property.Value{
-			tdataTypeKey:  property.New(string(typeJSON)),
-			tdataValueKey: v,
-		}))
+		inputs = inputs.Set(name, wrapped)
 	}
 	return inputs
 }
@@ -191,10 +178,10 @@ func unwrapTerraformDataValue(pv property.Value) (cty.Value, bool, error) {
 		return cty.Value{}, false, nil
 	}
 	m := pv.AsMap()
-	typeJSON, typeOk := m.GetOk(tdataTypeKey)
-	value, valueOk := m.GetOk(tdataValueKey)
+	typeJSON, typeOk := m.GetOk(packages.TerraformDataTypeKey)
+	value, valueOk := m.GetOk(packages.TerraformDataValueKey)
 	if !typeOk || !valueOk || m.Len() != 2 || !typeJSON.IsString() {
-		return cty.Value{}, false, fmt.Errorf("malformed {%s, %s} wrapper", tdataTypeKey, tdataValueKey)
+		return cty.Value{}, false, fmt.Errorf("malformed {%s, %s} wrapper", packages.TerraformDataTypeKey, packages.TerraformDataValueKey)
 	}
 	recorded, err := ctyjson.UnmarshalType([]byte(typeJSON.AsString()))
 	if err != nil {

--- a/pkg/hcl/run/terraform_data.go
+++ b/pkg/hcl/run/terraform_data.go
@@ -137,11 +137,7 @@ func wrapTerraformDataInputs(resType string, inputs property.Map, evaluated map[
 		if !ok {
 			continue
 		}
-		wrapped, err := packages.WrapTerraformDataValue(src.Type(), v)
-		if err != nil {
-			continue
-		}
-		inputs = inputs.Set(name, wrapped)
+		inputs = inputs.Set(name, packages.WrapTerraformDataValue(src.Type(), v))
 	}
 	return inputs
 }

--- a/tests/testutil/pulexec/run.go
+++ b/tests/testutil/pulexec/run.go
@@ -94,6 +94,10 @@ type Provider struct {
 type Result struct {
 	Outputs   map[string]string
 	Resources []apitype.ResourceV3
+	// Changes counts the up's resource operations by kind, as reported by the
+	// engine — including resources served in-process by the engine's builtin
+	// provider, which no provider-boundary recorder can observe.
+	Changes map[string]int
 	// Output is the combined stdout/stderr of the `pulumi up`, used by tests
 	// that assert on user-visible diagnostics (e.g. check-block warnings).
 	Output string
@@ -228,31 +232,37 @@ func (d *Driver) TryApply(t *testing.T, programFiles map[string]string) (Result,
 	var deployment apitype.DeploymentV3
 	require.NoError(t, json.Unmarshal(exported.Deployment, &deployment))
 
+	var changes map[string]int
+	if upResult.Summary.ResourceChanges != nil {
+		changes = *upResult.Summary.ResourceChanges
+	}
 	return Result{
 		Outputs:   outputs,
 		Resources: deployment.Resources,
+		Changes:   changes,
 		Output:    upResult.StdOut + "\n" + upResult.StdErr + "\n" + cap.Logs(),
 	}, upErr
 }
 
 // Preview runs `pulumi preview` and returns the error (nil on success).
 // Same captureT indirection as TryApply.
-func (d *Driver) Preview(t *testing.T, programFiles map[string]string) error {
+func (d *Driver) Preview(t *testing.T, programFiles map[string]string) (map[apitype.OpType]int, error) {
 	t.Helper()
 
 	d.writeFiles(t, programFiles)
 
+	var res auto.PreviewResult
 	cap := newCaptureT(t)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		d.pt.Preview(cap)
+		res = d.pt.Preview(cap)
 	}()
 	<-done
 	if cap.Failed() {
-		return fmt.Errorf("pulumi preview: %s", cap.Logs())
+		return nil, fmt.Errorf("pulumi preview: %s", cap.Logs())
 	}
-	return nil
+	return res.ChangeSummary, nil
 }
 
 // --run-program re-runs the language host during destroy so BeforeDelete

--- a/tests/testutil/pulexec/run.go
+++ b/tests/testutil/pulexec/run.go
@@ -94,8 +94,7 @@ type Provider struct {
 type Result struct {
 	Outputs   map[string]string
 	Resources []apitype.ResourceV3
-	// Changes counts the up's resource operations by kind.
-	Changes map[string]int
+	Changes   map[string]int
 	// Output is the combined stdout/stderr of the `pulumi up`, used by tests
 	// that assert on user-visible diagnostics (e.g. check-block warnings).
 	Output string

--- a/tests/testutil/pulexec/run.go
+++ b/tests/testutil/pulexec/run.go
@@ -94,9 +94,7 @@ type Provider struct {
 type Result struct {
 	Outputs   map[string]string
 	Resources []apitype.ResourceV3
-	// Changes counts the up's resource operations by kind, as reported by the
-	// engine — including resources served in-process by the engine's builtin
-	// provider, which no provider-boundary recorder can observe.
+	// Changes counts the up's resource operations by kind.
 	Changes map[string]int
 	// Output is the combined stdout/stderr of the `pulumi up`, used by tests
 	// that assert on user-visible diagnostics (e.g. check-block warnings).

--- a/tests/testutil/tfcompat/harness.go
+++ b/tests/testutil/tfcompat/harness.go
@@ -277,7 +277,7 @@ func runCaseFromDir(t *testing.T, caseDir string, c Case) {
 			defer wg.Done()
 			switch stage.Mode {
 			case StagePreview:
-				pulErr = pulDriver.Preview(t, stage.files)
+				_, pulErr = pulDriver.Preview(t, stage.files)
 			case StageDestroy:
 				pulErr = pulDriver.Destroy(t, stage.files)
 			default:

--- a/tests/testutil/tfcompat/importcheck.go
+++ b/tests/testutil/tfcompat/importcheck.go
@@ -66,9 +66,8 @@ func runImportCheck(
 
 		f, err := statefile.Read(bytes.NewReader(stateJSON), encryption.StateEncryptionDisabled())
 		require.NoError(t, err)
-		// Module-nested resources and terraform_data cannot import completely
-		// yet (pulumi/pulumi-hcl#167), so their previews would propose
-		// creates.
+		// Module-nested resources cannot import completely yet
+		// (pulumi/pulumi-hcl#167), so their previews would propose creates.
 		for _, mod := range f.State.Modules {
 			for _, res := range mod.Resources {
 				if res.Addr.Resource.Mode != addrs.ManagedResourceMode {
@@ -76,9 +75,6 @@ func runImportCheck(
 				}
 				if !mod.Addr.IsRoot() {
 					t.Skip("state has module-nested resources; import does not support modules yet")
-				}
-				if res.Addr.Resource.Type == "terraform_data" {
-					t.Skip("state has terraform_data resources; import does not support the builtin yet")
 				}
 			}
 		}
@@ -96,11 +92,30 @@ func runImportCheck(
 		// boundary — would execute on the real up. The stack shell, default
 		// providers, and module component shells are still created, but none
 		// of those reach a resource provider's mutating RPCs.
-		require.NoError(t, d.Preview(t, files))
+		summary, err := d.Preview(t, files)
+		require.NoError(t, err)
 		require.Empty(t, d.Mutations(), "preview after import proposed resource changes")
+		assertOnlyBenignOps(t, "preview", summary)
 
 		res, err := d.TryApply(t, files)
 		require.NoErrorf(t, err, "up after import failed:\n%s", res.Output)
 		require.Empty(t, d.Mutations(), "up after import performed resource changes")
+		assertOnlyBenignOps(t, "up", res.Changes)
 	})
+}
+
+// assertOnlyBenignOps fails on any operation beyond same, create (the stack
+// shell, default providers, and component shells), or read: resources served
+// in-process by the engine's builtin provider (e.g. terraform_data's Stash)
+// never reach a provider's mutating RPCs, so the recorder alone cannot see
+// them change.
+func assertOnlyBenignOps[K ~string](t *testing.T, phase string, ops map[K]int) {
+	t.Helper()
+	for op, n := range ops {
+		switch string(op) {
+		case "same", "create", "read":
+		default:
+			t.Errorf("%s after import performed %d %q operations", phase, n, op)
+		}
+	}
 }


### PR DESCRIPTION
One of the remaining exceptions to clean imports - `terraform_data`, which we attempt to map to a Pulumi `Stash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)