### PR TITLE
Order module init after the arguments it registers

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-506.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-506.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Module components record the arguments they were passed instead of intermittently dropping them
+time: 2026-08-04T16:11:42.93663+02:00
+custom:
+    Component: runtime
+    PR: "506"

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -524,12 +524,6 @@ func (g *Graph) ExpandableNodes() []*Node {
 	return out
 }
 
-// nodeKeyString names an interned node for deterministic ordering.
-func (g *Graph) nodeKeyString(n pdag.Node) string {
-	key := g.keyByDagNode[n]
-	return key.Module.String() + "\x00" + key.ID
-}
-
 // initEdges is one module init node and the nodes its component registration
 // reads, pending the cycle check that only a finished graph can answer.
 type initEdges struct {
@@ -683,7 +677,11 @@ func (g *Graph) addInitReadEdges() {
 	// one is refused depends on the order they are tried; modules are inlined
 	// in map order, so sort before draining or the choice varies per run.
 	slices.SortFunc(g.initReads, func(a, b initEdges) int {
-		return strings.Compare(g.nodeKeyString(a.init), g.nodeKeyString(b.init))
+		aN, bN := g.keyByDagNode[a.init], g.keyByDagNode[b.init]
+		if mCmp := modulepath.Compare(aN.Module, bN.Module); mCmp != 0 {
+			return mCmp
+		}
+		return cmp.Compare(aN.ID, bN.ID)
 	})
 	for _, e := range g.initReads {
 		for _, dep := range e.reads {

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -282,6 +282,8 @@ type Graph struct {
 	// dependents counts how many other nodes list a given key in their
 	// dependency list. Read by HasDependents at Walk time.
 	dependents map[NodeKey]int
+	// initReads are the module-init edges deferred to the end of the build.
+	initReads []initEdges
 
 	// moved holds the moved blocks of each module keyed by that module's path.
 	// A moved block's from/to addresses are relative to the module it is written
@@ -522,6 +524,19 @@ func (g *Graph) ExpandableNodes() []*Node {
 	return out
 }
 
+// nodeKeyString names an interned node for deterministic ordering.
+func (g *Graph) nodeKeyString(n pdag.Node) string {
+	key := g.keyByDagNode[n]
+	return key.Module.String() + "\x00" + key.ID
+}
+
+// initEdges is one module init node and the nodes its component registration
+// reads, pending the cycle check that only a finished graph can answer.
+type initEdges struct {
+	init  pdag.Node
+	reads []pdag.Node
+}
+
 // BuildFromConfig builds a dependency graph from an HCL configuration.
 // moduleLoader is required when config contains modules.
 func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir string) (*Graph, error) {
@@ -652,9 +667,34 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 		}
 	}
 
+	g.addInitReadEdges()
 	g.classifyPlanTimeReads()
 
 	return g, nil
+}
+
+// addInitReadEdges orders each module init after what its component
+// registration reads, skipping any edge that would close a cycle. Mutually
+// dependent modules are legal — the dependency runs from one module's outputs
+// to the other's variables, not between the calls — and there the argument
+// cannot be known that early, so init reports it unset.
+func (g *Graph) addInitReadEdges() {
+	// Two init edges can be individually acyclic and jointly cyclic, so which
+	// one is refused depends on the order they are tried; modules are inlined
+	// in map order, so sort before draining or the choice varies per run.
+	slices.SortFunc(g.initReads, func(a, b initEdges) int {
+		return strings.Compare(g.nodeKeyString(a.init), g.nodeKeyString(b.init))
+	})
+	for _, e := range g.initReads {
+		for _, dep := range e.reads {
+			if err := g.dag.NewEdge(dep, e.init); err != nil {
+				continue
+			}
+			if key, ok := g.keyByDagNode[dep]; ok {
+				g.dependents[key]++
+			}
+		}
+	}
 }
 
 // classifyPlanTimeReads marks each data-source node whose transitive
@@ -1599,8 +1639,18 @@ func (g *Graph) inlineModule(
 
 	_, initIdx := g.newNode(initKey)
 
-	// Variables: each depends on init + the corresponding input expression from the module block.
+	// Init evaluates the call's arguments, name and protect flag to register
+	// the component, so it should follow whatever they read. Recorded now,
+	// added once the graph is whole: an edge that closes a cycle is one the
+	// program cannot satisfy, and only the finished graph shows that.
+	initReads := append(g.exprDeps(mod.PulumiName, parentPath), g.exprDeps(mod.Protect, parentPath)...)
 	moduleInputAttrs, _ := mod.Config.JustAttributes()
+	for _, name := range slices.Sorted(maps.Keys(moduleInputAttrs)) {
+		initReads = append(initReads, g.exprDeps(moduleInputAttrs[name].Expr, parentPath)...)
+	}
+	g.initReads = append(g.initReads, initEdges{init: initIdx, reads: initReads})
+
+	// Variables: each depends on init + the corresponding input expression from the module block.
 	for varName, v := range loaded.Config.Variables {
 		varDeps := []pdag.Node{initIdx}
 		if inputAttr, ok := moduleInputAttrs[varName]; ok {

--- a/pkg/hcl/graph/module_init_test.go
+++ b/pkg/hcl/graph/module_init_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/ast"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/modulepath"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/parser"
+)
+
+func parse(t *testing.T, name, src string) *ast.Config {
+	t.Helper()
+	config, diags := parser.NewParser().ParseSource(name, []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+	return config
+}
+
+// TestModuleInitAwaitsItsArguments pins the ordering the component
+// registration needs: init evaluates the call's arguments to report them as
+// inputs, so it must follow whatever they read. Without the edge init races
+// the value and the argument is dropped with no error.
+func TestModuleInitAwaitsItsArguments(t *testing.T) {
+	t.Parallel()
+
+	child := parse(t, "child.hcl", `variable "v" { type = string }`)
+	root := parse(t, "root.hcl", `
+locals {
+  computed = "hello"
+}
+
+module "child" {
+  source = "./child"
+  v      = local.computed
+}
+`)
+
+	g, err := BuildFromConfig(root, fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: child, SourcePath: "./child"},
+	}}, ".")
+	require.NoError(t, err)
+	require.Empty(t, g.Validate())
+
+	initIdx, ok := g.KeyNode(NodeKey{
+		Module: modulepath.Root().Append(modulepath.NewStep("child")),
+		ID:     "__init__",
+	})
+	require.True(t, ok, "no init node for module.child")
+	localIdx, ok := g.KeyNode(NodeKey{Module: modulepath.Root(), ID: "local.computed"})
+	require.True(t, ok, "no node for local.computed")
+
+	assert.Contains(t, slices.Collect(g.dag.Predecessors(initIdx)), localIdx,
+		"module init does not depend on the local its argument reads")
+}
+
+// TestMutuallyDependentModulesBuild covers the case the ordering above cannot
+// have: two calls each passing the other's output. The dependency runs from
+// one module's outputs to the other's variables, not between the calls, so the
+// graph must still build — one of the two init edges is refused, and the same
+// one every time, or the component that keeps its argument would vary per run.
+func TestMutuallyDependentModulesBuild(t *testing.T) {
+	t.Parallel()
+
+	side := func(name string) *ast.Config {
+		return parse(t, name+".hcl", `
+variable "input" {
+  type = bool
+}
+# out comes from the resource that does not read var.input, so the two calls
+# depend on each other without either module depending on its own argument.
+resource "simple_resource" "independent" {
+  value = true
+}
+resource "simple_resource" "dependent" {
+  value = ! var.input
+}
+output "out" {
+  value = simple_resource.independent.value
+}
+`)
+	}
+	root := parse(t, "root.hcl", `
+module "first" {
+  source = "./first"
+  input  = module.second.out
+}
+module "second" {
+  source = "./second"
+  input  = module.first.out
+}
+`)
+	loader := fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./first":  {Config: side("first"), SourcePath: "./first"},
+		"./second": {Config: side("second"), SourcePath: "./second"},
+	}}
+
+	var first []string
+	for range 8 {
+		g, err := BuildFromConfig(root, loader, ".")
+		require.NoError(t, err, "mutually dependent modules must not cycle")
+		require.Empty(t, g.Validate())
+
+		var gated []string
+		for _, name := range []string{"first", "second"} {
+			init, ok := g.KeyNode(NodeKey{
+				Module: modulepath.Root().Append(modulepath.NewStep(name)),
+				ID:     "__init__",
+			})
+			require.True(t, ok)
+			if len(slices.Collect(g.dag.Predecessors(init))) > 0 {
+				gated = append(gated, name)
+			}
+		}
+		if first == nil {
+			first = gated
+			continue
+		}
+		assert.Equal(t, first, gated, "which call keeps its argument varies between builds")
+	}
+}


### PR DESCRIPTION
Registering modules that reference uninitialised values just fail silently on the first run. This PR re-organises module init calls to come after all their required values.