### PR TITLE
Failing test: replace_triggered_by added together with its trigger diverges from tofu

### DIFF
--- a/tests/tfcompat/l2_replace_triggered_by_new_ref_test.go
+++ b/tests/tfcompat/l2_replace_triggered_by_new_ref_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ReplaceTriggeredByNewRef adds, in one operation, both a new
+// `trigger` resource and a `replace_triggered_by` entry on the existing
+// `dependent` resource referencing the new trigger's computed attribute.
+// Both paths must plan and perform the same operations on `dependent` —
+// whether that is a replacement (the referenced value goes from nothing to a
+// value) or no change at all, tofu and pulumi must agree, and each path's
+// plan must agree with its own apply.
+func TestL2ReplaceTriggeredByNewRef(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_replace_triggered_by_new_ref", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_replace_triggered_by_new_ref/0/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_replace_triggered_by_new_ref/0/main.tf
@@ -1,0 +1,3 @@
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+}

--- a/tests/tfcompat/testdata/cases/l2_replace_triggered_by_new_ref/1/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_replace_triggered_by_new_ref/1/main.tf
@@ -1,0 +1,10 @@
+resource "simple_resource" "trigger" {
+  input_one = "a"
+}
+
+resource "simple_resource" "dependent" {
+  input_one = "constant"
+  lifecycle {
+    replace_triggered_by = [simple_resource.trigger.result]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a deliberately failing tfcompat case documenting a `replace_triggered_by` divergence found while verifying the resource-options docs against real deployments.

Adding, in one operation, both a new `trigger` resource and a `lifecycle.replace_triggered_by` entry on the existing `dependent` resource referencing it diverges between the two paths:

- **tofu** replaces `dependent` — its rtb decision is plan-time, and the referenced instance being created counts as a change (recorded ops: 3 creates + 1 delete).
- **pulumi** does not — rtb maps to the engine's stateful `replacementTrigger`, whose null→value transition never forces a replacement (recorded ops: 2 creates). Pulumi's own up previews `+-1 to replace` and then does not perform it.

## Expected CI state

`TestL2ReplaceTriggeredByNewRef` **fails by design** until the divergence is fixed; the failure message shows the ops mismatch above. Draft until a fix lands alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)