### PR TITLE
Have Renovate write changelog fragments for its updates

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -11,6 +11,11 @@ kinds:
   - label: Bug Fixes
     auto: patch
     key: bug-fixes
+  - label: Dependencies
+    auto: patch
+    key: dependencies
+    changeFormat: '- {{.Body}}'
+    skipGlobalChoices: true
 fragmentFileFormat: '{{.Custom.Component}}-{{.Kind}}-{{.Custom.PR}}'
 changeFormat: '- [{{.Custom.Component}}] {{.Body}} [#{{.Custom.PR}}](https://github.com/pulumi/pulumi-hcl/pull/{{.Custom.PR}})'
 custom:

--- a/.github/scripts/renovate-changelog.sh
+++ b/.github/scripts/renovate-changelog.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Generate a changie fragment for a dependency bump that Renovate applied.
+#
+# Invoked as `make renovate DEP=<name> VERSION=<new version> FILE=<package file>` from a
+# renovate postUpgradeTasks hook (see renovate.json5), which fills the arguments from its
+# {{{depName}}}/{{{newVersion}}}/{{{packageFile}}} template variables, once per updated
+# dependency. Only the root Go module ships in the released binaries, so anything else
+# (GitHub Actions, test-only modules) is a no-op.
+#
+# Runs before the PR exists, so fragments carry no PR number or component; the
+# `dependencies` kind in .changie.yaml is formatted accordingly.
+
+set -euo pipefail
+
+dep="$1"
+version="$2"
+file="$3"
+
+case "$file" in
+    go.mod) ;;
+    *) exit 0 ;;
+esac
+
+slug=$(printf '%s-%s' "$dep" "$version" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')
+slug=${slug#-}
+slug=${slug%-}
+
+# Pinned changie version; `go run` because the renovate container has Go but not our
+# mise toolchain.
+go run github.com/miniscruff/changie@v1.25.1 new \
+    --dry-run \
+    --kind dependencies \
+    --body "Update $dep to $version" \
+    > ".changes/unreleased/dependencies-$slug.yaml"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,10 @@ Run `changie new` from the repo root and answer the prompts:
 
 This writes a file under `.changes/unreleased/`. Commit it with your PR.
 
+The `Dependencies` kind is reserved for automated Renovate updates: a `postUpgradeTasks`
+hook runs `make renovate` (see `.github/scripts/renovate-changelog.sh`), so those
+fragments carry no component or PR number.
+
 2. **Cut a release PR.** 
 
 When you're ready to ship, run:

--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,7 @@ dev: ~/.pulumi/bin/$(LANGUAGE_HOST) ~/.pulumi/bin/$(CONVERTER)
 
 generate:
 	go generate ./...
+
+.PHONY: renovate
+renovate:
+	./.github/scripts/renovate-changelog.sh "$(DEP)" "$(VERSION)" "$(FILE)"

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,4 +1,16 @@
 {
     $schema: "https://docs.renovatebot.com/renovate-schema.json",
     extends: ["github>pulumi/renovate-config//default.json5"],
+    packageRules: [
+        {
+            description: "Write a changie fragment for each dependency bump",
+            matchPackageNames: ["*"],
+            postUpgradeTasks: {
+                commands: [
+                    "make renovate DEP='{{{depName}}}' VERSION='{{{newVersion}}}' FILE='{{{packageFile}}}'",
+                ],
+                executionMode: "update",
+            },
+        },
+    ],
 }


### PR DESCRIPTION
HCL version of https://github.com/pulumi/pulumi-dotnet/pull/1112
