### PR TITLE
Store the `id` under the correct property name

### DIFF
--- a/.changes/unreleased/converter-bug-fixes-512.yaml
+++ b/.changes/unreleased/converter-bug-fixes-512.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Project the imported state's `id` onto the dynamic bridge's renamed id property on `import --from hcl`
+time: 2026-08-05T18:55:29.535666+02:00
+custom:
+    Component: converter
+    PR: "512"

--- a/pkg/converter/convert_state.go
+++ b/pkg/converter/convert_state.go
@@ -527,21 +527,33 @@ func translateInstanceValues(
 	}
 	val = markSensitivePaths(val, current.AttrSensitivePaths)
 
-	m, err := transform.CtyToResourceOutputs(val, res, bridge.ResourceBodyMapping(info, tfType))
+	mapping := bridge.ResourceBodyMapping(info, tfType)
+	m, err := transform.CtyToResourceOutputs(val, res, mapping)
 	if err != nil {
 		return nil, nil, fmt.Errorf("translating attributes: %w", err)
 	}
 
 	outs = resource.ToResourcePropertyValue(property.New(m)).ObjectValue()
 	// Inputs are the outputs' input-property subset. Nested computed leaves
-	// are not stripped; revisit if the round-trip check flags diffs.
+	// are not stripped; revisit if the round-trip check flags diffs. A renamed
+	// id (the dynamic bridge's <resource>Id) is provider-populated: programs
+	// never set it, so it stays an output only.
+	idProp := transform.IDProperty(res, mapping)
 	ins = make(resource.PropertyMap, len(res.InputProperties))
 	for _, p := range res.InputProperties {
+		if idProp != nil && p.Name == idProp.Name {
+			continue
+		}
 		if pv, has := outs[resource.PropertyKey(p.Name)]; has {
 			ins[resource.PropertyKey(p.Name)] = pv
 		}
 	}
-	outs["id"] = resource.NewStringProperty(id)
+	if idProp == nil {
+		// Classic-bridge shape: the state's id becomes the plain `id` output.
+		// Under a renamed id the codec already projected the value, and native
+		// dynamic-bridge state carries no plain `id` output.
+		outs["id"] = resource.NewStringProperty(id)
+	}
 	return outs, ins, nil
 }
 

--- a/pkg/converter/convert_state.go
+++ b/pkg/converter/convert_state.go
@@ -548,8 +548,6 @@ func translateInstanceValues(
 		}
 	}
 	if idProp == nil {
-		// No schema home for id (classic shape): it becomes the plain `id`
-		// output. A renamed id was already projected by the codec.
 		outs["id"] = resource.NewStringProperty(id)
 	}
 	return outs, ins, nil

--- a/pkg/converter/convert_state.go
+++ b/pkg/converter/convert_state.go
@@ -534,10 +534,9 @@ func translateInstanceValues(
 	}
 
 	outs = resource.ToResourcePropertyValue(property.New(m)).ObjectValue()
-	// Inputs are the outputs' input-property subset. Nested computed leaves
-	// are not stripped; revisit if the round-trip check flags diffs. A renamed
-	// id (the dynamic bridge's <resource>Id) is provider-populated: programs
-	// never set it, so it stays an output only.
+	// Inputs are the outputs' input-property subset — minus the renamed id,
+	// which is provider-populated and never a program input. Nested computed
+	// leaves are not stripped; revisit if the round-trip check flags diffs.
 	idProp := transform.IDProperty(res, mapping)
 	ins = make(resource.PropertyMap, len(res.InputProperties))
 	for _, p := range res.InputProperties {
@@ -549,9 +548,8 @@ func translateInstanceValues(
 		}
 	}
 	if idProp == nil {
-		// Classic-bridge shape: the state's id becomes the plain `id` output.
-		// Under a renamed id the codec already projected the value, and native
-		// dynamic-bridge state carries no plain `id` output.
+		// No schema home for id (classic shape): it becomes the plain `id`
+		// output. A renamed id was already projected by the codec.
 		outs["id"] = resource.NewStringProperty(id)
 	}
 	return outs, ins, nil

--- a/pkg/converter/convert_state_test.go
+++ b/pkg/converter/convert_state_test.go
@@ -410,6 +410,81 @@ func TestConvertTFState_SuppliesValues(t *testing.T) {
 	assert.NotContains(t, ins, resource.PropertyKey("id"))
 }
 
+// TestConvertTFState_RenamedID pins the dynamic-bridge import shape (#512):
+// the parameterized terraform-provider maps the protocol schema, where SDKv2
+// injects `id` as Optional+Computed, and renames it to a per-resource
+// property (<resource>Id) that also carries the resource's identity. Imported
+// state must project the TF id onto that property — and only there — or the
+// provider's first Diff sees a null id and replaces the just-imported
+// resource.
+func TestConvertTFState_RenamedID(t *testing.T) {
+	t.Parallel()
+
+	state := parseState(t, `{
+		"resources": [
+			{
+				"mode": "managed", "type": "acme_thing", "name": "b",
+				"provider": "provider[\"registry.terraform.io/acme/acme\"]",
+				"instances": [ { "attributes": { "id": "t-1", "name": "hello" } } ]
+			}
+		]
+	}`)
+
+	src := fakeInfoSource{infos: map[string]*tfbridge.ProviderInfo{
+		"acme": roundtrip(t, tfbridge.ProviderInfo{
+			P: shimv2.NewProvider(&sdkschema.Provider{
+				ResourcesMap: map[string]*sdkschema.Resource{
+					"acme_thing": {Schema: map[string]*sdkschema.Schema{
+						"id":   {Type: sdkschema.TypeString, Optional: true, Computed: true},
+						"name": {Type: sdkschema.TypeString, Optional: true},
+					}},
+				},
+			}),
+			Name: "acme",
+			Resources: map[string]*tfbridge.ResourceInfo{
+				"acme_thing": {
+					Tok: "acme:index/thing:Thing",
+					// The rename fixID installs for every dynamic resource.
+					Fields: map[string]*tfbridge.SchemaInfo{"id": {Name: "thingId"}},
+				},
+			},
+		}),
+	}}
+	str := schema.TypeSpec{Type: "string"}
+	loader := schemaloader.New(t, schema.PackageSpec{
+		Name:    "acme",
+		Version: "1.0.0",
+		Meta:    &schema.MetadataSpec{ModuleFormat: bridgeModuleFormat},
+		Resources: map[string]schema.ResourceSpec{
+			"acme:index/thing:Thing": {
+				ObjectTypeSpec: schema.ObjectTypeSpec{Properties: map[string]schema.PropertySpec{
+					"thingId": {TypeSpec: str},
+					"name":    {TypeSpec: str},
+				}},
+				InputProperties: map[string]schema.PropertySpec{
+					"thingId": {TypeSpec: str},
+					"name":    {TypeSpec: str},
+				},
+			},
+		},
+	})
+
+	resp := convertTFState(t.Context(), src, loader, nil, nil, state)
+	require.Empty(t, resp.Diagnostics)
+	require.Len(t, resp.Resources, 1)
+	got := resp.Resources[0]
+
+	assert.Equal(t, "t-1", got.ID)
+	assert.Equal(t, resource.NewStringProperty("t-1"), got.Outputs["thingId"],
+		"the TF id projects onto the renamed property")
+	assert.NotContains(t, got.Outputs, resource.PropertyKey("id"),
+		"native dynamic-bridge state carries no plain id output")
+	assert.Equal(t, resource.NewStringProperty("hello"), got.Outputs["name"])
+	assert.Contains(t, got.Inputs, resource.PropertyKey("name"))
+	assert.NotContains(t, got.Inputs, resource.PropertyKey("thingId"),
+		"the renamed id is provider-populated, never a program input")
+}
+
 // TestConvertTFState_TerraformData pins the builtin's import shape: Stash
 // imports carrying the runtime's {type, value} wrapper encoding, an explicit
 // null input when absent, and no triggers_replace (the engine's replacement

--- a/pkg/converter/convert_state_test.go
+++ b/pkg/converter/convert_state_test.go
@@ -411,12 +411,8 @@ func TestConvertTFState_SuppliesValues(t *testing.T) {
 }
 
 // TestConvertTFState_RenamedID pins the dynamic-bridge import shape (#512):
-// the parameterized terraform-provider maps the protocol schema, where SDKv2
-// injects `id` as Optional+Computed, and renames it to a per-resource
-// property (<resource>Id) that also carries the resource's identity. Imported
-// state must project the TF id onto that property — and only there — or the
-// provider's first Diff sees a null id and replaces the just-imported
-// resource.
+// the TF id must project onto the bridge's renamed id property — and only
+// there — or the provider's first Diff sees a null id and replaces.
 func TestConvertTFState_RenamedID(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -686,13 +686,9 @@ func ctyToResourceInputs(val cty.Value, r *schema.Resource, attrExprs map[string
 }
 
 // CtyToResourceOutputs converts a TF-shaped attributes object (e.g. decoded
-// state attributes) into the resource's Pulumi output property map, dropping
-// what TF stores but Pulumi does not project: SDKv2 keeps the resource's
-// `timeouts` block in state attributes (the name is reserved, so it is never
-// a real schema field), and the classic bridge keeps `id` outside a Pulumi
-// resource's schema properties. The dynamic bridge instead renames `id` to a
-// real schema property (aws_s3_bucket → s3BucketId), so `id` is dropped only
-// when it does not project into the schema.
+// state attributes) into the resource's Pulumi output property map. State
+// attributes with no schema property are dropped: `timeouts` always (SDKv2
+// bookkeeping), `id` unless the schema models it (see IDProperty).
 func CtyToResourceOutputs(val cty.Value, r *schema.Resource, mapping *bridge.BodyMapping) (property.Map, error) {
 	if ty := val.Type(); ty.IsObjectType() && (ty.HasAttribute("id") || ty.HasAttribute("timeouts")) {
 		attrs := val.AsValueMap()
@@ -705,11 +701,10 @@ func CtyToResourceOutputs(val cty.Value, r *schema.Resource, mapping *bridge.Bod
 	return ctyToObject(r.Token, val, r.Properties, nil, false /* already in a secret */, mapping)
 }
 
-// IDProperty returns the schema property the TF `id` attribute projects to,
-// or nil when id lives outside the schema's properties. The dynamic bridge
-// renames id per resource (fixID installs the rename in the mapping's field
-// overrides); resolve through the mapping, never by reconstructing the naming
-// rule — the rename's fallback candidates vary with the schema's other fields.
+// IDProperty returns the Pulumi property that models the TF `id` attribute —
+// the dynamic bridge's renamed <resource>Id — or nil when the schema does not
+// model id. Always resolve via the mapping: fixID's naming rule varies with
+// the schema's other fields.
 func IDProperty(r *schema.Resource, mapping *bridge.BodyMapping) *schema.Property {
 	_, p := resolvePulumiProperty("id", r.Properties, mapping)
 	return p

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -687,18 +687,32 @@ func ctyToResourceInputs(val cty.Value, r *schema.Resource, attrExprs map[string
 
 // CtyToResourceOutputs converts a TF-shaped attributes object (e.g. decoded
 // state attributes) into the resource's Pulumi output property map, dropping
-// what TF stores but Pulumi does not project: `id` lives outside a Pulumi
-// resource's schema properties, and SDKv2 keeps the resource's `timeouts`
-// block in state attributes (the name is reserved, so it is never a real
-// schema field).
+// what TF stores but Pulumi does not project: SDKv2 keeps the resource's
+// `timeouts` block in state attributes (the name is reserved, so it is never
+// a real schema field), and the classic bridge keeps `id` outside a Pulumi
+// resource's schema properties. The dynamic bridge instead renames `id` to a
+// real schema property (aws_s3_bucket → s3BucketId), so `id` is dropped only
+// when it does not project into the schema.
 func CtyToResourceOutputs(val cty.Value, r *schema.Resource, mapping *bridge.BodyMapping) (property.Map, error) {
 	if ty := val.Type(); ty.IsObjectType() && (ty.HasAttribute("id") || ty.HasAttribute("timeouts")) {
 		attrs := val.AsValueMap()
-		delete(attrs, "id")
+		if IDProperty(r, mapping) == nil {
+			delete(attrs, "id")
+		}
 		delete(attrs, "timeouts")
 		val = cty.ObjectVal(attrs)
 	}
 	return ctyToObject(r.Token, val, r.Properties, nil, false /* already in a secret */, mapping)
+}
+
+// IDProperty returns the schema property the TF `id` attribute projects to,
+// or nil when id lives outside the schema's properties. The dynamic bridge
+// renames id per resource (fixID installs the rename in the mapping's field
+// overrides); resolve through the mapping, never by reconstructing the naming
+// rule — the rename's fallback candidates vary with the schema's other fields.
+func IDProperty(r *schema.Resource, mapping *bridge.BodyMapping) *schema.Property {
+	_, p := resolvePulumiProperty("id", r.Properties, mapping)
+	return p
 }
 
 func ctyToFunctionInputs(val cty.Value, r *schema.Function, attrExprs map[string]hcl.Expression, mapping *bridge.BodyMapping) (property.Map, error) {


### PR DESCRIPTION
When we import state, we previously removed the `id` property unconditionally. However, in many cases, there's a valid property name for the `id` in the schema we're importing into (e.g. `s3BucketId`, `resourceId`, and so on). This meant that, when we imported in, we would see changes in the `pulumi preview`: the resource's ID property was there before and isn't now, so we need to replace.

Now, we check whether we know where the ID property is, and map the ID value to it where possible.
Tested with the example in the issue. Closes https://github.com/pulumi/pulumi-hcl/issues/512.