### PR TITLE
Reject a null count meta-argument instead of panicking

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-550.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-550.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Return a diagnostic instead of panicking when a `count` meta-argument is null
+time: 2026-08-13T23:24:24Z
+custom:
+    Component: runtime
+    PR: "550"

--- a/pkg/hcl/eval/evaluator.go
+++ b/pkg/hcl/eval/evaluator.go
@@ -156,6 +156,15 @@ func (e *Evaluator) EvaluateCount(expr hcl.Expression) (count int, isBool bool, 
 		return 0, false, true, deps, nil
 	}
 
+	if val.IsNull() {
+		return 0, false, false, deps, hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "Invalid count value",
+			Detail:   "Count cannot be null.",
+			Subject:  expr.Range().Ptr(),
+		}}
+	}
+
 	if val.Type() == cty.Bool {
 		if val.True() {
 			return 1, true, false, deps, nil

--- a/pkg/hcl/eval/evaluator_test.go
+++ b/pkg/hcl/eval/evaluator_test.go
@@ -68,6 +68,8 @@ func TestEvaluateCount(t *testing.T) {
 	require.NoError(t, err)
 	ctx.SetVariable("instance_count", cty.NumberIntVal(3))
 	ctx.SetVariable("unknown_count", cty.UnknownVal(cty.Number))
+	ctx.SetVariable("null_count", cty.NullVal(cty.Number))
+	ctx.SetVariable("null_bool_count", cty.NullVal(cty.Bool))
 
 	eval := NewEvaluator(ctx)
 
@@ -86,6 +88,9 @@ func TestEvaluateCount(t *testing.T) {
 		{"bool_true", `true`, 1, true, false, false},
 		{"bool_false", `false`, 0, true, false, false},
 		{"unknown", `var.unknown_count`, 0, false, true, false},
+		{"null_number", `var.null_count`, 0, false, false, true},
+		{"null_bool", `var.null_bool_count`, 0, false, false, true},
+		{"null_literal", `null`, 0, false, false, true},
 	}
 
 	for _, tt := range tests {

--- a/tests/tfcompat/l2_count_null_test.go
+++ b/tests/tfcompat/l2_count_null_test.go
@@ -21,11 +21,7 @@ import (
 	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
 )
 
-// A count meta-argument that evaluates to null. OpenTofu rejects it with a
-// clean diagnostic ("count" must not be null). pulumi-hcl's EvaluateCount
-// checks IsKnown (null is known) but never IsNull, converts the null to a null
-// number, and calls AsBigFloat() on it, which panics ("value is null") and
-// crashes the language host instead of returning a diagnostic.
+// A count meta-argument that evaluates to null.
 func TestL2CountNull(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_count_null", tfcompat.Case{

--- a/tests/tfcompat/l2_count_null_test.go
+++ b/tests/tfcompat/l2_count_null_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A count meta-argument that evaluates to null. OpenTofu rejects it with a
+// clean diagnostic ("count" must not be null). pulumi-hcl's EvaluateCount
+// checks IsKnown (null is known) but never IsNull, converts the null to a null
+// number, and calls AsBigFloat() on it, which panics ("value is null") and
+// crashes the language host instead of returning a diagnostic.
+func TestL2CountNull(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_count_null", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StageApply, ExpectErr: "null"},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_count_null/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_count_null/main.tf
@@ -1,12 +1,3 @@
-# A count meta-argument evaluating to null.
-#
-# OpenTofu rejects this with a clean diagnostic:
-#   "The given "count" argument value is null. An argument for "count" must not
-#    be null."
-#
-# pulumi-hcl's EvaluateCount checks IsKnown (null is known) but never IsNull, so
-# it converts the null to a null number and calls AsBigFloat() on it, which
-# panics ("value is null") and crashes the language host.
 variable "n" {
   type    = number
   default = null

--- a/tests/tfcompat/testdata/cases/l2_count_null/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_count_null/main.tf
@@ -1,0 +1,19 @@
+# A count meta-argument evaluating to null.
+#
+# OpenTofu rejects this with a clean diagnostic:
+#   "The given "count" argument value is null. An argument for "count" must not
+#    be null."
+#
+# pulumi-hcl's EvaluateCount checks IsKnown (null is known) but never IsNull, so
+# it converts the null to a null number and calls AsBigFloat() on it, which
+# panics ("value is null") and crashes the language host.
+variable "n" {
+  type    = number
+  default = null
+}
+
+resource "simple_resource" "r" {
+  count     = var.n
+  input_one = "x"
+  input_two = false
+}


### PR DESCRIPTION
A `count` meta-argument that evaluates to null crashed the language host.

`EvaluateCount` checks `IsKnown` (null is a known value) but never `IsNull`, so a null `count` converts cleanly to a null number and reaches `AsBigFloat()`, which panics with `value is null`.

OpenTofu rejects the same program with a clean diagnostic (`The given "count" argument value is null.`). pulumi-hcl now returns a diagnostic too.

The `IsNull` guard is placed before the boolean branch, so it also fixes a related silent divergence: a null `bool` count was previously treated as `count = 0` rather than an error.

Sibling of #548 (the null `for_each` set-element panic) — same missing-`IsNull` pattern in the other meta-argument evaluator.

Covered by a tfcompat case (`l2_count_null`) and unit cases in `pkg/hcl/eval` (null number, null bool, null literal).