### PR TITLE
Add a native (non-bridged) provider option to putest

### DIFF
--- a/tests/testutil/pulexec/native.go
+++ b/tests/testutil/pulexec/native.go
@@ -1,0 +1,58 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulexec
+
+import (
+	"context"
+
+	p "github.com/pulumi/pulumi-go-provider"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// NativeProvider serves a native pulumi-go-provider.
+//
+// Unset config/CRUD methods are filled with succeeding echo stubs.
+func NativeProvider(name, version string, prov p.Provider) Provider {
+	echoCheck := func(_ context.Context, req p.CheckRequest) (p.CheckResponse, error) {
+		return p.CheckResponse{Inputs: req.Inputs}, nil
+	}
+	noDiff := func(context.Context, p.DiffRequest) (p.DiffResponse, error) {
+		return p.DiffResponse{}, nil
+	}
+	if prov.CheckConfig == nil {
+		prov.CheckConfig = echoCheck
+	}
+	if prov.DiffConfig == nil {
+		prov.DiffConfig = noDiff
+	}
+	if prov.Configure == nil {
+		prov.Configure = func(context.Context, p.ConfigureRequest) error { return nil }
+	}
+	if prov.Check == nil {
+		prov.Check = echoCheck
+	}
+	if prov.Diff == nil {
+		prov.Diff = noDiff
+	}
+	if prov.Create == nil {
+		prov.Create = func(_ context.Context, req p.CreateRequest) (p.CreateResponse, error) {
+			return p.CreateResponse{ID: "id-0", Properties: req.Properties}, nil
+		}
+	}
+	factory := p.RawServer(name, version, prov)
+	return Provider{Name: name, Start: func(context.Context) (pulumirpc.ResourceProviderServer, error) {
+		return factory(nil)
+	}}
+}

--- a/tests/testutil/putest/putest.go
+++ b/tests/testutil/putest/putest.go
@@ -30,6 +30,7 @@ import (
 
 	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	gp "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-hcl/tests/testutil"
 	"github.com/pulumi/pulumi-hcl/tests/testutil/pulexec"
 	"github.com/pulumi/pulumi-hcl/tests/testutil/tfexec"
@@ -43,10 +44,14 @@ import (
 type Provider struct {
 	Name string
 	// Factory builds an SDKv2 (helper/schema) provider. Exactly one of
-	// Factory and PFFactory must be set.
+	// Factory, PFFactory, and Native must be set.
 	Factory func() *schema.Provider
 	// PFFactory builds a terraform-plugin-framework provider.
 	PFFactory func() pfprovider.Provider
+	// Native builds a native pulumi-go-provider.
+	//
+	// It is an error to set Customize & Native.
+	Native func() gp.Provider
 	// Customize, if non-nil, runs against the bridged ProviderInfo so tests
 	// can apply non-default Pulumi-side renames (or any other ProviderInfo
 	// tweak) to exercise the bridge mapping behaviour.
@@ -58,6 +63,9 @@ type Case struct {
 	Providers []Provider
 	// Config is set as stack config.
 	Config map[string]string
+	// NoPreview skips the `pulumi preview` that otherwise precedes each stage's
+	// `pulumi up`. Assertions run against the apply.
+	NoPreview bool
 	// ExpectedOutputs, if non-nil, must equal the stack outputs exactly.
 	// Non-string outputs appear in their compact-JSON form (see
 	// pulexec.Result).
@@ -85,22 +93,31 @@ func RunCase(t *testing.T, caseName string, c Case) {
 
 	rec := &tfexec.Recorder{}
 	provs := make([]pulexec.Provider, len(c.Providers))
-	for i, p := range c.Providers {
+	for i, prov := range c.Providers {
 		switch {
-		case p.Factory != nil && p.PFFactory == nil:
-			factory := p.Factory
-			provs[i] = pulexec.SDKv2Provider(t, p.Name,
-				func() *schema.Provider { return tfexec.Wrap(factory(), rec) }, p.Customize)
-		case p.PFFactory != nil && p.Factory == nil:
-			provs[i] = pulexec.PFProvider(t, p.Name, p.PFFactory, rec, p.Customize)
+		case prov.Factory != nil && prov.PFFactory == nil && prov.Native == nil:
+			factory := prov.Factory
+			provs[i] = pulexec.SDKv2Provider(t, prov.Name,
+				func() *schema.Provider { return tfexec.Wrap(factory(), rec) }, prov.Customize)
+		case prov.PFFactory != nil && prov.Factory == nil && prov.Native == nil:
+			provs[i] = pulexec.PFProvider(t, prov.Name, prov.PFFactory, rec, prov.Customize)
+		case prov.Native != nil && prov.Factory == nil && prov.PFFactory == nil:
+			if prov.Customize != nil {
+				t.Fatalf("provider %q: Customize does not apply to a Native provider", prov.Name)
+			}
+			provs[i] = pulexec.NativeProvider(prov.Name, "0.0.1", prov.Native())
 		default:
-			t.Fatalf("provider %q: exactly one of Factory or PFFactory must be set", p.Name)
+			t.Fatalf("provider %q: exactly one of Factory, PFFactory, or Native must be set", prov.Name)
 		}
 	}
 
 	driver := pulexec.NewDriver(t, provs, c.Config)
 	var res pulexec.Result
 	for i, files := range stages {
+		if !c.NoPreview {
+			_, err = driver.Preview(t, files)
+			require.NoErrorf(t, err, "stage %d: pulumi preview failed", i)
+		}
 		res, err = driver.TryApply(t, files)
 		require.NoErrorf(t, err, "stage %d: pulumi up failed", i)
 	}


### PR DESCRIPTION
## Summary
Adds a native (non-Terraform-bridged) provider option to the Pulumi-only test harness, so tests can exercise schema shapes the Terraform bridge never emits — discriminated unions, plain-typed objects, and other codegen-only constructs.

- `pulexec.NativeProvider(name, version, prov)` takes a full `pulumi-go-provider` (`p.Provider`) and serves it directly (via `p.RawServer`, attached over the existing `Start` path). Any unset config/CRUD method is filled with a succeeding echo stub, so a caller can supply only `GetSchema`. pulumi-hcl resolves the HCL type to it by naming convention (`ResolveResource` falls back to the convention resolver when there is no bridge mapping), so no terraform mapping is required.
- `putest.Provider` gains a `Native func() p.Provider` option.
- `putest.RunCase` now runs each stage as a **preview then an apply** by default, so a preview-only crash is caught; assertions run against the apply. `Case.NoPreview` opts out.

Foundation for #552, which uses it to reproduce a union-discriminator panic.

## Testing
- `go test ./tests/putest/` (existing cases pass under the new preview-then-up default; the recorder captures only CRUD, and preview calls no Create, so op assertions are unaffected).