### PR TITLE
Record provider configuration input dependencies

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-554.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-554.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Preserve resource dependencies referenced by provider configuration properties
+time: 2026-08-17T16:44:48Z
+custom:
+    Component: runtime
+    PR: "555"

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1396,6 +1396,59 @@ func providerExprKey(expr hcl.Expression) string {
 	return name
 }
 
+// evalSchemaInputs evaluates schema inputs and reports successful values.
+func evalSchemaInputs(
+	hclCtx *hcl.EvalContext,
+	onEvaluated func(resource.PropertyKey, cty.Value),
+) transform.EvalFunc {
+	return func(propKey resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
+		c := hclCtx
+		if len(extraVars) > 0 {
+			c = hclCtx.NewChild()
+			c.Variables = extraVars
+		}
+		val, diags := expr.Value(c)
+		if !diags.HasErrors() && onEvaluated != nil {
+			onEvaluated(propKey, val)
+		}
+		return val, diags
+	}
+}
+
+// evalResourceInputs evaluates resource inputs and records property dependencies.
+func evalResourceInputs(
+	hclCtx *hcl.EvalContext,
+	inputProperties []*schema.Property,
+	onEvaluated func(resource.PropertyKey, cty.Value),
+) (transform.EvalFunc, map[string][]string) {
+	plainInputProps := make(map[string]bool, len(inputProperties))
+	for _, p := range inputProperties {
+		plainInputProps[p.Name] = p.Plain
+	}
+
+	dependsOn := make(map[string][]string)
+	record := func(propKey resource.PropertyKey, val cty.Value) {
+		if onEvaluated != nil {
+			onEvaluated(propKey, val)
+		}
+
+		prop := string(propKey)
+		if _, ok := dependsOn[prop]; !ok {
+			dependsOn[prop] = nil
+		}
+		if plainInputProps[prop] {
+			return
+		}
+		for _, urn := range eval.CollectDepURNs(val) {
+			idx, found := slices.BinarySearch(dependsOn[prop], urn)
+			if !found {
+				dependsOn[prop] = slices.Insert(dependsOn[prop], idx, urn)
+			}
+		}
+	}
+	return evalSchemaInputs(hclCtx, record), dependsOn
+}
+
 func (e *Engine) registerProviderInContext(
 	ctx context.Context, node *graph.Node, provider *ast.Provider,
 	evalCtx *eval.Context, parentURN urn.URN, modInst *moduleInstance,
@@ -1410,14 +1463,6 @@ func (e *Engine) registerProviderInContext(
 	}
 
 	hclCtx := evalCtx.HCLContext()
-	dependsOn := make(map[string][]string)
-	addToDependsOn := func(prop, urn string) {
-		idx, found := slices.BinarySearch(dependsOn[prop], urn)
-		if found {
-			return
-		}
-		dependsOn[prop] = slices.Insert(dependsOn[prop], idx, urn)
-	}
 
 	// Schema-aware eval is needed so schema.Property.Secret marks survive.
 	pkg, perr := packages.ResolvePackage(ctx, e.pkgLoader, knownProviders(e.config.Terraform), "pulumi_providers_"+pkgName)
@@ -1430,34 +1475,9 @@ func (e *Engine) registerProviderInContext(
 	}
 
 	providerMapping := e.resolver.ProviderConfigBodyMapping(ctx, pkgName)
-	plainInputProps := make(map[string]bool, len(resSchema.InputProperties))
-	for _, p := range resSchema.InputProperties {
-		plainInputProps[p.Name] = p.Plain
-	}
-	inputsMap, _, diags := transform.EvalResourceWithSchema(provider.Config, resSchema, providerMapping,
-		func(propKey resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
-			c := hclCtx
-			if len(extraVars) > 0 {
-				child := hclCtx.NewChild()
-				child.Variables = extraVars
-				c = child
-			}
-			val, diags := expr.Value(c)
-			if diags.HasErrors() {
-				return val, diags
-			}
-
-			if _, ok := dependsOn[string(propKey)]; !ok {
-				dependsOn[string(propKey)] = nil
-			}
-			if !plainInputProps[string(propKey)] {
-				for _, urn := range eval.CollectDepURNs(val) {
-					addToDependsOn(string(propKey), urn)
-				}
-			}
-
-			return val, diags
-		})
+	inputEval, dependsOn := evalResourceInputs(hclCtx, resSchema.InputProperties, nil)
+	inputsMap, _, diags := transform.EvalResourceWithSchema(
+		provider.Config, resSchema, providerMapping, inputEval)
 	if diags.HasErrors() {
 		return fmt.Errorf("evaluating provider %s config: %s", provider.Name, diags.Error())
 	}
@@ -1627,20 +1647,6 @@ func (e *Engine) registerResourceInstanceInContext(
 
 	hclCtx := evalCtx.HCLContext()
 
-	dependsOn := make(map[string][]string)
-	addToDependsOn := func(prop, urn string) {
-		idx, found := slices.BinarySearch(dependsOn[prop], urn)
-		if found {
-			return
-		}
-		dependsOn[prop] = slices.Insert(dependsOn[prop], idx, urn)
-	}
-
-	plainInputProps := make(map[string]bool, len(resSchema.InputProperties))
-	for _, p := range resSchema.InputProperties {
-		plainInputProps[p.Name] = p.Plain
-	}
-
 	resourceMapping := e.resolver.ResourceBodyMapping(ctx, res.Type)
 	// terraform_data's attributes are dynamically typed, so their cty types
 	// (e.g. set-ness) survive the Pulumi property round-trip only via the
@@ -1649,45 +1655,14 @@ func (e *Engine) registerResourceInstanceInContext(
 	if res.Type == packages.TerraformDataType {
 		tdataEvaluated = map[string]cty.Value{}
 	}
-	resourceInputs, ephemeralPaths, diags := transform.EvalResourceWithSchema(res.Config, resSchema, resourceMapping,
-		func(propKey resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
-			var val cty.Value
-			var diags hcl.Diagnostics
-			if len(extraVars) > 0 {
-				childCtx := hclCtx.NewChild()
-				childCtx.Variables = extraVars
-				val, diags = expr.Value(childCtx)
-			} else {
-				val, diags = expr.Value(hclCtx)
-			}
-			if diags.HasErrors() {
-				return val, diags
-			}
-
+	inputEval, dependsOn := evalResourceInputs(hclCtx, resSchema.InputProperties,
+		func(propKey resource.PropertyKey, val cty.Value) {
 			if tdataEvaluated != nil {
 				tdataEvaluated[string(propKey)] = val
 			}
-
-			// Record every evaluated property, even with no dependencies: an
-			// absent PropertyDependencies map makes the engine assume every
-			// property depends on every entry in Dependencies — but those
-			// include ordering-only dependencies (widened instance sets,
-			// depends_on, replace_triggered_by), and a delete-before-replace
-			// of such a target would then spuriously replace this resource.
-			if _, ok := dependsOn[string(propKey)]; !ok {
-				dependsOn[string(propKey)] = nil
-			}
-
-			if plainInputProps[string(propKey)] {
-				return val, diags
-			}
-
-			for _, urn := range eval.CollectDepURNs(val) {
-				addToDependsOn(string(propKey), urn)
-			}
-
-			return val, diags
 		})
+	resourceInputs, ephemeralPaths, diags := transform.EvalResourceWithSchema(
+		res.Config, resSchema, resourceMapping, inputEval)
 	if diags.HasErrors() {
 		return diags
 	}
@@ -3420,27 +3395,13 @@ func (e *Engine) invokeDataSourceOnce(
 	}
 
 	dataSourceMapping := e.resolver.DataSourceBodyMapping(ctx, ds.Type)
-	inputs, diags := transform.EvalFunctionWithSchema(ds.Config, funcSchema, dataSourceMapping,
-		func(propKey resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
-			var val cty.Value
-			var diags hcl.Diagnostics
-			if len(extraVars) > 0 {
-				childCtx := hclCtx.NewChild()
-				childCtx.Variables = extraVars
-				val, diags = expr.Value(childCtx)
-			} else {
-				val, diags = expr.Value(hclCtx)
-			}
-			if diags.HasErrors() {
-				return val, diags
-			}
-
-			for _, urn := range eval.CollectDepURNs(val) {
-				addURN(urn)
-			}
-
-			return val, diags
-		})
+	inputEval := evalSchemaInputs(hclCtx, func(_ resource.PropertyKey, val cty.Value) {
+		for _, urn := range eval.CollectDepURNs(val) {
+			addURN(urn)
+		}
+	})
+	inputs, diags := transform.EvalFunctionWithSchema(
+		ds.Config, funcSchema, dataSourceMapping, inputEval)
 	if diags.HasErrors() {
 		return cty.NilVal, diags
 	}
@@ -3721,15 +3682,9 @@ func (e *Engine) processCall(ctx context.Context, node *graph.Node) error {
 		filteredFunc.Inputs = &filteredInputs
 	}
 
-	userArgs, diags := transform.EvalFunctionWithSchema(call.Config, &filteredFunc, nil,
-		func(_ resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
-			if len(extraVars) > 0 {
-				childCtx := e.evaluator.Context().HCLContext().NewChild()
-				childCtx.Variables = extraVars
-				return expr.Value(childCtx)
-			}
-			return e.evaluator.EvaluateExpression(expr)
-		})
+	userArgs, diags := transform.EvalFunctionWithSchema(
+		call.Config, &filteredFunc, nil,
+		evalSchemaInputs(e.evaluator.Context().HCLContext(), nil))
 	if diags.HasErrors() {
 		return fmt.Errorf("evaluating call arguments for %s.%s: %s", call.ResourceName, call.MethodName, diags.Error())
 	}

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1410,6 +1410,14 @@ func (e *Engine) registerProviderInContext(
 	}
 
 	hclCtx := evalCtx.HCLContext()
+	dependsOn := make(map[string][]string)
+	addToDependsOn := func(prop, urn string) {
+		idx, found := slices.BinarySearch(dependsOn[prop], urn)
+		if found {
+			return
+		}
+		dependsOn[prop] = slices.Insert(dependsOn[prop], idx, urn)
+	}
 
 	// Schema-aware eval is needed so schema.Property.Secret marks survive.
 	pkg, perr := packages.ResolvePackage(ctx, e.pkgLoader, knownProviders(e.config.Terraform), "pulumi_providers_"+pkgName)
@@ -1422,15 +1430,33 @@ func (e *Engine) registerProviderInContext(
 	}
 
 	providerMapping := e.resolver.ProviderConfigBodyMapping(ctx, pkgName)
+	plainInputProps := make(map[string]bool, len(resSchema.InputProperties))
+	for _, p := range resSchema.InputProperties {
+		plainInputProps[p.Name] = p.Plain
+	}
 	inputsMap, _, diags := transform.EvalResourceWithSchema(provider.Config, resSchema, providerMapping,
-		func(_ resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
+		func(propKey resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
 			c := hclCtx
 			if len(extraVars) > 0 {
 				child := hclCtx.NewChild()
 				child.Variables = extraVars
 				c = child
 			}
-			return expr.Value(c)
+			val, diags := expr.Value(c)
+			if diags.HasErrors() {
+				return val, diags
+			}
+
+			if _, ok := dependsOn[string(propKey)]; !ok {
+				dependsOn[string(propKey)] = nil
+			}
+			if !plainInputProps[string(propKey)] {
+				for _, urn := range eval.CollectDepURNs(val) {
+					addToDependsOn(string(propKey), urn)
+				}
+			}
+
+			return val, diags
 		})
 	if diags.HasErrors() {
 		return fmt.Errorf("evaluating provider %s config: %s", provider.Name, diags.Error())
@@ -1530,6 +1556,11 @@ func (e *Engine) registerProviderInContext(
 	}
 
 	req.Inputs = property.NewMap(inputs)
+	req.PropertyDependencies = dependsOn
+	for _, deps := range dependsOn {
+		req.Dependencies = append(req.Dependencies, deps...)
+	}
+	req.Dependencies = e.cellURNs.widen(req.Dependencies)
 
 	resp, err := e.resmon.RegisterResource(ctx, req)
 	if err != nil {

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -5341,18 +5341,20 @@ resource "simple_resource" "r" {
 
 	assert.Equal(t, []run.RegisterResourceRequest{
 		{
-			Type:   "pulumi:providers:simple",
-			Name:   `by_key["a"]`,
-			Inputs: property.NewMap(map[string]property.Value{"prefix": property.New("alpha")}),
-			Custom: true,
-			Parent: stackURN,
+			Type:                 "pulumi:providers:simple",
+			Name:                 `by_key["a"]`,
+			Inputs:               property.NewMap(map[string]property.Value{"prefix": property.New("alpha")}),
+			PropertyDependencies: map[string][]string{"prefix": nil},
+			Custom:               true,
+			Parent:               stackURN,
 		},
 		{
-			Type:   "pulumi:providers:simple",
-			Name:   `by_key["b"]`,
-			Inputs: property.NewMap(map[string]property.Value{"prefix": property.New("beta")}),
-			Custom: true,
-			Parent: stackURN,
+			Type:                 "pulumi:providers:simple",
+			Name:                 `by_key["b"]`,
+			Inputs:               property.NewMap(map[string]property.Value{"prefix": property.New("beta")}),
+			PropertyDependencies: map[string][]string{"prefix": nil},
+			Custom:               true,
+			Parent:               stackURN,
 		},
 	}, providerRegs)
 

--- a/pkg/hcl/run/run_test.go
+++ b/pkg/hcl/run/run_test.go
@@ -5363,6 +5363,79 @@ resource "simple_resource" "r" {
 		"the resource must bind to the provider instance selected by its key")
 }
 
+// A provider configuration that consumes a resource output must carry that
+// dependency on its provider-resource registration. The program graph already
+// orders config before the provider during this run; the registration metadata
+// is what preserves the reverse ordering for a later state-driven destroy.
+func TestEngine_ProviderConfigDependencies(t *testing.T) {
+	t.Parallel()
+
+	src := []byte(`
+resource "simple_resource" "config" {
+  input = "token"
+}
+
+provider "simple" {
+  alias  = "configured"
+  prefix = simple_resource.config.input
+}
+
+resource "simple_resource" "consumer" {
+  provider = simple.configured
+  input    = "value"
+}
+`)
+
+	p := parser.NewParser()
+	config, diags := p.ParseSource("test.hcl", src)
+	require.False(t, diags.HasErrors(), "parse error: %s", diags.Error())
+
+	mock := &testutil.MockResourceMonitor{}
+	engine := newTestEngine(t, config, &run.EngineOptions{
+		ModuleLoader:    testModuleLoader(t),
+		ProjectName:     "test-project",
+		StackName:       "dev",
+		ResourceMonitor: mock,
+		WorkDir:         t.TempDir(),
+		RootDir:         t.TempDir(),
+		SchemaLoader: schemaloader.New(t, schema.PackageSpec{
+			Name: "simple",
+			Provider: &schema.ResourceSpec{
+				InputProperties: map[string]schema.PropertySpec{
+					"prefix": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+			Resources: map[string]schema.ResourceSpec{
+				"simple:index:Resource": {
+					InputProperties: map[string]schema.PropertySpec{
+						"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+					ObjectTypeSpec: schema.ObjectTypeSpec{
+						Properties: map[string]schema.PropertySpec{
+							"input": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+					},
+				},
+			},
+		}),
+	})
+
+	require.NoError(t, engine.Run(t.Context()))
+
+	var provider *run.RegisterResourceRequest
+	for i := range mock.RegisteredResources {
+		if mock.RegisteredResources[i].Type == "pulumi:providers:simple" {
+			provider = &mock.RegisteredResources[i]
+			break
+		}
+	}
+	require.NotNil(t, provider, "configured provider should register")
+
+	configURN := "urn:pulumi:test::project::simple:index:Resource::config"
+	assert.Equal(t, []string{configURN}, provider.Dependencies)
+	assert.Equal(t, map[string][]string{"prefix": {configURN}}, provider.PropertyDependencies)
+}
+
 // An aliased provider passed into a module via `providers` must survive a
 // second hop into a nested module, whether re-passed explicitly or inherited
 // implicitly as the nested call's default.

--- a/tests/testutil/tfcompat/providers/ordering.go
+++ b/tests/testutil/tfcompat/providers/ordering.go
@@ -38,6 +38,9 @@ func OrderProvider() *schema.Provider {
 	const delay = 1 * time.Second
 	noop := func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil }
 	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"token": {Type: schema.TypeString, Optional: true},
+		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"order_data": {
 				Schema: map[string]*schema.Schema{

--- a/tests/tfcompat/l2_provider_config_ref_test.go
+++ b/tests/tfcompat/l2_provider_config_ref_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestL2ProviderConfigRef pins the dependency metadata of a provider whose
+// configuration consumes a resource output. The metadata preserves the
+// reverse ordering needed by a later state-driven destroy.
+func TestL2ProviderConfigRef(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_provider_config_ref", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "order", Factory: providers.OrderProvider},
+		},
+		AssertState: func(t *testing.T, resources []apitype.ResourceV3) {
+			var config, configuredProvider *apitype.ResourceV3
+			for i := range resources {
+				r := &resources[i]
+				switch {
+				case r.Type == "pulumi:providers:order":
+					configuredProvider = r
+				case r.URN.Name() == "config":
+					config = r
+				}
+			}
+			require.NotNil(t, config, "configuration resource should be in state")
+			require.NotNil(t, configuredProvider, "configured provider should be in state")
+			assert.Equal(t, []resource.URN{config.URN}, configuredProvider.Dependencies)
+			assert.Equal(t,
+				[]resource.URN{config.URN},
+				configuredProvider.PropertyDependencies[resource.PropertyKey("token")])
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_provider_config_ref/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_provider_config_ref/main.tf
@@ -1,0 +1,17 @@
+resource "order_resource" "config" {
+  name = "config"
+}
+
+provider "order" {
+  alias = "configured"
+  token = order_resource.config.result
+}
+
+resource "order_resource" "consumer" {
+  provider = order.configured
+  name     = "consumer"
+}
+
+output "config_result" {
+  value = order_resource.config.result
+}


### PR DESCRIPTION
## Summary

- preserve resource dependencies referenced by provider configuration properties
- register both aggregate and per-property dependencies on explicit provider resources
- add unit and tfcompat state coverage for provider configurations that consume resource outputs

The runtime graph already ordered these resources correctly during an update, but provider registration discarded the dependency metadata. A later state-driven destroy could therefore delete provider credentials before the provider resources that consume them.

This registration path is shared by default, aliased, module, and `for_each` provider instances, so the fix applies consistently to provider configuration properties across those forms.

Closes https://github.com/pulumi/pulumi-hcl/issues/554

## Testing

- `make build`
- focused unit regression, demonstrated failing before the runtime fix and passing after it
- focused tfcompat state regression, demonstrated failing before the runtime fix and passing after it
- `go test ./pkg/hcl/... -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./...`
- full tfcompat suite (new and non-Docker cases pass; existing SSH provisioner cases require unavailable rootless Docker)
