### PR TITLE
Fail on invalid aliases expressions instead of silently ignoring them

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-502.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-502.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: 'Fail on invalid `aliases` expressions instead of silently ignoring them'
+time: 2026-08-03T18:37:16Z
+custom:
+    Component: runtime
+    PR: "502"

--- a/.changes/unreleased/runtime-bug-fixes-502.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-502.yaml
@@ -1,5 +1,5 @@
 kind: bug-fixes
-body: 'Fail on invalid `aliases` expressions instead of silently ignoring them'
+body: 'Fail on invalid `aliases` expressions instead of silently ignoring them; add `pulumiResourceURN`'
 time: 2026-08-03T18:37:16Z
 custom:
     Component: runtime

--- a/README.md
+++ b/README.md
@@ -421,9 +421,10 @@ call "my_bucket" "get_object" {
 
 The `call` block invokes a method on an existing resource. The first label is the resource's logical name (matching a declared resource) and the second is the method name. Results are referenced as `call.<resource>.<method>.<output>`.
 
-Two built-in functions provide access to a resource's Pulumi identity at runtime:
+Three built-in functions provide access to a resource's Pulumi identity at runtime:
 - `pulumiResourceName(resource)` — returns the logical name from the resource's URN
 - `pulumiResourceType(resource)` — returns the type token from the resource's URN
+- `pulumiResourceURN(resource)` — returns the resource's URN
 
 ## Development
 

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-failed-create-recover-continue-on-error/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-failed-create-recover-continue-on-error/main.tf
@@ -30,5 +30,5 @@ resource "simple_resource" "independent" {
   value = true
 }
 output "recovered" {
-  value = recover(fail_on_create_resource.failing.urn, "recovered: ${error}")
+  value = recover(pulumiResourceURN(fail_on_create_resource.failing), "recovered: ${error}")
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-alias/1/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-alias/1/main.tf
@@ -50,7 +50,7 @@ resource "simple_resource" "aliasParent" {
   pulumi {
     parent = simple_resource.parent
     aliases = [{
-      parent_urn = simple_resource.aliasURN.urn
+      parent_urn = pulumiResourceURN(simple_resource.aliasURN)
     }]
   }
   lifecycle {

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-failed-create-recover-continue-on-error/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-failed-create-recover-continue-on-error/main.tf
@@ -30,5 +30,5 @@ resource "simple_resource" "independent" {
   value = true
 }
 output "recovered" {
-  value = recover(fail_on_create_resource.failing.urn, "recovered: ${error}")
+  value = recover(pulumiResourceURN(fail_on_create_resource.failing), "recovered: ${error}")
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-alias/1/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-alias/1/main.tf
@@ -50,7 +50,7 @@ resource "simple_resource" "aliasParent" {
   pulumi {
     parent = simple_resource.parent
     aliases = [{
-      parent_urn = simple_resource.aliasURN.urn
+      parent_urn = pulumiResourceURN(simple_resource.aliasURN)
     }]
   }
   lifecycle {

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -840,6 +840,7 @@ Pulumi HCL supports nearly all Terraform built-in functions. Functions are group
 | `assetArchive(map)`            | Create a Pulumi `AssetArchive` from a map of assets/archives |
 | `pulumiResourceName(resource)` | Get the logical name from a resource's URN                   |
 | `pulumiResourceType(resource)` | Get the type token from a resource's URN                     |
+| `pulumiResourceURN(resource)`  | Get a resource's URN                                         |
 
 ## Stack References
 

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -51,6 +51,7 @@ which is Terraform-internal and has no equivalent here.
 | `entries`            | Collection      | Converts a map or object to a list of `{key, value}` objects.     |
 | `pulumiResourceName` | Pulumi-specific | Returns the Pulumi resource name for a resource reference.        |
 | `pulumiResourceType` | Pulumi-specific | Returns the Pulumi resource type for a resource reference.        |
+| `pulumiResourceURN`  | Pulumi-specific | Returns the Pulumi URN for a resource reference.                  |
 | `fileAsset`          | Asset/Archive   | Creates a Pulumi `FileAsset` from a local file path.              |
 | `stringAsset`        | Asset/Archive   | Creates a Pulumi `StringAsset` from a string value.               |
 | `remoteAsset`        | Asset/Archive   | Creates a Pulumi `RemoteAsset` from a URL.                        |

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -1631,18 +1631,14 @@ func (g *generator) aliasElemTokens(elem model.Expression) (hclwrite.Tokens, hcl
 			hclKey = "no_parent"
 			valTokens, d = g.exprTokens(item.Value, schema.BoolType)
 		case "parent":
-			// Transform resource reference to parent_urn = resource_type.name.urn
+			// Transform resource reference to parent_urn = pulumiResourceURN(resource_type.name)
 			hclKey = "parent_urn"
 			baseTokens, d2 := g.exprTokens(item.Value, schema.AnyType)
 			diags = append(diags, d2...)
 			if d2.HasErrors() {
 				return nil, diags
 			}
-			// Append .urn to get the resource's URN
-			valTokens = append(baseTokens,
-				&hclwrite.Token{Type: hclsyntax.TokenDot, Bytes: []byte(".")},
-				&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("urn")},
-			)
+			valTokens = pulumiResourceURNCallTokens(baseTokens)
 		default:
 			hclKey = transform.SnakeCaseFromPulumiCase(keyStr)
 			valTokens, d = g.exprTokens(item.Value, schema.AnyType)
@@ -2899,6 +2895,14 @@ func (g *generator) scopeTraversalTokens(expr *model.ScopeTraversalExpression) (
 		}
 		rewritten = append(rewritten, hcl.TraverseRoot{Name: hclType})
 		rewritten = append(rewritten, traverseNameStep(part.LogicalName()))
+		// PCL exposes a resource's URN as a `.urn` attribute; HCL resource
+		// values have no such attribute, so the traversal becomes a
+		// pulumiResourceURN call on the resource (or indexed instance).
+		if rest := traversal[1:]; len(rest) > 0 {
+			if attr, ok := rest[len(rest)-1].(hcl.TraverseAttr); ok && attr.Name == "urn" && allIndexSteps(rest[:len(rest)-1]) {
+				return pulumiResourceURNCallTokens(hclwrite.TokensForTraversal(append(rewritten, rest[:len(rest)-1]...))), nil
+			}
+		}
 		// part.Schema can be nil when the binder ran with SkipResourceTypechecking
 		// (or similar relaxed options); fall back to the unmodified traversal.
 		var props []*schema.Property
@@ -2965,6 +2969,27 @@ func (g *generator) scopeTraversalTokens(expr *model.ScopeTraversalExpression) (
 		}
 		return hclwrite.TokensForTraversal(traversal), nil
 	}
+}
+
+// pulumiResourceURNCallTokens wraps resource-reference tokens in a
+// pulumiResourceURN(...) call.
+func pulumiResourceURNCallTokens(resTokens hclwrite.Tokens) hclwrite.Tokens {
+	tokens := hclwrite.Tokens{
+		{Type: hclsyntax.TokenIdent, Bytes: []byte("pulumiResourceURN")},
+		{Type: hclsyntax.TokenOParen, Bytes: []byte("(")},
+	}
+	tokens = append(tokens, resTokens...)
+	return append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCParen, Bytes: []byte(")")})
+}
+
+// allIndexSteps reports whether every traversal step is an index step.
+func allIndexSteps(steps hcl.Traversal) bool {
+	for _, step := range steps {
+		if _, ok := step.(hcl.TraverseIndex); !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // passthroughFuncCallTokens generates tokens for a function call: name(arg1, arg2, ...).

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -1068,6 +1068,14 @@ func (ft *fileTransformer) transformExpr(expr hclsyntax.Expression) hclwrite.Tok
 				}
 			}
 		}
+		// pulumiResourceURN(<resource>) is the encoding generate.go emits
+		// for PCL's `<resource>.urn`; restore the attribute on eject.
+		if e.Name == "pulumiResourceURN" && len(e.Args) == 1 {
+			return append(ft.transformExpr(e.Args[0]),
+				&hclwrite.Token{Type: hclsyntax.TokenDot, Bytes: []byte(".")},
+				&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("urn")},
+			)
+		}
 		// A provider-defined function call ejects as a positional invoke:
 		// provider::<local>::<fn>(a, b) → invoke("<token>", a, b).
 		if _, _, ok := ast.ParseProviderFunctionName(e.Name); ok {

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -225,6 +225,7 @@ func Functions(baseDir string) map[string]function.Function {
 		// Pulumi-specific functions
 		"pulumiResourceName": pulumiResourceNameFunc,
 		"pulumiResourceType": pulumiResourceTypeFunc,
+		"pulumiResourceURN":  pulumiResourceURNFunc,
 
 		// Asset and archive functions
 		"fileAsset":     fileAssetFunc(baseDir),
@@ -2411,6 +2412,11 @@ var pulumiResourceNameFunc = resourceUrnFuncHelper("pulumiResourceName", func(u 
 // extracting it from the resource's URN.
 var pulumiResourceTypeFunc = resourceUrnFuncHelper("pulumiResourceType", func(u urn.URN) (cty.Value, error) {
 	return cty.StringVal(u.Type().String()), nil
+})
+
+// pulumiResourceURNFunc returns the URN of a Pulumi resource.
+var pulumiResourceURNFunc = resourceUrnFuncHelper("pulumiResourceURN", func(u urn.URN) (cty.Value, error) {
+	return cty.StringVal(string(u)), nil
 })
 
 func resourceUrnFuncHelper(fnName string, f func(urn.URN) (cty.Value, error)) function.Function {

--- a/pkg/hcl/run/aliases_error_test.go
+++ b/pkg/hcl/run/aliases_error_test.go
@@ -66,3 +66,57 @@ resource "pfx_res" "res" {
 	err := engine.Run(t.Context())
 	assert.ErrorContains(t, err, "aliases must be a list")
 }
+
+// TestEngine_AliasesParentURN pins that an alias's parent_urn can reference
+// another resource's URN via pulumiResourceURN.
+func TestEngine_AliasesParentURN(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "pfx_res" "first" {
+}
+
+resource "pfx_res" "second" {
+  pulumi {
+    aliases = [{
+      parent_urn = pulumiResourceURN(pfx_res.first)
+    }]
+  }
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "pfx",
+			Resources: map[string]schema.ResourceSpec{
+				"pfx:index:Res": {},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	var second *run.RegisterResourceRequest
+	for i := range mock.RegisteredResources {
+		if mock.RegisteredResources[i].Name == "second" {
+			second = &mock.RegisteredResources[i]
+			break
+		}
+	}
+	require.NotNil(t, second, "expected resource 'second' to be registered")
+
+	assert.Equal(t, []run.Alias{{Spec: &run.AliasSpec{
+		ParentURN: "urn:pulumi:test::project::pfx:index:Res::first",
+	}}}, second.Aliases)
+}

--- a/pkg/hcl/run/aliases_error_test.go
+++ b/pkg/hcl/run/aliases_error_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/parser"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/run"
+	"github.com/pulumi/pulumi-hcl/tests/testutil"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/schemaloader"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEngine_AliasesEvaluationError documents that an invalid `aliases`
+// expression must fail the run instead of being silently dropped. Today the
+// engine discards the error from evaluating `aliases` (run.go, "Handle
+// aliases attribute"), so a non-list value deploys as if no aliases were
+// set — and a rename intended to be covered by that alias would delete and
+// recreate the resource.
+func TestEngine_AliasesEvaluationError(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "pfx_res" "res" {
+  pulumi {
+    aliases = "old-name"
+  }
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "pfx",
+			Resources: map[string]schema.ResourceSpec{
+				"pfx:index:Res": {},
+			},
+		}),
+	})
+
+	err := engine.Run(t.Context())
+	assert.ErrorContains(t, err, "aliases must be a list")
+}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1981,9 +1981,10 @@ func (e *Engine) buildResourceOptions(
 	// Handle aliases attribute
 	if res.Aliases != nil {
 		aliases, err := e.evaluateAliases(res.Aliases)
-		if err == nil {
-			opts.Aliases = append(opts.Aliases, aliases...)
+		if err != nil {
+			return nil, err
 		}
+		opts.Aliases = append(opts.Aliases, aliases...)
 	}
 
 	// Handle import blocks - resolve import ID from import blocks that target this resource


### PR DESCRIPTION
## Summary

`evaluateAliases` errors were discarded at the call site (run.go, "Handle aliases attribute": `if err == nil { ... }`), so an invalid `aliases` expression — e.g. the non-list `aliases = "old-name"` — deployed as if no aliases were set. A rename that was meant to be covered by that alias would then delete and recreate the resource instead of preserving it. The error is now propagated, failing the run.

Surfacing the error exposed a second bug: codegen translated PCL's `resource.urn` into a bare `.urn` traversal, but HCL resource values deliberately expose no `urn` attribute (OpenTofu has none), so expressions like an alias's `parent_urn = simple_resource.aliasURN.urn` could never evaluate — the failure was previously swallowed, silently dropping the alias.

Since `.urn` is not supported in HCL, this adds a `pulumiResourceURN` built-in alongside `pulumiResourceName`/`pulumiResourceType`. Codegen now emits `pulumiResourceURN(resource)` for PCL `.urn` traversals and for alias `parent` references, and eject translates the call back to `.urn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)