### PR TITLE
Unblock l3-component-simple

### DIFF
--- a/.changes/unreleased/runtime-Improvements-507.yaml
+++ b/.changes/unreleased/runtime-Improvements-507.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Hydrate module input dependencies where possible
+time: 2026-08-04T17:20:20.799647+02:00
+custom:
+    Component: runtime
+    PR: "507"

--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -138,8 +138,6 @@ var expectedFailures = map[string]string{
 	"l2-resource-hook-on-error":      "PCL pcl.Hook nodes not yet supported by HCL codegen",
 	"l2-resource-hook-ignore-errors": "PCL pcl.Hook nodes not yet supported by HCL codegen",
 	"l2-resource-read":               "PCL pcl.ReadResource nodes not yet supported by HCL codegen",
-	"l3-component-simple": "HCL runtime does not propagate resource dependencies from a" +
-		" component's input expressions to the component registration",
 	"l2-provider-call-explicit": "upstream fixture declares `provider \"call\"`, which" +
 		" is reserved as the namespace for resource method calls in HCL",
 	"l2-config-default-from-invoke": "HCL codegen does not support a config variable whose" +

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-simple/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-simple/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-simple
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-simple/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-simple/main.pp
@@ -1,0 +1,12 @@
+resource "input" "simple:index:Resource" {
+  value = true
+}
+
+component "someComponent" "./myComponent" {
+  input = input.value
+}
+
+output "result" {
+  value = someComponent.output
+}
+

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-simple/myComponent/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l3-component-simple/myComponent/main.pp
@@ -1,0 +1,12 @@
+resource "res" "simple:index:Resource" {
+  value = input
+}
+
+config "input" "bool" {
+  description = "A simple input"
+}
+
+output "output" {
+  value = res.value
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-simple/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-simple/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-simple
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-simple/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-simple/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "input" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = true
+}
+module "someComponent" {
+  source = "./myComponent"
+  input  = simple_resource.input.value
+}
+output "result" {
+  value = module.someComponent.output
+}

--- a/cmd/pulumi-language-hcl/testdata/projects/l3-component-simple/myComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l3-component-simple/myComponent/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = var.input
+}
+variable "input" {
+  type        = bool
+  description = "A simple input"
+}
+output "output" {
+  value = simple_resource.res.value
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-simple/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-simple/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l3-component-simple
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-simple/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-simple/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "input" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = true
+}
+module "someComponent" {
+  source = "./myComponent"
+  input  = simple_resource.input.value
+}
+output "result" {
+  value = module.someComponent.output
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-simple/myComponent/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l3-component-simple/myComponent/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    simple = {
+      source  = "pulumi/simple"
+      version = "2.0.0"
+    }
+  }
+}
+
+resource "simple_resource" "res" {
+  pulumi {
+    name ="${pulumi.module.name}-res"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = var.input
+}
+variable "input" {
+  type        = bool
+  description = "A simple input"
+}
+output "output" {
+  value = simple_resource.res.value
+}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -4115,6 +4115,7 @@ func (e *Engine) initModuleCallIn(
 
 	// Evaluate module inputs for the component resource registration
 	inputs := make(map[string]property.Value)
+	inputDeps := make(map[string][]string)
 	attrs, _ := mod.Config.JustAttributes()
 	for name, attr := range attrs {
 		val, diags := attr.Expr.Value(parentEvalCtx.HCLContext())
@@ -4130,6 +4131,7 @@ func (e *Engine) initModuleCallIn(
 		pv, err := transform.CtyToPropertyValue(val)
 		if err == nil {
 			inputs[name] = pv
+			inputDeps[name] = eval.CollectDepURNs(val)
 		}
 	}
 
@@ -4143,7 +4145,15 @@ func (e *Engine) initModuleCallIn(
 		if err != nil {
 			return nil, err
 		}
-		componentOpts := &ResourceOptions{Parent: parentURN, Providers: passedProviders}
+		componentOpts := &ResourceOptions{
+			Parent:               parentURN,
+			Providers:            passedProviders,
+			PropertyDependencies: inputDeps,
+		}
+		for _, deps := range inputDeps {
+			componentOpts.DependsOn = append(componentOpts.DependsOn, deps...)
+		}
+		componentOpts.DependsOn = e.cellURNs.widen(componentOpts.DependsOn)
 		componentOpts.Aliases = e.moduleComponentAliases(instPath)
 		if mod.Protect != nil {
 			hclCtx := parentEvalCtx.HCLContextWithIteration(index, eachKey, eachVal)
@@ -4411,13 +4421,14 @@ func (e *Engine) registerComponentResource(
 
 	deps := opts.DependsOn
 	resp, err := e.resmon.RegisterResource(ctx, RegisterResourceRequest{
-		Type:         typeToken,
-		Name:         name,
-		Inputs:       inputs,
-		Dependencies: deps,
-		Parent:       opts.Parent,
-		Protect:      opts.Protect,
-		Providers:    opts.Providers,
+		Type:                 typeToken,
+		Name:                 name,
+		Inputs:               inputs,
+		Dependencies:         deps,
+		PropertyDependencies: opts.PropertyDependencies,
+		Parent:               opts.Parent,
+		Protect:              opts.Protect,
+		Providers:            opts.Providers,
 	})
 	if err != nil {
 		return "", "", property.Map{}, err


### PR DESCRIPTION
Building on top of https://github.com/pulumi/pulumi-hcl/pull/506, we can now unskip `l3-component-simple`.