### PR TITLE
Correctly type unlabeled properties

### DIFF
--- a/.changes/unreleased/resource-host-bug-fixes-516.yaml
+++ b/.changes/unreleased/resource-host-bug-fixes-516.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Correctly type unlabeled properties
+time: 2026-08-06T15:14:29.414897+02:00
+custom:
+    Component: resource-host
+    PR: "516"

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -105,10 +105,23 @@ type ModuleSchema struct {
 	RequiredOutputs []string `json:"requiredOutputs,omitempty"`
 }
 
+// PropertyType enumerates the types a schema property can have.
+type PropertyType string
+
+const (
+	TypeString  PropertyType = "string"
+	TypeNumber  PropertyType = "number"
+	TypeBoolean PropertyType = "boolean"
+	TypeArray   PropertyType = "array"
+	TypeObject  PropertyType = "object"
+	// TypeAny is a dynamic or unconstrained value.
+	TypeAny PropertyType = "any"
+)
+
 // PropertySpec describes a property in the schema.
 type PropertySpec struct {
 	// Type is the property type.
-	Type string `json:"type,omitempty"`
+	Type PropertyType `json:"type,omitempty"`
 
 	// Description is the property description.
 	Description string `json:"description,omitempty"`
@@ -482,7 +495,7 @@ func variableToPropertySpec(v *ast.Variable) (*PropertySpec, error) {
 		prop.Properties = typeSpec.Properties
 	} else {
 		// Default to any type if no constraint specified
-		prop.Type = "object"
+		prop.Type = TypeAny
 	}
 
 	// A variable default is a constant expression (it cannot reference other
@@ -526,7 +539,7 @@ func ctyToConstant(val cty.Value) (any, bool) {
 // outputToPropertySpec converts an HCL output to a PropertySpec. val is the
 // unknown value inferred from the output's value expression; its type gives the
 // property shape and its per-attribute nullability gives nested required fields.
-// A DynamicPseudoType maps to the "object" (any) type.
+// A DynamicPseudoType maps to the any type.
 func outputToPropertySpec(o *ast.Output, val cty.Value) (*PropertySpec, error) {
 	prop, err := ctyValueToPropertySpec(val)
 	if err != nil {
@@ -560,23 +573,23 @@ func ctyValueToPropertySpec(v cty.Value) (*PropertySpec, error) {
 		}
 	}
 	sort.Strings(required)
-	return &PropertySpec{Type: "object", Properties: props, Required: required}, nil
+	return &PropertySpec{Type: TypeObject, Properties: props, Required: required}, nil
 }
 
 // ctyTypeToPropertySpec converts a cty.Type to a PropertySpec.
 func ctyTypeToPropertySpec(t cty.Type) (*PropertySpec, error) {
 	switch {
 	case t == cty.String:
-		return &PropertySpec{Type: "string"}, nil
+		return &PropertySpec{Type: TypeString}, nil
 
 	case t == cty.Number:
-		return &PropertySpec{Type: "number"}, nil
+		return &PropertySpec{Type: TypeNumber}, nil
 
 	case t == cty.Bool:
-		return &PropertySpec{Type: "boolean"}, nil
+		return &PropertySpec{Type: TypeBoolean}, nil
 
 	case t == cty.DynamicPseudoType:
-		return &PropertySpec{Type: "object"}, nil
+		return &PropertySpec{Type: TypeAny}, nil
 
 	case t.IsListType():
 		elemSpec, err := ctyTypeToPropertySpec(t.ElementType())
@@ -584,7 +597,7 @@ func ctyTypeToPropertySpec(t cty.Type) (*PropertySpec, error) {
 			return nil, err
 		}
 		return &PropertySpec{
-			Type:  "array",
+			Type:  TypeArray,
 			Items: elemSpec,
 		}, nil
 
@@ -595,7 +608,7 @@ func ctyTypeToPropertySpec(t cty.Type) (*PropertySpec, error) {
 			return nil, err
 		}
 		return &PropertySpec{
-			Type:  "array",
+			Type:  TypeArray,
 			Items: elemSpec,
 		}, nil
 
@@ -605,7 +618,7 @@ func ctyTypeToPropertySpec(t cty.Type) (*PropertySpec, error) {
 			return nil, err
 		}
 		return &PropertySpec{
-			Type:                 "object",
+			Type:                 TypeObject,
 			AdditionalProperties: elemSpec,
 		}, nil
 
@@ -623,7 +636,7 @@ func ctyTypeToPropertySpec(t cty.Type) (*PropertySpec, error) {
 			return nil, err
 		}
 		return &PropertySpec{
-			Type:  "array",
+			Type:  TypeArray,
 			Items: elemSpec,
 		}, nil
 
@@ -643,14 +656,14 @@ func ctyTypeToPropertySpec(t cty.Type) (*PropertySpec, error) {
 		}
 		sort.Strings(required)
 		return &PropertySpec{
-			Type:       "object",
+			Type:       TypeObject,
 			Properties: props,
 			Required:   required,
 		}, nil
 
 	default:
-		// Fall back to object type for unknown types
-		return &PropertySpec{Type: "object"}, nil
+		// Fall back to the any type for unknown types
+		return &PropertySpec{Type: TypeAny}, nil
 	}
 }
 
@@ -835,7 +848,7 @@ func (s *ModuleSchema) schemaType(
 	prop *PropertySpec, typeName string, types map[string]pulumischema.ComplexTypeSpec,
 ) pulumischema.TypeSpec {
 	switch {
-	case len(prop.Properties) > 0:
+	case prop.Properties != nil:
 		token := fmt.Sprintf("%s:%s:%s", s.PackageName, s.Module, typeName)
 		fields := make(map[string]pulumischema.PropertySpec, len(prop.Properties))
 		for name, field := range prop.Properties {
@@ -857,7 +870,9 @@ func (s *ModuleSchema) schemaType(
 	case prop.Items != nil:
 		elem := s.schemaType(prop.Items, typeName+"Item", types)
 		return pulumischema.TypeSpec{Type: "array", Items: &elem}
+	case prop.Type == TypeAny:
+		return pulumischema.TypeSpec{Ref: "pulumi.json#/Any"}
 	default:
-		return pulumischema.TypeSpec{Type: prop.Type}
+		return pulumischema.TypeSpec{Type: string(prop.Type)}
 	}
 }

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -133,7 +133,7 @@ output "count" {
 		t.Context(), config, &Binder{ModuleDir: moduleDir},
 		componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
 	require.NoError(t, err)
-	assert.Equal(t, &PropertySpec{Type: "number"}, moduleSchema.OutputProperties["count"])
+	assert.Equal(t, &PropertySpec{Type: TypeNumber}, moduleSchema.OutputProperties["count"])
 }
 
 // TestGenerateModuleSchemaFileLocalMissingFile shows that a file-backed local
@@ -158,7 +158,7 @@ output "count" {
 		t.Context(), config, &Binder{ModuleDir: moduleDir},
 		componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
 	require.NoError(t, err)
-	assert.Equal(t, &PropertySpec{Type: "object"}, moduleSchema.OutputProperties["count"])
+	assert.Equal(t, &PropertySpec{Type: TypeAny}, moduleSchema.OutputProperties["count"])
 }
 
 // stubResolver resolves a fixed set of resources by TF type, plus optionally a
@@ -231,9 +231,9 @@ output "length" {
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]*PropertySpec{
-		"id":       {Type: "string"},
-		"pet_name": {Type: "string"},
-		"length":   {Type: "number"},
+		"id":       {Type: TypeString},
+		"pet_name": {Type: TypeString},
+		"length":   {Type: TypeNumber},
 	}, moduleSchema.OutputProperties)
 }
 
@@ -275,14 +275,14 @@ output "keyed_id" {
 		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
 	require.NoError(t, err)
 
-	elem := &PropertySpec{Type: "object", Properties: map[string]*PropertySpec{
-		"id":     {Type: "string"},
-		"length": {Type: "number"},
+	elem := &PropertySpec{Type: TypeObject, Properties: map[string]*PropertySpec{
+		"id":     {Type: TypeString},
+		"length": {Type: TypeNumber},
 	}, Required: []string{"length"}}
 	assert.Equal(t, map[string]*PropertySpec{
-		"counted_id":  {Type: "string"},
-		"keyed_id":    {Type: "string"},
-		"all_counted": {Type: "array", Items: elem},
+		"counted_id":  {Type: TypeString},
+		"keyed_id":    {Type: TypeString},
+		"all_counted": {Type: TypeArray, Items: elem},
 	}, moduleSchema.OutputProperties)
 }
 
@@ -358,7 +358,7 @@ output "mode" {
 		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
 	require.NoError(t, err)
 
-	assert.Equal(t, map[string]*PropertySpec{"mode": {Type: "string"}}, moduleSchema.OutputProperties)
+	assert.Equal(t, map[string]*PropertySpec{"mode": {Type: TypeString}}, moduleSchema.OutputProperties)
 }
 
 func TestTryWrappedScalarOutputIsTyped(t *testing.T) {
@@ -388,8 +388,8 @@ output "try_id" {
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]*PropertySpec{
-		"bare_id": {Type: "string"},
-		"try_id":  {Type: "string"},
+		"bare_id": {Type: TypeString},
+		"try_id":  {Type: TypeString},
 	}, moduleSchema.OutputProperties)
 }
 
@@ -447,8 +447,8 @@ output "config"       { value = random_pet.this.config }
 		Type:     "object",
 		Required: []string{"host"},
 		Properties: map[string]*PropertySpec{
-			"host": {Type: "string"},
-			"port": {Type: "number"},
+			"host": {Type: TypeString},
+			"port": {Type: TypeNumber},
 		},
 	}, moduleSchema.OutputProperties["config"])
 }
@@ -512,8 +512,8 @@ output "n" {
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]*PropertySpec{
-		"greeting": {Type: "string"},
-		"n":        {Type: "number"},
+		"greeting": {Type: TypeString},
+		"n":        {Type: TypeNumber},
 	}, moduleSchema.OutputProperties)
 }
 
@@ -639,16 +639,16 @@ func TestBoundaryNameConversion(t *testing.T) {
 
 	s := &ModuleSchema{
 		InputProperties: map[string]*PropertySpec{
-			"object_in": {Type: "object", Properties: map[string]*PropertySpec{
-				"field_one": {Type: "string"},
+			"object_in": {Type: TypeObject, Properties: map[string]*PropertySpec{
+				"field_one": {Type: TypeString},
 			}},
-			"map_in": {Type: "object", AdditionalProperties: &PropertySpec{Type: "string"}},
+			"map_in": {Type: TypeObject, AdditionalProperties: &PropertySpec{Type: TypeString}},
 		},
 		OutputProperties: map[string]*PropertySpec{
-			"object_out": {Type: "object", Properties: map[string]*PropertySpec{
-				"field_two": {Type: "string"},
+			"object_out": {Type: TypeObject, Properties: map[string]*PropertySpec{
+				"field_two": {Type: TypeString},
 			}},
-			"map_out": {Type: "object", AdditionalProperties: &PropertySpec{Type: "string"}},
+			"map_out": {Type: TypeObject, AdditionalProperties: &PropertySpec{Type: TypeString}},
 		},
 	}
 
@@ -675,6 +675,46 @@ func TestBoundaryNameConversion(t *testing.T) {
 		"object_out": map[string]any{"field_two": "c"},
 		"map_out":    map[string]any{"user_key": "d"},
 	})))
+}
+
+// TestAnyTypedVariableIsAny reproduces
+// https://github.com/pulumi/pulumi-hcl/issues/515: a module input declared
+// `type = any` (or with no type constraint) must surface in the Pulumi schema
+// as the Any type, not as a bare `object` — a bare `object` type spec means a
+// map of string, so generated SDKs reject a plain string value. An empty
+// object type is not any: it stays a named object type.
+func TestAnyTypedVariableIsAny(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+variable "source_path" {
+  type = any
+}
+
+variable "untyped" {
+}
+
+variable "empty_object" {
+  type = object({})
+}
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, nil, componentToken("lambda", "index", "Module"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+
+	pkgSpec := moduleSchema.ToPulumiPackageSchema()
+	_, bindDiags, err := pulumiSchema.BindSpec(pkgSpec, errLoader{}, pulumiSchema.ValidationOptions{})
+	require.NoError(t, err)
+	require.False(t, bindDiags.HasErrors(), bindDiags.Error())
+
+	inputs := pkgSpec.Resources["lambda:index:Module"].InputProperties
+	anyType := pulumiSchema.TypeSpec{Ref: "pulumi.json#/Any"}
+	assert.Equal(t, anyType, inputs["sourcePath"].TypeSpec)
+	assert.Equal(t, anyType, inputs["untyped"].TypeSpec)
+	assert.Equal(t, pulumiSchema.TypeSpec{Ref: "#/types/lambda:index:EmptyObject"}, inputs["emptyObject"].TypeSpec)
 }
 
 // TestProviderFunctionOutputIsTyped shows that an output calling a
@@ -714,7 +754,7 @@ output "arn" {
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]*PropertySpec{
-		"arn": {Type: "string"},
+		"arn": {Type: TypeString},
 	}, moduleSchema.OutputProperties)
 }
 
@@ -767,12 +807,12 @@ output "parsed" {
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]*PropertySpec{
-		"service": {Type: "string"},
+		"service": {Type: TypeString},
 		"parsed": {
-			Type: "object",
+			Type: TypeObject,
 			Properties: map[string]*PropertySpec{
-				"service":    {Type: "string"},
-				"account_id": {Type: "string"},
+				"service":    {Type: TypeString},
+				"account_id": {Type: TypeString},
 			},
 			Required: []string{"service"},
 		},

--- a/pkg/hcl/schema/testdata/sensitive/main.tf
+++ b/pkg/hcl/schema/testdata/sensitive/main.tf
@@ -5,7 +5,7 @@ variable "sensitive_string" {
 }
 
 variable "untyped_value" {
-  description = "No type constraint, so it defaults to the object (any) type."
+  description = "No type constraint, so it defaults to the any type."
 }
 
 output "sensitive_output" {

--- a/pkg/hcl/schema/testdata/sensitive/schema.json
+++ b/pkg/hcl/schema/testdata/sensitive/schema.json
@@ -14,8 +14,8 @@
           "secret": true
         },
         "untypedValue": {
-          "type": "object",
-          "description": "No type constraint, so it defaults to the object (any) type."
+          "$ref": "pulumi.json#/Any",
+          "description": "No type constraint, so it defaults to the any type."
         }
       },
       "type": "object",
@@ -29,8 +29,8 @@
           "secret": true
         },
         "untypedValue": {
-          "type": "object",
-          "description": "No type constraint, so it defaults to the object (any) type."
+          "$ref": "pulumi.json#/Any",
+          "description": "No type constraint, so it defaults to the any type."
         }
       },
       "requiredInputs": [


### PR DESCRIPTION
We had incorrectly used an empty `"object"` type to represent `any`, which in the Pulumi schema means an `map[string]string` type. This fix correctly changes our representation to a proper `"pulumi.json#/Any"` type.

Fixes https://github.com/pulumi/pulumi-hcl/issues/515