### PR TITLE
Treat null resource aliases as unset

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-556.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-556.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Handle null resource `aliases`
+time: 2026-08-17T20:07:11Z
+custom:
+    Component: runtime
+    PR: "556"

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ coverage.html
 
 # IDE
 .idea/
+.pi/
 .vscode/
 *.swp
 *.swo

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2772,6 +2772,9 @@ func (e *Engine) evaluateAliases(expr hcl.Expression) ([]Alias, error) {
 	if diags.HasErrors() {
 		return nil, diags
 	}
+	if val.IsNull() {
+		return nil, nil
+	}
 	if !val.Type().IsListType() && !val.Type().IsTupleType() {
 		return nil, fmt.Errorf("aliases must be a list")
 	}

--- a/tests/putest/l2_null_aliases_test.go
+++ b/tests/putest/l2_null_aliases_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package putest_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/putest"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+func TestL2NullAliases(t *testing.T) {
+	t.Parallel()
+	putest.RunCase(t, "l2_null_aliases", putest.Case{
+		Providers: []putest.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+	})
+}

--- a/tests/putest/testdata/cases/l2_null_aliases/main.tf
+++ b/tests/putest/testdata/cases/l2_null_aliases/main.tf
@@ -1,0 +1,5 @@
+resource "simple_resource" "res" {
+  pulumi {
+    aliases = tolist(null)
+  }
+}


### PR DESCRIPTION
Treats a null resource `aliases` list as unset instead of iterating it and panicking.

Adds a `putest` regression case covering `aliases = tolist(null)` and ignores project-local `.pi/` workflow state.
