### PR TITLE
Reject null for_each set elements instead of panicking

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-548.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-548.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Return a diagnostic instead of panicking when a `for_each` set contains a null element
+time: 2026-08-13T23:07:34Z
+custom:
+    Component: runtime
+    PR: "548"

--- a/pkg/hcl/eval/evaluator.go
+++ b/pkg/hcl/eval/evaluator.go
@@ -257,6 +257,15 @@ func (e *Evaluator) EvaluateForEach(expr hcl.Expression) (result map[string]cty.
 		for it := val.ElementIterator(); it.Next(); {
 			_, v := it.Element()
 			unmarkedV, _ := v.Unmark()
+			if unmarkedV.IsNull() {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid for_each value",
+					Detail:   "for_each set must not contain null values.",
+					Subject:  expr.Range().Ptr(),
+				})
+				return nil, false, deps, diags
+			}
 			result[unmarkedV.AsString()] = v
 		}
 	default:

--- a/pkg/hcl/eval/evaluator_test.go
+++ b/pkg/hcl/eval/evaluator_test.go
@@ -208,6 +208,15 @@ func TestEvaluateForEach(t *testing.T) {
 		}
 	})
 
+	t.Run("set with null element rejected", func(t *testing.T) {
+		t.Parallel()
+		expr := parseExpr(t, `toset(["a", null])`)
+		_, _, _, diags := eval.EvaluateForEach(expr)
+		require.Len(t, diags, 1)
+		assert.Equal(t, "Invalid for_each value", diags[0].Summary)
+		assert.Equal(t, "for_each set must not contain null values.", diags[0].Detail)
+	})
+
 	t.Run("nil returns nil", func(t *testing.T) {
 		t.Parallel()
 		result, unknown, _, diags := eval.EvaluateForEach(nil)

--- a/tests/tfcompat/l2_for_each_set_null_test.go
+++ b/tests/tfcompat/l2_for_each_set_null_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A for_each over a set containing a null element. Both runtimes must reject it.
+func TestL2ForEachSetNull(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_for_each_set_null", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply, ExpectErr: "null values"},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_for_each_set_null/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_for_each_set_null/main.tf
@@ -1,0 +1,14 @@
+# A for_each over a set containing a null element.
+#
+# OpenTofu rejects this with a clean diagnostic:
+#   "The given "for_each" argument value is unsuitable: "for_each" set includes
+#    a null value, which is not allowed."
+#
+# pulumi-hcl's EvaluateForEach passes the set through its element-type and
+# wholly-known guards (null is a known string), then calls AsString() on the
+# null element, which panics ("value is null") and crashes the language host.
+resource "simple_resource" "r" {
+  for_each  = toset(["a", null])
+  input_one = each.key
+  input_two = false
+}


### PR DESCRIPTION
A `for_each` over a set containing a null element (e.g. `toset(["a", null])`) crashed the language host.

`EvaluateForEach`'s set branch guards on element type and wholly-known, but a null string passes both — null is a known string value — so it called `AsString()` on the null element, which panics with `value is null`.

OpenTofu rejects the same program with a clean diagnostic (`"for_each" sets must not contain null values.`). pulumi-hcl now returns a diagnostic too instead of panicking.

Covered by a tfcompat case (`l2_for_each_set_null`) and a unit test in `pkg/hcl/eval`.