### PR TITLE
Accept nested property paths in pulumi-block `hide_diffs` and `replace_on_changes`

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-501.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-501.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Accept nested property paths in `hide_diffs` and `replace_on_changes`
+time: 2026-08-03T19:10:00Z
+custom:
+    Component: runtime
+    PR: "501"

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -1202,6 +1202,14 @@ func (g *Graph) bodyDeps(body hcl.Body, path modulepath.Path, exclude map[string
 	return g.refsToNodes(g.bodyDepRefs(body, path, exclude))
 }
 
+// propertyPathAttrs lists, per block type, the attributes whose entries are
+// property paths of the enclosing resource rather than references to other
+// nodes.
+var propertyPathAttrs = map[string]map[string]bool{
+	"lifecycle": {"ignore_changes": true},
+	"pulumi":    {"hide_diffs": true, "replace_on_changes": true},
+}
+
 // bodyDepRefs extracts one depRef per referencing traversal in an HCL body.
 func (g *Graph) bodyDepRefs(body hcl.Body, path modulepath.Path, exclude map[string]bool) []depRef {
 	if eb, ok := body.(*ast.EscapedBody); ok {
@@ -1230,12 +1238,13 @@ func (g *Graph) bodyDepRefs(body hcl.Body, path modulepath.Path, exclude map[str
 				maps.Copy(childExclude, exclude)
 				childExclude[iterName] = true
 				refs = append(refs, g.bodyDepRefs(block.Body, path, childExclude)...)
-			} else if block.Type == "lifecycle" {
-				// lifecycle blocks contain ignore_changes which holds property
-				// paths (e.g. tags["env"]), not dependency references. We must
-				// skip that attribute to avoid creating spurious graph nodes.
+			} else if skip := propertyPathAttrs[block.Type]; skip != nil {
+				// lifecycle and pulumi blocks contain attributes that hold
+				// property paths (e.g. tags["env"]), not dependency
+				// references. We must skip those attributes to avoid creating
+				// spurious graph nodes.
 				for attrName, attr := range block.Body.Attributes {
-					if attrName == "ignore_changes" {
+					if skip[attrName] {
 						continue
 					}
 					refs = append(refs, g.exprDepRefs(attr.Expr, path, exclude)...)

--- a/pkg/hcl/run/pulumi_options_paths_test.go
+++ b/pkg/hcl/run/pulumi_options_paths_test.go
@@ -27,12 +27,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestEngine_PulumiOptionsNestedPaths documents that `hide_diffs` and
+// TestEngine_PulumiOptionsNestedPaths checks that `hide_diffs` and
 // `replace_on_changes` entries in the `pulumi` block may be multi-segment
 // property paths, matching `lifecycle.ignore_changes` (which accepts the same
-// shapes). Today the graph builder treats any multi-segment entry as a
-// reference to another node and the run fails with `unknown node
-// "tags.stage"`; single top-level attribute names are the only accepted form.
+// shapes), rather than being treated as references to other nodes.
 func TestEngine_PulumiOptionsNestedPaths(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/hcl/run/pulumi_options_paths_test.go
+++ b/pkg/hcl/run/pulumi_options_paths_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/parser"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/run"
+	"github.com/pulumi/pulumi-hcl/tests/testutil"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/schemaloader"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEngine_PulumiOptionsNestedPaths documents that `hide_diffs` and
+// `replace_on_changes` entries in the `pulumi` block may be multi-segment
+// property paths, matching `lifecycle.ignore_changes` (which accepts the same
+// shapes). Today the graph builder treats any multi-segment entry as a
+// reference to another node and the run fails with `unknown node
+// "tags.stage"`; single top-level attribute names are the only accepted form.
+func TestEngine_PulumiOptionsNestedPaths(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "pfx_res" "res" {
+  tags = {
+    stage = "one"
+    owner = "team"
+  }
+
+  pulumi {
+    hide_diffs         = [tags["stage"]]
+    replace_on_changes = [tags["owner"]]
+  }
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	tagsProp := schema.PropertySpec{TypeSpec: schema.TypeSpec{
+		Type:                 "object",
+		AdditionalProperties: &schema.TypeSpec{Type: "string"},
+	}}
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "pfx",
+			Resources: map[string]schema.ResourceSpec{
+				"pfx:index:Res": {
+					InputProperties: map[string]schema.PropertySpec{"tags": tagsProp},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{"tags": tagsProp},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	require.Len(t, mock.RegisteredResources, 2)
+	req := mock.RegisteredResources[1]
+	assert.Equal(t, []property.Glob{
+		property.GlobFromSegments(property.NewSegment("tags"), property.NewSegment("stage")),
+	}, req.HideDiffs)
+	assert.Equal(t, []property.Glob{
+		property.GlobFromSegments(property.NewSegment("tags"), property.NewSegment("owner")),
+	}, req.ReplaceOnChanges)
+}


### PR DESCRIPTION
## Summary

Multi-segment entries in the resource `pulumi` block's `hide_diffs` or `replace_on_changes` — `tags["stage"]`, `default_action.type`, `default_action[0].forward[0].target_group[0].weight` — failed at run time with `unknown node "..."`: the graph builder's body walk treated the relative property path as a reference to another node. Only single top-level attribute names worked, while `lifecycle.ignore_changes` accepted the identical shapes (it had a dedicated skip in the walk) and `translateAttrPathTraversal` already supported nested paths.

The fix generalizes the `ignore_changes` exemption into a per-block-type table of property-path attributes covering the pulumi block's `hide_diffs` and `replace_on_changes`. `additional_secret_outputs` needs no entry: it only accepts single-segment names, which produce no graph references.

`TestEngine_PulumiOptionsNestedPaths` fails with `unknown node "tags.stage"` before the fix and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)