### PR TITLE
Treat an unknown prevent_destroy as unset instead of panicking

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-551.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-551.yaml
@@ -1,5 +1,5 @@
 kind: bug-fixes
-body: Treat an unknown `prevent_destroy` as unset instead of panicking
+body: Stop panicking on an unknown `prevent_destroy` and refuse a known-null one at destroy
 time: 2026-08-13T23:50:58Z
 custom:
     Component: runtime

--- a/.changes/unreleased/runtime-bug-fixes-551.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-551.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Treat an unknown `prevent_destroy` as unset instead of panicking
+time: 2026-08-13T23:50:58Z
+custom:
+    Component: runtime
+    PR: "551"

--- a/pkg/hcl/run/destroy_dispatch.go
+++ b/pkg/hcl/run/destroy_dispatch.go
@@ -171,8 +171,9 @@ type blockEntry struct {
 	moduleTarget bool
 	// preventDestroy refuses the orphan's delete: the block is still in
 	// configuration with its lifecycle guard set (a count shrink or dropped
-	// for_each key), so its instances may not be destroyed.
-	preventDestroy bool
+	// for_each key), so its instances may not be destroyed. A known-null guard
+	// errors the delete the way OpenTofu does.
+	preventDestroy preventDestroyGuard
 	// guardErr is a prevent_destroy evaluation failure, surfaced when an
 	// orphan of this block is actually deleted: a guard that cannot be
 	// evaluated must refuse the delete, not silently allow it.
@@ -218,8 +219,11 @@ func (b *blockEntry) run(ctx context.Context, args *ResourceHookArgs) error {
 	if b.guardErr != nil {
 		return b.guardErr
 	}
-	if b.preventDestroy {
+	switch b.preventDestroy {
+	case preventDestroyRefuse:
 		return preventDestroyRefusal(name)
+	case preventDestroyNull:
+		return preventDestroyNullRefusal(name)
 	}
 	if b.dryRun {
 		// Provisioners never run during plan.
@@ -337,8 +341,8 @@ func (e *Engine) recordBlockEntry(
 ) {
 	// Per-instance symbols are rejected by evalPreventDestroy, so the block's
 	// module scope evaluates the guard the same way the live-instance path does.
-	guarded, guardErr := evalPreventDestroy(res, evalCtx.HCLContext())
-	if guardErr == nil && !guarded && !hasDestroyProvisioners(res) {
+	guard, guardErr := evalPreventDestroy(res, evalCtx.HCLContext())
+	if guardErr == nil && guard == preventDestroyAllow && !hasDestroyProvisioners(res) {
 		return
 	}
 
@@ -354,7 +358,7 @@ func (e *Engine) recordBlockEntry(
 		token:          resSchema.Token,
 		prefix:         prefix,
 		evalCtx:        evalCtx,
-		preventDestroy: guarded,
+		preventDestroy: guard,
 		guardErr:       guardErr,
 	}
 	_, entry.parentChain = urnTypes(string(probeURN))

--- a/pkg/hcl/run/destroy_dispatch.go
+++ b/pkg/hcl/run/destroy_dispatch.go
@@ -172,7 +172,7 @@ type blockEntry struct {
 	// preventDestroy refuses the orphan's delete: the block is still in
 	// configuration with its lifecycle guard set (a count shrink or dropped
 	// for_each key), so its instances may not be destroyed. A known-null guard
-	// errors the delete the way OpenTofu does.
+	// errors the delete instead.
 	preventDestroy preventDestroyGuard
 	// guardErr is a prevent_destroy evaluation failure, surfaced when an
 	// orphan of this block is actually deleted: a guard that cannot be

--- a/pkg/hcl/run/provisioner.go
+++ b/pkg/hcl/run/provisioner.go
@@ -85,8 +85,7 @@ func (e *Engine) bindGlobalHooks(
 }
 
 // preventDestroyHook returns the hook refusing this instance's delete, or nil
-// when the lifecycle guard allows it. A known-null guard errors the delete the
-// way OpenTofu does, demanding an explicit false.
+// when the lifecycle guard allows it. A known-null guard errors the delete.
 func preventDestroyHook(opts *ResourceOptions, instance *graph.ExpandedResource) ResourceHookFunction {
 	addr := instance.Key.String()
 	switch opts.PreventDestroy {

--- a/pkg/hcl/run/provisioner.go
+++ b/pkg/hcl/run/provisioner.go
@@ -48,7 +48,7 @@ func (e *Engine) bindGlobalHooks(
 	opts *ResourceOptions,
 	resourceName string,
 ) error {
-	if len(res.Provisioners) == 0 && !opts.PreventDestroy {
+	if len(res.Provisioners) == 0 && opts.PreventDestroy == preventDestroyAllow {
 		return nil
 	}
 	if opts.Hooks == nil {
@@ -85,14 +85,21 @@ func (e *Engine) bindGlobalHooks(
 }
 
 // preventDestroyHook returns the hook refusing this instance's delete, or nil
-// when the lifecycle guard is not set.
+// when the lifecycle guard allows it. A known-null guard errors the delete the
+// way OpenTofu does, demanding an explicit false.
 func preventDestroyHook(opts *ResourceOptions, instance *graph.ExpandedResource) ResourceHookFunction {
-	if !opts.PreventDestroy {
-		return nil
-	}
 	addr := instance.Key.String()
-	return func(context.Context, *ResourceHookArgs) error {
-		return preventDestroyRefusal(addr)
+	switch opts.PreventDestroy {
+	case preventDestroyRefuse:
+		return func(context.Context, *ResourceHookArgs) error {
+			return preventDestroyRefusal(addr)
+		}
+	case preventDestroyNull:
+		return func(context.Context, *ResourceHookArgs) error {
+			return preventDestroyNullRefusal(addr)
+		}
+	default:
+		return nil
 	}
 }
 

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2194,7 +2194,8 @@ func evalPreventDestroy(res *ast.Resource, hclCtx *hcl.EvalContext) (bool, error
 			res.Type+"."+res.Name, err)
 	}
 
-	return val.True(), nil
+	// Unknown counts as false for preview.
+	return !val.IsNull() && val.IsKnown() && val.True(), nil
 }
 
 // preventDestroyRefusal is returned from the destroy dispatcher for a guarded

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2166,29 +2166,25 @@ func (e *Engine) buildResourceOptions(
 }
 
 // preventDestroyGuard is the delete-time decision for a resource's
-// lifecycle.prevent_destroy. Like OpenTofu, the guard is consulted only when a
-// destroy is planned: on create or update every state is inert.
+// lifecycle.prevent_destroy; it is consulted only when a destroy is planned, so
+// create and update are always inert.
 type preventDestroyGuard int
 
 const (
-	// preventDestroyAllow lets the delete proceed: prevent_destroy is unset,
-	// false, or unknown (a computed reference during preview).
+	// preventDestroyAllow lets the delete proceed: unset, false, or unknown.
 	preventDestroyAllow preventDestroyGuard = iota
 	// preventDestroyRefuse refuses the delete: prevent_destroy is true.
 	preventDestroyRefuse
-	// preventDestroyNull errors the delete: prevent_destroy is a known null,
-	// which OpenTofu refuses to interpret as either guarded or unguarded.
+	// preventDestroyNull errors the delete: prevent_destroy is a known null.
 	preventDestroyNull
 )
 
 // evalPreventDestroy evaluates res's lifecycle.prevent_destroy in hclCtx into a
-// delete-time guard. An unknown value (a computed reference during preview)
-// allows the delete; a known null becomes preventDestroyNull, which OpenTofu
-// rejects only when a destroy is actually planned, so it is surfaced by the
-// delete hook rather than failing the create. References to per-instance
-// symbols are rejected statically: the guard must be evaluable for instances
-// that have already been removed from the configuration, whose per-instance
-// data is gone.
+// delete-time guard. An unknown value allows the delete; a known null becomes
+// preventDestroyNull, surfaced by the delete hook rather than failing the
+// create. References to per-instance symbols are rejected statically: the guard
+// must be evaluable for instances that have already been removed from the
+// configuration, whose per-instance data is gone.
 func evalPreventDestroy(res *ast.Resource, hclCtx *hcl.EvalContext) (preventDestroyGuard, error) {
 	if res.Lifecycle == nil || res.Lifecycle.PreventDestroy == nil {
 		return preventDestroyAllow, nil
@@ -2233,8 +2229,7 @@ func preventDestroyRefusal(addr string) error {
 }
 
 // preventDestroyNullRefusal is returned when a to-be-destroyed instance's
-// prevent_destroy is a known null; OpenTofu emits the same demand for an
-// explicit false.
+// prevent_destroy is a known null.
 func preventDestroyNullRefusal(addr string) error {
 	return fmt.Errorf(
 		"resource instance %s has prevent_destroy set to null; when making a dynamic "+

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1743,7 +1743,7 @@ func (e *Engine) registerResourceInstanceInContext(
 		}
 	}
 
-	if len(res.Provisioners) > 0 || opts.PreventDestroy {
+	if len(res.Provisioners) > 0 || opts.PreventDestroy != preventDestroyAllow {
 		if err := e.bindGlobalHooks(ctx, res, resSchema, resourceMapping, instance, evalCtx, opts, resourceName); err != nil {
 			return err
 		}
@@ -1839,11 +1839,11 @@ func (e *Engine) buildResourceOptions(
 
 	// Handle lifecycle options
 	if res.Lifecycle != nil {
-		guarded, err := evalPreventDestroy(res, hclCtx)
+		guard, err := evalPreventDestroy(res, hclCtx)
 		if err != nil {
 			return nil, err
 		}
-		opts.PreventDestroy = guarded
+		opts.PreventDestroy = guard
 		// ignore_changes maps to ignoreChanges. The traversal names are TF
 		// (snake_case) attribute names; the Pulumi engine matches ignoreChanges
 		// paths against Pulumi (camelCase) property names, so they must be
@@ -2165,18 +2165,37 @@ func (e *Engine) buildResourceOptions(
 	return opts, nil
 }
 
-// evalPreventDestroy evaluates res's lifecycle.prevent_destroy in hclCtx. An
-// unknown value (a computed reference during preview) counts as unset.
-// References to per-instance symbols are rejected statically: the guard must
-// be evaluable for instances that have already been removed from the
-// configuration, whose per-instance data is gone.
-func evalPreventDestroy(res *ast.Resource, hclCtx *hcl.EvalContext) (bool, error) {
+// preventDestroyGuard is the delete-time decision for a resource's
+// lifecycle.prevent_destroy. Like OpenTofu, the guard is consulted only when a
+// destroy is planned: on create or update every state is inert.
+type preventDestroyGuard int
+
+const (
+	// preventDestroyAllow lets the delete proceed: prevent_destroy is unset,
+	// false, or unknown (a computed reference during preview).
+	preventDestroyAllow preventDestroyGuard = iota
+	// preventDestroyRefuse refuses the delete: prevent_destroy is true.
+	preventDestroyRefuse
+	// preventDestroyNull errors the delete: prevent_destroy is a known null,
+	// which OpenTofu refuses to interpret as either guarded or unguarded.
+	preventDestroyNull
+)
+
+// evalPreventDestroy evaluates res's lifecycle.prevent_destroy in hclCtx into a
+// delete-time guard. An unknown value (a computed reference during preview)
+// allows the delete; a known null becomes preventDestroyNull, which OpenTofu
+// rejects only when a destroy is actually planned, so it is surfaced by the
+// delete hook rather than failing the create. References to per-instance
+// symbols are rejected statically: the guard must be evaluable for instances
+// that have already been removed from the configuration, whose per-instance
+// data is gone.
+func evalPreventDestroy(res *ast.Resource, hclCtx *hcl.EvalContext) (preventDestroyGuard, error) {
 	if res.Lifecycle == nil || res.Lifecycle.PreventDestroy == nil {
-		return false, nil
+		return preventDestroyAllow, nil
 	}
 	for _, trav := range res.Lifecycle.PreventDestroy.Variables() {
 		if root := trav.RootName(); root == "count" || root == "each" {
-			return false, fmt.Errorf(
+			return preventDestroyAllow, fmt.Errorf(
 				"invalid reference in prevent_destroy on %q: the argument cannot refer to %s.*, "+
 					"because it must be evaluable for instances that have already been removed from the configuration",
 				res.Type+"."+res.Name, root)
@@ -2184,18 +2203,25 @@ func evalPreventDestroy(res *ast.Resource, hclCtx *hcl.EvalContext) (bool, error
 	}
 	val, diags := res.Lifecycle.PreventDestroy.Value(hclCtx)
 	if diags.HasErrors() {
-		return false, fmt.Errorf("evaluating prevent_destroy on %q: %s",
+		return preventDestroyAllow, fmt.Errorf("evaluating prevent_destroy on %q: %s",
 			res.Type+"."+res.Name, diags.Error())
 	}
 	val, _ = val.Unmark()
 	val, err := ctyconvert.Convert(val, cty.Bool)
 	if err != nil {
-		return false, fmt.Errorf("invalid prevent_destroy value on %q: %w",
+		return preventDestroyAllow, fmt.Errorf("invalid prevent_destroy value on %q: %w",
 			res.Type+"."+res.Name, err)
 	}
-
-	// Unknown counts as false for preview.
-	return !val.IsNull() && val.IsKnown() && val.True(), nil
+	switch {
+	case !val.IsKnown():
+		return preventDestroyAllow, nil
+	case val.IsNull():
+		return preventDestroyNull, nil
+	case val.True():
+		return preventDestroyRefuse, nil
+	default:
+		return preventDestroyAllow, nil
+	}
 }
 
 // preventDestroyRefusal is returned from the destroy dispatcher for a guarded
@@ -2204,6 +2230,15 @@ func preventDestroyRefusal(addr string) error {
 	return fmt.Errorf(
 		"resource instance %s has prevent_destroy set, but the plan calls for it to be destroyed. "+
 			"To proceed, disable prevent_destroy for this resource", addr)
+}
+
+// preventDestroyNullRefusal is returned when a to-be-destroyed instance's
+// prevent_destroy is a known null; OpenTofu emits the same demand for an
+// explicit false.
+func preventDestroyNullRefusal(addr string) error {
+	return fmt.Errorf(
+		"resource instance %s has prevent_destroy set to null; when making a dynamic "+
+			"decision to allow destroy, use false instead", addr)
 }
 
 // resolveMovedAliases finds the `moved` blocks that rename the resource instance
@@ -3216,7 +3251,7 @@ type ResourceOptions struct {
 	// engine: the guard must be re-evaluated from current configuration on
 	// every run, while an engine option would persist in state. Never
 	// forwarded to RegisterResource.
-	PreventDestroy bool
+	PreventDestroy preventDestroyGuard
 }
 
 // registerResource registers a resource with the Pulumi engine. tfType is the

--- a/tests/tfcompat/l2_prevent_destroy_null_test.go
+++ b/tests/tfcompat/l2_prevent_destroy_null_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A known-null prevent_destroy: inert on apply, but refused when a destroy is planned.
+func TestL2PreventDestroyNull(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_prevent_destroy_null", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{},
+			{Mode: tfcompat.StageDestroy, ExpectErr: "use false instead"},
+		},
+	})
+}

--- a/tests/tfcompat/l2_prevent_destroy_unknown_test.go
+++ b/tests/tfcompat/l2_prevent_destroy_unknown_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A prevent_destroy that evaluates to an unknown value during preview.
+func TestL2PreventDestroyUnknown(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_prevent_destroy_unknown", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		Stages: []tfcompat.Stage{
+			{Mode: tfcompat.StagePreview},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_null/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_null/main.tf
@@ -1,0 +1,8 @@
+resource "simple_resource" "r" {
+  input_one = "x"
+  input_two = false
+
+  lifecycle {
+    prevent_destroy = null
+  }
+}

--- a/tests/tfcompat/testdata/cases/l2_prevent_destroy_unknown/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_prevent_destroy_unknown/main.tf
@@ -1,0 +1,13 @@
+resource "simple_resource" "a" {
+  input_one = "x"
+  input_two = false
+}
+
+resource "simple_resource" "b" {
+  input_one = "y"
+  input_two = false
+
+  lifecycle {
+    prevent_destroy = simple_resource.a.result != ""
+  }
+}


### PR DESCRIPTION
A `lifecycle.prevent_destroy` that evaluates to an **unknown** value crashed the language host during preview: `evalPreventDestroy` converted to bool and called `cty.Value.True()` with no `IsKnown` guard, panicking `interface conversion: interface {} is *cty.unknownType, not bool`.

Fixing only that would collapse null and unknown both to "unset", which stops the panic but leaves a subtler divergence: a **known null** `prevent_destroy` would silently allow a destroy. OpenTofu refuses to guess — it errors when a destroy is planned, demanding an explicit `false`:

```
Resource instance ... has prevent_destroy set to null. When making a
dynamic decision to allow destroy, use false instead.
```

This models `prevent_destroy` as a delete-time tri-state (allow / refuse / null-error) instead of a bool:

- **unknown** (computed ref at preview) -> allow, deferred — no more panic;
- **known null** -> error, but only when a destroy is actually planned (surfaced by the delete hook, so create and update stay inert);
- **true** -> the existing refusal; **false / unset** -> allow.

Both enforcement paths honour it: the per-instance delete hook (a full destroy of an in-config resource) and the orphan-block entry (count shrink / dropped for_each key).

Third in a series of missing-guard panics on user HCL, after #548 (null `for_each` set element) and #550 (null `count`).

Covered by two tfcompat cases: `l2_prevent_destroy_unknown` (preview, no panic) and `l2_prevent_destroy_null` (inert on apply, refused on destroy).