### PR TITLE
Sync docs with the codebase for GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 A Pulumi language plugin that enables running Pulumi against a Terraform HCL IaC program.
 
-> [!WARNING]
-> This language is in active development and not yet suitable for production use.
-
 ## Overview
 
 This plugin allows you to use familiar Terraform/HCL syntax while leveraging Pulumi's state management, secrets handling, and cloud platform. It parses HCL files and translates them to Pulumi resource registrations at runtime.
@@ -27,8 +24,10 @@ output "bucket_arn" {
 
 ## Installation
 
-Pulumi HCL ships with the [`pulumi`](https://github.com/pulumi/pulumi) CLI. If you need the absolute latest version, you
-can install the plugin directly onto your path:
+Pulumi HCL requires the [`pulumi`](https://github.com/pulumi/pulumi) CLI v3.256.0 or later. The CLI downloads the
+language and converter plugins automatically the first time you use them — there is nothing to install by hand.
+
+To build the plugins from source for development, install them directly onto your path:
 
 ```bash
 go install github.com/pulumi/pulumi-hcl/cmd/pulumi-language-hcl@latest  # for the language
@@ -265,9 +264,10 @@ provider "aws" {
 ```
 
 Sources prefixed with `pulumi/` (e.g. `pulumi/aws`) consume a native Pulumi provider
-instead of bridging a Terraform one. `backend`, `required_version`, and `provider_meta` inside the
-`terraform` block are accepted for compatibility but ignored with a warning.  See
-[docs/providers.md](docs/providers.md) for details.
+instead of bridging a Terraform one, and must give a concrete semver version rather than a
+constraint. `backend`, `required_version`, `provider_meta`, and `experiments` inside the
+`terraform` block are accepted for compatibility but ignored with a warning. A `cloud` block is
+not accepted and fails to parse. See [docs/providers.md](docs/providers.md) for details.
 
 ## Design Overview
 
@@ -390,7 +390,8 @@ This plugin supports the majority of Terraform's HCL syntax. For detailed compat
 
 ### Not Supported
 
-- `backend`, `required_version`, and `provider_meta` in the `terraform` block — accepted but ignored with a warning; Pulumi manages state independently
+- `backend`, `required_version`, `provider_meta`, and `experiments` in the `terraform` block — accepted but ignored with a warning; Pulumi manages state independently
+- `cloud` blocks in the `terraform` block — not accepted at all; a `cloud` block is a parse error
 - WinRM `connection` blocks — `connection` supports `type = "ssh"` only
 - `List<Object>` empty vs null distinction: HCL block syntax cannot distinguish between an empty and null `List<Object>`, which is a known incompatibility with some Pulumi programs
 

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -841,14 +841,6 @@ Pulumi HCL supports nearly all Terraform built-in functions. Functions are group
 | `pulumiResourceName(resource)` | Get the logical name from a resource's URN                   |
 | `pulumiResourceType(resource)` | Get the type token from a resource's URN                     |
 
-### Functions Not Supported
-
-These Terraform functions have no equivalent:
-
-| Function          | Reason                                        |
-|-------------------|-----------------------------------------------|
-| `ephemeralasnull` | Pulumi has no ephemeral value concept         |
-
 ## Stack References
 
 Access outputs from other Pulumi stacks using the `pulumi_stack_reference` resource:
@@ -947,7 +939,8 @@ Differences from Terraform to be aware of:
 
 ### Unsupported Features
 
-- **`backend`, `required_version`, `provider_meta`** — Accepted inside the `terraform` block but ignored with a warning; Pulumi manages state independently and tracks its own version constraints via `required_version_range`.
+- **`backend`, `required_version`, `provider_meta`, `experiments`** — Accepted inside the `terraform` block but ignored with a warning; Pulumi manages state independently and tracks its own version constraints via `required_version_range`, and language experiments have no Pulumi HCL equivalent.
+- **`cloud`** — Not accepted inside the `terraform` block at all. It is absent from the block's schema, so a `cloud` block is a parse error rather than a warning.
 - **WinRM connections** — Only `type = "ssh"` is supported in `connection` blocks.
 - **`List<Object>` empty vs null** — HCL block syntax cannot distinguish between an empty and null `List<Object>`, a known incompatibility with some Pulumi programs.
 

--- a/docs/mlc.md
+++ b/docs/mlc.md
@@ -6,8 +6,9 @@ that can be consumed from any Pulumi language (TypeScript, Python, Go, C#, Java,
 ## Declaring a Component Module
 
 An HCL module becomes an MLC when it has a `PulumiPlugin.yaml` containing
-`runtime: hcl`. The `component` and `package` blocks inside the `terraform {}`
-block declare the component's identity and package metadata:
+`runtime: hcl`. That file is all you need — the optional `component` and
+`package` blocks inside the `terraform {}` block override the component's
+identity and package metadata when the defaults don't suit:
 
 ```hcl
 terraform {
@@ -21,7 +22,7 @@ terraform {
   required_providers {
     aws = {
       source  = "pulumi/aws"
-      version = ">= 6.0"
+      version = "6.0.0"
     }
   }
 }
@@ -40,18 +41,25 @@ output "vpc_id" {
 }
 ```
 
+Note that a `pulumi/`-sourced provider takes a concrete semver version, not a
+version constraint — `"6.0.0"`, never `">= 6.0"`.
+
+A module with no `terraform` block at all is still a valid MLC. It takes the
+default token `<package>:index:Module`, where `<package>` is the module's
+directory name, and consumers in HCL reference it as `<package>_module`.
+
 ## Block Reference
 
 ### `component` block
 
-Declares this module as a component resource. The block is optional; when it is
-omitted, the component name defaults to `"Module"` and the module segment to
-`"index"`. When the block is present, `name` is required.
+Overrides the component's name and module segment. The block is optional; when
+it is omitted, the component name defaults to `"Module"` and the module segment
+to `"index"`. When the block is present, `name` is required.
 
-| Field    | Required | Default    | Description                                  |
-|----------|----------|------------|----------------------------------------------|
-| `name`   | Yes      | `"Module"` | Component name (must be a valid Pulumi name) |
-| `module` | No       | `"index"`  | Module segment of the resource token         |
+| Field    | Required          | Default    | Description                                  |
+|----------|-------------------|------------|----------------------------------------------|
+| `name`   | Yes, if the block is present | `"Module"` | Component name (must be a valid Pulumi name) |
+| `module` | No                | `"index"`  | Module segment of the resource token         |
 
 With the default component name, the token is `{package}:index:Module` and is
 referenced in HCL as `{package}_module` — e.g. a package `randommodule` is
@@ -79,8 +87,9 @@ For the example above, the token would be `my-networking:index:VpcNetwork`.
 
 ## Validation Rules
 
-- `component.name` and `component.module` must be valid Pulumi names (alphanumeric,
-  hyphens, underscores; must start with a letter or underscore).
+- `component.name` and `component.module` must be valid Pulumi names: one or more
+  alphanumerics, hyphens, underscores, and periods. There is no restriction on the
+  first character.
 - `package.name` must be a valid Pulumi name when specified.
 - `package.version` must be a valid [semver](https://semver.org/) string when specified.
 - Only one `component` block and one `package` block are allowed per `terraform` block.
@@ -90,11 +99,24 @@ For the example above, the token would be `my-networking:index:VpcNetwork`.
 ## Relationship to PulumiPlugin.yaml
 
 The `PulumiPlugin.yaml` file tells the Pulumi engine how to run the component
-provider. For HCL MLCs, it should specify the `hcl` runtime:
+provider. For HCL MLCs, name the plugin and specify the `hcl` runtime:
 
 ```yaml
+name: my-networking
 runtime: hcl
 ```
 
-The `component` and `package` blocks in the HCL source replace any need to
-hardcode the provider name or version elsewhere.
+This file on its own is enough to make a module an MLC. Note that the package
+name and version of the generated component come from the `package` block in the
+HCL source, or from the module's directory name when that block is absent — not
+from the `name` field here.
+
+## Consuming an HCL component from other languages
+
+A component's inputs are its `variable` blocks and its outputs are its `output`
+blocks, but the names non-HCL consumers see are camelCased: a variable
+`cidr_block` is `cidrBlock` in the generated TypeScript, Python, Go, and C# SDKs.
+
+Every input is also echoed back as an output, so a consumer can read
+`cidrBlock` off the component instance as well as pass it in. An input that is
+not nullable is therefore always present on the result.

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -6,13 +6,22 @@ Pulumi HCL should be able to run all valid Terraform config programs without cha
 
 A small number of Terraform features are not modeled:
 
-- **`backend`, `required_version`, and `provider_meta`** in the `terraform` block are accepted but ignored with a warning. Pulumi manages state independently and tracks its own version constraints via `required_version_range`.
+- **`backend`, `required_version`, `provider_meta`, and `experiments`** in the `terraform` block are accepted but ignored with a warning. Pulumi manages state independently and tracks its own version constraints via `required_version_range`; language experiments have no Pulumi HCL equivalent.
+- **`cloud`** in the `terraform` block is not accepted at all. Unlike the arguments above it is not part of the `terraform` block's schema, so a `cloud` block is a parse error rather than a warning. Remove it — Pulumi's own backend configuration lives outside the program.
 - **WinRM `connection` blocks** are not supported — `connection` accepts `type = "ssh"` only.
 - **`List<Object>` empty vs null** — HCL block syntax cannot distinguish an empty `List<Object>` from a null one, a known incompatibility with some Pulumi programs.
 - **Resource-wide destroy ordering of late-created instances** — Terraform rebuilds destroy-time dependencies from configuration, so every instance of a `count`/`for_each` resource waits for a consumer's delete even when the consumer referenced only one instance (`depends_on = [a["x"]]`). Pulumi records each resource's dependencies once, when it is created, and cannot depend on an instance that registers later. A sibling instance created *after* the consumer is therefore not held back by it during destroy and may be deleted first.
 - **`ignore_changes` on `terraform_data`'s `triggers_replace`** is honored only when it is present from the resource's creation. Adding `ignore_changes = [triggers_replace]` in the same update that changes `triggers_replace` (on a resource first created without it) still forces one replacement: `triggers_replace` is carried as a replacement trigger rather than a stored input, so it cannot be reconciled against the prior state the way an ignored input is.
 
-State files are not interchangeable: import existing resources with `pulumi import` rather than reusing a Terraform state file. By default `create_before_destroy` matches Terraform's delete-first replacement order.
+State files are not interchangeable — Pulumi cannot read a Terraform state file as its own — but you do not have to import resources one at a time. Point the converter at an existing Terraform or OpenTofu state file to import everything it describes in bulk:
+
+```bash
+pulumi import --from hcl terraform.tfstate
+```
+
+This reads the state file, maps each Terraform resource type to its Pulumi token, and imports the resources into your stack. Only root-module resources are imported: resources nested inside a `module` block are skipped with a warning, as are `terraform_data` resources and any resource with no `id` in state. Anything that cannot be imported is reported as a warning rather than aborting the run, so the importable remainder still lands.
+
+By default `create_before_destroy` matches Terraform's delete-first replacement order.
 
 ## CLI Reference
 
@@ -25,19 +34,15 @@ State files are not interchangeable: import existing resources with `pulumi impo
 | `terraform import`  | `pulumi import`  |
 | Workspaces          | Stacks           |
 
-Terraform state files are not compatible. Import existing resources with `pulumi import`.
-
 ## Built-in Functions
 
 Pulumi HCL supports nearly all of Terraform's built-in functions with identical behavior. The sections below document the exceptions.
 
 ### Functions in Terraform but not supported here
 
-| Function          | Category        | Notes                                                                         |
-|-------------------|-----------------|-------------------------------------------------------------------------------|
-| `ephemeralasnull` | Type Conversion | Replaces ephemeral values with `null`; Pulumi has no ephemeral value concept. |
-
-The `provider::terraform::*` provider functions and `terraform.applying` are Terraform-internal and have no equivalent here.
+Every Terraform built-in function is supported, including the `provider::terraform::*` provider functions
+(`decode_tfvars`, `encode_expr`, `encode_tfvars`). The only exception is the `terraform.applying` symbol,
+which is Terraform-internal and has no equivalent here.
 
 ### Functions supported here but not in Terraform
 


### PR DESCRIPTION
## Summary

Fixes found while verifying the website's HCL docs claim-by-claim against this repo ahead of GA. Every change below traces to code or tests; nothing but docs is touched.

- **README**: remove the not-production-ready warning for GA, and replace "ships with the `pulumi` CLI" with the on-demand plugin download behavior (CLI v3.256.0 or later; the `go install` lines remain as the development-build path). Document that `experiments` is accepted but ignored, a `cloud` block is a parse error, and `pulumi/`-sourced providers take a concrete semver.
- **docs/mlc.md**: fix the example — a `pulumi/`-sourced provider takes a concrete semver (`"6.0.0"`), not a constraint (`">= 6.0"` is a parse error, `pkg/hcl/parser/parser.go:415-428`). Make the `component` block optional as implemented (default token `<package>:index:Module`, `pkg/server/provider.go:153-190`; proven by `tests/smoke/smoke_test.go:117-122`). Correct the name-validation rule to the real `tokens.IsName` grammar (alphanumerics, hyphens, underscores, periods; no leading-character restriction). Add `name:` to the PulumiPlugin.yaml snippet, matching all shipped fixtures. Document camelCase exposure for non-HCL consumers and inputs echoed as outputs.
- **docs/terraform-compatibility.md**: document that a `cloud` block is a parse error (absent from `terraformSchema`) while `experiments` joins the accepted-but-warned set; describe bulk state import with `pulumi import --from hcl`; remove the `ephemeralasnull` and `provider::terraform::*` "not supported" claims, which `pkg/hcl/eval/functions.go:212` and `terraform_provider_functions.go` contradict.
- **docs/language-reference.md**: same `ephemeralasnull` correction (the file both listed it as unsupported and documented its behavior three paragraphs earlier), plus the `experiments` and `cloud` entries.

## Verification

Docs-only change. Each fact was re-verified against the implementation before editing; file/line evidence is in the commit message and above.