### PR TITLE
Add a Java example to the registry overview

### DIFF
--- a/registry/_index.md
+++ b/registry/_index.md
@@ -20,7 +20,7 @@ The following program instantiates the community
 [`terraform-aws-modules/vpc/aws`](https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws)
 module and exports the resulting VPC id.
 
-{{< chooser language "typescript,python,go,csharp,yaml" / >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
 
 {{% choosable language typescript %}}
 
@@ -117,6 +117,35 @@ return await Deployment.RunAsync(() =>
         ["vpcId"] = vpc.Outputs.Apply(o => o["vpc_id"]),
     };
 });
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+package myproject;
+
+import com.pulumi.Pulumi;
+import com.pulumi.hcl.Module;
+import com.pulumi.hcl.ModuleArgs;
+import java.util.Map;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(ctx -> {
+            var vpc = new Module("vpc", ModuleArgs.builder()
+                .source("terraform-aws-modules/vpc/aws")
+                .version("5.0.0")
+                .inputs(Map.of(
+                    "name", "example-vpc",
+                    "cidr", "10.0.0.0/16"))
+                .build());
+
+            ctx.export("vpcId", vpc.outputs().applyValue(o -> o.get("vpc_id")));
+        });
+    }
+}
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
v0.13.0 published the first Java SDK to Maven Central as
[`com.pulumi:hcl`](https://central.sonatype.com/artifact/com.pulumi/hcl/0.13.0), so the
registry overview page should show a Java example alongside the other languages.

The example was verified end-to-end against the published artifact: the exact code in the
doc compiles against `com.pulumi:hcl:0.13.0` from Maven Central, and `pulumi preview`/`up`
/`destroy` ran clean, with `up` exporting the expected `vpcId`.

Docs-only change; no changelog fragment.