### PR TITLE
Publish released binaries to get.pulumi.com

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,39 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Mirror the released plugin tarballs to get.pulumi.com.
+  publish-binaries:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      VERSION: ${{ needs.release.outputs.version }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ESC_ACTION_OIDC_AUTH: true
+      ESC_ACTION_OIDC_ORGANIZATION: pulumi
+      ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+      ESC_ACTION_ENVIRONMENT: imports/github-secrets
+      ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+    steps:
+      - name: Fetch the AWS upload credentials from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ steps.esc-secrets.outputs.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ steps.esc-secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_UPLOAD_ROLE_ARN }}
+          role-external-id: upload-pulumi-release
+          role-session-name: pulumi-hcl@githubActions
+      - name: Download the released binaries
+        run: gh release download "${VERSION}" --pattern '*.tar.gz' --dir dist --repo "${{ github.repository }}"
+      - name: Upload to get.pulumi.com
+        run: aws s3 cp dist "s3://get.pulumi.com/releases/plugins/" --recursive
+
   # Publish the Go SDK to our sdk-releases branch, then tag it.
   publish-go-sdk:
     needs: release


### PR DESCRIPTION
Adds a `publish-binaries` job to the release workflow that mirrors every released plugin tarball (`pulumi-language-hcl`, `pulumi-converter-hcl`, `pulumi-resource-hcl`) to `s3://get.pulumi.com/releases/plugins/`.

The tarballs are downloaded from the GitHub release with `gh release download`, not rebuilt, so the mirrored bytes are exactly what GoReleaser shipped — and the GoReleaser archive names already match the CLI's `standardAssetName` format (`pulumi-<kind>-hcl-v<version>-<os>-<arch>.tar.gz`), so no renaming is needed.

Why: the Pulumi CLI's default plugin source resolution tries GitHub first and falls back to `get.pulumi.com/releases/plugins`. Today nothing hcl-related exists there, so unauthenticated installs are exposed to GitHub API rate limits with no fallback. Together with the pulumi/pulumi change that drops the hardcoded `PluginDownloadURL` for hcl (letting the default fallback resolution engage), this makes the fallback real.

Credentials copy the provider publishing pipeline (ci-mgmt's generated `publish.yml`, e.g. pulumi-random): the GitHub OIDC token is exchanged for the org-wide `imports/github-secrets` ESC environment, and its AWS keys assume the release-upload role (`role-external-id: upload-pulumi-release`, `us-east-2`). The ESC OIDC exchange from this repo is confirmed working since the post-transfer subject-claim fix (the v0.13.0 publish jobs re-ran green).

The job is idempotent: `aws s3 cp` overwrites, and it can be backfilled for existing releases by re-running the workflow.