### PR TITLE
Include system in default module path

### DIFF
--- a/.changes/unreleased/resource-host-bug-fixes-0000.yaml
+++ b/.changes/unreleased/resource-host-bug-fixes-0000.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Include system in module package path
+time: 2026-08-06T10:34:17.292349+02:00
+custom:
+    Component: resource-host
+    PR: "0000"

--- a/pkg/server/parameterize.go
+++ b/pkg/server/parameterize.go
@@ -478,7 +478,11 @@ func bundleResolver(unpackDir string, manifest bundleManifest) modules.ResolverF
 func defaultPackageName(source string) string {
 	pkgSource, _ := getmodules.SplitPackageSubdir(source)
 	if mod, err := regaddr.ParseModuleSource(pkgSource); err == nil {
-		return sanitizePackageName(mod.Package.Name)
+		pkg := sanitizePackageName(mod.Package.Name, "module")
+		if sys := sanitizePackageName(mod.Package.TargetSystem, ""); sys != "" {
+			pkg += "-" + sys
+		}
+		return pkg
 	}
 	s := pkgSource
 	if i := strings.IndexByte(s, '?'); i >= 0 {
@@ -489,12 +493,12 @@ func defaultPackageName(source string) string {
 		s = s[i+1:]
 	}
 	s = strings.TrimSuffix(s, ".git")
-	return sanitizePackageName(s)
+	return sanitizePackageName(s, "module")
 }
 
 // sanitizePackageName reduces a name to the lowercase alphanumeric-and-hyphen
 // form Pulumi package names use, falling back to "module" when nothing remains.
-func sanitizePackageName(name string) string {
+func sanitizePackageName(name, fallback string) string {
 	var b strings.Builder
 	for _, r := range strings.ToLower(name) {
 		switch {
@@ -507,7 +511,7 @@ func sanitizePackageName(name string) string {
 	if out := strings.Trim(b.String(), "-"); out != "" {
 		return out
 	}
-	return "module"
+	return fallback
 }
 
 // bundleEpoch is the fixed modification time stamped on every archive entry, so

--- a/pkg/server/parameterize_test.go
+++ b/pkg/server/parameterize_test.go
@@ -41,8 +41,8 @@ func TestDefaultPackageName(t *testing.T) {
 		source string
 		want   string
 	}{
-		{"terraform-aws-modules/vpc/aws", "vpc"},
-		{"terraform-aws-modules/vpc/aws//modules/subnets", "vpc"},
+		{"terraform-aws-modules/vpc/aws", "vpc-aws"},
+		{"terraform-aws-modules/vpc/aws//modules/subnets", "vpc-aws"},
 		{"github.com/org/my-repo", "my-repo"},
 		{"git::https://github.com/org/repo.git//subdir", "repo"},
 		{"git::https://example.com/foo/Bar_Baz.git", "bar-baz"},


### PR DESCRIPTION
Incorporate system into the generated package name of TF modules. For context, the grammer looks like this:

```
registry://terraform-modules/{source}/{publisher}/{name}-{system}[@{version}]
```