### PR TITLE
Unmark and defer an unknown union discriminator instead of panicking

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-552.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-552.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Stop panicking on a marked or unknown discriminated-union discriminator
+time: 2026-08-14T00:46:33Z
+custom:
+    Component: runtime
+    PR: "552"

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -2143,11 +2143,19 @@ func selectUnionMemberByConst(val cty.Value, u *schema.UnionType) (schema.Type, 
 
 	attrs := val.AsValueMap()
 	discVal, ok := attrs[hclName]
+	if ok {
+		discVal, _ = discVal.Unmark()
+	}
 	if !ok || discVal.IsNull() {
 		return nil, &missingDiscriminatorError{
 			Discriminator: hclName,
 			Allowed:       allowed,
 		}
+	}
+	if !discVal.IsKnown() {
+		// The discriminator is a computed value not yet known, so the variant
+		// cannot be chosen; a generic object conversion is used instead.
+		return nil, nil
 	}
 
 	for _, c := range withConst {

--- a/tests/putest/l2_union_discriminator_test.go
+++ b/tests/putest/l2_union_discriminator_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 
 	gp "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/putest"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
-	"github.com/pulumi/pulumi-hcl/tests/testutil/putest"
 )
 
 // unionProvider is a native provider whose `union:index:Thing` resource takes a

--- a/tests/putest/l2_union_discriminator_test.go
+++ b/tests/putest/l2_union_discriminator_test.go
@@ -76,6 +76,8 @@ func unionProvider() gp.Provider {
 
 // TestL2UnionDiscriminatorSensitive applies a union whose discriminator is a
 // sensitive (marked) value; it must be unmarked before it is compared.
+//
+// TODO[https://github.com/pulumi/pulumi/pull/24337]: This test can be replaced by a conformance test.
 func TestL2UnionDiscriminatorSensitive(t *testing.T) {
 	t.Parallel()
 	putest.RunCase(t, "l2_union_discriminator_sensitive", putest.Case{
@@ -86,6 +88,8 @@ func TestL2UnionDiscriminatorSensitive(t *testing.T) {
 // TestL2UnionDiscriminatorUnknown previews a union whose discriminator is a
 // computed output, unknown during preview; the variant cannot be chosen so the
 // conversion defers instead of comparing an unknown value.
+//
+// TODO[https://github.com/pulumi/pulumi/pull/24337]: This test can be replaced by a conformance test.
 func TestL2UnionDiscriminatorUnknown(t *testing.T) {
 	t.Parallel()
 	putest.RunCase(t, "l2_union_discriminator_unknown", putest.Case{

--- a/tests/putest/l2_union_discriminator_test.go
+++ b/tests/putest/l2_union_discriminator_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package putest_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	gp "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/putest"
+)
+
+// unionProvider is a native provider whose `union:index:Thing` resource takes a
+// `cfg` input typed as a discriminated union: two object members distinguished
+// by a const `type` property. The Terraform bridge never emits this shape, so
+// it is served natively rather than bridged.
+func unionProvider() gp.Provider {
+	return gp.Provider{
+		GetSchema: func(context.Context, gp.GetSchemaRequest) (gp.GetSchemaResponse, error) {
+			member := func(disc string) schema.ComplexTypeSpec {
+				return schema.ComplexTypeSpec{ObjectTypeSpec: schema.ObjectTypeSpec{
+					Type: "object",
+					Properties: map[string]schema.PropertySpec{
+						"type":  {TypeSpec: schema.TypeSpec{Type: "string"}, Const: disc},
+						"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				}}
+			}
+			cfg := schema.PropertySpec{TypeSpec: schema.TypeSpec{OneOf: []schema.TypeSpec{
+				{Ref: "#/types/union:index:MemberA"},
+				{Ref: "#/types/union:index:MemberB"},
+			}}}
+			out := schema.PropertySpec{TypeSpec: schema.TypeSpec{Type: "string"}}
+			spec := schema.PackageSpec{
+				Name:    "union",
+				Version: "0.0.1",
+				Resources: map[string]schema.ResourceSpec{
+					"union:index:Thing": {
+						InputProperties: map[string]schema.PropertySpec{"cfg": cfg},
+						ObjectTypeSpec: schema.ObjectTypeSpec{
+							Properties: map[string]schema.PropertySpec{"cfg": cfg, "out": out},
+							Required:   []string{"out"},
+						},
+					},
+				},
+				Types: map[string]schema.ComplexTypeSpec{
+					"union:index:MemberA": member("a"),
+					"union:index:MemberB": member("b"),
+				},
+			}
+			raw, err := json.Marshal(spec)
+			return gp.GetSchemaResponse{Schema: string(raw)}, err
+		},
+		// `out` is a known discriminator once applied, so the unknown-at-preview
+		// case still resolves a variant at up.
+		Create: func(_ context.Context, req gp.CreateRequest) (gp.CreateResponse, error) {
+			return gp.CreateResponse{ID: "id-0", Properties: req.Properties.Set("out", property.New("a"))}, nil
+		},
+	}
+}
+
+// TestL2UnionDiscriminatorSensitive applies a union whose discriminator is a
+// sensitive (marked) value; it must be unmarked before it is compared.
+func TestL2UnionDiscriminatorSensitive(t *testing.T) {
+	t.Parallel()
+	putest.RunCase(t, "l2_union_discriminator_sensitive", putest.Case{
+		Providers: []putest.Provider{{Name: "union", Native: unionProvider}},
+	})
+}
+
+// TestL2UnionDiscriminatorUnknown previews a union whose discriminator is a
+// computed output, unknown during preview; the variant cannot be chosen so the
+// conversion defers instead of comparing an unknown value.
+func TestL2UnionDiscriminatorUnknown(t *testing.T) {
+	t.Parallel()
+	putest.RunCase(t, "l2_union_discriminator_unknown", putest.Case{
+		Providers: []putest.Provider{{Name: "union", Native: unionProvider}},
+	})
+}

--- a/tests/putest/testdata/cases/l2_union_discriminator_sensitive/main.tf
+++ b/tests/putest/testdata/cases/l2_union_discriminator_sensitive/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    union = {
+      source = "union"
+    }
+  }
+}
+
+variable "disc" {
+  type      = string
+  sensitive = true
+  default   = "a"
+}
+
+resource "union_thing" "t" {
+  cfg = {
+    type  = var.disc
+    value = "x"
+  }
+}

--- a/tests/putest/testdata/cases/l2_union_discriminator_unknown/main.tf
+++ b/tests/putest/testdata/cases/l2_union_discriminator_unknown/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    union = {
+      source = "union"
+    }
+  }
+}
+
+resource "union_thing" "a" {
+  cfg = {
+    type  = "a"
+    value = "x"
+  }
+}
+
+resource "union_thing" "b" {
+  cfg = {
+    type  = union_thing.a.out
+    value = "y"
+  }
+}


### PR DESCRIPTION
## Summary
A resource input typed as a discriminated union (a `oneOf` whose members carry a const discriminator property) crashed the language host when the discriminator value was **marked** (a `sensitive` value, or a `DepMark` on a computed reference) or **unknown** during preview.

`selectUnionMemberByConst` compared the discriminator against each member's const with only an `IsNull` check, then called `AsString`/`True`/`AsBigFloat` — all of which `cty` panics on for a marked or unknown value, even when the static type matches.

The fix unmarks the discriminator before comparing, and returns no match when it is not yet known so the conversion falls back to a generic object conversion instead of crashing.

Stacked on #553, which adds the native-provider test harness this uses. The schema shape (a const-discriminated union) is one the Terraform bridge never emits, and `pulumi-go-provider`'s `infer` cannot express either (no union/const support), so the tests serve it via a native provider whose `GetSchema` returns the authored schema.

Fourth in the missing-guard-panic series after #548, #550, #551. Unlike those it has no OpenTofu-parity angle — the schema shape is Pulumi-only — so it is a robustness fix.

## Testing
- `tests/putest/l2_union_discriminator_test.go`: `TestL2UnionDiscriminatorSensitive` (marked discriminator) and `TestL2UnionDiscriminatorUnknown` (computed output, unknown at preview). Each is previewed then applied; both crash the langhost on master and pass with the fix.