### PR TITLE
Emit one component per consumable module directory

### DIFF
--- a/.changes/unreleased/resource-host-improvements-529.yaml
+++ b/.changes/unreleased/resource-host-improvements-529.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Serve one component per consumable module directory (root and `modules/<name>`), including packages with no root `.tf` files
+time: 2026-08-10T12:00:00Z
+custom:
+    Component: resource-host
+    PR: "529"

--- a/docs/mlc.md
+++ b/docs/mlc.md
@@ -85,6 +85,34 @@ The component's resource token is formed as:
 
 For the example above, the token would be `my-networking:index:VpcNetwork`.
 
+## Submodules
+
+A module package serves one component per consumable directory, following the
+registry convention that both the root and `modules/<name>` directories are
+consumed directly:
+
+| Terraform directory                 | Pulumi component token    |
+|-------------------------------------|---------------------------|
+| the root, when it holds `.tf` files | `{package}:index:Module`  |
+| `modules/<name>`                    | `{package}:<name>:Module` |
+
+The root module names the package (its `package` and `component` blocks apply
+as described above); submodules are always served as `Module` under a module
+segment derived from their directory name, sanitized to lowercase
+alphanumerics and hyphens (`modules/_user_data` becomes `user-data`,
+`modules/a.b` becomes `a-b`). In generated Go SDKs, a module segment that is
+not a valid Go package name maps to one (`user-data` becomes package
+`userdata`, `2fa` becomes `_2fa`). A package whose root holds no `.tf` files at
+all — common for registry packages such as `terraform-aws-modules/iam/aws` —
+serves only its submodule components, named after its source (or directory)
+and versioned by the resolved source version.
+
+Each component resolves its providers independently, as the separate
+configuration it is: sibling submodules may pin the same provider to
+different versions, or use one local name for different providers. Local
+packages are the exception — their components share the package's `sdks/`
+descriptor pool, which holds one descriptor per provider name.
+
 ## Validation Rules
 
 - `component.name` and `component.module` must be valid Pulumi names: one or more

--- a/pkg/hcl/modules/loader.go
+++ b/pkg/hcl/modules/loader.go
@@ -65,6 +65,21 @@ type Loader struct {
 	callStack []string
 
 	resolve ResolverFunc
+	// resolved caches successful package resolutions, so one package resolves
+	// (and, for registry sources, selects a version) once per Loader no matter
+	// how many of its subdirectories are loaded.
+	resolved map[resolveKey]resolvedPackage
+}
+
+type resolveKey struct {
+	packageSource     string
+	versionConstraint string
+	callerDir         string
+}
+
+type resolvedPackage struct {
+	dir     string
+	version string
 }
 
 // LoadedModule represents a loaded and parsed module.
@@ -80,9 +95,10 @@ type ResolverFunc = func(packageSource, versionConstraint, callerDir string) (di
 // the registry, and remote getters, downloading and caching as needed.
 func NewLoader(resolver ResolverFunc) *Loader {
 	return &Loader{
-		parser:  parser.NewParser(),
-		cache:   make(map[string]*LoadedModule),
-		resolve: resolver,
+		parser:   parser.NewParser(),
+		cache:    make(map[string]*LoadedModule),
+		resolve:  resolver,
+		resolved: make(map[resolveKey]resolvedPackage),
 	}
 }
 
@@ -185,15 +201,31 @@ func (l *Loader) LoadModule(ctx context.Context, source, versionConstraint, call
 	return module, nil
 }
 
+// ResolveDir resolves a module source to its directory on disk — downloading it
+// if necessary — without parsing it, plus the concrete version a registry source
+// resolved to.
+func (l *Loader) ResolveDir(source, versionConstraint, callerDir string) (string, string, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.resolveSource(source, versionConstraint, callerDir)
+}
+
 // resolveSource resolves a module source to an absolute path on disk, plus the
 // concrete version a registry source resolved to. versionConstraint applies
 // only to registry sources.
 func (l *Loader) resolveSource(source, versionConstraint, callerDir string) (string, string, error) {
 	packageSource, subdir := getmodules.SplitPackageSubdir(source)
-	packageDir, version, err := l.resolve(packageSource, versionConstraint, callerDir)
-	if err != nil {
-		return "", "", err
+	key := resolveKey{packageSource, versionConstraint, callerDir}
+	pkg, ok := l.resolved[key]
+	if !ok {
+		packageDir, version, err := l.resolve(packageSource, versionConstraint, callerDir)
+		if err != nil {
+			return "", "", err
+		}
+		pkg = resolvedPackage{dir: packageDir, version: version}
+		l.resolved[key] = pkg
 	}
+	packageDir, version := pkg.dir, pkg.version
 
 	if subdir != "" {
 		resolved := filepath.Join(packageDir, subdir)

--- a/pkg/hcl/modules/loader_test.go
+++ b/pkg/hcl/modules/loader_test.go
@@ -430,22 +430,22 @@ func TestLoaderResolvesViaCustomResolver(t *testing.T) {
 	}
 
 	l := NewLoader(func(packageSource, versionConstraint, _ string) (string, string, error) {
-		require.Equal(t, "acme/widget/aws", packageSource)
+		require.Equal(t, "acme/widget/cloud", packageSource)
 		require.Equal(t, "~> 4.0", versionConstraint)
 		return pkg, "4.2.0", nil
 	})
 
-	root, err := l.LoadModule(t.Context(), "acme/widget/aws", "~> 4.0", t.TempDir())
+	root, err := l.LoadModule(t.Context(), "acme/widget/cloud", "~> 4.0", t.TempDir())
 	require.NoError(t, err)
 	require.Equal(t, pkg, root.SourcePath)
 
 	// Two subdir references into the one resolved package resolve under it; the
 	// resolver only ever sees the package source.
-	a, err := l.LoadModule(t.Context(), "acme/widget/aws//a", "~> 4.0", t.TempDir())
+	a, err := l.LoadModule(t.Context(), "acme/widget/cloud//a", "~> 4.0", t.TempDir())
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(pkg, "a"), a.SourcePath)
 
-	b, err := l.LoadModule(t.Context(), "acme/widget/aws//b", "~> 4.0", t.TempDir())
+	b, err := l.LoadModule(t.Context(), "acme/widget/cloud//b", "~> 4.0", t.TempDir())
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(pkg, "b"), b.SourcePath)
 }
@@ -487,4 +487,34 @@ func TestSourceName(t *testing.T) {
 	for source, want := range tests {
 		assert.Equal(t, want, SourceName(source), source)
 	}
+}
+
+// TestLoaderResolvesPackageOnce verifies one package resolves once per Loader
+// regardless of how many of its subdirectories are loaded, while a different
+// constraint or caller still resolves anew.
+func TestLoaderResolvesPackageOnce(t *testing.T) {
+	t.Parallel()
+
+	pkg := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(pkg, "main.tf"), []byte(`output "r" { value = 1 }`), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(pkg, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkg, "sub", "main.tf"), []byte(`output "s" { value = 2 }`), 0o600))
+
+	count := 0
+	l := NewLoader(func(string, string, string) (string, string, error) {
+		count++
+		return pkg, "1.0.0", nil
+	})
+
+	_, _, err := l.ResolveDir("acme/widget/cloud", "", ".")
+	require.NoError(t, err)
+	_, err = l.LoadModule(t.Context(), "acme/widget/cloud", "", ".")
+	require.NoError(t, err)
+	_, err = l.LoadModule(t.Context(), "acme/widget/cloud//sub", "", ".")
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	_, err = l.LoadModule(t.Context(), "acme/widget/cloud", "~> 2", ".")
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
 }

--- a/pkg/hcl/parser/loader.go
+++ b/pkg/hcl/parser/loader.go
@@ -109,6 +109,26 @@ func (l *Loader) Files() map[string]*hcl.File {
 	return l.parser.Files()
 }
 
+// DirHasTerraformFiles reports whether dir contains at least one regular file
+// that LoadDirectory would parse. Symlinks are not counted: the
+// parameterization archive preserves only regular files, and discovery must
+// agree with what the archive replays.
+func DirHasTerraformFiles(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if !entry.Type().IsRegular() {
+			continue
+		}
+		if name := entry.Name(); !isIgnoredFile(name) && isTerraformFile(name) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // isTerraformFile returns true if the filename indicates a Terraform configuration file.
 func isTerraformFile(name string) bool {
 	return strings.HasSuffix(name, ".tf") || strings.HasSuffix(name, ".tf.json")

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	gotoken "go/token"
 	"maps"
 	"slices"
 	"sort"
@@ -756,12 +757,89 @@ func convertPropertyNames(v property.Value, spec *PropertySpec, toPulumi bool) p
 }
 
 // ToPulumiPackageSchema converts the module schema to a full Pulumi package
-// schema. Variable and output names, which are snake_case in HCL, are exposed
-// under their camelCase Pulumi property names. Object types are emitted as named
-// types in the `types` section and referenced via `$ref`, so a consumer binds
-// them as proper object types (a property's inline type spec cannot carry
-// `properties`).
+// schema serving this single component.
 func (s *ModuleSchema) ToPulumiPackageSchema() pulumischema.PackageSpec {
+	spec, err := PackageSchema(s, []*ModuleSchema{s})
+	if err != nil {
+		panic(err)
+	}
+	return spec
+}
+
+// PackageSchema builds the package schema serving components, one component
+// resource each. Package identity comes from the first component; the package
+// description comes from root, which is nil for a package whose root directory
+// holds no component.
+func PackageSchema(root *ModuleSchema, components []*ModuleSchema) (pulumischema.PackageSpec, error) {
+	if len(components) == 0 {
+		return pulumischema.PackageSpec{}, fmt.Errorf("no components to combine")
+	}
+	spec := pulumischema.PackageSpec{
+		Name:      components[0].PackageName,
+		Version:   components[0].Version,
+		Types:     map[string]pulumischema.ComplexTypeSpec{},
+		Resources: map[string]pulumischema.ResourceSpec{},
+	}
+	if root != nil {
+		spec.Description = root.Description
+	}
+	for _, c := range components {
+		token, res, types := c.resourceSpec()
+		if _, ok := spec.Resources[token]; ok {
+			return pulumischema.PackageSpec{}, fmt.Errorf("component token %q is defined twice", token)
+		}
+		spec.Resources[token] = res
+		for t, typ := range types {
+			if _, ok := spec.Types[t]; ok {
+				return pulumischema.PackageSpec{}, fmt.Errorf("type token %q is defined twice", t)
+			}
+			spec.Types[t] = typ
+		}
+	}
+	overrides, err := goModuleOverrides(components)
+	if err != nil {
+		return pulumischema.PackageSpec{}, err
+	}
+	if len(overrides) > 0 {
+		info, err := json.Marshal(map[string]any{
+			"moduleToPackage":      overrides,
+			"respectSchemaVersion": true,
+		})
+		if err != nil {
+			return pulumischema.PackageSpec{}, err
+		}
+		spec.Language = map[string]pulumischema.RawMessage{"go": info}
+	}
+	return spec, nil
+}
+
+// goModuleOverrides maps module segments that would render as invalid Go
+// package names to valid ones, so the generated Go SDK parses.
+func goModuleOverrides(components []*ModuleSchema) (map[string]string, error) {
+	overrides := map[string]string{}
+	seen := map[string]string{}
+	for _, c := range components {
+		pkg := strings.ReplaceAll(c.Module, "-", "")
+		if !gotoken.IsIdentifier(pkg) {
+			pkg = "_" + pkg
+		}
+		if prev, ok := seen[pkg]; ok && prev != c.Module {
+			return nil, fmt.Errorf("modules %q and %q both map to Go package %q", prev, c.Module, pkg)
+		}
+		seen[pkg] = c.Module
+		if pkg != c.Module {
+			overrides[c.Module] = pkg
+		}
+	}
+	return overrides, nil
+}
+
+// resourceSpec renders the component's resource spec and the named types it
+// references. Variable and output names, which are snake_case in HCL, are
+// exposed under their camelCase Pulumi property names. Object types are emitted
+// as named types and referenced via `$ref`, so a consumer binds them as proper
+// object types (a property's inline type spec cannot carry `properties`).
+func (s *ModuleSchema) resourceSpec() (string, pulumischema.ResourceSpec, map[string]pulumischema.ComplexTypeSpec) {
 	componentToken := fmt.Sprintf("%s:%s:%s", s.PackageName, s.Module, s.ComponentName)
 	types := make(map[string]pulumischema.ComplexTypeSpec)
 
@@ -797,25 +875,17 @@ func (s *ModuleSchema) ToPulumiPackageSchema() pulumischema.PackageSpec {
 	}
 	sort.Strings(requiredOutputs)
 
-	return pulumischema.PackageSpec{
-		Name:        s.PackageName,
-		Version:     s.Version,
-		Description: s.Description,
-		Types:       types,
-		Resources: map[string]pulumischema.ResourceSpec{
-			componentToken: {
-				ObjectTypeSpec: pulumischema.ObjectTypeSpec{
-					Type:        "object",
-					Description: s.Description,
-					Properties:  outputProps,
-					Required:    requiredOutputs,
-				},
-				IsComponent:     true,
-				InputProperties: inputProps,
-				RequiredInputs:  requiredInputs,
-			},
+	return componentToken, pulumischema.ResourceSpec{
+		ObjectTypeSpec: pulumischema.ObjectTypeSpec{
+			Type:        "object",
+			Description: s.Description,
+			Properties:  outputProps,
+			Required:    requiredOutputs,
 		},
-	}
+		IsComponent:     true,
+		InputProperties: inputProps,
+		RequiredInputs:  requiredInputs,
+	}, types
 }
 
 // pascalCase upper-cases the first letter of a camelCase name, for use in a type

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/blang/semver"
@@ -858,4 +860,88 @@ func (errLoader) LoadPackageV2(
 	ctx context.Context, descriptor *pulumiSchema.PackageDescriptor,
 ) (*pulumiSchema.Package, error) {
 	return nil, assert.AnError
+}
+
+func TestPackageSchema(t *testing.T) {
+	t.Parallel()
+
+	makeComponent := func(module string) *ModuleSchema {
+		return &ModuleSchema{
+			PackageName:   "pkg",
+			Version:       "1.0.0",
+			ComponentName: "Module",
+			Module:        module,
+			Description:   module + " description",
+			InputProperties: map[string]*PropertySpec{
+				"nested": {
+					Type:       TypeObject,
+					Properties: map[string]*PropertySpec{"field": {Type: TypeString}},
+				},
+			},
+		}
+	}
+
+	t.Run("merges components and types", func(t *testing.T) {
+		t.Parallel()
+		root := makeComponent("index")
+		spec, err := PackageSchema(root, []*ModuleSchema{root, makeComponent("alpha")})
+		require.NoError(t, err)
+		require.Equal(t, "pkg", spec.Name)
+		require.Equal(t, "index description", spec.Description)
+		require.Equal(t, []string{"pkg:alpha:Module", "pkg:index:Module"}, slices.Sorted(maps.Keys(spec.Resources)))
+		require.Equal(t, []string{"pkg:alpha:Nested", "pkg:index:Nested"}, slices.Sorted(maps.Keys(spec.Types)))
+		require.Empty(t, spec.Language)
+	})
+
+	t.Run("no root leaves the description empty", func(t *testing.T) {
+		t.Parallel()
+		spec, err := PackageSchema(nil, []*ModuleSchema{makeComponent("alpha")})
+		require.NoError(t, err)
+		require.Equal(t, "", spec.Description)
+	})
+
+	t.Run("duplicate component token", func(t *testing.T) {
+		t.Parallel()
+		_, err := PackageSchema(nil, []*ModuleSchema{makeComponent("alpha"), makeComponent("alpha")})
+		require.EqualError(t, err, `component token "pkg:alpha:Module" is defined twice`)
+	})
+
+	t.Run("duplicate type token across module segment", func(t *testing.T) {
+		t.Parallel()
+		other := makeComponent("alpha")
+		other.ComponentName = "Other"
+		_, err := PackageSchema(nil, []*ModuleSchema{makeComponent("alpha"), other})
+		require.EqualError(t, err, `type token "pkg:alpha:Nested" is defined twice`)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		_, err := PackageSchema(nil, nil)
+		require.EqualError(t, err, "no components to combine")
+	})
+
+	t.Run("go overrides for invalid package names", func(t *testing.T) {
+		t.Parallel()
+		spec, err := PackageSchema(nil, []*ModuleSchema{
+			makeComponent("index"), makeComponent("user-data"), makeComponent("2fa"), makeComponent("type"),
+		})
+		require.NoError(t, err)
+		var info struct {
+			ModuleToPackage      map[string]string `json:"moduleToPackage"`
+			RespectSchemaVersion bool              `json:"respectSchemaVersion"`
+		}
+		require.NoError(t, json.Unmarshal(spec.Language["go"], &info))
+		require.Equal(t, map[string]string{
+			"user-data": "userdata",
+			"2fa":       "_2fa",
+			"type":      "_type",
+		}, info.ModuleToPackage)
+		require.True(t, info.RespectSchemaVersion)
+	})
+
+	t.Run("colliding go package names", func(t *testing.T) {
+		t.Parallel()
+		_, err := PackageSchema(nil, []*ModuleSchema{makeComponent("user-data"), makeComponent("userdata")})
+		require.EqualError(t, err, `modules "user-data" and "userdata" both map to Go package "userdata"`)
+	})
 }

--- a/pkg/server/components.go
+++ b/pkg/server/components.go
@@ -1,0 +1,281 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/blang/semver"
+	pulumiSchema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"google.golang.org/grpc/codes"
+
+	"github.com/pulumi/pulumi-hcl/pkg/grpcerr"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/modules"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/parser"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/schema"
+	"github.com/pulumi/pulumi-hcl/pkg/potel"
+	"github.com/pulumi/pulumi-hcl/vendored/getmodules"
+)
+
+// component is one consumable directory of a module package, served as its own
+// component resource. source addresses the directory through the package's
+// loader; packages are the component's own resolved provider descriptors —
+// sibling components are independent configurations and resolve independently.
+type component struct {
+	schema   *schema.ModuleSchema
+	source   string
+	packages map[string]workspace.PackageDescriptor
+}
+
+// loadedComponent pairs a discovered component directory with its parsed
+// configuration, the source that addresses it through the loader, and its
+// resolved provider descriptors.
+type loadedComponent struct {
+	dir      componentDir
+	source   string
+	loaded   *modules.LoadedModule
+	packages map[string]workspace.PackageDescriptor
+}
+
+// loadComponents loads every consumable component of a module package and
+// returns the concrete version its source resolved to.
+func loadComponents(
+	ctx context.Context, loader *modules.Loader, source, versionConstraint string,
+) ([]loadedComponent, string, error) {
+	rootDir, resolvedVersion, err := loader.ResolveDir(source, versionConstraint, ".")
+	if err != nil {
+		return nil, "", err
+	}
+	dirs, err := discoverComponentDirs(rootDir)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(dirs) == 0 {
+		return nil, "", fmt.Errorf(
+			"no Terraform files found: neither the module root nor any modules/<name> directory contains .tf files")
+	}
+	comps := make([]loadedComponent, 0, len(dirs))
+	for _, d := range dirs {
+		src := componentSource(source, d)
+		loaded, err := loader.LoadModule(ctx, src, versionConstraint, ".")
+		if err != nil {
+			return nil, "", fmt.Errorf("loading %s: %w", d.describe(), err)
+		}
+		comps = append(comps, loadedComponent{dir: d, source: src, loaded: loaded})
+	}
+	return comps, resolvedVersion, nil
+}
+
+// loadRecordedComponents loads the component set a bundle recorded — the keys
+// of its per-component package maps — attaching each component's descriptors.
+// The bundle is the source of truth: discovery ran once, at `package add` time.
+func loadRecordedComponents(
+	ctx context.Context, loader *modules.Loader, root moduleRef,
+	packages map[string]map[string]workspace.PackageDescriptor,
+) ([]loadedComponent, error) {
+	comps := make([]loadedComponent, 0, len(packages))
+	for _, subdir := range slices.Sorted(maps.Keys(packages)) {
+		d := componentDir{Subdir: subdir}
+		src := componentSource(root.Source, d)
+		loaded, err := loader.LoadModule(ctx, src, root.Version, ".")
+		if err != nil {
+			return nil, fmt.Errorf("loading %s: %w", d.describe(), err)
+		}
+		comps = append(comps, loadedComponent{dir: d, source: src, loaded: loaded, packages: packages[subdir]})
+	}
+	return comps, nil
+}
+
+// indexComponent returns the root ("index") component, or nil when the package
+// root holds no Terraform files.
+func indexComponent(comps []loadedComponent) *loadedComponent {
+	for i := range comps {
+		if comps[i].dir.Subdir == "" {
+			return &comps[i]
+		}
+	}
+	return nil
+}
+
+// packageIdentity derives the package name, version, and root component token.
+// The root module names the package — its terraform `package` and `component`
+// blocks apply — while a package with no root falls back to defaultName and the
+// version its source resolved to, with an empty token.
+func packageIdentity(
+	comps []loadedComponent, defaultName string, forceDefault bool, resolvedVersion string,
+) (string, tokens.Type, semver.Version, error) {
+	if root := indexComponent(comps); root != nil {
+		rootToken, version, err := moduleIdentity(root.loaded, defaultName, forceDefault)
+		if err != nil {
+			return "", "", semver.Version{}, err
+		}
+		return rootToken.Package().Name().String(), rootToken, version, nil
+	}
+	version, err := semver.ParseTolerant(cmp.Or(resolvedVersion, "0.0.0-dev"))
+	if err != nil {
+		return "", "", semver.Version{}, fmt.Errorf("parsing module version %q: %w", resolvedVersion, err)
+	}
+	return defaultName, "", version, nil
+}
+
+// buildComponents generates each component's schema — the root under rootToken,
+// submodules as pkg:<segment>:Module — and combines them into the package
+// schema.
+func buildComponents(
+	ctx context.Context, comps []loadedComponent, pkgName string, rootToken tokens.Type, version semver.Version,
+	newBinder func(loadedComponent) *schema.Binder,
+) (map[tokens.Type]component, pulumiSchema.PackageSpec, error) {
+	ctx, span := potel.Start(ctx, "buildComponents")
+	defer span.End()
+
+	components := make(map[tokens.Type]component, len(comps))
+	schemas := make([]*schema.ModuleSchema, 0, len(comps))
+	var root *schema.ModuleSchema
+	for _, c := range comps {
+		token := rootToken
+		if c.dir.Subdir != "" {
+			token = tokens.Type(fmt.Sprintf("%s:%s:Module", pkgName, c.dir.module()))
+		}
+		sch, err := schema.GenerateModuleSchema(ctx, c.loaded.Config, newBinder(c), token, version)
+		if err != nil {
+			return nil, pulumiSchema.PackageSpec{}, fmt.Errorf("generating schema for %s: %w", c.dir.describe(), err)
+		}
+		if c.dir.Subdir == "" {
+			root = sch
+		}
+		components[token] = component{schema: sch, source: c.source, packages: c.packages}
+		schemas = append(schemas, sch)
+	}
+	spec, err := schema.PackageSchema(root, schemas)
+	if err != nil {
+		return nil, pulumiSchema.PackageSpec{}, grpcerr.Classify(err, codes.InvalidArgument)
+	}
+	return components, spec, nil
+}
+
+// componentDir names one consumable directory of a module package by its
+// root-relative path: "" for the package root itself, "modules/<name>" for a
+// submodule directory.
+type componentDir struct {
+	Subdir string
+}
+
+// module is the token module segment the directory's component is served
+// under: "index" for the root, the sanitized directory name otherwise.
+func (c componentDir) module() string {
+	if c.Subdir == "" {
+		return "index"
+	}
+	return sanitizePackageName(path.Base(c.Subdir), "")
+}
+
+// describe names the component directory in error messages.
+func (c componentDir) describe() string {
+	if c.Subdir == "" {
+		return "the module root"
+	}
+	return fmt.Sprintf("submodule %q", c.Subdir)
+}
+
+// discoverComponentDirs lists the consumable directories under rootDir: the
+// root itself when it holds Terraform files, plus each modules/<name>
+// directory that does.
+func discoverComponentDirs(rootDir string) ([]componentDir, error) {
+	var components []componentDir
+	hasRoot, err := parser.DirHasTerraformFiles(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("reading module directory: %w", err)
+	}
+	if hasRoot {
+		components = append(components, componentDir{})
+	}
+
+	entries, err := os.ReadDir(filepath.Join(rootDir, "modules"))
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("reading modules directory: %w", err)
+	}
+	seen := map[string]string{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() || name[0] == '.' {
+			continue
+		}
+		hasFiles, err := parser.DirHasTerraformFiles(filepath.Join(rootDir, "modules", name))
+		if err != nil {
+			return nil, fmt.Errorf("reading submodule directory %q: %w", name, err)
+		}
+		if !hasFiles {
+			continue
+		}
+		d := componentDir{Subdir: path.Join("modules", name)}
+		segment := d.module()
+		if segment == "" {
+			return nil, fmt.Errorf("submodule directory %q does not sanitize to a usable module name", name)
+		}
+		if prev, ok := seen[segment]; ok {
+			return nil, fmt.Errorf("submodule directories %q and %q both map to module name %q", prev, name, segment)
+		}
+		seen[segment] = name
+		components = append(components, d)
+	}
+	return components, nil
+}
+
+// requirementDirs lists the directories whose provider requirements a program
+// directory serves: the directory itself, plus every submodule component
+// directory when it is a component package (marked by PulumiPlugin.yaml).
+func requirementDirs(programDir string) ([]string, error) {
+	dirs := []string{programDir}
+	if _, err := os.Stat(filepath.Join(programDir, "PulumiPlugin.yaml")); err != nil {
+		return dirs, nil
+	}
+	comps, err := discoverComponentDirs(programDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range comps {
+		if c.Subdir != "" {
+			dirs = append(dirs, filepath.Join(programDir, filepath.FromSlash(c.Subdir)))
+		}
+	}
+	return dirs, nil
+}
+
+// componentSource addresses a component directory through the module source that
+// resolved to its package root, appending the component's root-relative path to
+// the source's subdir. The root component is the source itself.
+func componentSource(source string, c componentDir) string {
+	if c.Subdir == "" {
+		return source
+	}
+	pkgSource, subdir := getmodules.SplitPackageSubdir(source)
+	// The query string must follow the //subdir for the result to re-split.
+	pkgSource, query, hasQuery := strings.Cut(pkgSource, "?")
+	s := pkgSource + "//" + path.Join(subdir, c.Subdir)
+	if hasQuery {
+		s += "?" + query
+	}
+	return s
+}

--- a/pkg/server/components_test.go
+++ b/pkg/server/components_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/vendored/getmodules"
+	"github.com/stretchr/testify/require"
+)
+
+// writeModuleTree writes empty .tf files at the given root-relative paths and
+// returns the root directory.
+func writeModuleTree(t *testing.T, paths ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, p := range paths {
+		full := filepath.Join(root, filepath.FromSlash(p))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, nil, 0o600))
+	}
+	return root
+}
+
+func TestDiscoverComponentDirs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("root only", func(t *testing.T) {
+		t.Parallel()
+		root := writeModuleTree(t, "main.tf")
+		got, err := discoverComponentDirs(root)
+		require.NoError(t, err)
+		require.Equal(t, []componentDir{{}}, got)
+	})
+
+	t.Run("root and submodules", func(t *testing.T) {
+		t.Parallel()
+		root := writeModuleTree(t, "main.tf", "modules/alpha/main.tf", "modules/beta/main.tf")
+		got, err := discoverComponentDirs(root)
+		require.NoError(t, err)
+		require.Equal(t, []componentDir{
+			{},
+			{Subdir: "modules/alpha"},
+			{Subdir: "modules/beta"},
+		}, got)
+	})
+
+	t.Run("submodules only", func(t *testing.T) {
+		t.Parallel()
+		root := writeModuleTree(t, "modules/alpha/main.tf")
+		got, err := discoverComponentDirs(root)
+		require.NoError(t, err)
+		require.Equal(t, []componentDir{{Subdir: "modules/alpha"}}, got)
+	})
+
+	t.Run("sanitizes directory names", func(t *testing.T) {
+		t.Parallel()
+		root := writeModuleTree(t, "modules/_user_data/main.tf", "modules/a.b/main.tf")
+		got, err := discoverComponentDirs(root)
+		require.NoError(t, err)
+		require.Equal(t, []componentDir{{Subdir: "modules/_user_data"}, {Subdir: "modules/a.b"}}, got)
+		require.Equal(t, "user-data", got[0].module())
+		require.Equal(t, "a-b", got[1].module())
+	})
+
+	t.Run("skips non-module directories", func(t *testing.T) {
+		t.Parallel()
+		root := writeModuleTree(t, "main.tf", "modules/docs/README.md", "modules/.hidden/main.tf")
+		got, err := discoverComponentDirs(root)
+		require.NoError(t, err)
+		require.Equal(t, []componentDir{{}}, got)
+	})
+
+	t.Run("no components", func(t *testing.T) {
+		t.Parallel()
+		root := writeModuleTree(t, "README.md")
+		got, err := discoverComponentDirs(root)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("colliding names", func(t *testing.T) {
+		t.Parallel()
+		root := writeModuleTree(t, "modules/user-data/main.tf", "modules/user_data/main.tf")
+		_, err := discoverComponentDirs(root)
+		require.EqualError(t, err,
+			`submodule directories "user-data" and "user_data" both map to module name "user-data"`)
+	})
+
+	t.Run("skips symlinked files and directories", func(t *testing.T) {
+		t.Parallel()
+		root := writeModuleTree(t, "main.tf")
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "modules", "symfile"), 0o755))
+		require.NoError(t, os.Symlink(filepath.Join(root, "main.tf"),
+			filepath.Join(root, "modules", "symfile", "main.tf")))
+		real := writeModuleTree(t, "main.tf")
+		require.NoError(t, os.Symlink(real, filepath.Join(root, "modules", "symdir")))
+		got, err := discoverComponentDirs(root)
+		require.NoError(t, err)
+		require.Equal(t, []componentDir{{}}, got)
+	})
+
+	t.Run("unusable name", func(t *testing.T) {
+		t.Parallel()
+		root := writeModuleTree(t, "modules/---/main.tf")
+		_, err := discoverComponentDirs(root)
+		require.EqualError(t, err, `submodule directory "---" does not sanitize to a usable module name`)
+	})
+}
+
+func TestComponentSource(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		source string
+		dir    componentDir
+		want   string
+	}{
+		{"root", "acme/widget/cloud", componentDir{}, "acme/widget/cloud"},
+		{
+			"registry submodule",
+			"acme/widget/cloud",
+			componentDir{Subdir: "modules/alpha"},
+			"acme/widget/cloud//modules/alpha",
+		},
+		{
+			"source with existing subdir",
+			"git::https://example.com/repo.git//nested",
+			componentDir{Subdir: "modules/alpha"},
+			"git::https://example.com/repo.git//nested/modules/alpha",
+		},
+		{
+			"registry with version query",
+			"acme/widget/cloud?version=1.2.3",
+			componentDir{Subdir: "modules/alpha"},
+			"acme/widget/cloud//modules/alpha?version=1.2.3",
+		},
+		{
+			"git with ref query",
+			"git::https://example.com/repo.git?ref=v1",
+			componentDir{Subdir: "modules/alpha"},
+			"git::https://example.com/repo.git//modules/alpha?ref=v1",
+		},
+		{
+			"subdir and query",
+			"https://example.com/x.zip//sub?ref=y",
+			componentDir{Subdir: "modules/alpha"},
+			"https://example.com/x.zip//sub/modules/alpha?ref=y",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, componentSource(tc.source, tc.dir))
+			if tc.dir.Subdir != "" {
+				_, subdir := getmodules.SplitPackageSubdir(tc.want)
+				require.NotEmpty(t, subdir, "the produced source must re-split into a subdir")
+			}
+		})
+	}
+}

--- a/pkg/server/module_resource.go
+++ b/pkg/server/module_resource.go
@@ -153,13 +153,13 @@ func (m *moduleProvider) handshake(ctx context.Context, req p.HandshakeRequest) 
 }
 
 // getSchema returns the static hcl:index:Module schema, or — once the provider
-// has been parameterized — the parameterized module's typed component schema. A
-// bundle-backed parameterization carries its Value so a generated SDK can
+// has been parameterized — the parameterized package's typed component schemas.
+// A bundle-backed parameterization carries its Value so a generated SDK can
 // re-parameterize; a locally-born provider has no bundle.
 func (m *moduleProvider) getSchema(context.Context, p.GetSchemaRequest) (p.GetSchemaResponse, error) {
 	spec := moduleResourceSchema(m.version)
 	if m.param != nil {
-		spec = m.param.schema.ToPulumiPackageSchema()
+		spec = m.param.spec
 		if m.param.value != nil {
 			spec.Parameterization = &pulumiSchema.ParameterizationSpec{
 				BaseProvider: pulumiSchema.BaseProviderSpec{Name: "hcl", Version: m.version},
@@ -298,18 +298,21 @@ func (m *moduleProvider) construct(ctx context.Context, req p.ConstructRequest) 
 	}, nil
 }
 
-// constructParameterized runs the parameterized module: it maps the typed
-// component inputs to the module's HCL variables, runs the engine against the
-// bundled (offline) module tree, and exposes the module's outputs under their
-// typed schema property names. It mirrors HCLProvider.Construct, the local-path
-// MLC equivalent.
+// constructParameterized runs one component of the parameterized module
+// package, selected by the request's type token: it maps the typed component
+// inputs to the module's HCL variables, runs the engine against the module tree
+// (bundled and offline on the parameterize path, the local directory on the
+// RunPlugin path), and exposes the module's outputs under their typed schema
+// property names. Handshake preconditions are enforced by parameterize and the
+// local birth, not here.
 func (m *moduleProvider) constructParameterized(ctx context.Context, req p.ConstructRequest) (p.ConstructResponse, error) {
-	if m.schemaLoader == nil || m.providerInfoSource == nil {
-		return p.ConstructResponse{}, fmt.Errorf("construct called before a successful handshake")
-	}
 	param := m.param
+	comp, ok := param.components[req.Urn.Type()]
+	if !ok {
+		return p.ConstructResponse{}, fmt.Errorf("unknown resource type: %q", req.Urn.Type())
+	}
 
-	loaded, err := param.loader.LoadModule(ctx, param.rootSource, param.rootVersion, ".")
+	loaded, err := param.loader.LoadModule(ctx, comp.source, param.versionConstraint, ".")
 	if err != nil {
 		return p.ConstructResponse{}, fmt.Errorf("loading module %q: %w", param.name, err)
 	}
@@ -335,10 +338,10 @@ func (m *moduleProvider) constructParameterized(ctx context.Context, req p.Const
 		return p.ConstructResponse{}, fmt.Errorf("starting hook callback server: %w", err)
 	}
 	resmon := m.newConstructMonitor(ctx, req,
-		pulumirpc.NewResourceMonitorClient(monitorConn), componentInputs, param.schema.OutputsToPulumi, hooks)
+		pulumirpc.NewResourceMonitorClient(monitorConn), componentInputs, comp.schema.OutputsToPulumi, hooks)
 
 	loader := pulumiSchema.NewCachedLoader(packages.NewParameterizationAwareLoader(
-		m.schemaLoader, param.packages))
+		m.schemaLoader, comp.packages))
 
 	engineRun, err := run.NewEngine(ctx, loaded.Config, &run.EngineOptions{
 		ProjectName:        string(req.Urn.Project()),
@@ -349,11 +352,11 @@ func (m *moduleProvider) constructParameterized(ctx context.Context, req p.Const
 		WorkDir:            loaded.SourcePath,
 		RootDir:            loaded.SourcePath,
 		AbsolutePaths:      true,
-		Config:             moduleConfig(string(req.Urn.Project()), param.schema.InputsToHCL(req.Inputs)),
+		Config:             moduleConfig(string(req.Urn.Project()), comp.schema.InputsToHCL(req.Inputs)),
 		ResourceMonitor:    resmon,
 		SchemaLoader:       loader,
 		ProviderInfoSource: m.providerInfoSource,
-		Packages:           param.packages,
+		Packages:           comp.packages,
 		ModuleLoader:       param.loader,
 		Parallel:           int(req.Parallel),
 	})

--- a/pkg/server/parameterize.go
+++ b/pkg/server/parameterize.go
@@ -53,20 +53,20 @@ import (
 
 // parameterizedModule is the state of a moduleProvider that has been
 // parameterized by a specific module source. While set, the provider serves that
-// module's typed component schema rather than the generic hcl:index:Module.
+// module package's typed component schemas rather than the generic
+// hcl:index:Module.
 type parameterizedModule struct {
-	// schema is the typed schema, identical to the one the local-path MLC
-	// (HCLProvider) generates for the same module.
-	schema *schema.ModuleSchema
-	// loader resolves the module and its children. On the usage path it resolves
-	// entirely from the unpacked bundle, with no network access.
+	// spec is the combined package schema of every component.
+	spec pulumiSchema.PackageSpec
+	// components maps each component token to the schema and source Construct
+	// dispatches on.
+	components map[tokens.Type]component
+	// loader resolves the components and their children. On the usage path it
+	// resolves entirely from the unpacked bundle, with no network access.
 	loader *modules.Loader
-	// rootSource and rootVersion address the root module through loader.
-	rootSource  string
-	rootVersion string
-	// packages are the resolved provider descriptors, baked into the bundle at
-	// `package add` time.
-	packages map[string]workspace.PackageDescriptor
+	// versionConstraint is the constraint component sources are loaded under
+	// through loader, as passed to `pulumi package add`.
+	versionConstraint string
 	// value is the parameterization Value (the encoded bundle), surfaced in the
 	// schema so a generated SDK can re-parameterize without re-downloading.
 	value []byte
@@ -82,9 +82,10 @@ type bundle struct {
 	// Manifest records how every module reference resolves within Archive, and
 	// how to reach the root module.
 	Manifest bundleManifest `json:"manifest"`
-	// Packages are the resolved provider descriptors, keyed by local provider
-	// name, computed once at `package add` time.
-	Packages map[string]workspace.PackageDescriptor `json:"packages"`
+	// Packages are each component's resolved provider descriptors, keyed by the
+	// component's root-relative directory ("" for the root) and then by local
+	// provider name, computed once at `package add` time.
+	Packages map[string]map[string]workspace.PackageDescriptor `json:"packages"`
 	// Archive is the deterministic tar.gz of the module package directories.
 	Archive []byte `json:"archive"`
 }
@@ -207,27 +208,41 @@ func (m *moduleProvider) parameterizeArgs(ctx context.Context, args []string) (p
 	rec := newResolveRecorder(modules.LiveResolver(ctx))
 	loader := modules.NewLoader(rec.resolve)
 
-	loaded, err := loader.LoadModule(ctx, source, version, ".")
+	comps, resolvedVersion, err := loadComponents(ctx, loader, source, version)
 	if err != nil {
 		return p.ParameterizeResponse{}, fmt.Errorf("loading module %q: %w", source, err)
 	}
 
-	// Resolve every provider now, while the recording loader is active, so the
+	// Resolve each component's providers now — independently, as the separate
+	// configurations they are — while the recording loader is active, so the
 	// descriptors can be baked into the bundle and reused offline at usage.
-	resolved, err := m.resolvePackages(ctx, loader, loaded.Config, loaded.SourcePath)
-	if err != nil {
-		return p.ParameterizeResponse{}, err
+	for i := range comps {
+		comps[i].packages, err = m.resolvePackages(ctx, loader, comps[i].loaded.Config, comps[i].loaded.SourcePath)
+		if err != nil {
+			return p.ParameterizeResponse{}, fmt.Errorf("%s: %w", comps[i].dir.describe(), err)
+		}
 	}
 
 	// finishParameterize's schema walk drives the recorder too; bundle the
 	// recorded tree once it has run.
-	return m.finishParameterize(ctx, loader, loaded, source, version, nameOverride, "", nil, resolved, func() ([]byte, error) {
-		value, err := rec.bundle(moduleRef{Source: source, Version: version}, resolved)
-		if err != nil {
-			return nil, fmt.Errorf("bundling module %q: %w", source, err)
-		}
-		return value, nil
-	})
+	return m.finishParameterize(ctx, loader, comps, resolvedVersion, source, version, nameOverride, "", nil,
+		func() ([]byte, error) {
+			value, err := rec.bundle(moduleRef{Source: source, Version: version}, componentPackages(comps))
+			if err != nil {
+				return nil, fmt.Errorf("bundling module %q: %w", source, err)
+			}
+			return value, nil
+		})
+}
+
+// componentPackages collects each component's resolved descriptors, keyed by
+// the component's root-relative directory ("" for the root).
+func componentPackages(comps []loadedComponent) map[string]map[string]workspace.PackageDescriptor {
+	out := make(map[string]map[string]workspace.PackageDescriptor, len(comps))
+	for _, c := range comps {
+		out[c.dir.Subdir] = c.packages
+	}
+	return out
 }
 
 // parameterizeValue handles re-parameterization from a generated SDK. It unpacks
@@ -268,13 +283,13 @@ func (m *moduleProvider) parameterizeValue(
 	}
 
 	loader := modules.NewLoader(bundleResolver(dir, b.Manifest))
-	loaded, err := loader.LoadModule(ctx, b.Manifest.Root.Source, b.Manifest.Root.Version, ".")
+	comps, err := loadRecordedComponents(ctx, loader, b.Manifest.Root, b.Packages)
 	if err != nil {
 		return p.ParameterizeResponse{}, fmt.Errorf("loading bundled module %q: %w", b.Manifest.Root.Source, err)
 	}
 
-	resp, err := m.finishParameterize(ctx, loader, loaded, b.Manifest.Root.Source, b.Manifest.Root.Version, name, dir,
-		&version, b.Packages, func() ([]byte, error) { return value, nil })
+	resp, err := m.finishParameterize(ctx, loader, comps, "", b.Manifest.Root.Source,
+		b.Manifest.Root.Version, name, dir, &version, func() ([]byte, error) { return value, nil })
 	if err != nil {
 		return p.ParameterizeResponse{}, err
 	}
@@ -282,20 +297,22 @@ func (m *moduleProvider) parameterizeValue(
 	return resp, nil
 }
 
-// finishParameterize derives the package identity, generates the schema, and
-// installs the parameterized state. A non-nil pkgVersion (the usage path, where
-// the engine echoes the version the args path returned) overrides the version
-// moduleIdentity derives.
+// finishParameterize derives the package identity, generates every component's
+// schema, and installs the parameterized state. A non-nil pkgVersion (the usage
+// path, where the engine echoes the version the args path returned) overrides
+// the version derived from the package. resolvedVersion is the concrete version
+// the package's source resolved to, naming the package version when there is no
+// root module to carry a terraform `package` block.
 func (m *moduleProvider) finishParameterize(
-	ctx context.Context, loader *modules.Loader, loaded *modules.LoadedModule,
-	rootSource, rootVersion, pkgName, tempDir string, pkgVersion *semver.Version,
-	resolved map[string]workspace.PackageDescriptor, makeValue func() ([]byte, error),
+	ctx context.Context, loader *modules.Loader, comps []loadedComponent, resolvedVersion,
+	rootSource, versionConstraint, pkgName, tempDir string, pkgVersion *semver.Version,
+	makeValue func() ([]byte, error),
 ) (p.ParameterizeResponse, error) {
 	forceDefault := pkgName != ""
 	if pkgName == "" {
 		pkgName = defaultPackageName(rootSource)
 	}
-	token, pkgVer, err := moduleIdentity(loaded, pkgName, forceDefault)
+	pkgName, rootToken, pkgVer, err := packageIdentity(comps, pkgName, forceDefault, resolvedVersion)
 	if err != nil {
 		return p.ParameterizeResponse{}, err
 	}
@@ -303,12 +320,13 @@ func (m *moduleProvider) finishParameterize(
 		pkgVer = *pkgVersion
 	}
 
-	sch, err := m.generateModuleSchema(ctx, loader, loaded, resolved, token, pkgVer)
+	components, spec, err := buildComponents(ctx, comps, pkgName, rootToken, pkgVer,
+		m.componentBinderFactory(loader))
 	if err != nil {
 		// A module that loaded but cannot be typed uses something the
 		// conversion does not support, unless the chain pins a more specific
 		// cause (a registry or network failure resolving a child module).
-		return p.ParameterizeResponse{}, grpcerr.Classify(fmt.Errorf("generating schema: %w", err), codes.Unimplemented)
+		return p.ParameterizeResponse{}, grpcerr.Classify(err, codes.Unimplemented)
 	}
 
 	value, err := makeValue()
@@ -316,22 +334,20 @@ func (m *moduleProvider) finishParameterize(
 		return p.ParameterizeResponse{}, err
 	}
 
-	pkgName = token.Package().Name().String()
 	m.param = &parameterizedModule{
-		schema:      sch,
-		loader:      loader,
-		rootSource:  rootSource,
-		rootVersion: rootVersion,
-		packages:    resolved,
-		value:       value,
-		name:        pkgName,
-		tempDir:     tempDir,
+		spec:              spec,
+		components:        components,
+		loader:            loader,
+		versionConstraint: versionConstraint,
+		value:             value,
+		name:              pkgName,
+		tempDir:           tempDir,
 	}
 	return p.ParameterizeResponse{Name: pkgName, Version: pkgVer}, nil
 }
 
-// resolvePackages resolves every provider the module tree references to a
-// concrete descriptor, walking child modules through loader.
+// resolvePackages resolves every provider the module tree rooted at config
+// references to a concrete descriptor, walking child modules through loader.
 func (m *moduleProvider) resolvePackages(
 	ctx context.Context, loader *modules.Loader, config *ast.Config, workDir string,
 ) (map[string]workspace.PackageDescriptor, error) {
@@ -344,25 +360,20 @@ func (m *moduleProvider) resolvePackages(
 	return resolved, nil
 }
 
-// generateModuleSchema builds the typed schema for a loaded module, resolving
-// resource/data source references through the handshake schema loader and bridge
-// mapper, and child modules through loader, exactly as the local-path MLC
-// (NewHCLProvider) does.
-func (m *moduleProvider) generateModuleSchema(
-	ctx context.Context, loader *modules.Loader, loaded *modules.LoadedModule,
-	resolved map[string]workspace.PackageDescriptor,
-	token tokens.Type, version semver.Version,
-) (*schema.ModuleSchema, error) {
-	ctx, span := potel.Start(ctx, "generateModuleSchema")
-	defer span.End()
-	cachedLoader := pulumiSchema.NewCachedLoader(
-		packages.NewParameterizationAwareLoader(m.schemaLoader, resolved))
-	binder := &schema.Binder{
-		Resources: packages.NewResolver(cachedLoader, m.providerInfoSource, resolved, knownProviderNames(loaded.Config)),
-		Modules:   moduleLoaderAdapter{loader},
-		ModuleDir: loaded.SourcePath,
+// componentBinderFactory builds the per-component binder schema generation
+// resolves resource, data source, and child-module references through.
+func (m *moduleProvider) componentBinderFactory(
+	loader *modules.Loader,
+) func(loadedComponent) *schema.Binder {
+	return func(c loadedComponent) *schema.Binder {
+		cachedLoader := pulumiSchema.NewCachedLoader(
+			packages.NewParameterizationAwareLoader(m.schemaLoader, c.packages))
+		return &schema.Binder{
+			Resources: packages.NewResolver(cachedLoader, m.providerInfoSource, c.packages, knownProviderNames(c.loaded.Config)),
+			Modules:   moduleLoaderAdapter{loader},
+			ModuleDir: c.loaded.SourcePath,
+		}
 	}
-	return schema.GenerateModuleSchema(ctx, loaded.Config, binder, token, version)
 }
 
 // knownProviderNames lists the local names the module's terraform block declares,
@@ -431,7 +442,9 @@ func (r *resolveRecorder) rel(dir string) string {
 	return rel
 }
 
-func (r *resolveRecorder) bundle(root moduleRef, packages map[string]workspace.PackageDescriptor) ([]byte, error) {
+func (r *resolveRecorder) bundle(
+	root moduleRef, packages map[string]map[string]workspace.PackageDescriptor,
+) ([]byte, error) {
 	dirs := make(map[string]string, len(r.pkgRel))
 	for absDir, rel := range r.pkgRel {
 		dirs[rel] = absDir
@@ -504,6 +517,9 @@ func bundleResolver(unpackDir string, manifest bundleManifest) modules.ResolverF
 // their module name segment; other sources use the last path component.
 func defaultPackageName(source string) string {
 	pkgSource, _ := getmodules.SplitPackageSubdir(source)
+	if i := strings.IndexByte(pkgSource, '?'); i >= 0 {
+		pkgSource = pkgSource[:i]
+	}
 	if mod, err := regaddr.ParseModuleSource(pkgSource); err == nil {
 		pkg := sanitizePackageName(mod.Package.Name, "module")
 		if sys := sanitizePackageName(mod.Package.TargetSystem, ""); sys != "" {
@@ -511,11 +527,7 @@ func defaultPackageName(source string) string {
 		}
 		return pkg
 	}
-	s := pkgSource
-	if i := strings.IndexByte(s, '?'); i >= 0 {
-		s = s[:i]
-	}
-	s = strings.TrimRight(s, "/")
+	s := strings.TrimRight(pkgSource, "/")
 	if i := strings.LastIndexByte(s, '/'); i >= 0 {
 		s = s[i+1:]
 	}
@@ -531,7 +543,7 @@ func sanitizePackageName(name, fallback string) string {
 		switch {
 		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
 			b.WriteRune(r)
-		case r == '_' || r == ' ':
+		case r == '_' || r == ' ' || r == '.':
 			b.WriteByte('-')
 		}
 	}

--- a/pkg/server/parameterize_test.go
+++ b/pkg/server/parameterize_test.go
@@ -15,20 +15,27 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/blang/semver"
 	p "github.com/pulumi/pulumi-go-provider"
 	pulumiSchema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -73,8 +80,9 @@ func TestDefaultPackageName(t *testing.T) {
 		source string
 		want   string
 	}{
-		{"terraform-aws-modules/vpc/aws", "vpc-aws"},
-		{"terraform-aws-modules/vpc/aws//modules/subnets", "vpc-aws"},
+		{"acme-modules/widget/cloud", "widget-cloud"},
+		{"acme-modules/widget/cloud?version=1.2.3", "widget-cloud"},
+		{"acme-modules/widget/cloud//modules/subnets", "widget-cloud"},
 		{"github.com/org/my-repo", "my-repo"},
 		{"git::https://github.com/org/repo.git//subdir", "repo"},
 		{"git::https://example.com/foo/Bar_Baz.git", "bar-baz"},
@@ -93,13 +101,13 @@ func TestParameterizeArgsRejected(t *testing.T) {
 
 	t.Run("before handshake", func(t *testing.T) {
 		t.Parallel()
-		_, err := (&moduleProvider{}).parameterizeArgs(t.Context(), []string{"module", "acme/widget/aws"})
+		_, err := (&moduleProvider{}).parameterizeArgs(t.Context(), []string{"module", "acme/widget/cloud"})
 		require.EqualError(t, err, "parameterize called before a successful handshake")
 	})
 
 	t.Run("missing module keyword", func(t *testing.T) {
 		t.Parallel()
-		_, err := (&moduleProvider{resolver: stubResolver{}}).parameterizeArgs(t.Context(), []string{"acme/widget/aws"})
+		_, err := (&moduleProvider{resolver: stubResolver{}}).parameterizeArgs(t.Context(), []string{"acme/widget/cloud"})
 		require.EqualError(t, err,
 			`the hcl provider is parameterized by a module: expected "module" as the first argument`)
 	})
@@ -264,7 +272,7 @@ func TestBundleRoundTripResolvesOffline(t *testing.T) {
 
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(
-		filepath.Join(root, "main.tf"), []byte(`module "c" { source = "acme/widget/aws" }`), 0o600))
+		filepath.Join(root, "main.tf"), []byte(`module "c" { source = "acme/widget/cloud" }`), 0o600))
 
 	// A custom resolver stands in for the network: the absolute-path root
 	// resolves to itself and the submodule to the child package.
@@ -272,7 +280,7 @@ func TestBundleRoundTripResolvesOffline(t *testing.T) {
 		switch packageSource {
 		case root:
 			return root, "", nil
-		case "acme/widget/aws":
+		case "acme/widget/cloud":
 			return child, "", nil
 		default:
 			return "", "", fmt.Errorf("unexpected source %q", packageSource)
@@ -283,7 +291,7 @@ func TestBundleRoundTripResolvesOffline(t *testing.T) {
 	// Loading the tree records every resolution into the recorder.
 	loaded, err := loader.LoadModule(t.Context(), root, "", ".")
 	require.NoError(t, err)
-	_, err = loader.LoadModule(t.Context(), "acme/widget/aws", "", loaded.SourcePath)
+	_, err = loader.LoadModule(t.Context(), "acme/widget/cloud", "", loaded.SourcePath)
 	require.NoError(t, err)
 
 	value, err := rec.bundle(moduleRef{Source: root}, nil)
@@ -304,7 +312,7 @@ func TestBundleRoundTripResolvesOffline(t *testing.T) {
 	require.True(t, strings.HasPrefix(rootAgain.SourcePath, dest),
 		"root must resolve inside the unpacked bundle, got %q", rootAgain.SourcePath)
 
-	childAgain, err := offline.LoadModule(t.Context(), "acme/widget/aws", "", rootAgain.SourcePath)
+	childAgain, err := offline.LoadModule(t.Context(), "acme/widget/cloud", "", rootAgain.SourcePath)
 	require.NoError(t, err)
 	require.Contains(t, childAgain.Config.Outputs, "id")
 	require.True(t, strings.HasPrefix(childAgain.SourcePath, dest),
@@ -491,21 +499,21 @@ func TestPackArchiveExcludesVCSArtifacts(t *testing.T) {
 func TestBundleBakesPackages(t *testing.T) {
 	t.Parallel()
 
-	awsVer := semver.MustParse("6.46.0")
+	bridgedVer := semver.MustParse("1.2.3")
 	tfVer := semver.MustParse("0.9.0")
-	packages := map[string]workspace.PackageDescriptor{
-		"aws": {
+	packages := map[string]map[string]workspace.PackageDescriptor{
+		"": {"bridged": {
 			PluginDescriptor: workspace.PluginDescriptor{
 				Name:    "terraform-provider",
 				Kind:    apitype.ResourcePlugin,
 				Version: &tfVer,
 			},
 			Parameterization: &workspace.Parameterization{
-				Name:    "aws",
-				Version: awsVer,
-				Value:   []byte(`{"remote":{"url":"registry.opentofu.org/hashicorp/aws","version":"6.46.0"}}`),
+				Name:    "bridged",
+				Version: bridgedVer,
+				Value:   []byte(`{"remote":{"url":"registry.example.com/acme/bridged","version":"1.2.3"}}`),
 			},
-		},
+		}},
 	}
 
 	dir := t.TempDir()
@@ -533,18 +541,176 @@ func TestDedupeEdges(t *testing.T) {
 	t.Parallel()
 
 	got := dedupeEdges([]resolvedEdge{
-		{Caller: "0", Source: "b/m/aws", Target: "2"},
+		{Caller: "0", Source: "b/m/cloud", Target: "2"},
 		{Caller: "", Source: "root", Target: "0"},
-		{Caller: "0", Source: "a/m/aws", Target: "1"},
+		{Caller: "0", Source: "a/m/cloud", Target: "1"},
 		{Caller: "", Source: "root", Target: "0"},     // duplicate
-		{Caller: "0", Source: "b/m/aws", Target: "2"}, // duplicate
+		{Caller: "0", Source: "b/m/cloud", Target: "2"}, // duplicate
 	})
 
 	require.Equal(t, []resolvedEdge{
 		{Caller: "", Source: "root", Target: "0"},
-		{Caller: "0", Source: "a/m/aws", Target: "1"},
-		{Caller: "0", Source: "b/m/aws", Target: "2"},
+		{Caller: "0", Source: "a/m/cloud", Target: "1"},
+		{Caller: "0", Source: "b/m/cloud", Target: "2"},
 	}, got)
+}
+
+// writeMultiComponentModule writes a package with a root module and two
+// modules/<name> submodules; withRoot=false leaves the root empty.
+func writeMultiComponentModule(t *testing.T, withRoot bool) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, content string) {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+	}
+	if withRoot {
+		write("main.tf", `
+variable "name" { type = string }
+output "greeting" { value = "hello ${var.name}" }
+`)
+	}
+	write("modules/greeter/main.tf", `
+variable "who" { type = string }
+output "hello" { value = "hi ${var.who}" }
+`)
+	write("modules/_user_data/main.tf", `
+output "data" { value = "data" }
+`)
+	return root
+}
+
+// TestParameterizeArgsMultiComponent verifies a package with a root and
+// submodules serves one component per consumable directory — pkg:index:Module
+// for the root and pkg:<name>:Module per modules/<name> — and that a fresh
+// provider re-parameterized from the returned Value serves the identical
+// schema offline.
+func TestParameterizeArgsMultiComponent(t *testing.T) {
+	t.Parallel()
+
+	dir := writeMultiComponentModule(t, true)
+
+	m := &moduleProvider{version: "1.2.3", resolver: stubResolver{}}
+	resp, err := m.parameterizeArgs(t.Context(), []string{"module", dir, "--name", "multi"})
+	require.NoError(t, err)
+	require.Equal(t, "multi", resp.Name)
+
+	assertMultiSchema := func(m *moduleProvider) pulumiSchema.PackageSpec {
+		out, err := m.getSchema(t.Context(), p.GetSchemaRequest{})
+		require.NoError(t, err)
+		var spec pulumiSchema.PackageSpec
+		require.NoError(t, json.Unmarshal([]byte(out.Schema), &spec))
+		require.Equal(t, "multi", spec.Name)
+		require.Equal(t,
+			[]string{"multi:greeter:Module", "multi:index:Module", "multi:user-data:Module"},
+			slices.Sorted(maps.Keys(spec.Resources)))
+		for token, res := range spec.Resources {
+			require.True(t, res.IsComponent, "%s must be a component", token)
+		}
+		require.Equal(t, "string", spec.Resources["multi:index:Module"].InputProperties["name"].Type)
+		require.Equal(t, "string", spec.Resources["multi:greeter:Module"].InputProperties["who"].Type)
+		require.Equal(t, "string", spec.Resources["multi:user-data:Module"].Properties["data"].Type)
+		return spec
+	}
+	spec := assertMultiSchema(m)
+
+	usage := &moduleProvider{version: "1.2.3", resolver: stubResolver{}}
+	resp2, err := usage.parameterize(t.Context(), p.ParameterizeRequest{
+		Value: &p.ParameterizeRequestValue{
+			Name:    resp.Name,
+			Version: resp.Version,
+			Value:   spec.Parameterization.Parameter,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, resp, resp2)
+	assertMultiSchema(usage)
+}
+
+// TestParameterizeArgsSubmodulesOnly verifies a package whose root holds no .tf
+// files — previously a hard "No Terraform files found" failure — parameterizes
+// into submodule components with no index component.
+func TestParameterizeArgsSubmodulesOnly(t *testing.T) {
+	t.Parallel()
+
+	dir := writeMultiComponentModule(t, false)
+
+	m := &moduleProvider{version: "1.2.3", resolver: stubResolver{}}
+	resp, err := m.parameterizeArgs(t.Context(), []string{"module", dir, "--name", "rootless"})
+	require.NoError(t, err)
+	require.Equal(t, "rootless", resp.Name)
+	require.Equal(t, semver.MustParse("0.0.0-dev"), resp.Version)
+
+	assertRootlessSchema := func(m *moduleProvider) pulumiSchema.PackageSpec {
+		out, err := m.getSchema(t.Context(), p.GetSchemaRequest{})
+		require.NoError(t, err)
+		var spec pulumiSchema.PackageSpec
+		require.NoError(t, json.Unmarshal([]byte(out.Schema), &spec))
+		require.Equal(t, "rootless", spec.Name)
+		require.Equal(t,
+			[]string{"rootless:greeter:Module", "rootless:user-data:Module"},
+			slices.Sorted(maps.Keys(spec.Resources)))
+		return spec
+	}
+	spec := assertRootlessSchema(m)
+
+	usage := &moduleProvider{version: "1.2.3", resolver: stubResolver{}}
+	resp2, err := usage.parameterize(t.Context(), p.ParameterizeRequest{
+		Value: &p.ParameterizeRequestValue{
+			Name:    resp.Name,
+			Version: resp.Version,
+			Value:   spec.Parameterization.Parameter,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, resp, resp2)
+	assertRootlessSchema(usage)
+}
+
+// TestConstructParameterizedDispatch drives Construct against a parameterized
+// multi-component package: the submodule token runs the submodule's module (its
+// outputs come back under their schema names), and an unknown token is
+// rejected.
+func TestConstructParameterizedDispatch(t *testing.T) {
+	t.Parallel()
+
+	dir := writeMultiComponentModule(t, true)
+	_, m, endpoint := serveMonitor(t)
+	m.version = "1.2.3"
+	_, err := m.parameterizeArgs(t.Context(), []string{"module", dir, "--name", "multi"})
+	require.NoError(t, err)
+
+	t.Run("submodule component", func(t *testing.T) {
+		t.Parallel()
+		resp, err := m.construct(t.Context(), p.ConstructRequest{
+			Urn:             resource.URN("urn:pulumi:test::proj::multi:greeter:Module::g"),
+			MonitorEndpoint: endpoint,
+			Inputs:          property.NewMap(map[string]property.Value{"who": property.New("world")}),
+		})
+		require.NoError(t, err)
+		require.Equal(t, property.New("hi world"), resp.State.Get("hello"))
+	})
+
+	t.Run("index component", func(t *testing.T) {
+		t.Parallel()
+		resp, err := m.construct(t.Context(), p.ConstructRequest{
+			Urn:             resource.URN("urn:pulumi:test::proj::multi:index:Module::r"),
+			MonitorEndpoint: endpoint,
+			Inputs:          property.NewMap(map[string]property.Value{"name": property.New("world")}),
+		})
+		require.NoError(t, err)
+		require.Equal(t, property.New("hello world"), resp.State.Get("greeting"))
+	})
+
+	t.Run("unknown token", func(t *testing.T) {
+		t.Parallel()
+		_, err := m.construct(t.Context(), p.ConstructRequest{
+			Urn:             resource.URN("urn:pulumi:test::proj::multi:nope:Module::x"),
+			MonitorEndpoint: endpoint,
+		})
+		require.EqualError(t, err, `unknown resource type: "multi:nope:Module"`)
+	})
 }
 
 // nopResolver is a non-nil PackageResolverClient so parameterize gets past its
@@ -580,7 +746,118 @@ func TestParameterizeBeforeHandshakeIsFailedPrecondition(t *testing.T) {
 	t.Parallel()
 	m := &moduleProvider{}
 	_, err := m.parameterize(t.Context(), p.ParameterizeRequest{
-		Args: &p.ParameterizeRequestArgs{Args: []string{"module", "acme/thing/aws"}},
+		Args: &p.ParameterizeRequestArgs{Args: []string{"module", "acme/thing/cloud"}},
 	})
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+// TestParameterizeSubmoduleNamedIndex verifies a modules/index directory is an
+// ordinary submodule: its terraform `package` and `component` blocks must not
+// name the package, which only the root directory may do.
+func TestParameterizeSubmoduleNamedIndex(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+	}
+	write("modules/index/main.tf", `
+terraform {
+  package {
+    name    = "hijacked"
+    version = "9.9.9"
+  }
+  component {
+    name = "Weird"
+  }
+}
+output "x" { value = 1 }
+`)
+	write("modules/other/main.tf", `output "y" { value = 2 }`)
+
+	m := &moduleProvider{version: "1.2.3", resolver: stubResolver{}}
+	resp, err := m.parameterizeArgs(t.Context(), []string{"module", dir, "--name", "pkg"})
+	require.NoError(t, err)
+	require.Equal(t, p.ParameterizeResponse{Name: "pkg", Version: semver.MustParse("0.0.0-dev")}, resp)
+
+	out, err := m.getSchema(t.Context(), p.GetSchemaRequest{})
+	require.NoError(t, err)
+	var spec pulumiSchema.PackageSpec
+	require.NoError(t, json.Unmarshal([]byte(out.Schema), &spec))
+	require.Equal(t, "pkg", spec.Name)
+	require.Equal(t,
+		[]string{"pkg:index:Module", "pkg:other:Module"},
+		slices.Sorted(maps.Keys(spec.Resources)))
+}
+
+// recordingResolver is a PackageResolverClient that records every spec it
+// resolves and answers with a minimal descriptor.
+type recordingResolver struct {
+	pulumirpc.PackageResolverClient
+	mu    sync.Mutex
+	specs []*pulumirpc.PackageSpec
+}
+
+func (r *recordingResolver) ResolvePackage(
+	_ context.Context, spec *pulumirpc.PackageSpec, _ ...grpc.CallOption,
+) (*pulumirpc.PackageDependency, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.specs = append(r.specs, spec)
+	return &pulumirpc.PackageDependency{Name: "terraform-provider", Kind: "resource", Version: "1.0.0"}, nil
+}
+
+// TestParameterizePerComponentProviderResolution verifies sibling components
+// resolve their providers as the independent configurations they are: the same
+// local name may name different sources in different components, and each
+// component's constraint resolves alone rather than intersecting with its
+// siblings'.
+func TestParameterizePerComponentProviderResolution(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	write := func(rel, content string) {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+	}
+	write("main.tf", `
+terraform {
+  required_providers {
+    foo = {
+      source  = "acme/foo"
+      version = "~> 5.0"
+    }
+  }
+}
+output "r" { value = 1 }
+`)
+	write("modules/legacy/main.tf", `
+terraform {
+  required_providers {
+    foo = {
+      source  = "other/foo"
+      version = "~> 4.0"
+    }
+  }
+}
+output "l" { value = 1 }
+`)
+
+	rec := &recordingResolver{}
+	m := &moduleProvider{version: "1.2.3", resolver: rec}
+	_, err := m.parameterizeArgs(t.Context(), []string{"module", dir, "--name", "pkg"})
+	require.NoError(t, err)
+
+	got := make([]string, len(rec.specs))
+	for i, s := range rec.specs {
+		got[i] = s.Source + " " + strings.Join(s.Parameters, " ")
+	}
+	slices.Sort(got)
+	require.Equal(t, []string{
+		"terraform-provider acme/foo ~> 5.0",
+		"terraform-provider other/foo ~> 4.0",
+	}, got)
 }

--- a/pkg/server/parameterize_test.go
+++ b/pkg/server/parameterize_test.go
@@ -544,7 +544,7 @@ func TestDedupeEdges(t *testing.T) {
 		{Caller: "0", Source: "b/m/cloud", Target: "2"},
 		{Caller: "", Source: "root", Target: "0"},
 		{Caller: "0", Source: "a/m/cloud", Target: "1"},
-		{Caller: "", Source: "root", Target: "0"},     // duplicate
+		{Caller: "", Source: "root", Target: "0"},       // duplicate
 		{Caller: "0", Source: "b/m/cloud", Target: "2"}, // duplicate
 	})
 

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -37,10 +37,11 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// NewLocalProvider serves the HCL module at modulePath as a source MLC: the
-// module provider born parameterized by the local module, reading provider
-// descriptors from the module's own sdks folder. addr is the engine's
-// schema-loader target, which also serves the mapper.
+// NewLocalProvider serves the HCL module package at modulePath as a source
+// MLC: the module provider born parameterized by the local package — one
+// component per consumable directory — reading provider descriptors from the
+// package's own sdks folder. addr is the engine's schema-loader target, which
+// also serves the mapper.
 func NewLocalProvider(ctx context.Context, modulePath, addr string) (pulumirpc.ResourceProviderServer, error) {
 	loader := modules.NewLoader(modules.LiveResolver(ctx))
 	pkgLoader, err := pulumiSchema.NewLoaderClient(addr)
@@ -64,12 +65,16 @@ func NewLocalProvider(ctx context.Context, modulePath, addr string) (pulumirpc.R
 	}
 	paramDescriptors := sdkDescriptors(sdkInfos)
 
-	loaded, err := loader.LoadModule(ctx, modulePath, "", ".")
+	comps, resolvedVersion, err := loadComponents(ctx, loader, modulePath, "")
 	if err != nil {
 		return nil, fmt.Errorf("loading module: %w", err)
 	}
-
-	token, version, err := moduleIdentity(loaded, filepath.Base(modulePath), false)
+	// The sdks folder is the package's shared descriptor pool; every component
+	// draws from it.
+	for i := range comps {
+		comps[i].packages = paramDescriptors
+	}
+	pkgName, rootToken, version, err := packageIdentity(comps, filepath.Base(modulePath), false, resolvedVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -80,17 +85,16 @@ func NewLocalProvider(ctx context.Context, modulePath, addr string) (pulumirpc.R
 		schemaLoader:       pkgLoader,
 		providerInfoSource: providerInfoSource,
 	}
-	moduleSchema, err := m.generateModuleSchema(ctx, loader, loaded, paramDescriptors, token, version)
+	components, spec, err := buildComponents(ctx, comps, pkgName, rootToken, version,
+		m.componentBinderFactory(loader))
 	if err != nil {
-		return nil, fmt.Errorf("generating schema: %w", err)
+		return nil, err
 	}
 
-	pkgName := token.Package().Name().String()
 	m.param = &parameterizedModule{
-		schema:     moduleSchema,
+		spec:       spec,
+		components: components,
 		loader:     loader,
-		rootSource: modulePath,
-		packages:   paramDescriptors,
 		name:       pkgName,
 	}
 	return p.RawServer(pkgName, version.String(), m.asProvider())(nil)

--- a/pkg/server/provider_test.go
+++ b/pkg/server/provider_test.go
@@ -17,7 +17,10 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"maps"
+	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 
@@ -82,7 +85,6 @@ func TestNewLocalProvider(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hello world", resp.State.Fields["greeting"].GetStringValue())
 
-	// The component registration carries the forwarded resource options.
 	component := mon.registeredType("module-one-var:index:Module")
 	require.NotNil(t, component, "the component itself must be registered")
 	require.Equal(t, []string{"urn:pulumi:test::proj::pkg:index:Other::sibling"}, component.ReplaceWith)
@@ -185,4 +187,73 @@ func TestConstructForwardsResourceHooks(t *testing.T) {
 		AfterDelete:  []string{"after-delete"},
 		OnError:      []string{"on-error"},
 	}, component.Hooks, protocmp.Transform()))
+}
+
+// TestNewLocalProviderMultiComponent verifies the local package serves one
+// component per consumable directory and dispatches Construct on the request's
+// type token.
+func TestNewLocalProviderMultiComponent(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	pkgDir := filepath.Join(base, "mypkg")
+	require.NoError(t, os.Rename(writeMultiComponentModule(t, true), pkgDir))
+
+	prov, err := NewLocalProvider(t.Context(), pkgDir, "127.0.0.1:1")
+	require.NoError(t, err)
+
+	out, err := prov.GetSchema(t.Context(), &pulumirpc.GetSchemaRequest{})
+	require.NoError(t, err)
+	var spec pulumiSchema.PackageSpec
+	require.NoError(t, json.Unmarshal([]byte(out.Schema), &spec))
+	require.Equal(t, "mypkg", spec.Name)
+	require.Equal(t,
+		[]string{"mypkg:greeter:Module", "mypkg:index:Module", "mypkg:user-data:Module"},
+		slices.Sorted(maps.Keys(spec.Resources)))
+
+	_, _, endpoint := serveMonitor(t)
+	inputs, err := structpb.NewStruct(map[string]any{"who": "world"})
+	require.NoError(t, err)
+	resp, err := prov.Construct(t.Context(), &pulumirpc.ConstructRequest{
+		Type:                "mypkg:greeter:Module",
+		Name:                "g",
+		Project:             "proj",
+		Stack:               "test",
+		MonitorEndpoint:     endpoint,
+		Inputs:              inputs,
+		AcceptsOutputValues: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "hi world", resp.State.Fields["hello"].GetStringValue())
+
+	_, err = prov.Construct(t.Context(), &pulumirpc.ConstructRequest{
+		Type:                "mypkg:nope:Module",
+		Name:                "x",
+		MonitorEndpoint:     endpoint,
+		AcceptsOutputValues: true,
+	})
+	require.ErrorContains(t, err, `unknown resource type: "mypkg:nope:Module"`)
+}
+
+// TestNewLocalProviderSubmodulesOnly verifies a local package whose root holds
+// no .tf files — previously a hard failure — serves its submodule components.
+func TestNewLocalProviderSubmodulesOnly(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	pkgDir := filepath.Join(base, "mypkg")
+	require.NoError(t, os.Rename(writeMultiComponentModule(t, false), pkgDir))
+
+	prov, err := NewLocalProvider(t.Context(), pkgDir, "127.0.0.1:1")
+	require.NoError(t, err)
+
+	out, err := prov.GetSchema(t.Context(), &pulumirpc.GetSchemaRequest{})
+	require.NoError(t, err)
+	var spec pulumiSchema.PackageSpec
+	require.NoError(t, json.Unmarshal([]byte(out.Schema), &spec))
+	require.Equal(t, "mypkg", spec.Name)
+	require.Equal(t, "0.0.0-dev", spec.Version)
+	require.Equal(t,
+		[]string{"mypkg:greeter:Module", "mypkg:user-data:Module"},
+		slices.Sorted(maps.Keys(spec.Resources)))
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -171,15 +171,14 @@ func (host *LanguageHost) GetRequiredPackages(
 ) (*pulumirpc.GetRequiredPackagesResponse, error) {
 	logging.V(5).Infof("GetRequiredPackages: program=%s", req.Info.ProgramDirectory)
 
-	p := parser.NewParser()
-	config, diags := p.ParseDirectory(req.Info.ProgramDirectory)
-	if diags.HasErrors() {
-		return &pulumirpc.GetRequiredPackagesResponse{}, nil
-	}
-
 	sdks, err := readSDKInfos(req.Info.ProgramDirectory)
 	if err != nil {
 		return &pulumirpc.GetRequiredPackagesResponse{}, fmt.Errorf("unable to read SDKs folder: %w", err)
+	}
+
+	dirs, err := requirementDirs(req.Info.ProgramDirectory)
+	if err != nil {
+		return &pulumirpc.GetRequiredPackagesResponse{}, err
 	}
 
 	// Resolve every provider referenced anywhere in the module tree to its
@@ -189,8 +188,19 @@ func (host *LanguageHost) GetRequiredPackages(
 	// (the terraform-provider plugin intersects them at resolve time, erroring on
 	// an empty intersection just as tofu does), and distinct sources are distinct
 	// installs.
-	tfReqs, pulumiPkgs, _ := collectRequirements(ctx, modules.NewLoader(modules.LiveResolver(ctx)),
-		config, req.Info.ProgramDirectory)
+	p := parser.NewParser()
+	loader := modules.NewLoader(modules.LiveResolver(ctx))
+	tfReqs := map[string]*tfRequirement{}
+	pulumiPkgs := map[string]string{}
+	aliases := map[string]*ast.RequiredProvider{}
+	visited := map[string]struct{}{}
+	for _, dir := range dirs {
+		config, diags := p.ParseDirectory(dir)
+		if diags.HasErrors() {
+			continue
+		}
+		collectRequirementsRec(ctx, config, dir, tfReqs, pulumiPkgs, aliases, loader, visited)
+	}
 
 	// Distinct sources resolving to one package name cannot both live at
 	// sdks/<name>: `pulumi install` would overwrite one SDK with the other

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1018,6 +1018,82 @@ data "terraform_remote_state" "rs" {
 	}, resp.Packages[0])
 }
 
+// writeSubmodulePackage writes a component package whose modules/greeter
+// submodule requires a provider the root never references.
+func writeSubmodulePackage(t *testing.T, withPlugin, withRoot bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	if withPlugin {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "PulumiPlugin.yaml"), []byte("runtime: hcl\n"), 0o600))
+	}
+	if withRoot {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+output "x" {
+  value = 1
+}
+`), 0o600))
+	}
+	greeterDir := filepath.Join(dir, "modules", "greeter")
+	require.NoError(t, os.MkdirAll(greeterDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(greeterDir, "main.tf"), []byte(`
+terraform {
+  required_providers {
+    greeting = {
+      source  = "acme/greeting"
+      version = ">= 3.0"
+    }
+  }
+}
+
+resource "greeting_card" "p" {}
+`), 0o600))
+	return dir
+}
+
+func getRequiredPackages(t *testing.T, dir string) *pulumirpc.GetRequiredPackagesResponse {
+	t.Helper()
+	host := &LanguageHost{}
+	resp, err := host.GetRequiredPackages(t.Context(), &pulumirpc.GetRequiredPackagesRequest{
+		Info: &pulumirpc.ProgramInfo{
+			ProgramDirectory: dir,
+			RootDirectory:    dir,
+			EntryPoint:       ".",
+		},
+	})
+	require.NoError(t, err)
+	return resp
+}
+
+func TestGetRequiredPackages_SubmoduleComponentProviders(t *testing.T) {
+	t.Parallel()
+
+	resp := getRequiredPackages(t, writeSubmodulePackage(t, true, true))
+	assert.Empty(t, resp.Packages)
+	assert.Equal(t, []*pulumirpc.PackageSpec{{
+		Source:     "terraform-provider",
+		Parameters: []string{"acme/greeting", ">= 3.0"},
+	}}, resp.Specs)
+}
+
+func TestGetRequiredPackages_RootlessComponentProviders(t *testing.T) {
+	t.Parallel()
+
+	resp := getRequiredPackages(t, writeSubmodulePackage(t, true, false))
+	assert.Empty(t, resp.Packages)
+	assert.Equal(t, []*pulumirpc.PackageSpec{{
+		Source:     "terraform-provider",
+		Parameters: []string{"acme/greeting", ">= 3.0"},
+	}}, resp.Specs)
+}
+
+func TestGetRequiredPackages_ProgramSkipsUnreferencedModules(t *testing.T) {
+	t.Parallel()
+
+	resp := getRequiredPackages(t, writeSubmodulePackage(t, false, true))
+	assert.Empty(t, resp.Packages)
+	assert.Empty(t, resp.Specs)
+}
+
 // TestPackageDescriptorFromSchemaExtension verifies that an extension
 // parameterization in a package schema is read into the descriptor's extension
 // slot, naming the base provider (whose namespace the extension's tokens use).


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-hcl/issues/529

A module package now serves one component per consumable directory, per the registry convention that both the root and `modules/<name>` are consumed directly:

| Terraform directory | Pulumi component |
|---|---|
| root, when it holds `.tf` files | `pkg:index:Module`, exactly as today |
| `modules/<name>` | `pkg:<name>:Module` |

A package whose root holds no `.tf` files — previously the hard failure quoted in the issue — serves only its submodule components, named from its source (`terraform-aws-modules/iam/aws` → `iam-aws`) and versioned by the resolved source version. Existing single-component packages are unchanged, so the mapping is additive.

## How

- **Discovery** (`pkg/server/components.go`): the root when it holds Terraform files, plus each `modules/<name>` directory that does (one level deep), segments sanitized to lowercase alphanumerics/hyphens (`_user_data` → `user-data`). No components, colliding segments, or a component that fails to load or type fails the whole parameterize, naming the directory — no partial packages.
- **Both providers share one pipeline**: `loadComponents` → `packageIdentity` (the root's `package`/`component` blocks apply as before; defaults when there is no root) → `buildComponents` (per-component schema generation + combined `PackageSpec`). The parameterize path (`pulumi package add hcl module <source>`) and the local-path MLC (`HCLProvider`) differ only in where provider descriptors come from, which the binder factory carries. Both `Construct`s dispatch on the request's type token.
- **Provider requirements union across components**, exactly as they already union across the child modules of one root.
- **No bundle format change**: subdir splitting happens above the resolver, so submodule loads (`<source>//modules/<name>`) resolve through the already-recorded package edge and the archive already contains `modules/`. Old bundles keep working; the usage path re-runs the same discovery against the unpacked bundle.

## Verification

Beyond unit coverage (discovery, multi-component and submodules-only parameterize with offline value round-trips, construct dispatch on both providers), verified against the real registry with the dev build:

- `terraform-aws-modules/iam/aws` (empty root, the issue's repro) generates a valid Python SDK — `iam_role/`, `iam_account/`, …, all files parse.
- `terraform-aws-modules/eks/aws` generates the TS SDK exactly as the issue sketches: root `Module` plus `karpenter/`, `fargate-profile/`, `eks-managed-node-group/`, `user-data/`, ….
- `terraform-google-modules/network/google` fails whole-parameterize naming `modules/network-firewall-policy`, which uses `google_compute_network_firewall_policy_packet_mirroring_rule` — a resource the bridged google provider does not serve. This is the issue's explicit "partial packages are worse than none" choice, but note the trade-off: a package whose root parameterized fine before can now fail on a submodule. If that proves too strict in practice, a follow-up could add an opt-out.