### PR TITLE
Record component inputs and dependencies at registration

### DIFF
--- a/.changes/unreleased/codegen-improvements-494.yaml
+++ b/.changes/unreleased/codegen-improvements-494.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Support the `providers` option on components
+time: 2026-08-03T10:39:47Z
+custom:
+    Component: codegen
+    PR: "494"

--- a/.changes/unreleased/runtime-bug-fixes-495.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-495.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Record a component's evaluated inputs and their dependencies on its registration
+time: 2026-08-03T10:57:52Z
+custom:
+    Component: runtime
+    PR: "495"

--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -138,8 +138,6 @@ var expectedFailures = map[string]string{
 	"l2-resource-hook-on-error":      "PCL pcl.Hook nodes not yet supported by HCL codegen",
 	"l2-resource-hook-ignore-errors": "PCL pcl.Hook nodes not yet supported by HCL codegen",
 	"l2-resource-read":               "PCL pcl.ReadResource nodes not yet supported by HCL codegen",
-	"l3-component-simple": "HCL runtime does not propagate resource dependencies from a" +
-		" component's input expressions to the component registration",
 	"l2-provider-call-explicit": "upstream fixture declares `provider \"call\"`, which" +
 		" is reserved as the namespace for resource method calls in HCL",
 	"l2-config-default-from-invoke": "HCL codegen does not support a config variable whose" +

--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -144,8 +144,6 @@ var expectedFailures = map[string]string{
 		" is reserved as the namespace for resource method calls in HCL",
 	"l2-config-default-from-invoke": "HCL codegen does not support a config variable whose" +
 		" default is sourced from an invoke result",
-	"l3-component-invoke": "the HCL runtime does not parent invokes inside a component to" +
-		" the component, so the invoke does not inherit the component's explicit provider",
 }
 
 // expectedEjectFailures lists tests whose eject (HCL→PCL conversion) step is

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-invoke/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-invoke/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-invoke
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-invoke/invokeComponent/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-invoke/invokeComponent/main.pp
@@ -1,0 +1,10 @@
+// A multi-argument invoke passes its arguments positionally and omits the ones the program leaves
+// out, so parenting it must not displace the options bag into an argument slot.
+greeting = invoke("multi-argument-invoke:index:multiArgumentInvoke", "hello", null)
+
+output "result" {
+  value = invoke("config:index:getConfig", {
+    text = greeting.result
+  }).text
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-invoke/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-invoke/main.pp
@@ -1,0 +1,12 @@
+resource "prov" "pulumi:providers:config" {
+  name = "my config"
+}
+
+component "myComponent" "./invokeComponent" {
+  options {
+    providers = {
+      config = prov
+    }
+  }
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-simple/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-simple/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-simple
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-simple/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-simple/main.pp
@@ -1,0 +1,12 @@
+resource "input" "simple:index:Resource" {
+  value = true
+}
+
+component "someComponent" "./myComponent" {
+  input = input.value
+}
+
+output "result" {
+  value = someComponent.output
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-simple/myComponent/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-simple/myComponent/main.pp
@@ -1,0 +1,12 @@
+resource "res" "simple:index:Resource" {
+  value = input
+}
+
+config "input" "bool" {
+  description = "A simple input"
+}
+
+output "output" {
+  value = res.value
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-invoke/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-invoke/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-invoke
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-invoke/invokeComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-invoke/invokeComponent/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    config = {
+      source  = "pulumi/config"
+      version = "9.0.0"
+    }
+    multi-argument-invoke = {
+      source  = "pulumi/multi-argument-invoke"
+      version = "44.0.0"
+    }
+  }
+}
+
+data "config_config" "providerConfig" {
+  text = local.greeting.result
+}
+
+// A multi-argument invoke passes its arguments positionally and omits the ones the program leaves
+// out, so parenting it must not displace the options bag into an argument slot.
+locals {
+  greeting = provider::multi-argument-invoke::multi_argument_invoke("hello", null)
+}
+output "result" {
+  value = data.config_config.providerConfig.text
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-invoke/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-invoke/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    config = {
+      source  = "pulumi/config"
+      version = "9.0.0"
+    }
+    multi-argument-invoke = {
+      source  = "pulumi/multi-argument-invoke"
+      version = "44.0.0"
+    }
+  }
+}
+
+provider "config" {
+  alias = "prov"
+  name  = "my config"
+}
+module "myComponent" {
+  source = "./invokeComponent"
+  providers = {
+    config = config.prov
+  }
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-simple/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-simple/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-simple
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-simple/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-simple/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "input" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = true
+}
+module "someComponent" {
+  source = "./myComponent"
+  input  = simple_resource.input.value
+}
+output "result" {
+  value = module.someComponent.output
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-simple/myComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-simple/myComponent/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = var.input
+}
+variable "input" {
+  type        = bool
+  description = "A simple input"
+}
+output "output" {
+  value = simple_resource.res.value
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-invoke/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-invoke/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-invoke
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-invoke/invokeComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-invoke/invokeComponent/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    config = {
+      source  = "pulumi/config"
+      version = "9.0.0"
+    }
+    multi-argument-invoke = {
+      source  = "pulumi/multi-argument-invoke"
+      version = "44.0.0"
+    }
+  }
+}
+
+data "config_config" "invoke_0" {
+  text = local.greeting.result
+}
+
+// A multi-argument invoke passes its arguments positionally and omits the ones the program leaves
+// out, so parenting it must not displace the options bag into an argument slot.
+locals {
+  greeting = provider::multi-argument-invoke::multi_argument_invoke("hello", null)
+}
+output "result" {
+  value = data.config_config.invoke_0.text
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-invoke/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-invoke/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    config = {
+      source  = "pulumi/config"
+      version = "9.0.0"
+    }
+    multi-argument-invoke = {
+      source  = "pulumi/multi-argument-invoke"
+      version = "44.0.0"
+    }
+  }
+}
+
+provider "config" {
+  alias = "prov"
+  name  = "my config"
+}
+module "myComponent" {
+  source = "./invokeComponent"
+  providers = {
+    config = config.prov
+  }
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-simple/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-simple/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-simple
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-simple/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-simple/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "input" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = true
+}
+module "someComponent" {
+  source = "./myComponent"
+  input  = simple_resource.input.value
+}
+output "result" {
+  value = module.someComponent.output
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-simple/myComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-simple/myComponent/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = var.input
+}
+variable "input" {
+  type        = bool
+  description = "A simple input"
+}
+output "output" {
+  value = simple_resource.res.value
+}

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -1985,6 +1985,11 @@ func (g *generator) genModule(body *hclwrite.Body, c *pcl.Component) hcl.Diagnos
 		pulumiBody().SetAttributeRaw("name", tokens)
 	}
 
+	if c.Options != nil && c.Options.Providers != nil {
+		d := g.genModuleProviders(block.Body(), c.Options.Providers)
+		diags = append(diags, d...)
+	}
+
 	if c.Options != nil && c.Options.Protect != nil {
 		tokens, d := g.exprTokens(c.Options.Protect, schema.BoolType)
 		diags = append(diags, d...)
@@ -1999,6 +2004,73 @@ func (g *generator) genModule(body *hclwrite.Body, c *pcl.Component) hcl.Diagnos
 		diags = append(diags, d...)
 	}
 	return diags
+}
+
+// genModuleProviders emits a module block's `providers` map from a PCL
+// component's providers option. PCL accepts a list of provider resources or a
+// map of local provider name to provider resource; the list form infers each
+// entry's key from the referenced provider's package name, which is also the
+// local name the child module's required_providers declares.
+func (g *generator) genModuleProviders(body *hclwrite.Body, providers model.Expression) hcl.Diagnostics {
+	var entries []hclwrite.ObjectAttrTokens
+	var diags hcl.Diagnostics
+
+	badEntry := func(rng hcl.Range) hcl.Diagnostics {
+		return append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "invalid providers option",
+			Detail:   "each providers entry must reference a provider resource",
+			Subject:  &rng,
+		})
+	}
+
+	addEntry := func(name, value model.Expression, extractName func(model.Expression) (string, bool)) {
+		key, ok := extractName(name)
+		if !ok {
+			diags = badEntry(name.SyntaxNode().Range())
+			return
+		}
+		v, d := g.exprTokens(value, schema.AnyResourceType)
+		if !d.HasErrors() {
+			entries = append(entries, hclwrite.ObjectAttrTokens{
+				Name:  hclwrite.TokensForIdentifier(key),
+				Value: v,
+			})
+		}
+		diags = diags.Extend(d)
+	}
+
+	switch e := providers.(type) {
+	case *model.TupleConsExpression:
+		for _, elem := range e.Expressions {
+			addEntry(elem, elem, providerPackageNameFromExpr)
+		}
+	case *model.ObjectConsExpression:
+		for _, item := range e.Items {
+			addEntry(item.Key, item.Value, extractStringLiteral)
+		}
+	default:
+		return badEntry(providers.SyntaxNode().Range())
+	}
+
+	body.SetAttributeRaw("providers", hclwrite.TokensForObject(entries))
+	return diags
+}
+
+// providerPackageNameFromExpr returns the package name of the provider
+// resource an expression references, or ok=false when the expression is not a
+// reference to a provider resource.
+func providerPackageNameFromExpr(expr model.Expression) (string, bool) {
+	st, ok := expr.(*model.ScopeTraversalExpression)
+	if !ok || len(st.Parts) == 0 {
+		return "", false
+	}
+	r, ok := st.Parts[0].(*pcl.Resource)
+	if !ok || r.Schema == nil || !r.Schema.IsProvider {
+		return "", false
+	}
+	token, _ := r.GetToken()
+	return string(tokens.Type(token).Name()), true
 }
 
 func (g *generator) genBlocks(body *hclwrite.Body, name string, expr model.Expression, objType *schema.ObjectType) hcl.Diagnostics {

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -676,7 +676,7 @@ func (ft *fileTransformer) emitFile(
 			if pclName != logicalName {
 				blk.Body().SetAttributeRaw("__logicalName", hclwrite.TokensForValue(cty.StringVal(logicalName)))
 			}
-			var rangeExpr hclsyntax.Expression
+			var rangeExpr, providersExpr hclsyntax.Expression
 			for _, attr := range sortedAttributes(block.Body.Attributes) {
 				switch attr.Name {
 				case "source":
@@ -684,16 +684,24 @@ func (ft *fileTransformer) emitFile(
 				case "count", "for_each":
 					rangeExpr = attr.Expr
 					continue
-				case "depends_on", "providers", "version":
+				case "providers":
+					providersExpr = attr.Expr
+					continue
+				case "depends_on", "version":
 					continue
 				}
 				start := attr.Range().Start.Byte
 				ft.emitLeadingComments(blk.Body(), start)
 				blk.Body().SetAttributeRaw(attr.Name, ft.withTrailing(ft.transformExpr(attr.Expr), start))
 			}
-			if rangeExpr != nil {
+			if rangeExpr != nil || providersExpr != nil {
 				optBlk := blk.Body().AppendNewBlock("options", nil)
-				optBlk.Body().SetAttributeRaw("range", ft.transformExpr(rangeExpr))
+				if rangeExpr != nil {
+					optBlk.Body().SetAttributeRaw("range", ft.transformExpr(rangeExpr))
+				}
+				if providersExpr != nil {
+					optBlk.Body().SetAttributeRaw("providers", ft.transformExpr(providersExpr))
+				}
 			}
 			out.AppendNewline()
 

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -1561,9 +1561,12 @@ func (g *Graph) inlineModule(
 		ParentSourcePath: workDir,
 	}
 
-	// Init node: depends on count/for_each/depends_on from parent scope,
-	// plus the parent module's init (so a nested module never initializes
-	// before its enclosing module's instance/eval-context is registered).
+	// Init node: depends on count/for_each/depends_on and the call's input
+	// expressions from the parent scope (the component registration reports
+	// the evaluated inputs and their dependencies, so they must resolve
+	// first), plus the parent module's init (so a nested module never
+	// initializes before its enclosing module's instance/eval-context is
+	// registered).
 	initKey := NodeKey{Module: path, ID: "__init__"}
 	var initDeps []pdag.Node
 	if !parentPath.IsRoot() {
@@ -1573,6 +1576,12 @@ func (g *Graph) inlineModule(
 	initDeps = append(initDeps, g.exprDeps(mod.Count, parentPath)...)
 	initDeps = append(initDeps, g.exprDeps(mod.ForEach, parentPath)...)
 	initDeps = append(initDeps, g.refsToNodes(g.traversalDepRefs(parentPath, mod.DependsOn...))...)
+	initDeps = append(initDeps, g.exprDeps(mod.PulumiName, parentPath)...)
+	initDeps = append(initDeps, g.exprDeps(mod.Protect, parentPath)...)
+	moduleInputAttrs, _ := mod.Config.JustAttributes()
+	for _, inputAttr := range moduleInputAttrs {
+		initDeps = append(initDeps, g.exprDeps(inputAttr.Expr, parentPath)...)
+	}
 	if err := g.AddNode(&Node{
 		Key:        initKey,
 		Type:       NodeTypeModuleInit,
@@ -1585,7 +1594,6 @@ func (g *Graph) inlineModule(
 	_, initIdx := g.newNode(initKey)
 
 	// Variables: each depends on init + the corresponding input expression from the module block.
-	moduleInputAttrs, _ := mod.Config.JustAttributes()
 	for varName, v := range loaded.Config.Variables {
 		varDeps := []pdag.Node{initIdx}
 		if inputAttr, ok := moduleInputAttrs[varName]; ok {

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -4070,13 +4070,26 @@ func (e *Engine) initModuleCallIn(
 		parentURN, parentEvalCtx, parentPath, parentName = parent.URN, parent.EvalCtx, parent.Path, parent.Name
 	}
 
-	// Evaluate module inputs for the component resource registration
+	// Evaluate module inputs for the component resource registration. The
+	// inputs' dep marks become the component's dependencies, so the engine
+	// sees the module call depend on the resources its arguments reference.
 	inputs := make(map[string]property.Value)
+	propertyDeps := make(map[string][]string)
+	var deps []string
+	seenDeps := make(map[string]bool)
 	attrs, _ := mod.Config.JustAttributes()
 	for name, attr := range attrs {
 		val, diags := attr.Expr.Value(parentEvalCtx.HCLContext())
 		if diags.HasErrors() {
 			continue
+		}
+		urns := eval.CollectDepURNs(val)
+		propertyDeps[name] = urns
+		for _, u := range urns {
+			if !seenDeps[u] {
+				seenDeps[u] = true
+				deps = append(deps, u)
+			}
 		}
 		// Coerce to the variable's declared type if available.
 		if v, ok := childMod.Config.Variables[name]; ok && v.TypeConstraint != cty.NilType {
@@ -4096,7 +4109,11 @@ func (e *Engine) initModuleCallIn(
 		if err != nil {
 			return nil, err
 		}
-		componentOpts := &ResourceOptions{Parent: parentURN}
+		componentOpts := &ResourceOptions{
+			Parent:               parentURN,
+			DependsOn:            deps,
+			PropertyDependencies: propertyDeps,
+		}
 		componentOpts.Aliases = e.moduleComponentAliases(instPath)
 		if mod.Protect != nil {
 			hclCtx := parentEvalCtx.HCLContextWithIteration(index, eachKey, eachVal)
@@ -4362,14 +4379,14 @@ func (e *Engine) registerComponentResource(
 		return urn, "", inputs, nil
 	}
 
-	deps := opts.DependsOn
 	resp, err := e.resmon.RegisterResource(ctx, RegisterResourceRequest{
-		Type:         typeToken,
-		Name:         name,
-		Inputs:       inputs,
-		Dependencies: deps,
-		Parent:       opts.Parent,
-		Protect:      opts.Protect,
+		Type:                 typeToken,
+		Name:                 name,
+		Inputs:               inputs,
+		Dependencies:         opts.DependsOn,
+		PropertyDependencies: opts.PropertyDependencies,
+		Parent:               opts.Parent,
+		Protect:              opts.Protect,
 	})
 	if err != nil {
 		return "", "", property.Map{}, err


### PR DESCRIPTION
Enables the `l3-component-simple` conformance test.

A module call's component resource registered with empty `Inputs` and no dependencies whenever an input expression referenced another resource: `processModuleInit` evaluates the call's inputs in the parent scope, but the module init graph node only gated on `count`/`for_each`/`depends_on` — the input expressions gated the per-variable nodes instead. The unresolved references made input evaluation fail, and the failure was silently skipped.

- **graph**: the module init node now also depends on the call's input expressions, plus the `pulumi` block's `name` and `protect` expressions, which are evaluated at init in the same parent scope and had the same gap. This matches other language runtimes, which await a component's arguments before registering it.
- **runtime**: `initModuleCallIn` collects each input's dependency URNs from its dep marks and reports them on the component registration as `Dependencies` and per-property `PropertyDependencies`; `registerComponentResource` now forwards `PropertyDependencies`.

Stacked on https://github.com/pulumi/pulumi-hcl/pull/494 (auto-merging).