### PR TITLE
tfcompat: default stages to preview then apply

### DIFF
--- a/tests/testutil/tfcompat/harness.go
+++ b/tests/testutil/tfcompat/harness.go
@@ -148,8 +148,8 @@ type Case struct {
 	// matched positionally. For a case directory with numbered stage subdirs
 	// its length must equal the subdir count. For a flat directory each entry
 	// runs the whole directory's file set, so N entries drive N operations
-	// over the same program. Omitted entries (or a nil Stages) default to a
-	// plain apply.
+	// over the same program. A nil Stages runs each disk stage as a preview
+	// followed by an apply.
 	Stages []Stage
 
 	// SkipImport, when non-empty, skips the case's state checks with the
@@ -197,32 +197,37 @@ func RunCase(t *testing.T, caseName string, c Case) {
 }
 
 // resolveStages matches Case.Stages positionally against the file sets loaded
-// from disk. A flat case directory (one file set) fans out to max(1, len(meta))
-// stages over the same files; numbered stage dirs require len(meta) to be
-// zero or exactly the dir count.
+// from disk. A nil Stages runs each file set as preview then apply; otherwise
+// a flat case directory (one file set) fans out to len(meta) stages over the
+// same files, and numbered stage dirs require exactly one entry per dir.
 func resolveStages(fileSets []map[string]string, numbered bool, meta []Stage) ([]stageRun, error) {
+	if len(meta) == 0 {
+		// No explicit stages: each disk stage runs as preview then apply.
+		var runs []stageRun
+		for _, files := range fileSets {
+			runs = append(runs,
+				stageRun{files: files, Stage: Stage{Mode: StagePreview}},
+				stageRun{files: files, Stage: Stage{Mode: StageApply}})
+		}
+		return runs, nil
+	}
+
 	if numbered {
-		if len(meta) != 0 && len(meta) != len(fileSets) {
+		if len(meta) != len(fileSets) {
 			return nil, fmt.Errorf(
 				"case has %d numbered stage dirs but Case.Stages has %d entries",
 				len(fileSets), len(meta))
 		}
 		runs := make([]stageRun, len(fileSets))
 		for i, files := range fileSets {
-			runs[i] = stageRun{files: files}
-			if len(meta) != 0 {
-				runs[i].Stage = meta[i]
-			}
+			runs[i] = stageRun{files: files, Stage: meta[i]}
 		}
 		return runs, nil
 	}
 
-	runs := make([]stageRun, max(1, len(meta)))
+	runs := make([]stageRun, len(meta))
 	for i := range runs {
-		runs[i] = stageRun{files: fileSets[0]}
-		if i < len(meta) {
-			runs[i].Stage = meta[i]
-		}
+		runs[i] = stageRun{files: fileSets[0], Stage: meta[i]}
 	}
 	return runs, nil
 }

--- a/tests/testutil/tfcompat/loader_test.go
+++ b/tests/testutil/tfcompat/loader_test.go
@@ -34,7 +34,10 @@ func TestResolveStages(t *testing.T) {
 		t.Parallel()
 		runs, err := resolveStages([]map[string]string{a}, false, nil)
 		require.NoError(t, err)
-		assert.Equal(t, []stageRun{{files: a}}, runs)
+		assert.Equal(t, []stageRun{
+			{files: a, Stage: Stage{Mode: StagePreview}},
+			{files: a, Stage: Stage{Mode: StageApply}},
+		}, runs)
 	})
 
 	t.Run("flat fans out over metadata", func(t *testing.T) {
@@ -67,7 +70,12 @@ func TestResolveStages(t *testing.T) {
 		t.Parallel()
 		runs, err := resolveStages([]map[string]string{a, b}, true, nil)
 		require.NoError(t, err)
-		assert.Equal(t, []stageRun{{files: a}, {files: b}}, runs)
+		assert.Equal(t, []stageRun{
+			{files: a, Stage: Stage{Mode: StagePreview}},
+			{files: a, Stage: Stage{Mode: StageApply}},
+			{files: b, Stage: Stage{Mode: StagePreview}},
+			{files: b, Stage: Stage{Mode: StageApply}},
+		}, runs)
 	})
 
 	t.Run("numbered count mismatch", func(t *testing.T) {

--- a/tests/tfcompat/README.md
+++ b/tests/tfcompat/README.md
@@ -35,8 +35,10 @@ loaded and fed verbatim to both paths.
 ## Stages
 
 Each case runs as one or more *stages* — sequential operations against the
-same stack. A stage is an apply by default; `Case.Stages` attaches optional
-per-stage behavior, matched positionally against the stages loaded from disk:
+same stack. With no `Case.Stages`, each file set loaded from disk runs as a
+preview followed by an apply. Setting `Case.Stages` replaces that default
+entirely, attaching per-stage behavior matched positionally against the stages
+loaded from disk:
 
 ```go
 type Stage struct {


### PR DESCRIPTION
A case with no explicit `Case.Stages` previously ran a single apply per disk stage, so preview-only divergences (typically around unknown values) were invisible unless a test opted into a `StagePreview` stage.

Now a nil `Case.Stages` resolves each disk file set to a preview followed by an apply — for numbered cases, each subdir gets its own preview+apply pair — so every default case exercises `tofu plan`/`pulumi preview` as well as the apply on both runtimes. Explicit `Stages` behave exactly as before.

Ran the full tfcompat suite locally with the new default: 559 passed; the only failures were pre-existing environmental ones (Docker down for the sshd provisioner tests, and the known local OpenTofu 1.12.0 failure in `TestL2TdataIgnoreTriggersKeepsReplaceTriggeredBy`). No new divergences surfaced, including in the recorded provider-op comparison.