### PR TITLE
Forward resource hooks attached to an HCL component

### DIFF
--- a/.changes/unreleased/resource-host-bug-fixes-542.yaml
+++ b/.changes/unreleased/resource-host-bug-fixes-542.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Forward resource hooks attached to an HCL component
+time: 2026-08-10T18:00:00.000000-04:00
+custom:
+    Component: resource-host
+    PR: "542"

--- a/pkg/server/construct_hooks_test.go
+++ b/pkg/server/construct_hooks_test.go
@@ -17,7 +17,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"net"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -195,18 +194,13 @@ func (s *hookInvokingMonitor) invokeHook(
 func serveMonitor(t *testing.T) (*hookInvokingMonitor, *moduleProvider, string) {
 	t.Helper()
 	mon := newHookInvokingMonitor()
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	srv := grpc.NewServer()
-	pulumirpc.RegisterResourceMonitorServer(srv, mon)
-	go func() { _ = srv.Serve(lis) }()
-	t.Cleanup(srv.Stop)
+	endpoint := serveResourceMonitor(t, mon)
 
 	m := &moduleProvider{
 		moduleLoader: modules.NewLoader(modules.LiveResolver(t.Context())),
 		resolver:     stubResolver{},
 	}
-	return mon, m, lis.Addr().String()
+	return mon, m, endpoint
 }
 
 func construct(

--- a/pkg/server/construct_monitor_test.go
+++ b/pkg/server/construct_monitor_test.go
@@ -115,9 +115,9 @@ func TestConstructMonitorForwardsCallRouting(t *testing.T) {
 	}, capture.callReq, protocmp.Transform()))
 }
 
-// newTestConstructMonitor serves the given monitor implementation over gRPC and
-// returns a constructResourceMonitor connected to it.
-func newTestConstructMonitor(t *testing.T, srv pulumirpc.ResourceMonitorServer) *constructResourceMonitor {
+// serveResourceMonitor serves the given monitor implementation over gRPC for
+// the duration of the test and returns its endpoint.
+func serveResourceMonitor(t *testing.T, srv pulumirpc.ResourceMonitorServer) string {
 	t.Helper()
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
@@ -126,8 +126,15 @@ func newTestConstructMonitor(t *testing.T, srv pulumirpc.ResourceMonitorServer) 
 	pulumirpc.RegisterResourceMonitorServer(grpcServer, srv)
 	go func() { _ = grpcServer.Serve(lis) }()
 	t.Cleanup(grpcServer.Stop)
+	return lis.Addr().String()
+}
 
-	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+// newTestConstructMonitor serves the given monitor implementation over gRPC and
+// returns a constructResourceMonitor connected to it.
+func newTestConstructMonitor(t *testing.T, srv pulumirpc.ResourceMonitorServer) *constructResourceMonitor {
+	t.Helper()
+
+	conn, err := grpc.NewClient(serveResourceMonitor(t, srv), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 

--- a/pkg/server/module_resource.go
+++ b/pkg/server/module_resource.go
@@ -401,7 +401,26 @@ func (m *moduleProvider) newConstructMonitor(
 		replaceWith:             urnsToStrings(req.ReplaceWith),
 		replacementTrigger:      replacementTriggerToProto(req.ReplacementTrigger),
 		customTimeouts:          customTimeoutsToProto(req.CustomTimeouts),
+		resourceHooks:           resourceHooksToProto(req.ResourceHooks),
 		mapOutputs:              mapOutputs,
+	}
+}
+
+// resourceHooksToProto converts the hook binding the engine sent on the
+// ConstructRequest into the form the component's own registration carries;
+// nil stays nil so the field is omitted.
+func resourceHooksToProto(h *p.ResourceHooksBinding) *pulumirpc.RegisterResourceRequest_ResourceHooksBinding {
+	if h == nil {
+		return nil
+	}
+	return &pulumirpc.RegisterResourceRequest_ResourceHooksBinding{
+		BeforeCreate: h.BeforeCreate,
+		AfterCreate:  h.AfterCreate,
+		BeforeUpdate: h.BeforeUpdate,
+		AfterUpdate:  h.AfterUpdate,
+		BeforeDelete: h.BeforeDelete,
+		AfterDelete:  h.AfterDelete,
+		OnError:      h.OnError,
 	}
 }
 

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -184,6 +184,7 @@ type constructResourceMonitor struct {
 	replaceWith             []string
 	customTimeouts          *pulumirpc.ConstructRequest_CustomTimeouts
 	replacementTrigger      *structpb.Value
+	resourceHooks           *pulumirpc.RegisterResourceRequest_ResourceHooksBinding
 
 	componentURN urn.URN
 	outputs      property.Map
@@ -233,6 +234,7 @@ func (m *constructResourceMonitor) RegisterResource(
 			RetainOnDelete:          m.retainOnDelete,
 			ReplaceOnChanges:        m.replaceOnChanges,
 			ReplaceWith:             m.replaceWith,
+			Hooks:                   m.resourceHooks,
 			AcceptSecrets:           true,
 			AcceptResources:         true,
 			AcceptsByteString:       true,

--- a/pkg/server/provider_test.go
+++ b/pkg/server/provider_test.go
@@ -15,13 +15,18 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"path/filepath"
+	"sync"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	pulumiSchema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -82,4 +87,102 @@ func TestNewLocalProvider(t *testing.T) {
 	require.NotNil(t, component, "the component itself must be registered")
 	require.Equal(t, []string{"urn:pulumi:test::proj::pkg:index:Other::sibling"}, component.ReplaceWith)
 	require.Equal(t, structpb.NewStringValue("trigger"), component.ReplacementTrigger)
+}
+
+// captureMonitor records registrations without invoking bound hooks, so a
+// forwarding test can bind hook names no program ever registered.
+type captureMonitor struct {
+	pulumirpc.UnimplementedResourceMonitorServer
+	mu         sync.Mutex
+	registered []*pulumirpc.RegisterResourceRequest
+}
+
+func (s *captureMonitor) RegisterResource(
+	_ context.Context, req *pulumirpc.RegisterResourceRequest,
+) (*pulumirpc.RegisterResourceResponse, error) {
+	s.mu.Lock()
+	s.registered = append(s.registered, req)
+	s.mu.Unlock()
+	return &pulumirpc.RegisterResourceResponse{
+		Urn:    "urn:pulumi:test::proj::" + req.Type + "::" + req.Name,
+		Object: req.Object,
+	}, nil
+}
+
+func (s *captureMonitor) RegisterResourceHook(
+	_ context.Context, _ *pulumirpc.RegisterResourceHookRequest,
+) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+func (s *captureMonitor) RegisterResourceOutputs(
+	_ context.Context, _ *pulumirpc.RegisterResourceOutputsRequest,
+) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+// registeredType returns the recorded registration for the given type token.
+func (s *captureMonitor) registeredType(typ string) *pulumirpc.RegisterResourceRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, req := range s.registered {
+		if req.Type == typ {
+			return req
+		}
+	}
+	return nil
+}
+
+// TestConstructForwardsResourceHooks guards against dropping the consumer's
+// hook binding on the component: the engine sends it on the ConstructRequest
+// and expects the provider to re-attach it to the component's own
+// RegisterResourceRequest, where it flows into state and fires around the
+// component's lifecycle steps.
+// https://github.com/pulumi/pulumi-hcl/issues/542
+func TestConstructForwardsResourceHooks(t *testing.T) {
+	t.Parallel()
+
+	dir, err := filepath.Abs(filepath.Join("testdata", "module-one-var"))
+	require.NoError(t, err)
+
+	prov, err := NewLocalProvider(t.Context(), dir, "127.0.0.1:1")
+	require.NoError(t, err)
+	_, err = prov.Handshake(t.Context(), &pulumirpc.ProviderHandshakeRequest{})
+	require.NoError(t, err)
+
+	mon := &captureMonitor{}
+	endpoint := serveResourceMonitor(t, mon)
+	inputs, err := structpb.NewStruct(map[string]any{"name": "world"})
+	require.NoError(t, err)
+	_, err = prov.Construct(t.Context(), &pulumirpc.ConstructRequest{
+		Type:            "module-one-var:index:Module",
+		Name:            "greet",
+		Project:         "proj",
+		Stack:           "test",
+		MonitorEndpoint: endpoint,
+		Inputs:          inputs,
+		ResourceHooks: &pulumirpc.ConstructRequest_ResourceHooksBinding{
+			BeforeCreate: []string{"notify-start"},
+			AfterCreate:  []string{"notify-done"},
+			BeforeUpdate: []string{"before-update"},
+			AfterUpdate:  []string{"after-update"},
+			BeforeDelete: []string{"prevent-destroy"},
+			AfterDelete:  []string{"after-delete"},
+			OnError:      []string{"on-error"},
+		},
+		AcceptsOutputValues: true,
+	})
+	require.NoError(t, err)
+
+	component := mon.registeredType("module-one-var:index:Module")
+	require.NotNil(t, component, "the component itself must be registered")
+	assert.Empty(t, cmp.Diff(&pulumirpc.RegisterResourceRequest_ResourceHooksBinding{
+		BeforeCreate: []string{"notify-start"},
+		AfterCreate:  []string{"notify-done"},
+		BeforeUpdate: []string{"before-update"},
+		AfterUpdate:  []string{"after-update"},
+		BeforeDelete: []string{"prevent-destroy"},
+		AfterDelete:  []string{"after-delete"},
+		OnError:      []string{"on-error"},
+	}, component.Hooks, protocmp.Transform()))
 }

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -294,6 +294,42 @@ func TestSmokeDestroyHooks(t *testing.T) {
 		"destroy-time provisioner should have run during destroy --run-program")
 }
 
+// TestSmokeComponentPrecondition proves resource hooks the consuming program
+// attaches to an MLC component instance itself are honored. A lifecycle
+// precondition on the component-typed resource block is a before-create hook
+// the engine hands to Construct via ConstructRequest.resource_hooks, and the
+// provider must re-attach it to the component's own registration — otherwise
+// the guard is silently dropped and the update succeeds where it must fail.
+// https://github.com/pulumi/pulumi-hcl/issues/542
+func TestSmokeComponentPrecondition(t *testing.T) {
+	t.Parallel()
+	pulumiBin := lookPath(t, "pulumi")
+
+	base := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(base, "state"), 0o755))
+	env := []string{
+		"PULUMI_CONFIG_PASSPHRASE=test",
+		"PULUMI_BACKEND_URL=file://" + filepath.Join(base, "state"),
+		"PULUMI_HOME=" + filepath.Join(base, "home"),
+	}
+
+	// `pulumi package add` derives the package name from the directory name and
+	// mutates the program dir, so copy both fixtures out of testdata.
+	moduleDir := filepath.Join(base, "guardedmodule")
+	copyDir(t, filepath.Join("testdata", "component-hooks", "module"), moduleDir)
+	progDir := filepath.Join(base, "program")
+	copyDir(t, filepath.Join("testdata", "component-hooks", "program"), progDir)
+
+	mustRun(t, progDir, env, pulumiBin, "stack", "init", "dev")
+	mustRun(t, progDir, env, pulumiBin, "package", "add", moduleDir)
+
+	out, err := runCapture(progDir, env, pulumiBin, "up", "--yes", "--skip-preview")
+	require.Error(t, err,
+		"a false precondition on the component must fail the update, but it succeeded:\n%s", out)
+	require.Contains(t, out, "PRECONDITION_FAILED: the module must be enabled",
+		"the update must fail with the precondition's error message")
+}
+
 func copyDir(t *testing.T, src, dst string) {
 	t.Helper()
 	require.NoError(t, filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
@@ -460,4 +496,14 @@ func run(dir string, env []string, name string, args ...string) error {
 func mustRun(t *testing.T, dir string, env []string, name string, args ...string) {
 	t.Helper()
 	require.NoError(t, run(dir, env, name, args...))
+}
+
+// runCapture is run, but returns the combined output so tests can assert on
+// the failure message of a command that is expected to fail.
+func runCapture(dir string, env []string, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), env...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
 }

--- a/tests/smoke/testdata/component-hooks/module/PulumiPlugin.yaml
+++ b/tests/smoke/testdata/component-hooks/module/PulumiPlugin.yaml
@@ -1,0 +1,2 @@
+name: guardedmodule
+runtime: hcl

--- a/tests/smoke/testdata/component-hooks/module/main.tf
+++ b/tests/smoke/testdata/component-hooks/module/main.tf
@@ -1,0 +1,7 @@
+variable "name" {
+  type = string
+}
+
+output "greeting" {
+  value = "hello ${var.name}"
+}

--- a/tests/smoke/testdata/component-hooks/program/Pulumi.yaml
+++ b/tests/smoke/testdata/component-hooks/program/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: smoke-component-hooks
+runtime: hcl
+description: Attaches a lifecycle precondition to an MLC component instance.

--- a/tests/smoke/testdata/component-hooks/program/main.tf
+++ b/tests/smoke/testdata/component-hooks/program/main.tf
@@ -1,0 +1,20 @@
+# Never true, so the precondition on the component below must fail the update.
+variable "enabled" {
+  type    = bool
+  default = false
+}
+
+resource "guardedmodule_module" "guarded" {
+  name = "world"
+
+  lifecycle {
+    precondition {
+      condition     = var.enabled
+      error_message = "PRECONDITION_FAILED: the module must be enabled"
+    }
+  }
+}
+
+output "greeting" {
+  value = guardedmodule_module.guarded.greeting
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-hcl/issues/542

The engine sends hooks bound to a remote component to the provider on `ConstructRequest.resource_hooks` and expects the provider to re-attach them when it registers the component — both first-party provider SDKs do this. The construct monitor dropped the binding, so no hook a consumer attached to an HCL component ever fired, silently: a false `lifecycle.precondition` on a component-typed block did not fail the update, `prevent_destroy` (implemented as a `beforeDelete` hook) did not prevent the destroy, and provisioners never ran. The component's state carried no hook binding at all, so `pulumi destroy` without `--run-program` also succeeded where it should refuse.

This threads the binding from the `ConstructRequest` through the construct monitor onto the component's own `RegisterResourceRequest`. Since https://github.com/pulumi/pulumi-hcl/pull/541 both the local-path and parameterized MLC paths share that monitor, so one fix covers both.

Coverage:
- `TestConstructForwardsResourceHooks` asserts at the wire level that the binding sent on `Construct` lands on the component's registration.
- `TestSmokeComponentPrecondition` drives the real `pulumi` CLI: an HCL program attaches a false `lifecycle.precondition` to a `pulumi package add`-ed component and the update must fail with the precondition's error message. Before the fix the update succeeded silently.

Noticed while testing, not addressed here: `pulumi up` warns `resource hook already registered for name "pulumi-hcl:provisioner:before-delete"` when both the top-level language host and the module provider's Construct engine register the constant destroy-dispatcher hook.