### PR TITLE
Lowercase the built-in function names

### DIFF
--- a/.changes/unreleased/runtime-Improvements-504.yaml
+++ b/.changes/unreleased/runtime-Improvements-504.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: 'Lowercase the built-in function names (`fileasset`, `pulumiresourceurn`, …) to match Terraform naming'
+time: 2026-08-03T20:30:00Z
+custom:
+    Component: runtime
+    PR: "504"

--- a/README.md
+++ b/README.md
@@ -422,9 +422,9 @@ call "my_bucket" "get_object" {
 The `call` block invokes a method on an existing resource. The first label is the resource's logical name (matching a declared resource) and the second is the method name. Results are referenced as `call.<resource>.<method>.<output>`.
 
 Three built-in functions provide access to a resource's Pulumi identity at runtime:
-- `pulumiResourceName(resource)` — returns the logical name from the resource's URN
-- `pulumiResourceType(resource)` — returns the type token from the resource's URN
-- `pulumiResourceURN(resource)` — returns the resource's URN
+- `pulumiresourcename(resource)` — returns the logical name from the resource's URN
+- `pulumiresourcetype(resource)` — returns the type token from the resource's URN
+- `pulumiresourceurn(resource)` — returns the resource's URN
 
 ## Development
 

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-failed-create-recover-continue-on-error/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-failed-create-recover-continue-on-error/main.tf
@@ -30,5 +30,5 @@ resource "simple_resource" "independent" {
   value = true
 }
 output "recovered" {
-  value = recover(pulumiResourceURN(fail_on_create_resource.failing), "recovered: ${error}")
+  value = recover(pulumiresourceurn(fail_on_create_resource.failing), "recovered: ${error}")
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-any/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-any/main.tf
@@ -46,5 +46,5 @@ resource "any-handled_resource" "anAsset" {
   lifecycle {
     create_before_destroy = true
   }
-  value = stringAsset("the asset contents")
+  value = stringasset("the asset contents")
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-asset-archive/subdir/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-asset-archive/subdir/main.tf
@@ -11,68 +11,68 @@ resource "asset-archive_asset_resource" "ass" {
   lifecycle {
     create_before_destroy = true
   }
-  value = fileAsset("../test.txt")
+  value = fileasset("../test.txt")
 }
 resource "asset-archive_archive_resource" "arc" {
   lifecycle {
     create_before_destroy = true
   }
-  value = fileArchive("../archive.tar")
+  value = filearchive("../archive.tar")
 }
 resource "asset-archive_archive_resource" "dir" {
   lifecycle {
     create_before_destroy = true
   }
-  value = fileArchive("../folder")
+  value = filearchive("../folder")
 }
 resource "asset-archive_archive_resource" "assarc" {
   lifecycle {
     create_before_destroy = true
   }
-  value = assetArchive({
-    "string"  = stringAsset("file contents")
-    "file"    = fileAsset("../test.txt")
-    "folder"  = fileArchive("../folder")
-    "archive" = fileArchive("../archive.tar")
+  value = assetarchive({
+    "string"  = stringasset("file contents")
+    "file"    = fileasset("../test.txt")
+    "folder"  = filearchive("../folder")
+    "archive" = filearchive("../archive.tar")
   })
 }
 resource "asset-archive_asset_resource" "remoteass" {
   lifecycle {
     create_before_destroy = true
   }
-  value = remoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt")
+  value = remoteasset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt")
 }
 resource "asset-archive_archive_resource" "remotearc" {
   lifecycle {
     create_before_destroy = true
   }
-  value = remoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")
+  value = remotearchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")
 }
 // Plain (non-nested) asset/archive outputs must round-trip through stack
 // outputs in every language.
 output "assetOutput" {
-  value = fileAsset("../test.txt")
+  value = fileasset("../test.txt")
 }
 output "archiveOutput" {
-  value = fileArchive("../archive.tar")
+  value = filearchive("../archive.tar")
 }
 // Regression test for pulumi/pulumi#16384: array and map of assets/archives
 // must compose properly through Go program generation.
 output "assetList" {
-  value = [fileAsset("../test.txt"), stringAsset("file contents")]
+  value = [fileasset("../test.txt"), stringasset("file contents")]
 }
 output "archiveList" {
-  value = [fileArchive("../archive.tar"), fileArchive("../folder")]
+  value = [filearchive("../archive.tar"), filearchive("../folder")]
 }
 output "assetMap" {
   value = {
-    "file"   = fileAsset("../test.txt")
-    "string" = stringAsset("file contents")
+    "file"   = fileasset("../test.txt")
+    "string" = stringasset("file contents")
   }
 }
 output "archiveMap" {
   value = {
-    "tar"    = fileArchive("../archive.tar")
-    "folder" = fileArchive("../folder")
+    "tar"    = filearchive("../archive.tar")
+    "folder" = filearchive("../folder")
   }
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-name-type/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-name-type/main.tf
@@ -14,8 +14,8 @@ resource "simple_resource" "res1" {
   value = true
 }
 output "name" {
-  value = pulumiResourceName(simple_resource.res1)
+  value = pulumiresourcename(simple_resource.res1)
 }
 output "type" {
-  value = pulumiResourceType(simple_resource.res1)
+  value = pulumiresourcetype(simple_resource.res1)
 }

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-alias/1/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-option-alias/1/main.tf
@@ -50,7 +50,7 @@ resource "simple_resource" "aliasParent" {
   pulumi {
     parent = simple_resource.parent
     aliases = [{
-      parent_urn = pulumiResourceURN(simple_resource.aliasURN)
+      parent_urn = pulumiresourceurn(simple_resource.aliasURN)
     }]
   }
   lifecycle {

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-failed-create-recover-continue-on-error/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-failed-create-recover-continue-on-error/main.tf
@@ -30,5 +30,5 @@ resource "simple_resource" "independent" {
   value = true
 }
 output "recovered" {
-  value = recover(pulumiResourceURN(fail_on_create_resource.failing), "recovered: ${error}")
+  value = recover(pulumiresourceurn(fail_on_create_resource.failing), "recovered: ${error}")
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-any/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-any/main.tf
@@ -46,5 +46,5 @@ resource "any-handled_resource" "anAsset" {
   lifecycle {
     create_before_destroy = true
   }
-  value = stringAsset("the asset contents")
+  value = stringasset("the asset contents")
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-asset-archive/subdir/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-asset-archive/subdir/main.tf
@@ -11,68 +11,68 @@ resource "asset-archive_asset_resource" "ass" {
   lifecycle {
     create_before_destroy = true
   }
-  value = fileAsset("../test.txt")
+  value = fileasset("../test.txt")
 }
 resource "asset-archive_archive_resource" "arc" {
   lifecycle {
     create_before_destroy = true
   }
-  value = fileArchive("../archive.tar")
+  value = filearchive("../archive.tar")
 }
 resource "asset-archive_archive_resource" "dir" {
   lifecycle {
     create_before_destroy = true
   }
-  value = fileArchive("../folder")
+  value = filearchive("../folder")
 }
 resource "asset-archive_archive_resource" "assarc" {
   lifecycle {
     create_before_destroy = true
   }
-  value = assetArchive({
-    "string"  = stringAsset("file contents")
-    "file"    = fileAsset("../test.txt")
-    "folder"  = fileArchive("../folder")
-    "archive" = fileArchive("../archive.tar")
+  value = assetarchive({
+    "string"  = stringasset("file contents")
+    "file"    = fileasset("../test.txt")
+    "folder"  = filearchive("../folder")
+    "archive" = filearchive("../archive.tar")
   })
 }
 resource "asset-archive_asset_resource" "remoteass" {
   lifecycle {
     create_before_destroy = true
   }
-  value = remoteAsset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt")
+  value = remoteasset("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/test.txt")
 }
 resource "asset-archive_archive_resource" "remotearc" {
   lifecycle {
     create_before_destroy = true
   }
-  value = remoteArchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")
+  value = remotearchive("https://raw.githubusercontent.com/pulumi/pulumi/7b0eb7fb10694da2f31c0d15edf671df843e0d4c/cmd/pulumi-test-language/tests/testdata/l2-resource-asset-archive/archive.tar")
 }
 // Plain (non-nested) asset/archive outputs must round-trip through stack
 // outputs in every language.
 output "assetOutput" {
-  value = fileAsset("../test.txt")
+  value = fileasset("../test.txt")
 }
 output "archiveOutput" {
-  value = fileArchive("../archive.tar")
+  value = filearchive("../archive.tar")
 }
 // Regression test for pulumi/pulumi#16384: array and map of assets/archives
 // must compose properly through Go program generation.
 output "assetList" {
-  value = [fileAsset("../test.txt"), stringAsset("file contents")]
+  value = [fileasset("../test.txt"), stringasset("file contents")]
 }
 output "archiveList" {
-  value = [fileArchive("../archive.tar"), fileArchive("../folder")]
+  value = [filearchive("../archive.tar"), filearchive("../folder")]
 }
 output "assetMap" {
   value = {
-    "file"   = fileAsset("../test.txt")
-    "string" = stringAsset("file contents")
+    "file"   = fileasset("../test.txt")
+    "string" = stringasset("file contents")
   }
 }
 output "archiveMap" {
   value = {
-    "tar"    = fileArchive("../archive.tar")
-    "folder" = fileArchive("../folder")
+    "tar"    = filearchive("../archive.tar")
+    "folder" = filearchive("../folder")
   }
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-name-type/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-name-type/main.tf
@@ -14,8 +14,8 @@ resource "simple_resource" "res1" {
   value = true
 }
 output "name" {
-  value = pulumiResourceName(simple_resource.res1)
+  value = pulumiresourcename(simple_resource.res1)
 }
 output "type" {
-  value = pulumiResourceType(simple_resource.res1)
+  value = pulumiresourcetype(simple_resource.res1)
 }

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-alias/1/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-option-alias/1/main.tf
@@ -50,7 +50,7 @@ resource "simple_resource" "aliasParent" {
   pulumi {
     parent = simple_resource.parent
     aliases = [{
-      parent_urn = pulumiResourceURN(simple_resource.aliasURN)
+      parent_urn = pulumiresourceurn(simple_resource.aliasURN)
     }]
   }
   lifecycle {

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -842,15 +842,15 @@ Pulumi HCL supports nearly all Terraform built-in functions. Functions are group
 
 | Function                       | Description                                                  |
 |--------------------------------|--------------------------------------------------------------|
-| `fileAsset(path)`              | Create a Pulumi `FileAsset` from a local file path           |
-| `stringAsset(text)`            | Create a Pulumi `StringAsset` from a string value            |
-| `remoteAsset(uri)`             | Create a Pulumi `RemoteAsset` from a URL                     |
-| `fileArchive(path)`            | Create a Pulumi `FileArchive` from a local path              |
-| `remoteArchive(uri)`           | Create a Pulumi `RemoteArchive` from a URL                   |
-| `assetArchive(map)`            | Create a Pulumi `AssetArchive` from a map of assets/archives |
-| `pulumiResourceName(resource)` | Get the logical name from a resource's URN                   |
-| `pulumiResourceType(resource)` | Get the type token from a resource's URN                     |
-| `pulumiResourceURN(resource)`  | Get a resource's URN                                         |
+| `fileasset(path)`              | Create a Pulumi `FileAsset` from a local file path           |
+| `stringasset(text)`            | Create a Pulumi `StringAsset` from a string value            |
+| `remoteasset(uri)`             | Create a Pulumi `RemoteAsset` from a URL                     |
+| `filearchive(path)`            | Create a Pulumi `FileArchive` from a local path              |
+| `remotearchive(uri)`           | Create a Pulumi `RemoteArchive` from a URL                   |
+| `assetarchive(map)`            | Create a Pulumi `AssetArchive` from a map of assets/archives |
+| `pulumiresourcename(resource)` | Get the logical name from a resource's URN                   |
+| `pulumiresourcetype(resource)` | Get the type token from a resource's URN                     |
+| `pulumiresourceurn(resource)`  | Get a resource's URN                                         |
 
 ## Stack References
 

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -49,15 +49,15 @@ which is Terraform-internal and has no equivalent here.
 | Function             | Category        | Notes                                                             |
 |----------------------|-----------------|-------------------------------------------------------------------|
 | `entries`            | Collection      | Converts a map or object to a list of `{key, value}` objects.     |
-| `pulumiResourceName` | Pulumi-specific | Returns the Pulumi resource name for a resource reference.        |
-| `pulumiResourceType` | Pulumi-specific | Returns the Pulumi resource type for a resource reference.        |
-| `pulumiResourceURN`  | Pulumi-specific | Returns the Pulumi URN for a resource reference.                  |
-| `fileAsset`          | Asset/Archive   | Creates a Pulumi `FileAsset` from a local file path.              |
-| `stringAsset`        | Asset/Archive   | Creates a Pulumi `StringAsset` from a string value.               |
-| `remoteAsset`        | Asset/Archive   | Creates a Pulumi `RemoteAsset` from a URL.                        |
-| `fileArchive`        | Asset/Archive   | Creates a Pulumi `FileArchive` from a local path.                 |
-| `remoteArchive`      | Asset/Archive   | Creates a Pulumi `RemoteArchive` from a URL.                      |
-| `assetArchive`       | Asset/Archive   | Creates a Pulumi `AssetArchive` from a map of assets or archives. |
+| `pulumiresourcename` | Pulumi-specific | Returns the Pulumi resource name for a resource reference.        |
+| `pulumiresourcetype` | Pulumi-specific | Returns the Pulumi resource type for a resource reference.        |
+| `pulumiresourceurn`  | Pulumi-specific | Returns the Pulumi URN for a resource reference.                  |
+| `fileasset`          | Asset/Archive   | Creates a Pulumi `FileAsset` from a local file path.              |
+| `stringasset`        | Asset/Archive   | Creates a Pulumi `StringAsset` from a string value.               |
+| `remoteasset`        | Asset/Archive   | Creates a Pulumi `RemoteAsset` from a URL.                        |
+| `filearchive`        | Asset/Archive   | Creates a Pulumi `FileArchive` from a local path.                 |
+| `remotearchive`      | Asset/Archive   | Creates a Pulumi `RemoteArchive` from a URL.                      |
+| `assetarchive`       | Asset/Archive   | Creates a Pulumi `AssetArchive` from a map of assets or archives. |
 
 ## Getting Help
 

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -1631,7 +1631,7 @@ func (g *generator) aliasElemTokens(elem model.Expression) (hclwrite.Tokens, hcl
 			hclKey = "no_parent"
 			valTokens, d = g.exprTokens(item.Value, schema.BoolType)
 		case "parent":
-			// Transform resource reference to parent_urn = pulumiResourceURN(resource_type.name)
+			// Transform resource reference to parent_urn = pulumiresourceurn(resource_type.name)
 			hclKey = "parent_urn"
 			baseTokens, d2 := g.exprTokens(item.Value, schema.AnyType)
 			diags = append(diags, d2...)
@@ -2473,6 +2473,22 @@ func (g *generator) funcCallTokens(expr *model.FunctionCallExpression) (hclwrite
 		return g.passthroughFuncCallTokens("jsonencode", expr.Args)
 	case "readFile":
 		return g.passthroughFuncCallTokens("file", expr.Args)
+	case "fileAsset":
+		return g.passthroughFuncCallTokens("fileasset", expr.Args)
+	case "fileArchive":
+		return g.passthroughFuncCallTokens("filearchive", expr.Args)
+	case "stringAsset":
+		return g.passthroughFuncCallTokens("stringasset", expr.Args)
+	case "assetArchive":
+		return g.passthroughFuncCallTokens("assetarchive", expr.Args)
+	case "remoteAsset":
+		return g.passthroughFuncCallTokens("remoteasset", expr.Args)
+	case "remoteArchive":
+		return g.passthroughFuncCallTokens("remotearchive", expr.Args)
+	case "pulumiResourceName":
+		return g.passthroughFuncCallTokens("pulumiresourcename", expr.Args)
+	case "pulumiResourceType":
+		return g.passthroughFuncCallTokens("pulumiresourcetype", expr.Args)
 	case "notImplemented":
 		return g.notImplementedTokens(expr)
 	default:
@@ -2972,10 +2988,10 @@ func (g *generator) scopeTraversalTokens(expr *model.ScopeTraversalExpression) (
 }
 
 // pulumiResourceURNCallTokens wraps resource-reference tokens in a
-// pulumiResourceURN(...) call.
+// pulumiresourceurn(...) call.
 func pulumiResourceURNCallTokens(resTokens hclwrite.Tokens) hclwrite.Tokens {
 	tokens := hclwrite.Tokens{
-		{Type: hclsyntax.TokenIdent, Bytes: []byte("pulumiResourceURN")},
+		{Type: hclsyntax.TokenIdent, Bytes: []byte("pulumiresourceurn")},
 		{Type: hclsyntax.TokenOParen, Bytes: []byte("(")},
 	}
 	tokens = append(tokens, resTokens...)

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -1068,9 +1068,9 @@ func (ft *fileTransformer) transformExpr(expr hclsyntax.Expression) hclwrite.Tok
 				}
 			}
 		}
-		// pulumiResourceURN(<resource>) is the encoding generate.go emits
+		// pulumiresourceurn(<resource>) is the encoding generate.go emits
 		// for PCL's `<resource>.urn`; restore the attribute on eject.
-		if e.Name == "pulumiResourceURN" && len(e.Args) == 1 {
+		if e.Name == "pulumiresourceurn" && len(e.Args) == 1 {
 			return append(ft.transformExpr(e.Args[0]),
 				&hclwrite.Token{Type: hclsyntax.TokenDot, Bytes: []byte(".")},
 				&hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte("urn")},
@@ -2394,6 +2394,22 @@ func transformFunctionName(name string) string {
 		return "unsecret"
 	case "file":
 		return "readFile"
+	case "fileasset":
+		return "fileAsset"
+	case "filearchive":
+		return "fileArchive"
+	case "stringasset":
+		return "stringAsset"
+	case "assetarchive":
+		return "assetArchive"
+	case "remoteasset":
+		return "remoteAsset"
+	case "remotearchive":
+		return "remoteArchive"
+	case "pulumiresourcename":
+		return "pulumiResourceName"
+	case "pulumiresourcetype":
+		return "pulumiResourceType"
 	default:
 		return name
 	}

--- a/pkg/hcl/eval/functions.go
+++ b/pkg/hcl/eval/functions.go
@@ -223,17 +223,17 @@ func Functions(baseDir string) map[string]function.Function {
 		"type":            typeFunc,
 
 		// Pulumi-specific functions
-		"pulumiResourceName": pulumiResourceNameFunc,
-		"pulumiResourceType": pulumiResourceTypeFunc,
-		"pulumiResourceURN":  pulumiResourceURNFunc,
+		"pulumiresourcename": pulumiResourceNameFunc,
+		"pulumiresourcetype": pulumiResourceTypeFunc,
+		"pulumiresourceurn":  pulumiResourceURNFunc,
 
 		// Asset and archive functions
-		"fileAsset":     fileAssetFunc(baseDir),
-		"fileArchive":   fileArchiveFunc(baseDir),
-		"stringAsset":   stringAssetFunc(),
-		"assetArchive":  assetArchiveFunc(),
-		"remoteAsset":   remoteAssetFunc(),
-		"remoteArchive": remoteArchiveFunc(),
+		"fileasset":     fileAssetFunc(baseDir),
+		"filearchive":   fileArchiveFunc(baseDir),
+		"stringasset":   stringAssetFunc(),
+		"assetarchive":  assetArchiveFunc(),
+		"remoteasset":   remoteAssetFunc(),
+		"remotearchive": remoteArchiveFunc(),
 	}
 
 	// templatefile and templatestring render a file or string as a template. The
@@ -341,7 +341,7 @@ func TypeInferenceFunctions(baseDir string) map[string]function.Function {
 	for _, name := range []string{
 		"file", "filebase64", "fileexists", "fileset", "templatefile",
 		"filemd5", "filesha1", "filesha256", "filesha512",
-		"filebase64sha256", "filebase64sha512", "fileAsset", "fileArchive",
+		"filebase64sha256", "filebase64sha512", "fileasset", "filearchive",
 	} {
 		funcs[name] = unknownOnError(funcs[name])
 	}
@@ -2404,18 +2404,18 @@ func ctyToGo(val cty.Value) any {
 
 // pulumiResourceNameFunc returns the logical name of a Pulumi resource by
 // extracting it from the resource's URN.
-var pulumiResourceNameFunc = resourceUrnFuncHelper("pulumiResourceName", func(u urn.URN) (cty.Value, error) {
+var pulumiResourceNameFunc = resourceUrnFuncHelper("pulumiresourcename", func(u urn.URN) (cty.Value, error) {
 	return cty.StringVal(u.Name()), nil
 })
 
 // pulumiResourceTypeFunc returns the type token of a Pulumi resource by
 // extracting it from the resource's URN.
-var pulumiResourceTypeFunc = resourceUrnFuncHelper("pulumiResourceType", func(u urn.URN) (cty.Value, error) {
+var pulumiResourceTypeFunc = resourceUrnFuncHelper("pulumiresourcetype", func(u urn.URN) (cty.Value, error) {
 	return cty.StringVal(u.Type().String()), nil
 })
 
 // pulumiResourceURNFunc returns the URN of a Pulumi resource.
-var pulumiResourceURNFunc = resourceUrnFuncHelper("pulumiResourceURN", func(u urn.URN) (cty.Value, error) {
+var pulumiResourceURNFunc = resourceUrnFuncHelper("pulumiresourceurn", func(u urn.URN) (cty.Value, error) {
 	return cty.StringVal(string(u)), nil
 })
 
@@ -2452,7 +2452,7 @@ func fileAssetFunc(baseDir string) function.Function {
 			path := args[0].AsString()
 			a, err := asset.FromPathWithWD(path, baseDir)
 			if err != nil {
-				return cty.NilVal, fmt.Errorf("fileAsset: %w", err)
+				return cty.NilVal, fmt.Errorf("fileasset: %w", err)
 			}
 			return cty.CapsuleVal(AssetCapsuleType, a), nil
 		},
@@ -2467,7 +2467,7 @@ func fileArchiveFunc(baseDir string) function.Function {
 			path := args[0].AsString()
 			a, err := archive.FromPathWithWD(path, baseDir)
 			if err != nil {
-				return cty.NilVal, fmt.Errorf("fileArchive: %w", err)
+				return cty.NilVal, fmt.Errorf("filearchive: %w", err)
 			}
 			return cty.CapsuleVal(ArchiveCapsuleType, a), nil
 		},
@@ -2493,7 +2493,7 @@ func assetArchiveFunc() function.Function {
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			val := args[0]
 			if !val.Type().IsObjectType() && !val.Type().IsMapType() {
-				return cty.NilVal, fmt.Errorf("assetArchive: argument must be an object or map")
+				return cty.NilVal, fmt.Errorf("assetarchive: argument must be an object or map")
 			}
 			assets := make(map[string]any)
 			for it := val.ElementIterator(); it.Next(); {
@@ -2505,7 +2505,7 @@ func assetArchiveFunc() function.Function {
 				case v.Type().Equals(ArchiveCapsuleType):
 					assets[key] = v.EncapsulatedValue().(*archive.Archive)
 				default:
-					return cty.NilVal, fmt.Errorf("assetArchive: value for key %q must be an asset or archive, got %s",
+					return cty.NilVal, fmt.Errorf("assetarchive: value for key %q must be an asset or archive, got %s",
 						key, v.Type().FriendlyName())
 				}
 			}
@@ -2523,7 +2523,7 @@ func remoteAssetFunc() function.Function {
 			uri := args[0].AsString()
 			a, err := asset.FromURI(uri)
 			if err != nil {
-				return cty.NilVal, fmt.Errorf("remoteAsset: %w", err)
+				return cty.NilVal, fmt.Errorf("remoteasset: %w", err)
 			}
 			return cty.CapsuleVal(AssetCapsuleType, a), nil
 		},
@@ -2538,7 +2538,7 @@ func remoteArchiveFunc() function.Function {
 			uri := args[0].AsString()
 			a, err := archive.FromURI(uri)
 			if err != nil {
-				return cty.NilVal, fmt.Errorf("remoteArchive: %w", err)
+				return cty.NilVal, fmt.Errorf("remotearchive: %w", err)
 			}
 			return cty.CapsuleVal(ArchiveCapsuleType, a), nil
 		},

--- a/pkg/hcl/run/aliases_error_test.go
+++ b/pkg/hcl/run/aliases_error_test.go
@@ -68,7 +68,7 @@ resource "pfx_res" "res" {
 }
 
 // TestEngine_AliasesParentURN pins that an alias's parent_urn can reference
-// another resource's URN via pulumiResourceURN.
+// another resource's URN via pulumiresourceurn.
 func TestEngine_AliasesParentURN(t *testing.T) {
 	t.Parallel()
 
@@ -79,7 +79,7 @@ resource "pfx_res" "first" {
 resource "pfx_res" "second" {
   pulumi {
     aliases = [{
-      parent_urn = pulumiResourceURN(pfx_res.first)
+      parent_urn = pulumiresourceurn(pfx_res.first)
     }]
   }
 }

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -221,7 +221,7 @@ resource "aws_instance" "web" {
 }
 
 output "name" {
-  value = pulumiResourceName({ key = aws_instance.web })
+  value = pulumiresourcename({ key = aws_instance.web })
 }
 `)
 
@@ -276,11 +276,11 @@ resource "aws_instance" "mapped" {
 }
 
 output "count_name" {
-  value = pulumiResourceName(aws_instance.counted[1])
+  value = pulumiresourcename(aws_instance.counted[1])
 }
 
 output "each_name" {
-  value = pulumiResourceName(aws_instance.mapped["a"])
+  value = pulumiresourcename(aws_instance.mapped["a"])
 }
 `)
 
@@ -597,7 +597,7 @@ resource "aws_instance" "web" {
 }
 
 resource "aws_instance" "named" {
-  ami = pulumiResourceName(aws_instance.web)
+  ami = pulumiresourcename(aws_instance.web)
 }
 `)
 


### PR DESCRIPTION
## Summary

Terraform built-ins are all-lowercase (`filebase64`, `templatefile`), while the Pulumi-specific additions were camelCase. This renames them to match Terraform's naming convention:

| Before | After |
|---|---|
| `fileAsset` | `fileasset` |
| `fileArchive` | `filearchive` |
| `stringAsset` | `stringasset` |
| `assetArchive` | `assetarchive` |
| `remoteAsset` | `remoteasset` |
| `remoteArchive` | `remotearchive` |
| `pulumiResourceName` | `pulumiresourcename` |
| `pulumiResourceType` | `pulumiresourcetype` |
| `pulumiResourceURN` | `pulumiresourceurn` |

Codegen emits the lowercase names; eject maps them back to their camelCase PCL equivalents. PCL-side names are unchanged. Docs and conformance goldens regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)