### PR TITLE
Classify invalid-input module errors as gRPC InvalidArgument

### DIFF
--- a/.changes/unreleased/resource-host-bug-fixes-530.yaml
+++ b/.changes/unreleased/resource-host-bug-fixes-530.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Report module parse failures and other invalid-input errors as gRPC `InvalidArgument` instead of `Unknown`
+time: 2026-08-11T23:58:41Z
+custom:
+    Component: resource-host
+    PR: "530"

--- a/pkg/hcl/modules/loader.go
+++ b/pkg/hcl/modules/loader.go
@@ -162,8 +162,8 @@ func (l *Loader) LoadModule(ctx context.Context, source, versionConstraint, call
 	}
 
 	if slices.Contains(l.callStack, resolvedPath) {
-		return nil, fmt.Errorf("module cycle detected: %s",
-			strings.Join(append(l.callStack, resolvedPath), " -> "))
+		return nil, classified(ErrInvalid, fmt.Errorf("module cycle detected: %s",
+			strings.Join(append(l.callStack, resolvedPath), " -> ")))
 	}
 
 	if cached, ok := l.cache[resolvedPath]; ok {
@@ -177,7 +177,7 @@ func (l *Loader) LoadModule(ctx context.Context, source, versionConstraint, call
 
 	config, diags := l.parser.ParseDirectory(resolvedPath)
 	if diags.HasErrors() {
-		return nil, fmt.Errorf("parsing module: %s", diags.Error())
+		return nil, classified(ErrInvalid, fmt.Errorf("parsing module: %s", diags.Error()))
 	}
 
 	module := &LoadedModule{Config: config, SourcePath: resolvedPath, Version: resolvedVersion}
@@ -230,7 +230,7 @@ func statDir(p string) (string, error) {
 		return "", fmt.Errorf("accessing module directory: %w", err)
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("module source is not a directory: %s", p)
+		return "", classified(ErrInvalid, fmt.Errorf("module source is not a directory: %s", p))
 	}
 	return p, nil
 }
@@ -240,7 +240,7 @@ func statDir(p string) (string, error) {
 func (l *networkResolver) fetchRemote(source, kind string) (string, error) {
 	pkgAddr, detectedSubdir, err := getmodules.NormalizePackageAddress(source)
 	if err != nil {
-		return "", fmt.Errorf("normalizing module source %q: %w", source, err)
+		return "", classified(ErrInvalid, fmt.Errorf("normalizing module source %q: %w", source, err))
 	}
 	if detectedSubdir != "" {
 		return "", fmt.Errorf("module source %q resolved to package %q with unexpected subdir %q",

--- a/pkg/hcl/modules/loader_test.go
+++ b/pkg/hcl/modules/loader_test.go
@@ -450,6 +450,34 @@ func TestLoaderResolvesViaCustomResolver(t *testing.T) {
 	require.Equal(t, filepath.Join(pkg, "b"), b.SourcePath)
 }
 
+func TestLoadModule_ParseFailureIsErrInvalid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		files map[string]string
+	}{
+		{name: "no tf files", files: nil},
+		{name: "syntax error", files: map[string]string{"main.tf": `output "root" {`}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pkg := t.TempDir()
+			for name, content := range tt.files {
+				require.NoError(t, os.WriteFile(filepath.Join(pkg, name), []byte(content), 0o600))
+			}
+
+			l := NewLoader(func(_, _, _ string) (string, string, error) {
+				return pkg, "", nil
+			})
+			_, err := l.LoadModule(t.Context(), "./mod", "", t.TempDir())
+			assert.ErrorIs(t, err, ErrInvalid)
+		})
+	}
+}
+
 // buildModuleTarGz packs `files` (name → content) into a gzipped tar archive
 // using the system `tar`. The returned bytes are the raw .tar.gz body that
 // PackageFetcher / go-getter can consume.

--- a/pkg/server/parameterize.go
+++ b/pkg/server/parameterize.go
@@ -106,16 +106,16 @@ func (b bundle) encode() []byte {
 func decodeBundle(value []byte) (bundle, error) {
 	gz, err := gzip.NewReader(bytes.NewReader(value))
 	if err != nil {
-		return bundle{}, fmt.Errorf("decompressing bundle: %w", err)
+		return bundle{}, grpcerr.Errorf(codes.InvalidArgument, "decompressing bundle: %w", err)
 	}
 	defer func() { _ = gz.Close() }()
 	data, err := io.ReadAll(gz)
 	if err != nil {
-		return bundle{}, fmt.Errorf("decompressing bundle: %w", err)
+		return bundle{}, grpcerr.Errorf(codes.InvalidArgument, "decompressing bundle: %w", err)
 	}
 	var b bundle
 	if err := json.Unmarshal(data, &b); err != nil {
-		return bundle{}, fmt.Errorf("decoding bundle: %w", err)
+		return bundle{}, grpcerr.Errorf(codes.InvalidArgument, "decoding bundle: %w", err)
 	}
 	return b, nil
 }

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/blang/semver"
 	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-hcl/pkg/grpcerr"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/bridge"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/modules"
@@ -34,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -136,7 +138,7 @@ func moduleIdentity(loaded *modules.LoadedModule, defaultName string, forceDefau
 	}
 	version, err := semver.ParseTolerant(pkgVersion)
 	if err != nil {
-		return "", version, fmt.Errorf("parsing module version %q: %w", pkgVersion, err)
+		return "", version, grpcerr.Errorf(codes.InvalidArgument, "parsing module version %q: %w", pkgVersion, err)
 	}
 	return tokens.Type(fmt.Sprintf("%s:%s:%s", pkgName, module, componentName)), version, nil
 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-hcl/issues/530

Parameterizing a directory with no `.tf` files — or any module that fails to parse — came back as gRPC `Unknown`, which callers cannot tell apart from an internal or transient error. `grpcerr.Classify` only maps errors that carry a `modules.Err*` sentinel; the `ParseDirectory` diagnostics path returned a bare `fmt.Errorf`, so it fell through to the `Unknown` fallback.

This wraps parse diagnostics with `ErrInvalid` (already mapped to `InvalidArgument`), covering both the no-files case and syntax errors, and pins both cases with `TestLoadModule_ParseFailureIsErrInvalid`.

An audit of the surrounding area found sibling deterministic user-input failures with the same gap, also fixed here:

- module cycle detection (`loader.go`)
- malformed package address from `NormalizePackageAddress` (`loader.go`)
- module source that is a file rather than a directory (`loader.go` — the not-exist branch already carried `ErrNotFound`)
- unparseable `package { version = ... }` (`pkg/server/provider.go`)
- corrupt gzip/JSON in the parameterization bundle (`pkg/server/parameterize.go`)

Left unclassified deliberately: the go-getter fetch path (conflates bad URLs, network, and auth failures with no structured status to split them — any single sentinel would be wrong for some case) and registry-protocol violations (mix flaky-registry with pointed-at-a-non-registry-host readings). Both keep the safe non-retriable `Unknown`.