### PR TITLE
Pass a component's providers option through module blocks

### DIFF
--- a/.changes/unreleased/codegen-improvements-494.yaml
+++ b/.changes/unreleased/codegen-improvements-494.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Support the `providers` option on components
+time: 2026-08-03T10:39:47Z
+custom:
+    Component: codegen
+    PR: "494"

--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -144,8 +144,6 @@ var expectedFailures = map[string]string{
 		" is reserved as the namespace for resource method calls in HCL",
 	"l2-config-default-from-invoke": "HCL codegen does not support a config variable whose" +
 		" default is sourced from an invoke result",
-	"l3-component-invoke": "the HCL runtime does not parent invokes inside a component to" +
-		" the component, so the invoke does not inherit the component's explicit provider",
 }
 
 // expectedEjectFailures lists tests whose eject (HCL→PCL conversion) step is

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-invoke/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-invoke/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-invoke
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-invoke/invokeComponent/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-invoke/invokeComponent/main.pp
@@ -1,0 +1,10 @@
+// A multi-argument invoke passes its arguments positionally and omits the ones the program leaves
+// out, so parenting it must not displace the options bag into an argument slot.
+greeting = invoke("multi-argument-invoke:index:multiArgumentInvoke", "hello", null)
+
+output "result" {
+  value = invoke("config:index:getConfig", {
+    text = greeting.result
+  }).text
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-invoke/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-invoke/main.pp
@@ -1,0 +1,12 @@
+resource "prov" "pulumi:providers:config" {
+  name = "my config"
+}
+
+component "myComponent" "./invokeComponent" {
+  options {
+    providers = {
+      config = prov
+    }
+  }
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-invoke/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-invoke/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-invoke
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-invoke/invokeComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-invoke/invokeComponent/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    config = {
+      source  = "pulumi/config"
+      version = "9.0.0"
+    }
+    multi-argument-invoke = {
+      source  = "pulumi/multi-argument-invoke"
+      version = "44.0.0"
+    }
+  }
+}
+
+data "config_config" "providerConfig" {
+  text = local.greeting.result
+}
+
+// A multi-argument invoke passes its arguments positionally and omits the ones the program leaves
+// out, so parenting it must not displace the options bag into an argument slot.
+locals {
+  greeting = provider::multi-argument-invoke::multi_argument_invoke("hello", null)
+}
+output "result" {
+  value = data.config_config.providerConfig.text
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-invoke/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-invoke/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    config = {
+      source  = "pulumi/config"
+      version = "9.0.0"
+    }
+    multi-argument-invoke = {
+      source  = "pulumi/multi-argument-invoke"
+      version = "44.0.0"
+    }
+  }
+}
+
+provider "config" {
+  alias = "prov"
+  name  = "my config"
+}
+module "myComponent" {
+  source = "./invokeComponent"
+  providers = {
+    config = config.prov
+  }
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-invoke/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-invoke/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-invoke
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-invoke/invokeComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-invoke/invokeComponent/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    config = {
+      source  = "pulumi/config"
+      version = "9.0.0"
+    }
+    multi-argument-invoke = {
+      source  = "pulumi/multi-argument-invoke"
+      version = "44.0.0"
+    }
+  }
+}
+
+data "config_config" "invoke_0" {
+  text = local.greeting.result
+}
+
+// A multi-argument invoke passes its arguments positionally and omits the ones the program leaves
+// out, so parenting it must not displace the options bag into an argument slot.
+locals {
+  greeting = provider::multi-argument-invoke::multi_argument_invoke("hello", null)
+}
+output "result" {
+  value = data.config_config.invoke_0.text
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-invoke/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-invoke/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    config = {
+      source  = "pulumi/config"
+      version = "9.0.0"
+    }
+    multi-argument-invoke = {
+      source  = "pulumi/multi-argument-invoke"
+      version = "44.0.0"
+    }
+  }
+}
+
+provider "config" {
+  alias = "prov"
+  name  = "my config"
+}
+module "myComponent" {
+  source = "./invokeComponent"
+  providers = {
+    config = config.prov
+  }
+}

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -1985,6 +1985,11 @@ func (g *generator) genModule(body *hclwrite.Body, c *pcl.Component) hcl.Diagnos
 		pulumiBody().SetAttributeRaw("name", tokens)
 	}
 
+	if c.Options != nil && c.Options.Providers != nil {
+		d := g.genModuleProviders(block.Body(), c.Options.Providers)
+		diags = append(diags, d...)
+	}
+
 	if c.Options != nil && c.Options.Protect != nil {
 		tokens, d := g.exprTokens(c.Options.Protect, schema.BoolType)
 		diags = append(diags, d...)
@@ -1999,6 +2004,73 @@ func (g *generator) genModule(body *hclwrite.Body, c *pcl.Component) hcl.Diagnos
 		diags = append(diags, d...)
 	}
 	return diags
+}
+
+// genModuleProviders emits a module block's `providers` map from a PCL
+// component's providers option. PCL accepts a list of provider resources or a
+// map of local provider name to provider resource; the list form infers each
+// entry's key from the referenced provider's package name, which is also the
+// local name the child module's required_providers declares.
+func (g *generator) genModuleProviders(body *hclwrite.Body, providers model.Expression) hcl.Diagnostics {
+	var entries []hclwrite.ObjectAttrTokens
+	var diags hcl.Diagnostics
+
+	badEntry := func(rng hcl.Range) hcl.Diagnostics {
+		return append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "invalid providers option",
+			Detail:   "each providers entry must reference a provider resource",
+			Subject:  &rng,
+		})
+	}
+
+	addEntry := func(name, value model.Expression, extractName func(model.Expression) (string, bool)) {
+		key, ok := extractName(name)
+		if !ok {
+			diags = badEntry(name.SyntaxNode().Range())
+			return
+		}
+		v, d := g.exprTokens(value, schema.AnyResourceType)
+		if !d.HasErrors() {
+			entries = append(entries, hclwrite.ObjectAttrTokens{
+				Name:  hclwrite.TokensForIdentifier(key),
+				Value: v,
+			})
+		}
+		diags = diags.Extend(d)
+	}
+
+	switch e := providers.(type) {
+	case *model.TupleConsExpression:
+		for _, elem := range e.Expressions {
+			addEntry(elem, elem, providerPackageNameFromExpr)
+		}
+	case *model.ObjectConsExpression:
+		for _, item := range e.Items {
+			addEntry(item.Key, item.Value, extractStringLiteral)
+		}
+	default:
+		return badEntry(providers.SyntaxNode().Range())
+	}
+
+	body.SetAttributeRaw("providers", hclwrite.TokensForObject(entries))
+	return diags
+}
+
+// providerPackageNameFromExpr returns the package name of the provider
+// resource an expression references, or ok=false when the expression is not a
+// reference to a provider resource.
+func providerPackageNameFromExpr(expr model.Expression) (string, bool) {
+	st, ok := expr.(*model.ScopeTraversalExpression)
+	if !ok || len(st.Parts) == 0 {
+		return "", false
+	}
+	r, ok := st.Parts[0].(*pcl.Resource)
+	if !ok || r.Schema == nil || !r.Schema.IsProvider {
+		return "", false
+	}
+	token, _ := r.GetToken()
+	return string(tokens.Type(token).Name()), true
 }
 
 func (g *generator) genBlocks(body *hclwrite.Body, name string, expr model.Expression, objType *schema.ObjectType) hcl.Diagnostics {

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -676,7 +676,7 @@ func (ft *fileTransformer) emitFile(
 			if pclName != logicalName {
 				blk.Body().SetAttributeRaw("__logicalName", hclwrite.TokensForValue(cty.StringVal(logicalName)))
 			}
-			var rangeExpr hclsyntax.Expression
+			var rangeExpr, providersExpr hclsyntax.Expression
 			for _, attr := range sortedAttributes(block.Body.Attributes) {
 				switch attr.Name {
 				case "source":
@@ -684,16 +684,24 @@ func (ft *fileTransformer) emitFile(
 				case "count", "for_each":
 					rangeExpr = attr.Expr
 					continue
-				case "depends_on", "providers", "version":
+				case "providers":
+					providersExpr = attr.Expr
+					continue
+				case "depends_on", "version":
 					continue
 				}
 				start := attr.Range().Start.Byte
 				ft.emitLeadingComments(blk.Body(), start)
 				blk.Body().SetAttributeRaw(attr.Name, ft.withTrailing(ft.transformExpr(attr.Expr), start))
 			}
-			if rangeExpr != nil {
+			if rangeExpr != nil || providersExpr != nil {
 				optBlk := blk.Body().AppendNewBlock("options", nil)
-				optBlk.Body().SetAttributeRaw("range", ft.transformExpr(rangeExpr))
+				if rangeExpr != nil {
+					optBlk.Body().SetAttributeRaw("range", ft.transformExpr(rangeExpr))
+				}
+				if providersExpr != nil {
+					optBlk.Body().SetAttributeRaw("providers", ft.transformExpr(providersExpr))
+				}
 			}
 			out.AppendNewline()
 


### PR DESCRIPTION
Enables the `l3-component-invoke` conformance test.

The test instantiates a component with `providers = [prov]` and expects an invoke inside the component to be served by that provider. It failed because both codegen directions dropped the component's `providers` resource option — the invoke inside the module fell back to a default `config` provider, which is invalid without configuration.

The runtime needed no changes: `resolvePassThroughProvider` already resolves a module block's `providers` map for data sources.

- **codegen**: `genModule` now emits the Terraform `providers` map on module blocks (`providers = { config = config.prov }`). Both PCL forms are accepted: the list form (`providers = [prov]`), whose keys are inferred from each provider's package name, and the explicit map form. Emitted with `hclwrite.TokensForObject`.
- **converter**: ejecting a module block to a PCL component previously skipped the `providers` attribute; it now converts the map into the component's `options` block. The map form is kept so a local provider name that differs from the package name survives a round trip.

The round-tripped HCL is byte-identical to the first-pass generation.