### PR TITLE
Classify plan-time reads through root locals' classified deps

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-514.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-514.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Fix false `Cycle found` when a data source reaches a resource only through a root local
+time: 2026-08-06T13:56:28Z
+custom:
+    Component: runtime
+    PR: "514"

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -707,14 +707,34 @@ func (g *Graph) classifyPlanTimeReads() {
 			return v
 		}
 		memo[n] = false
-		if in, ok := g.seen[g.keyByDagNode[n]]; ok && in.n.Type == NodeTypeResource {
-			memo[n] = true
-			return true
+		var node *Node
+		if in, ok := g.seen[g.keyByDagNode[n]]; ok {
+			node = in.n
+			if node.Type == NodeTypeResource {
+				memo[n] = true
+				return true
+			}
 		}
 		for p := range g.dag.Predecessors(n) {
 			if reachesResource(p) {
 				memo[n] = true
 				return true
+			}
+		}
+		// A node whose classified deps omit block-level edges (root locals)
+		// still reads the blocks those deps name.
+		if node != nil && node.Deps != nil {
+			for _, whole := range node.Deps.Whole {
+				if in, ok := g.seen[whole]; ok && reachesResource(in.i) {
+					memo[n] = true
+					return true
+				}
+			}
+			for _, narrow := range node.Deps.Narrow {
+				if in, ok := g.seen[narrow.Node]; ok && reachesResource(in.i) {
+					memo[n] = true
+					return true
+				}
 			}
 		}
 		return false

--- a/tests/tfcompat/l2_data_ref_via_local_chain_test.go
+++ b/tests/tfcompat/l2_data_ref_via_local_chain_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2DataRefViaLocalChain exercises a data source that reaches a resource
+// through a chain of root locals: the read must defer until the resource is
+// applied, exactly as with a single intermediate local.
+//
+// https://github.com/pulumi/pulumi-hcl/issues/514
+func TestL2DataRefViaLocalChain(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_ref_via_local_chain", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_data_ref_via_local_test.go
+++ b/tests/tfcompat/l2_data_ref_via_local_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2DataRefViaLocal exercises a data source whose only path to a resource
+// runs through a root local: the read must defer until the resource is
+// applied, exactly as it would with a direct resource reference.
+//
+// https://github.com/pulumi/pulumi-hcl/issues/514
+func TestL2DataRefViaLocal(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_data_ref_via_local", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_module_input_via_local_test.go
+++ b/tests/tfcompat/l2_module_input_via_local_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2ModuleInputViaLocal exercises a module call whose input reaches a
+// resource only through a root local: the data source inside the module reads
+// that input, so its read must defer until the resource is applied rather
+// than gate the plan phase.
+//
+// https://github.com/pulumi/pulumi-hcl/issues/514
+func TestL2ModuleInputViaLocal(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_module_input_via_local", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_data_ref_via_local/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_ref_via_local/main.tf
@@ -1,0 +1,18 @@
+# A data source that references a resource only through a root local. The
+# read cannot happen at plan time — its input is computed by the resource —
+# so it defers until the resource is applied.
+resource "simple_resource" "res" {
+  input_one = "a"
+}
+
+locals {
+  val = simple_resource.res.result
+}
+
+data "simple_lookup" "lookup" {
+  query = local.val
+}
+
+output "out" {
+  value = data.simple_lookup.lookup.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_data_ref_via_local_chain/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_data_ref_via_local_chain/main.tf
@@ -1,0 +1,18 @@
+# A data source that reaches a resource through a chain of root locals. The
+# read defers until the resource is applied, exactly as with a single local.
+resource "simple_resource" "res" {
+  input_one = "a"
+}
+
+locals {
+  val     = simple_resource.res.result
+  chained = "${local.val}-c"
+}
+
+data "simple_lookup" "lookup" {
+  query = local.chained
+}
+
+output "out" {
+  value = data.simple_lookup.lookup.prefix_result
+}

--- a/tests/tfcompat/testdata/cases/l2_module_input_via_local/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_input_via_local/main.tf
@@ -1,0 +1,19 @@
+# A module call whose input reaches a resource only through a root local. The
+# data source inside the module reads that input, so its read defers until the
+# resource is applied.
+resource "simple_resource" "res" {
+  input_one = "a"
+}
+
+locals {
+  val = simple_resource.res.result
+}
+
+module "child" {
+  source = "./modules/child"
+  query  = local.val
+}
+
+output "out" {
+  value = module.child.out
+}

--- a/tests/tfcompat/testdata/cases/l2_module_input_via_local/modules/child/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_module_input_via_local/modules/child/main.tf
@@ -1,0 +1,11 @@
+variable "query" {
+  type = string
+}
+
+data "simple_lookup" "lookup" {
+  query = var.query
+}
+
+output "out" {
+  value = data.simple_lookup.lookup.prefix_result
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-hcl/issues/514

Instantiating locals-heavy modules (`terraform-aws-modules/vpc/aws`, `terraform-aws-modules/lambda/aws`) failed during graph construction with `materializing expansion cells: Cycle found`.

## Root cause

Root locals deliberately carry no block-level edges in the static graph — the engine wires their resource/data dependencies at instance granularity (`wireRootLocals`) so narrowness flows through them. But `classifyPlanTimeReads` ran its resource-reachability walk over that same static graph, so a data source that reaches a resource **only through a root local** was misclassified as a plan-time read. Wiring then produced the cycle:

```
data-complete → plan barrier → resource-expand → resource-complete → local → data-expand
```

In the VPC module the instance is `aws_cloudwatch_log_group.flow_log` → `local.flow_log_group_arns` → `data.aws_iam_policy_document.vpc_flow_log_cloudwatch`. Since `hcl.Module` runs the module source as the root config of a nested engine, module-internal shapes hit `materializeRootCells` directly.

## Fix

The reachability walk now also follows the classified `Deps.Whole`/`Deps.Narrow` keys of nodes that omit block-level edges — the same pattern `ForcedCreateBeforeDestroy` already uses for the same reason. Such reads classify as deferred and the existing deferred-read machinery handles them.

Two tfcompat cases pin the fix, both failing with the exact issue error before it:

- `l2_data_ref_via_local` — the direct shape: resource → root local → data source.
- `l2_module_input_via_local` — the sibling from the same root cause: a module call whose input reaches a resource through a root local, with a data source inside the module reading that input (pre-fix this cycled at the init→barrier ordering instead).

Verified additionally that `terraform-aws-modules/vpc/aws` 6.0.0 now materializes its root cells cleanly.