### PR TITLE
Name the participating nodes in dependency-cycle errors

### DIFF
--- a/.changes/unreleased/runtime-improvements-526.yaml
+++ b/.changes/unreleased/runtime-improvements-526.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Name the participating nodes in dependency-cycle errors instead of `Cycle found`
+time: 2026-08-06T15:00:03Z
+custom:
+    Component: runtime
+    PR: "526"

--- a/pkg/hcl/graph/expansion.go
+++ b/pkg/hcl/graph/expansion.go
@@ -78,15 +78,15 @@ func (g *Graph) NewBlockExpansion(key NodeKey, static bool, expandExec func(cont
 		defer b.finish()
 		return expandExec(ctx)
 	}
+	expandDesc := nodeDesc{block: key, aspect: aspectExpand}
 	if static {
-		b.expand, b.armExpand = g.internExecNode(NodeKey{Module: key.Module, ID: key.ID + "!expand"}, exec)
+		b.expand, b.armExpand = g.internExecNode(NodeKey{Module: key.Module, ID: key.ID + "!expand"}, expandDesc, exec)
 	} else {
-		// The key is display-only (cycle reports), deliberately not interned.
-		b.expand, b.armExpand = g.dag.NewNode(dagNode{key: NodeKey{Module: key.Module, ID: key.ID + "!expand"}, exec: exec})
+		b.expand, b.armExpand = g.dag.NewNode(dagNode{desc: expandDesc, exec: exec})
 	}
 
 	complete, armComplete := g.dag.NewNode(dagNode{
-		key:  NodeKey{Module: key.Module, ID: key.ID + "!complete"},
+		desc: nodeDesc{block: key, aspect: aspectComplete},
 		exec: func(context.Context) error { return nil },
 	})
 	b.complete = complete
@@ -115,7 +115,7 @@ func (b *BlockExpansion) Gate(suffix string) pdag.Node {
 		return gate
 	}
 	gate, arm := b.g.dag.NewNode(dagNode{
-		key:  NodeKey{Module: b.key.Module, ID: b.key.ID + suffix + "!gate"},
+		desc: nodeDesc{block: b.key, aspect: aspectGate, index: suffix},
 		exec: func(context.Context) error { return nil },
 	})
 	contract.AssertNoErrorf(b.g.dag.NewEdge(b.expand, gate), "fresh nodes cannot form a cycle")
@@ -141,7 +141,7 @@ func (b *BlockExpansion) CompleteBefore(n pdag.Node) error {
 // returns (finish arms them after all wiring).
 func (b *BlockExpansion) AddInstance(suffix string, exec func(context.Context) error) error {
 	inst, arm := b.g.dag.NewNode(dagNode{
-		key:  NodeKey{Module: b.key.Module, ID: b.key.ID + suffix},
+		desc: nodeDesc{block: b.key, aspect: aspectInstance, index: suffix},
 		exec: exec,
 	})
 	// Arm even on the error paths: a node left preparing stalls the walk

--- a/pkg/hcl/graph/expansion.go
+++ b/pkg/hcl/graph/expansion.go
@@ -81,10 +81,14 @@ func (g *Graph) NewBlockExpansion(key NodeKey, static bool, expandExec func(cont
 	if static {
 		b.expand, b.armExpand = g.internExecNode(NodeKey{Module: key.Module, ID: key.ID + "!expand"}, exec)
 	} else {
-		b.expand, b.armExpand = g.dag.NewNode(dagNode{exec: exec})
+		// The key is display-only (cycle reports), deliberately not interned.
+		b.expand, b.armExpand = g.dag.NewNode(dagNode{key: NodeKey{Module: key.Module, ID: key.ID + "!expand"}, exec: exec})
 	}
 
-	complete, armComplete := g.dag.NewNode(dagNode{exec: func(context.Context) error { return nil }})
+	complete, armComplete := g.dag.NewNode(dagNode{
+		key:  NodeKey{Module: key.Module, ID: key.ID + "!complete"},
+		exec: func(context.Context) error { return nil },
+	})
 	b.complete = complete
 	contract.AssertNoErrorf(g.dag.NewEdge(b.expand, complete), "fresh nodes cannot form a cycle")
 	armComplete()
@@ -94,7 +98,7 @@ func (g *Graph) NewBlockExpansion(key NodeKey, static bool, expandExec func(cont
 // DependOn orders the expansion after dep: no instance is created (and so no
 // instance work runs) until dep is done.
 func (b *BlockExpansion) DependOn(dep pdag.Node) error {
-	return b.g.dag.NewEdge(dep, b.expand)
+	return cycleError(b.g.dag.NewEdge(dep, b.expand))
 }
 
 // Complete returns the node that is done once every instance has finished.
@@ -110,7 +114,10 @@ func (b *BlockExpansion) Gate(suffix string) pdag.Node {
 	if gate, ok := b.gates[suffix]; ok {
 		return gate
 	}
-	gate, arm := b.g.dag.NewNode(dagNode{exec: func(context.Context) error { return nil }})
+	gate, arm := b.g.dag.NewNode(dagNode{
+		key:  NodeKey{Module: b.key.Module, ID: b.key.ID + suffix + "!gate"},
+		exec: func(context.Context) error { return nil },
+	})
 	contract.AssertNoErrorf(b.g.dag.NewEdge(b.expand, gate), "fresh nodes cannot form a cycle")
 	arm()
 	b.gates[suffix] = gate
@@ -125,7 +132,7 @@ func (b *BlockExpansion) Arm() { b.armExpand() }
 // the expansion (the block's own graph node, in particular) waits for every
 // instance.
 func (b *BlockExpansion) CompleteBefore(n pdag.Node) error {
-	return b.g.dag.NewEdge(b.complete, n)
+	return cycleError(b.g.dag.NewEdge(b.complete, n))
 }
 
 // AddInstance creates the node that runs one instance's work, ordered before
@@ -133,15 +140,18 @@ func (b *BlockExpansion) CompleteBefore(n pdag.Node) error {
 // Only call from the expand exec. Instances become runnable when the exec
 // returns (finish arms them after all wiring).
 func (b *BlockExpansion) AddInstance(suffix string, exec func(context.Context) error) error {
-	inst, arm := b.g.dag.NewNode(dagNode{exec: exec})
+	inst, arm := b.g.dag.NewNode(dagNode{
+		key:  NodeKey{Module: b.key.Module, ID: b.key.ID + suffix},
+		exec: exec,
+	})
 	// Arm even on the error paths: a node left preparing stalls the walk
 	// forever, while an armed node at worst runs before the walk aborts.
 	b.armPending = append(b.armPending, arm)
-	if err := b.g.dag.NewEdge(inst, b.complete); err != nil {
+	if err := cycleError(b.g.dag.NewEdge(inst, b.complete)); err != nil {
 		return err
 	}
 	if gate, ok := b.gates[suffix]; ok {
-		if err := b.g.dag.NewEdge(inst, gate); err != nil {
+		if err := cycleError(b.g.dag.NewEdge(inst, gate)); err != nil {
 			return err
 		}
 		delete(b.gates, suffix)

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -396,7 +396,7 @@ func (g *Graph) InjectAfter(f func(context.Context) error, match func(*Node) boo
 			err = g.dag.NewEdge(n, node.i)
 		}
 		if err != nil {
-			return err
+			return cycleError(err)
 		}
 	}
 	return nil
@@ -423,7 +423,7 @@ func (g *Graph) AddNode(node *Node, deps []pdag.Node) error {
 	n, i := g.newNode(node.Key)
 	*n = *node
 	for _, dep := range deps {
-		err := g.dag.NewEdge(dep, i)
+		err := cycleError(g.dag.NewEdge(dep, i))
 		if err != nil {
 			return err
 		}
@@ -766,7 +766,29 @@ func (g *Graph) NewJoinNode(key string) pdag.Node {
 
 // Order adds the edge from → to.
 func (g *Graph) Order(from, to pdag.Node) error {
-	return g.dag.NewEdge(from, to)
+	return cycleError(g.dag.NewEdge(from, to))
+}
+
+// cycleError rewraps a pdag cycle error to name the participating nodes in
+// dependency order, closing the loop back on the first node. Nodes without a
+// key (display or interned) are dropped from the report; other errors pass
+// through unchanged.
+func cycleError(err error) error {
+	var c pdag.ErrorCycle[dagNode]
+	if !errors.As(err, &c) {
+		return err
+	}
+	var parts []string
+	for _, n := range c.Cycle {
+		if s := n.key.String(); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	if len(parts) == 0 {
+		return err
+	}
+	parts = append(parts, parts[0])
+	return fmt.Errorf("dependency cycle: %s", strings.Join(parts, " -> "))
 }
 
 // defaultProviderDeps returns an implicit dependency on the un-aliased

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -306,8 +306,53 @@ type Graph struct {
 	missingProviders map[string]*hcl.Diagnostic
 }
 
+// aspect is the scheduling role a dag node plays for its block: the block's
+// own graph node, or one of the expansion-skeleton nodes serving it.
+type aspect int
+
+const (
+	aspectBlock aspect = iota
+	aspectExpand
+	aspectComplete
+	aspectGate
+	aspectInstance
+	aspectSync
+)
+
+// nodeDesc says what a dag node stands for, for diagnostics only — identity
+// lives in the graph's interning maps. The zero value describes an anonymous
+// node and renders empty.
+type nodeDesc struct {
+	block  NodeKey // the config block the node serves; zero for named synthetics
+	aspect aspect
+	index  string // instance suffix for gates/instances: `[0]`, `["x"]`
+	name   string // for named synchronization points ("plan barrier")
+}
+
+func (d nodeDesc) String() string {
+	if d.name != "" {
+		return d.name
+	}
+	addr := d.block.String()
+	if addr == "" {
+		return ""
+	}
+	switch d.aspect {
+	case aspectExpand:
+		return addr + " (expand)"
+	case aspectComplete:
+		return addr + " (completion)"
+	case aspectGate:
+		return addr + d.index + " (gate)"
+	case aspectInstance:
+		return addr + d.index
+	default:
+		return addr
+	}
+}
+
 type dagNode struct {
-	key  NodeKey
+	desc nodeDesc
 	exec func(context.Context) error
 }
 
@@ -350,7 +395,7 @@ func (g *Graph) Walk(ctx context.Context, apply func(context.Context, *Node) err
 		if n.exec != nil {
 			return n.exec(ctx)
 		}
-		node, ok := g.seen[n.key]
+		node, ok := g.seen[n.desc.block]
 		contract.Assertf(ok, "invalid graph - key not interned")
 		return apply(ctx, node.n)
 	}, pdag.MaxProcs(parallel))
@@ -407,7 +452,7 @@ func (g *Graph) newNode(key NodeKey) (*Node, pdag.Node) {
 		contract.Assertf(n.n.Key == key, "key should not be changed")
 		return n.n, n.i
 	}
-	i, done := g.dag.NewNode(dagNode{key: key})
+	i, done := g.dag.NewNode(dagNode{desc: nodeDesc{block: key}})
 	n := &Node{Key: key}
 	done() // We don't execute the graph as we build - so this is always safe
 	g.seen[key] = internedNode{
@@ -749,17 +794,19 @@ func (g *Graph) classifyPlanTimeReads() {
 // internExecNode creates an exec node interned under key (as a Builtin, so
 // pre-walk passes see it but Validate accepts it), leaving arming to the
 // caller.
-func (g *Graph) internExecNode(key NodeKey, exec func(context.Context) error) (pdag.Node, pdag.Done) {
-	i, done := g.dag.NewNode(dagNode{key: key, exec: exec})
+func (g *Graph) internExecNode(key NodeKey, desc nodeDesc, exec func(context.Context) error) (pdag.Node, pdag.Done) {
+	i, done := g.dag.NewNode(dagNode{desc: desc, exec: exec})
 	g.seen[key] = internedNode{i: i, n: &Node{Key: key, Type: NodeTypeBuiltin}}
 	g.keyByDagNode[i] = key
 	return i, done
 }
 
 // NewJoinNode creates an armed no-op node interned under key, for the engine
-// to use as a synchronization point (edges added via Order).
-func (g *Graph) NewJoinNode(key string) pdag.Node {
-	i, done := g.internExecNode(NodeKey{ID: key}, func(context.Context) error { return nil })
+// to use as a synchronization point (edges added via Order). name is how the
+// node reads in diagnostics.
+func (g *Graph) NewJoinNode(key, name string) pdag.Node {
+	i, done := g.internExecNode(NodeKey{ID: key}, nodeDesc{aspect: aspectSync, name: name},
+		func(context.Context) error { return nil })
 	done()
 	return i
 }
@@ -770,9 +817,8 @@ func (g *Graph) Order(from, to pdag.Node) error {
 }
 
 // cycleError rewraps a pdag cycle error to name the participating nodes in
-// dependency order, closing the loop back on the first node. Nodes without a
-// key (display or interned) are dropped from the report; other errors pass
-// through unchanged.
+// dependency order, closing the loop back on the first node. Anonymous nodes
+// are dropped from the report; other errors pass through unchanged.
 func cycleError(err error) error {
 	var c pdag.ErrorCycle[dagNode]
 	if !errors.As(err, &c) {
@@ -780,7 +826,7 @@ func cycleError(err error) error {
 	}
 	var parts []string
 	for _, n := range c.Cycle {
-		if s := n.key.String(); s != "" {
+		if s := n.desc.String(); s != "" {
 			parts = append(parts, s)
 		}
 	}

--- a/pkg/hcl/graph/graph_test.go
+++ b/pkg/hcl/graph/graph_test.go
@@ -66,7 +66,7 @@ output "instance_id" {
 	// Verify topological sort works
 	var sorted []string
 	err = g.dag.Walk(t.Context(), func(_ context.Context, n dagNode) error {
-		sorted = append(sorted, n.key.String())
+		sorted = append(sorted, n.desc.String())
 		return nil
 	}, pdag.MaxProcs(1))
 	require.NoError(t, err)
@@ -131,7 +131,7 @@ output "gate" {
 
 	var sorted []string
 	err = g.dag.Walk(t.Context(), func(_ context.Context, n dagNode) error {
-		key := n.key.String()
+		key := n.desc.String()
 		if n.exec != nil {
 			key = barrierKey
 		}
@@ -423,5 +423,5 @@ func TestCycleErrorLabelsExpansionNodes(t *testing.T) {
 	b := g.NewBlockExpansion(nk("pfx_res.a"), true, func(context.Context) error { return nil })
 
 	assert.EqualError(t, b.DependOn(b.Complete()),
-		"dependency cycle: pfx_res.a!complete -> pfx_res.a!expand -> pfx_res.a!complete")
+		"dependency cycle: pfx_res.a (completion) -> pfx_res.a (expand) -> pfx_res.a (completion)")
 }

--- a/pkg/hcl/graph/graph_test.go
+++ b/pkg/hcl/graph/graph_test.go
@@ -402,3 +402,26 @@ func TestModuleAddress(t *testing.T) {
 	assert.Equal(t, "aws_instance.web",
 		NodeKey{ID: "aws_instance.web"}.String())
 }
+
+func TestCycleErrorNamesNodes(t *testing.T) {
+	t.Parallel()
+	g := NewGraph()
+	require.NoError(t, g.AddNode(&Node{Key: nk("local.a")}, nil))
+	aIdx, ok := g.KeyNode(nk("local.a"))
+	require.True(t, ok)
+	require.NoError(t, g.AddNode(&Node{Key: nk("local.b")}, []pdag.Node{aIdx}))
+	bIdx, ok := g.KeyNode(nk("local.b"))
+	require.True(t, ok)
+
+	assert.EqualError(t, g.Order(bIdx, aIdx),
+		"dependency cycle: local.b -> local.a -> local.b")
+}
+
+func TestCycleErrorLabelsExpansionNodes(t *testing.T) {
+	t.Parallel()
+	g := NewGraph()
+	b := g.NewBlockExpansion(nk("pfx_res.a"), true, func(context.Context) error { return nil })
+
+	assert.EqualError(t, b.DependOn(b.Complete()),
+		"dependency cycle: pfx_res.a!complete -> pfx_res.a!expand -> pfx_res.a!complete")
+}

--- a/pkg/hcl/graph/provisioner_reference_test.go
+++ b/pkg/hcl/graph/provisioner_reference_test.go
@@ -52,7 +52,7 @@ func walkOrder(t *testing.T, g *Graph) []string {
 	t.Helper()
 	var order []string
 	err := g.dag.Walk(t.Context(), func(_ context.Context, n dagNode) error {
-		order = append(order, n.key.String())
+		order = append(order, n.desc.String())
 		return nil
 	}, pdag.MaxProcs(1))
 	require.NoError(t, err)

--- a/pkg/hcl/run/cells.go
+++ b/pkg/hcl/run/cells.go
@@ -120,7 +120,7 @@ func (r *urnRegistry) widen(urns []string) []string {
 // resource/data block, plus the plan barrier separating plan-time data reads
 // from resource creation. Runs after graph validation and before the walk.
 func (e *Engine) materializeRootCells(g *graph.Graph) error {
-	e.planBarrier = g.NewJoinNode("!plan-reads")
+	e.planBarrier = g.NewJoinNode("!plan-reads", "plan barrier")
 
 	var blocks, locals []*graph.Node
 	for _, node := range g.ExpandableNodes() {


### PR DESCRIPTION
The error-reporting follow-up from https://github.com/pulumi/pulumi-hcl/issues/514: a dependency-graph cycle surfaced as a bare `Cycle found`, which is what made that issue undiagnosable from the report alone. `pdag.ErrorCycle` carries the participating nodes; now every graph seam that can return a cycle rewraps it with the participants in dependency order:

```
dependency cycle: simple_resource.a -> simple_resource.b -> simple_resource.a
```

The dag payload now carries a typed `nodeDesc` — the block a node serves, the scheduling aspect it plays (expand, completion, gate, instance, sync), and an instance suffix — instead of overloading the interning key with `!`-suffixed pseudo-IDs. Identity stays in the graph's interning maps; one `String` method owns the rendering, so a cycle through the expansion skeleton names the block and aspect involved. The #514 false cycle would have rendered as:

```
dependency cycle: simple_resource.res (completion) -> local.val -> data.simple_lookup.d (expand) -> data.simple_lookup.d (completion) -> plan barrier -> simple_resource.res (expand) -> simple_resource.res (completion)
```

Unit tests pin both the plain-address and expansion-node renderings. No tfcompat case: the exact text is runtime-specific, so both runtimes cannot share an error assertion.