### PR TITLE
Support OpenTofu's `language` block for declaring Pulumi compatibility

### DIFF
--- a/.changes/unreleased/runtime-improvements-531.yaml
+++ b/.changes/unreleased/runtime-improvements-531.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Support OpenTofu's `language` block, honoring `compatible_with { pulumi = "..." }` version constraints
+time: 2026-08-10T16:57:16Z
+custom:
+    Component: runtime
+    PR: "531"

--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -879,6 +879,21 @@ terraform {
 }
 ```
 
+The Pulumi CLI version can also be constrained with OpenTofu's extensible
+[`language` block](https://opentofu.org/docs/language/settings/#declaring-implementation-compatibility). Only the
+`pulumi` argument of a `compatible_with` block is interpreted; arguments addressed to other software (such as
+`opentofu`) are ignored without validation, so a single module can declare compatibility with several implementations
+at once:
+
+```hcl
+language {
+  compatible_with {
+    opentofu = ">= 1.12"
+    pulumi   = ">= 3.0.0"
+  }
+}
+```
+
 ### Multi-Language Components
 
 The `component` and `package` blocks declare an HCL module as a reusable component consumable from any Pulumi
@@ -950,7 +965,7 @@ Differences from Terraform to be aware of:
 
 ### Unsupported Features
 
-- **`backend`, `required_version`, `provider_meta`, `experiments`** — Accepted inside the `terraform` block but ignored with a warning; Pulumi manages state independently and tracks its own version constraints via `required_version_range`, and language experiments have no Pulumi HCL equivalent.
+- **`backend`, `required_version`, `provider_meta`, `experiments`** — Accepted inside the `terraform` block but ignored with a warning; Pulumi manages state independently and tracks its own version constraints via `required_version_range` or a `language` block's `compatible_with { pulumi = ... }` argument, and language experiments have no Pulumi HCL equivalent.
 - **`cloud`** — Not accepted inside the `terraform` block at all. It is absent from the block's schema, so a `cloud` block is a parse error rather than a warning.
 - **WinRM connections** — Only `type = "ssh"` is supported in `connection` blocks.
 - **`List<Object>` empty vs null** — HCL block syntax cannot distinguish between an empty and null `List<Object>`, a known incompatibility with some Pulumi programs.

--- a/docs/terraform-compatibility.md
+++ b/docs/terraform-compatibility.md
@@ -6,7 +6,7 @@ Pulumi HCL should be able to run all valid Terraform config programs without cha
 
 A small number of Terraform features are not modeled:
 
-- **`backend`, `required_version`, `provider_meta`, and `experiments`** in the `terraform` block are accepted but ignored with a warning. Pulumi manages state independently and tracks its own version constraints via `required_version_range`; language experiments have no Pulumi HCL equivalent.
+- **`backend`, `required_version`, `provider_meta`, and `experiments`** in the `terraform` block are accepted but ignored with a warning. Pulumi manages state independently and tracks its own version constraints via `required_version_range` or a `language` block's `compatible_with { pulumi = ... }` argument; language experiments have no Pulumi HCL equivalent.
 - **`cloud`** in the `terraform` block is not accepted at all. Unlike the arguments above it is not part of the `terraform` block's schema, so a `cloud` block is a parse error rather than a warning. Remove it — Pulumi's own backend configuration lives outside the program.
 - **WinRM `connection` blocks** are not supported — `connection` accepts `type = "ssh"` only.
 - **`List<Object>` empty vs null** — HCL block syntax cannot distinguish an empty `List<Object>` from a null one, a known incompatibility with some Pulumi programs.

--- a/pkg/hcl/ast/config.go
+++ b/pkg/hcl/ast/config.go
@@ -26,6 +26,10 @@ type Config struct {
 	// and provider requirements).
 	Terraform *Terraform
 
+	// Language contains the language block's Pulumi compatibility
+	// declaration, if any.
+	Language *Language
+
 	// Providers maps provider alias to provider configuration.
 	// The key is the provider local name (e.g., "aws") or alias (e.g., "aws.west").
 	Providers map[string]*Provider

--- a/pkg/hcl/ast/terraform.go
+++ b/pkg/hcl/ast/terraform.go
@@ -60,6 +60,29 @@ type Terraform struct {
 	DeclRange hcl.Range
 }
 
+// Language represents a language block declaring implementation
+// compatibility (OpenTofu's extensible successor to required_version).
+//
+// Syntax:
+//
+//	language {
+//	  compatible_with {
+//	    opentofu = ">= 1.12"
+//	    pulumi   = ">= 3.0.0"
+//	  }
+//	}
+//
+// Only the pulumi argument is interpreted; arguments addressed to other
+// software (such as opentofu) are ignored without validation so a module can
+// declare compatibility with several implementations at once.
+type Language struct {
+	// CompatibleWithPulumi is the version range expression for the Pulumi CLI.
+	CompatibleWithPulumi hcl.Expression
+
+	// DeclRange is the source range of the compatible_with pulumi argument.
+	DeclRange hcl.Range
+}
+
 // ComponentBlock declares a component within a terraform block.
 type ComponentBlock struct {
 	// Name is the component name (required). Must be a valid Pulumi name.

--- a/pkg/hcl/ast/terraform.go
+++ b/pkg/hcl/ast/terraform.go
@@ -71,10 +71,6 @@ type Terraform struct {
 //	    pulumi   = ">= 3.0.0"
 //	  }
 //	}
-//
-// Only the pulumi argument is interpreted; arguments addressed to other
-// software (such as opentofu) are ignored without validation so a module can
-// declare compatibility with several implementations at once.
 type Language struct {
 	// CompatibleWithPulumi is the version range expression for the Pulumi CLI.
 	CompatibleWithPulumi hcl.Expression

--- a/pkg/hcl/parser/override.go
+++ b/pkg/hcl/parser/override.go
@@ -66,9 +66,6 @@ func applyOverrides(primary, override []*hcl.Block) (blocks, deferred []*hcl.Blo
 			deferred = append(deferred, block)
 			continue
 		case "language":
-			// Language blocks have whole-module scope, so allowing overrides
-			// would have surprising effects on declarations elsewhere in the
-			// module.
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Language selections in override file",

--- a/pkg/hcl/parser/override.go
+++ b/pkg/hcl/parser/override.go
@@ -65,6 +65,18 @@ func applyOverrides(primary, override []*hcl.Block) (blocks, deferred []*hcl.Blo
 		case "locals", "terraform":
 			deferred = append(deferred, block)
 			continue
+		case "language":
+			// Language blocks have whole-module scope, so allowing overrides
+			// would have surprising effects on declarations elsewhere in the
+			// module.
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Language selections in override file",
+				Detail: "Language-related settings in \"language\" blocks are not allowed in " +
+					"override files. Place these settings in a normal configuration file.",
+				Subject: &block.DefRange,
+			})
+			continue
 		case "moved", "import", "removed":
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,

--- a/pkg/hcl/parser/override_test.go
+++ b/pkg/hcl/parser/override_test.go
@@ -279,3 +279,21 @@ moved {
 	require.Len(t, diags, 1)
 	assert.Equal(t, `Cannot override "moved" blocks`, diags[0].Summary)
 }
+
+func TestOverrideLanguageRejected(t *testing.T) {
+	t.Parallel()
+
+	_, diags := parseDir(t, map[string]string{
+		"main.tf": `resource "simple_resource" "r" { input_one = "base" }`,
+		"override.tf": `
+language {
+  compatible_with {
+    pulumi = ">= 3.0.0"
+  }
+}
+`,
+	})
+
+	require.Len(t, diags, 1)
+	assert.Equal(t, "Language selections in override file", diags[0].Summary)
+}

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -139,6 +139,8 @@ func (p *Parser) parseBlock(config *ast.Config, block *hcl.Block) hcl.Diagnostic
 	switch block.Type {
 	case "terraform":
 		return p.parseTerraformBlock(config, block)
+	case "language":
+		return p.parseLanguageBlock(config, block)
 	case "provider":
 		return p.parseProviderBlock(config, block)
 	case "variable":
@@ -282,6 +284,88 @@ func (p *Parser) parseTerraformBlock(config *ast.Config, block *hcl.Block) hcl.D
 	}
 
 	config.Terraform = tf
+	return diags
+}
+
+// parseLanguageBlock parses a language block, OpenTofu's extensible syntax
+// for declaring implementation compatibility. Only the `pulumi` argument of a
+// compatible_with block is interpreted; arguments addressed to other software
+// (such as opentofu) are ignored without validation so the same module can
+// declare compatibility with several implementations at once.
+func (p *Parser) parseLanguageBlock(config *ast.Config, block *hcl.Block) hcl.Diagnostics {
+	content, diags := block.Body.Content(languageSchema)
+
+	if attr, ok := content.Attributes["edition"]; ok {
+		// Language editions are reserved for future use; the only living
+		// edition is the default, so naming any other one means the module
+		// targets a language this version does not implement.
+		const currentEdition = "tofu2024"
+		switch kw := hcl.ExprAsKeyword(attr.Expr); {
+		case kw == "":
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid language edition",
+				Detail: fmt.Sprintf("The \"edition\" argument expects a bare language edition keyword. "+
+					"Pulumi HCL supports only language edition %s, which is the default.", currentEdition),
+				Subject: attr.Expr.Range().Ptr(),
+			})
+		case kw != currentEdition:
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Unsupported language edition",
+				Detail: fmt.Sprintf("Pulumi HCL does not support language edition %q; only %s is supported. "+
+					"This module may be intended for use with other software.", kw, currentEdition),
+				Subject: attr.Expr.Range().Ptr(),
+			})
+		}
+	}
+
+	if attr, ok := content.Attributes["experiments"]; ok {
+		exprs, moreDiags := hcl.ExprList(attr.Expr)
+		diags = append(diags, moreDiags...)
+		for _, expr := range exprs {
+			kw := hcl.ExprAsKeyword(expr)
+			if kw == "" {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid experiment keyword",
+					Detail:   "Elements of \"experiments\" must all be keywords representing active experiments.",
+					Subject:  expr.Range().Ptr(),
+				})
+				continue
+			}
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Unknown experiment keyword",
+				Detail:   fmt.Sprintf("There is no current experiment with the keyword %q.", kw),
+				Subject:  expr.Range().Ptr(),
+			})
+		}
+	}
+
+	for _, subBlock := range content.Blocks {
+		sub, _, subDiags := subBlock.Body.PartialContent(languageCompatibleWithSchema)
+		diags = append(diags, subDiags...)
+		attr, ok := sub.Attributes["pulumi"]
+		if !ok {
+			continue
+		}
+		if config.Language != nil {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Duplicate compatible_with pulumi argument",
+				Detail: fmt.Sprintf("The Pulumi version constraint was already declared at %s.",
+					config.Language.DeclRange),
+				Subject: attr.Range.Ptr(),
+			})
+			continue
+		}
+		config.Language = &ast.Language{
+			CompatibleWithPulumi: attr.Expr,
+			DeclRange:            attr.Range,
+		}
+	}
+
 	return diags
 }
 

--- a/pkg/hcl/parser/parser.go
+++ b/pkg/hcl/parser/parser.go
@@ -296,9 +296,6 @@ func (p *Parser) parseLanguageBlock(config *ast.Config, block *hcl.Block) hcl.Di
 	content, diags := block.Body.Content(languageSchema)
 
 	if attr, ok := content.Attributes["edition"]; ok {
-		// Language editions are reserved for future use; the only living
-		// edition is the default, so naming any other one means the module
-		// targets a language this version does not implement.
 		const currentEdition = "tofu2024"
 		switch kw := hcl.ExprAsKeyword(attr.Expr); {
 		case kw == "":

--- a/pkg/hcl/parser/parser_test.go
+++ b/pkg/hcl/parser/parser_test.go
@@ -528,6 +528,92 @@ terraform {
 	})
 }
 
+func TestLanguageBlock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pulumi_constraint_parsed", func(t *testing.T) {
+		t.Parallel()
+		src := `
+language {
+  compatible_with {
+    opentofu = ">= 1.12"
+    pulumi   = ">= 3.0.0"
+  }
+}`
+		cfg, diags := NewParser().ParseSource("test.hcl", []byte(src))
+		require.False(t, diags.HasErrors(), "unexpected errors: %v", diags)
+		require.NotNil(t, cfg.Language)
+		val, valDiags := cfg.Language.CompatibleWithPulumi.Value(nil)
+		require.False(t, valDiags.HasErrors(), valDiags.Error())
+		assert.Equal(t, cty.StringVal(">= 3.0.0"), val)
+	})
+
+	t.Run("other_software_ignored", func(t *testing.T) {
+		t.Parallel()
+		src := `
+language {
+  compatible_with {
+    opentofu       = ">= 1.12"
+    other_software = ["not", "a", "version"]
+  }
+}`
+		cfg, diags := NewParser().ParseSource("test.hcl", []byte(src))
+		require.False(t, diags.HasErrors(), "unexpected errors: %v", diags)
+		assert.Nil(t, cfg.Language)
+	})
+
+	t.Run("duplicate_pulumi_across_blocks", func(t *testing.T) {
+		t.Parallel()
+		src := `
+language {
+  compatible_with {
+    pulumi = ">= 3.0.0"
+  }
+}
+
+language {
+  compatible_with {
+    pulumi = ">= 4.0.0"
+  }
+}`
+		_, diags := NewParser().ParseSource("test.hcl", []byte(src))
+		require.True(t, diags.HasErrors(), "expected duplicate-pulumi error, got %v", diags)
+		require.Equal(t, "Duplicate compatible_with pulumi argument", diags[0].Summary)
+	})
+
+	t.Run("current_edition_accepted", func(t *testing.T) {
+		t.Parallel()
+		src := `
+language {
+  edition = tofu2024
+}`
+		_, diags := NewParser().ParseSource("test.hcl", []byte(src))
+		require.False(t, diags.HasErrors(), "unexpected errors: %v", diags)
+	})
+
+	t.Run("future_edition_rejected", func(t *testing.T) {
+		t.Parallel()
+		src := `
+language {
+  edition = tofu2030
+}`
+		_, diags := NewParser().ParseSource("test.hcl", []byte(src))
+		require.True(t, diags.HasErrors(), "expected unsupported-edition error, got %v", diags)
+		require.Equal(t, "Unsupported language edition", diags[0].Summary)
+	})
+
+	t.Run("experiments_rejected", func(t *testing.T) {
+		t.Parallel()
+		src := `
+language {
+  experiments = [some_experiment]
+}`
+		_, diags := NewParser().ParseSource("test.hcl", []byte(src))
+		require.True(t, diags.HasErrors(), "expected unknown-experiment error, got %v", diags)
+		require.Equal(t, "Unknown experiment keyword", diags[0].Summary)
+	})
+}
+
 func TestParseUnknownBlockType(t *testing.T) {
 	t.Parallel()
 	src := []byte(`

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -68,9 +68,8 @@ var terraformSchema = &hcl.BodySchema{
 }
 
 // languageSchema defines the structure of a language block. `edition` and
-// `experiments` are reserved arguments validated like OpenTofu validates
-// them, so a module written for a future language edition fails loudly
-// instead of misbehaving.
+// `experiments` are reserved: a module targeting a future language edition or
+// an active experiment fails loudly instead of misbehaving.
 var languageSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{Name: "edition"},
@@ -82,9 +81,8 @@ var languageSchema = &hcl.BodySchema{
 }
 
 // languageCompatibleWithSchema lists only the argument Pulumi HCL interprets
-// in a compatible_with block. The block is decoded with PartialContent so
-// arguments addressed to other software (e.g. opentofu) are ignored without
-// validation.
+// in a compatible_with block; decode with PartialContent so the rest is
+// ignored.
 var languageCompatibleWithSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{Name: "pulumi"},

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -23,6 +23,7 @@ import (
 var rootSchema = &hcl.BodySchema{
 	Blocks: []hcl.BlockHeaderSchema{
 		{Type: "terraform"},
+		{Type: "language"},
 		{Type: "provider", LabelNames: []string{"name"}},
 		{Type: "variable", LabelNames: []string{"name"}},
 		{Type: "locals"},
@@ -63,6 +64,30 @@ var terraformSchema = &hcl.BodySchema{
 		{Type: "package"},
 		{Type: "backend", LabelNames: []string{"type"}},
 		{Type: "provider_meta", LabelNames: []string{"provider"}},
+	},
+}
+
+// languageSchema defines the structure of a language block. `edition` and
+// `experiments` are reserved arguments validated like OpenTofu validates
+// them, so a module written for a future language edition fails loudly
+// instead of misbehaving.
+var languageSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "edition"},
+		{Name: "experiments"},
+	},
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "compatible_with"},
+	},
+}
+
+// languageCompatibleWithSchema lists only the argument Pulumi HCL interprets
+// in a compatible_with block. The block is decoded with PartialContent so
+// arguments addressed to other software (e.g. opentofu) are ignored without
+// validation.
+var languageCompatibleWithSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "pulumi"},
 	},
 }
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -831,7 +831,11 @@ func (e *Engine) processNode(ctx context.Context, node *graph.Node) error {
 }
 
 func (e *Engine) processGraph(ctx context.Context, g *graph.Graph) error {
-	if err := g.InjectAfter(e.checkPulumiVersion, func(n *graph.Node) bool {
+	check := func(ctx context.Context) error {
+		return e.checkConfigPulumiVersion(ctx,
+			e.config, e.evaluator.EvaluateExpression)
+	}
+	if err := g.InjectAfter(check, func(n *graph.Node) bool {
 		return n.Type == graph.NodeTypeVariable && n.ModuleInfo == nil
 	}); err != nil {
 		return err
@@ -4939,14 +4943,6 @@ func evaluateCheckAssert(evaluator *eval.Evaluator, rule *ast.CheckRule) string 
 		return msg
 	}
 	return "assertion failed"
-}
-
-// checkPulumiVersion checks if the Pulumi CLI version satisfies the root
-// config's declared version constraints: the terraform block's
-// required_version_range attribute and the language block's compatible_with
-// pulumi argument.
-func (e *Engine) checkPulumiVersion(ctx context.Context) error {
-	return e.checkConfigPulumiVersion(ctx, e.config, e.evaluator.EvaluateExpression)
 }
 
 // checkModulePulumiVersion enforces a child module's declared version

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -4077,6 +4077,10 @@ func (e *Engine) processModuleInit(ctx context.Context, node *graph.Node) error 
 		return fmt.Errorf("loading module %s for input types: %w", mod.Source, err)
 	}
 
+	if err := e.checkModulePulumiVersion(ctx, mod.Source, childMod.Config); err != nil {
+		return err
+	}
+
 	// One table serves every instance: the functions a module can call depend
 	// on its config and call site, not on the count/for_each iteration.
 	moduleFunctions, err := e.providerFunctionTable(ctx, childMod.Config, modInfo)
@@ -4937,32 +4941,58 @@ func evaluateCheckAssert(evaluator *eval.Evaluator, rule *ast.CheckRule) string 
 	return "assertion failed"
 }
 
-// checkPulumiVersion checks if the Pulumi CLI version satisfies the required version range.
-// The version requirement is specified via the pulumi block's requiredVersionRange attribute.
+// checkPulumiVersion checks if the Pulumi CLI version satisfies the root
+// config's declared version constraints: the terraform block's
+// required_version_range attribute and the language block's compatible_with
+// pulumi argument.
 func (e *Engine) checkPulumiVersion(ctx context.Context) error {
-	// Check if the pulumi block exists and has a version requirement
-	if e.config.Terraform == nil || e.config.Terraform.RequiredVersionRange == nil {
-		// No version requirement specified
-		return nil
+	return e.checkConfigPulumiVersion(ctx, e.config, e.evaluator.EvaluateExpression)
+}
+
+// checkModulePulumiVersion enforces a child module's declared version
+// constraints. The module's own scope does not exist yet when its call is
+// initialized, so the constraint expressions evaluate statically — matching
+// Terraform, which requires them to be literal strings.
+func (e *Engine) checkModulePulumiVersion(ctx context.Context, source string, config *ast.Config) error {
+	err := e.checkConfigPulumiVersion(ctx, config, func(expr hcl.Expression) (cty.Value, hcl.Diagnostics) {
+		return expr.Value(nil)
+	})
+	if err != nil {
+		return fmt.Errorf("module %s: %w", source, err)
+	}
+	return nil
+}
+
+func (e *Engine) checkConfigPulumiVersion(
+	ctx context.Context, config *ast.Config,
+	evalExpr func(hcl.Expression) (cty.Value, hcl.Diagnostics),
+) error {
+	var exprs []hcl.Expression
+	if tf := config.Terraform; tf != nil && tf.RequiredVersionRange != nil {
+		exprs = append(exprs, tf.RequiredVersionRange)
+	}
+	if l := config.Language; l != nil {
+		exprs = append(exprs, l.CompatibleWithPulumi)
 	}
 
-	// Evaluate the requiredVersionRange expression
-	versionVal, diags := e.evaluator.EvaluateExpression(e.config.Terraform.RequiredVersionRange)
-	if diags.HasErrors() {
-		return fmt.Errorf("evaluating requiredVersionRange: %s", diags.Error())
+	for _, expr := range exprs {
+		versionVal, diags := evalExpr(expr)
+		if diags.HasErrors() {
+			return fmt.Errorf("evaluating Pulumi version constraint: %s", diags.Error())
+		}
+		if versionVal.Type() != cty.String {
+			return fmt.Errorf("Pulumi version constraint must be a string, got %s",
+				versionVal.Type().FriendlyName())
+		}
+		versionRange := versionVal.AsString()
+		if versionRange == "" {
+			continue
+		}
+		if err := e.resmon.CheckPulumiVersion(ctx, versionRange); err != nil {
+			return err
+		}
 	}
-
-	// Get the version range string
-	if versionVal.Type() != cty.String {
-		return fmt.Errorf("requiredVersionRange must be a string, got %s", versionVal.Type().FriendlyName())
-	}
-
-	versionRange := versionVal.AsString()
-	if versionRange == "" {
-		return nil
-	}
-
-	return e.resmon.CheckPulumiVersion(ctx, versionRange)
+	return nil
 }
 
 func ptr[T any](v T) *T { return &v }

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -4951,8 +4951,7 @@ func (e *Engine) checkPulumiVersion(ctx context.Context) error {
 
 // checkModulePulumiVersion enforces a child module's declared version
 // constraints. The module's own scope does not exist yet when its call is
-// initialized, so the constraint expressions evaluate statically — matching
-// Terraform, which requires them to be literal strings.
+// initialized, so the constraint expressions evaluate statically.
 func (e *Engine) checkModulePulumiVersion(ctx context.Context, source string, config *ast.Config) error {
 	err := e.checkConfigPulumiVersion(ctx, config, func(expr hcl.Expression) (cty.Value, hcl.Diagnostics) {
 		return expr.Value(nil)

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -4981,7 +4981,7 @@ func (e *Engine) checkConfigPulumiVersion(
 			return fmt.Errorf("evaluating Pulumi version constraint: %s", diags.Error())
 		}
 		if versionVal.Type() != cty.String {
-			return fmt.Errorf("Pulumi version constraint must be a string, got %s",
+			return fmt.Errorf("the Pulumi version constraint must be a string, got %s",
 				versionVal.Type().FriendlyName())
 		}
 		versionRange := versionVal.AsString()

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/blang/semver"
@@ -508,6 +509,93 @@ module "keyed" {
 		"renamed.derived", "renamed-pinned", "renamed.null_override",
 		"keyed-k.derived", "keyed-k-pinned", "keyed-k.null_override",
 	}, instanceNames)
+}
+
+// Version constraints are enforced per module: the root's
+// required_version_range and a child module's language block both reach
+// CheckPulumiVersion, and a failing child constraint names the module.
+func TestEngine_ModulePulumiVersionCheck(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T) (*ast.Config, string) {
+		tmpDir := t.TempDir()
+		moduleDir := tmpDir + "/modules/child"
+		require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+
+		moduleMain := `
+language {
+  compatible_with {
+    opentofu = ">= 1.12"
+    pulumi   = ">= 999.0.0"
+  }
+}
+`
+		require.NoError(t, os.WriteFile(moduleDir+"/main.tf", []byte(moduleMain), 0o644))
+
+		rootMain := `
+terraform {
+  required_version_range = ">= 3.0.0"
+}
+
+module "child" {
+  source = "./modules/child"
+}
+`
+		require.NoError(t, os.WriteFile(tmpDir+"/main.tf", []byte(rootMain), 0o644))
+
+		config, diags := parser.NewParser().ParseDirectory(tmpDir)
+		require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+		return config, tmpDir
+	}
+
+	newEngine := func(t *testing.T, config *ast.Config, tmpDir string, mock *testutil.MockResourceMonitor) *run.Engine {
+		return newTestEngine(t, config, &run.EngineOptions{
+			ModuleLoader:    testLiveModuleLoader(t),
+			ProjectName:     "test-project",
+			StackName:       "dev",
+			ResourceMonitor: mock,
+			WorkDir:         tmpDir,
+			RootDir:         tmpDir,
+			SchemaLoader:    schemaloader.New(t, schema.PackageSpec{Name: "aws"}),
+		})
+	}
+
+	t.Run("both_constraints_checked", func(t *testing.T) {
+		t.Parallel()
+		config, tmpDir := setup(t)
+
+		var mu sync.Mutex
+		var ranges []string
+		mock := &testutil.MockResourceMonitor{
+			CheckPulumiVersionHandler: func(ctx context.Context, versionRange string) error {
+				mu.Lock()
+				defer mu.Unlock()
+				ranges = append(ranges, versionRange)
+				return nil
+			},
+		}
+
+		require.NoError(t, newEngine(t, config, tmpDir, mock).Run(t.Context()))
+		assert.ElementsMatch(t, []string{">= 3.0.0", ">= 999.0.0"}, ranges)
+	})
+
+	t.Run("failing_child_constraint_names_module", func(t *testing.T) {
+		t.Parallel()
+		config, tmpDir := setup(t)
+
+		mock := &testutil.MockResourceMonitor{
+			CheckPulumiVersionHandler: func(ctx context.Context, versionRange string) error {
+				if versionRange == ">= 999.0.0" {
+					return fmt.Errorf("Pulumi CLI version does not satisfy %q", versionRange)
+				}
+				return nil
+			},
+		}
+
+		err := newEngine(t, config, tmpDir, mock).Run(t.Context())
+		require.Error(t, err)
+		assert.ErrorContains(t, err, `module ./modules/child: Pulumi CLI version does not satisfy ">= 999.0.0"`)
+	})
 }
 
 // Distinct addresses must derive distinct names even when labels and keys

--- a/tests/testutil/monitor.go
+++ b/tests/testutil/monitor.go
@@ -44,6 +44,9 @@ type MockResourceMonitor struct {
 
 	// RegisterResourceHandler, if  set, is  called for each  RegisterResource instead of the default behavior.
 	RegisterResourceHandler func(ctx context.Context, req run.RegisterResourceRequest) (*run.RegisterResourceResponse, error)
+
+	// CheckPulumiVersionHandler, if set, is called for each CheckPulumiVersion instead of the default behavior.
+	CheckPulumiVersionHandler func(ctx context.Context, versionRange string) error
 }
 
 type registeredHook struct {
@@ -180,6 +183,9 @@ func (m *MockResourceMonitor) Call(ctx context.Context, req run.CallRequest) (*r
 }
 
 func (m *MockResourceMonitor) CheckPulumiVersion(ctx context.Context, versionRange string) error {
+	if m.CheckPulumiVersionHandler != nil {
+		return m.CheckPulumiVersionHandler(ctx, versionRange)
+	}
 	return nil
 }
 

--- a/tests/tfcompat/l1_language_test.go
+++ b/tests/tfcompat/l1_language_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// TestL1Language exercises the `language` block's `compatible_with`
+// declarations: each path enforces only its own argument and ignores the
+// rest, so satisfied constraints for both implementations run cleanly.
+func TestL1Language(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_language", tfcompat.Case{})
+}
+
+// TestL1LanguageIncompatible drives a `compatible_with` block whose
+// constraints exclude both running versions; each path must refuse to run.
+// Both error messages surface the offending constraint text.
+func TestL1LanguageIncompatible(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_language_incompatible", tfcompat.Case{
+		Stages: []tfcompat.Stage{{ExpectErr: "< 1.0.0"}},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l1_language/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_language/main.tf
@@ -1,0 +1,14 @@
+# A language block declares compatibility with several implementations at
+# once: each implementation honors its own argument and silently ignores the
+# rest, including arguments whose values are not version constraints at all.
+language {
+  compatible_with {
+    opentofu       = ">= 1.12.0"
+    pulumi         = ">= 3.0.0"
+    other_software = ["not", "a", "version"]
+  }
+}
+
+output "attr" {
+  value = "ok"
+}

--- a/tests/tfcompat/testdata/cases/l1_language_incompatible/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_language_incompatible/main.tf
@@ -1,0 +1,12 @@
+# Both implementations reject their own constraint when it excludes the
+# running version.
+language {
+  compatible_with {
+    opentofu = "< 1.0.0"
+    pulumi   = "< 1.0.0"
+  }
+}
+
+output "attr" {
+  value = "unreachable"
+}


### PR DESCRIPTION
Implements OpenTofu's extensible syntax for declaring implementation compatibility, as suggested in https://github.com/pulumi/pulumi-hcl/issues/531:

```hcl
language {
  compatible_with {
    pulumi   = ">= 3.0.0"
  }
}
```

Only the `pulumi` argument is interpreted — as a version constraint on the Pulumi CLI, enforced through the existing `RequirePulumiVersion` RPC. Everything else in `compatible_with` (including `opentofu`) is decoded with `PartialContent` and ignored without any validation or evaluation, per the [OpenTofu docs](https://opentofu.org/docs/language/settings/#declaring-implementation-compatibility), so one module can declare compatibility with several implementations at once.

The semantics mirror OpenTofu's `internal/configs/language.go`:

- The reserved `edition` and `experiments` arguments validate as OpenTofu validates them: `tofu2024` is accepted silently; other editions and any experiment keyword error, so a module targeting a future language fails loudly instead of misbehaving.
- `language` blocks are rejected in override files.
- A duplicate `pulumi` constraint errors, matching the existing `required_version_range` posture.

Version constraints are also now enforced **per module**: every child module the engine loads (at any nesting depth) has its `required_version_range` and `language` constraints checked, not just the root. Child constraints evaluate statically, matching Terraform's requirement that they be literal strings; a failing constraint names the module in the error. Known hole: a module nested under a parent that expanded to zero instances is never loaded by the engine, so its constraint goes unchecked — OpenTofu enforces it since it loads the whole config tree statically.

Closes https://github.com/pulumi/pulumi-hcl/issues/531.