### PR TITLE
Forward spec-form aliases attached to an HCL component

### DIFF
--- a/.changes/unreleased/resource-host-bug-fixes-543.yaml
+++ b/.changes/unreleased/resource-host-bug-fixes-543.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Forward spec-form aliases attached to an HCL component
+time: 2026-08-18T14:44:04Z
+custom:
+    Component: resource-host
+    PR: "543"

--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -142,8 +142,6 @@ var expectedFailures = map[string]string{
 		" is reserved as the namespace for resource method calls in HCL",
 	"l2-config-default-from-invoke": "HCL codegen does not support a config variable whose" +
 		" default is sourced from an invoke result",
-	"provider-alias-component": "component aliases are not propagated to children, so re-parenting" +
-		" an aliased component recreates it (https://github.com/pulumi/pulumi-hcl/issues/543)",
 }
 
 // expectedEjectFailures lists tests whose eject (HCL→PCL conversion) step is

--- a/cmd/pulumi-resource-hcl/main.go
+++ b/cmd/pulumi-resource-hcl/main.go
@@ -25,6 +25,8 @@ import (
 	"os"
 
 	p "github.com/pulumi/pulumi-go-provider"
+	comProvider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"github.com/pulumi/pulumi-hcl/pkg/server"
 	"github.com/pulumi/pulumi-hcl/pkg/version"
@@ -40,7 +42,17 @@ func main() {
 
 	ctx := context.Background()
 	v := version.Version().String()
-	if err := p.RunProvider(ctx, "hcl", v, server.NewModuleProvider(ctx, v)); err != nil {
+	// Expanded from p.RunProvider so the rpc server can be wrapped: spec-form
+	// Construct aliases must be collapsed before pulumi-go-provider decodes
+	// (and would drop) them.
+	err := comProvider.MainContext(ctx, "hcl", func(host *comProvider.HostClient) (pulumirpc.ResourceProviderServer, error) {
+		srv, err := p.RawServer("hcl", v, server.NewModuleProvider(ctx, v))(host)
+		if err != nil {
+			return nil, err
+		}
+		return server.WithCollapsedConstructAliases(srv), nil
+	})
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "fatal: %v\n", err)
 		os.Exit(1)
 	}

--- a/pkg/server/construct_aliases.go
+++ b/pkg/server/construct_aliases.go
@@ -1,0 +1,87 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// WithCollapsedConstructAliases wraps a provider server so that spec-form
+// aliases on an incoming Construct request are collapsed into URN aliases
+// before the request is handled. pulumi-go-provider's typed ConstructRequest
+// carries aliases as bare URNs, so spec aliases (e.g. `noParent: true`) would
+// otherwise be silently discarded and an aliased component would be recreated
+// instead of preserved. Once
+// https://github.com/pulumi/pulumi-go-provider/issues/572 is fixed this
+// wrapper can be removed.
+func WithCollapsedConstructAliases(inner pulumirpc.ResourceProviderServer) pulumirpc.ResourceProviderServer {
+	return &collapsedConstructAliases{ResourceProviderServer: inner}
+}
+
+type collapsedConstructAliases struct {
+	pulumirpc.ResourceProviderServer
+}
+
+func (s *collapsedConstructAliases) Construct(
+	ctx context.Context, req *pulumirpc.ConstructRequest,
+) (*pulumirpc.ConstructResponse, error) {
+	req.Aliases = collapseSpecAliases(
+		req.GetAliases(), req.GetType(), req.GetName(), req.GetParent(), req.GetProject(), req.GetStack())
+	return s.ResourceProviderServer.Construct(ctx, req)
+}
+
+// collapseSpecAliases resolves each spec-form alias against the constructed
+// component's own type, name, parent, project, and stack into the URN it
+// denotes, leaving URN-form aliases untouched.
+func collapseSpecAliases(aliases []*pulumirpc.Alias, typ, name, parent, project, stack string) []*pulumirpc.Alias {
+	collapsed := make([]*pulumirpc.Alias, len(aliases))
+	for i, alias := range aliases {
+		spec := alias.GetSpec()
+		if spec == nil {
+			collapsed[i] = alias
+			continue
+		}
+		aliasName := spec.GetName()
+		if aliasName == "" {
+			aliasName = name
+		}
+		aliasType := spec.GetType()
+		if aliasType == "" {
+			aliasType = typ
+		}
+		aliasParent := spec.GetParentUrn()
+		if aliasParent == "" && !spec.GetNoParent() {
+			aliasParent = parent
+		}
+		if spec.GetNoParent() ||
+			(aliasParent != "" && resource.URN(aliasParent).QualifiedType() == resource.RootStackType) {
+			aliasParent = ""
+		}
+		aliasProject := spec.GetProject()
+		if aliasProject == "" {
+			aliasProject = project
+		}
+		aliasStack := spec.GetStack()
+		if aliasStack == "" {
+			aliasStack = stack
+		}
+		urn := resource.CreateURN(aliasName, aliasType, resource.URN(aliasParent), aliasProject, aliasStack)
+		collapsed[i] = &pulumirpc.Alias{Alias: &pulumirpc.Alias_Urn{Urn: string(urn)}}
+	}
+	return collapsed
+}

--- a/pkg/server/construct_aliases_test.go
+++ b/pkg/server/construct_aliases_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func urnAlias(urn string) *pulumirpc.Alias {
+	return &pulumirpc.Alias{Alias: &pulumirpc.Alias_Urn{Urn: urn}}
+}
+
+func specAlias(spec *pulumirpc.Alias_Spec) *pulumirpc.Alias {
+	return &pulumirpc.Alias{Alias: &pulumirpc.Alias_Spec_{Spec: spec}}
+}
+
+func TestCollapseSpecAliases(t *testing.T) {
+	t.Parallel()
+
+	const (
+		typ    = "conformance-component:index:Simple"
+		name   = "res"
+		parent = "urn:pulumi:stack::project::simple:index:Resource::parent"
+	)
+
+	cases := []struct {
+		name  string
+		alias *pulumirpc.Alias
+		want  string
+	}{
+		{
+			name:  "urn passthrough",
+			alias: urnAlias("urn:pulumi:stack::project::a:b:C::old"),
+			want:  "urn:pulumi:stack::project::a:b:C::old",
+		},
+		{
+			name: "noParent",
+			alias: specAlias(&pulumirpc.Alias_Spec{
+				Parent: &pulumirpc.Alias_Spec_NoParent{NoParent: true},
+			}),
+			want: "urn:pulumi:stack::project::conformance-component:index:Simple::res",
+		},
+		{
+			name:  "empty spec inherits the current parent",
+			alias: specAlias(&pulumirpc.Alias_Spec{}),
+			want:  "urn:pulumi:stack::project::simple:index:Resource$conformance-component:index:Simple::res",
+		},
+		{
+			name: "previous name",
+			alias: specAlias(&pulumirpc.Alias_Spec{
+				Name:   "old",
+				Parent: &pulumirpc.Alias_Spec_NoParent{NoParent: true},
+			}),
+			want: "urn:pulumi:stack::project::conformance-component:index:Simple::old",
+		},
+		{
+			name: "previous type",
+			alias: specAlias(&pulumirpc.Alias_Spec{
+				Type:   "pkg:index:Old",
+				Parent: &pulumirpc.Alias_Spec_NoParent{NoParent: true},
+			}),
+			want: "urn:pulumi:stack::project::pkg:index:Old::res",
+		},
+		{
+			name: "previous parent",
+			alias: specAlias(&pulumirpc.Alias_Spec{
+				Parent: &pulumirpc.Alias_Spec_ParentUrn{
+					ParentUrn: "urn:pulumi:stack::project::a:b:C::p",
+				},
+			}),
+			want: "urn:pulumi:stack::project::a:b:C$conformance-component:index:Simple::res",
+		},
+		{
+			name: "root stack parent is no parent",
+			alias: specAlias(&pulumirpc.Alias_Spec{
+				Parent: &pulumirpc.Alias_Spec_ParentUrn{
+					ParentUrn: "urn:pulumi:stack::project::pulumi:pulumi:Stack::project-stack",
+				},
+			}),
+			want: "urn:pulumi:stack::project::conformance-component:index:Simple::res",
+		},
+		{
+			name: "previous project and stack",
+			alias: specAlias(&pulumirpc.Alias_Spec{
+				Project: "proj2",
+				Stack:   "stack2",
+				Parent:  &pulumirpc.Alias_Spec_NoParent{NoParent: true},
+			}),
+			want: "urn:pulumi:stack2::proj2::conformance-component:index:Simple::res",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := collapseSpecAliases(
+				[]*pulumirpc.Alias{tc.alias}, typ, name, parent, "project", "stack")
+			require.Len(t, got, 1)
+			assert.Equal(t, tc.want, got[0].GetUrn())
+		})
+	}
+}
+
+// TestConstructForwardsSpecAliases guards against dropping spec-form aliases
+// on the component: the engine sends them on the ConstructRequest and expects
+// the provider to attach the URNs they denote to the component's own
+// RegisterResourceRequest, where the engine matches them against old state
+// and inherits them onto the component's children.
+// https://github.com/pulumi/pulumi-hcl/issues/543
+func TestConstructForwardsSpecAliases(t *testing.T) {
+	t.Parallel()
+
+	dir, err := filepath.Abs(filepath.Join("testdata", "module-one-var"))
+	require.NoError(t, err)
+
+	prov, err := NewLocalProvider(t.Context(), dir, "127.0.0.1:1")
+	require.NoError(t, err)
+	_, err = prov.Handshake(t.Context(), &pulumirpc.ProviderHandshakeRequest{})
+	require.NoError(t, err)
+
+	mon := &captureMonitor{}
+	endpoint := serveResourceMonitor(t, mon)
+	inputs, err := structpb.NewStruct(map[string]any{"name": "world"})
+	require.NoError(t, err)
+	_, err = prov.Construct(t.Context(), &pulumirpc.ConstructRequest{
+		Type:            "module-one-var:index:Module",
+		Name:            "greet",
+		Project:         "proj",
+		Stack:           "test",
+		MonitorEndpoint: endpoint,
+		Inputs:          inputs,
+		Aliases: []*pulumirpc.Alias{
+			specAlias(&pulumirpc.Alias_Spec{
+				Parent: &pulumirpc.Alias_Spec_NoParent{NoParent: true},
+			}),
+			urnAlias("urn:pulumi:test::proj::pkg:index:Old::previous"),
+		},
+		AcceptsOutputValues: true,
+	})
+	require.NoError(t, err)
+
+	component := mon.registeredType("module-one-var:index:Module")
+	require.NotNil(t, component, "the component itself must be registered")
+	assert.Empty(t, cmp.Diff([]*pulumirpc.Alias{
+		urnAlias("urn:pulumi:test::proj::module-one-var:index:Module::greet"),
+		urnAlias("urn:pulumi:test::proj::pkg:index:Old::previous"),
+	}, component.Aliases, protocmp.Transform()))
+}

--- a/pkg/server/provider.go
+++ b/pkg/server/provider.go
@@ -99,7 +99,11 @@ func NewLocalProvider(ctx context.Context, modulePath, addr string) (pulumirpc.R
 		loader:     loader,
 		name:       pkgName,
 	}
-	return p.RawServer(pkgName, version.String(), m.asProvider())(nil)
+	srv, err := p.RawServer(pkgName, version.String(), m.asProvider())(nil)
+	if err != nil {
+		return nil, err
+	}
+	return WithCollapsedConstructAliases(srv), nil
 }
 
 // moduleIdentity derives a module's component token and version. The terraform


### PR DESCRIPTION
## Summary

- collapse spec-form Construct aliases into the URNs they denote before pulumi-go-provider decodes the request, on both the module-provider and RunPlugin serve paths
- un-park the `provider-alias-component` conformance test
- add unit coverage for the collapse and for alias forwarding onto the component registration

The engine marshals spec-form aliases (e.g. `noParent: true`) into `ConstructRequest.aliases` as `Alias_Spec` values, but pulumi-go-provider's typed `ConstructRequest` carries aliases as bare URNs and silently drops every spec (https://github.com/pulumi/pulumi-go-provider/issues/572). An aliased component was therefore registered with no aliases at all, so re-parenting it recreated the component and all of its children.

This differs from the cause hypothesized in the issue: no child-alias derivation is needed in the construct monitor. Once the component's own registration carries its alias, the engine's step generator matches it against old state and multiplies the alias onto the children itself (`generateAliases`/`inheritedChildAlias`, including the `res` → `res-child` name-prefix rewrite that matches this provider's child naming). The children register after the component's registration has completed, so the engine's parent-alias map is already populated when they arrive.

Collapsing spec → URN at the raw gRPC boundary is safe because everything a spec resolves against (type, name, parent, project, stack) is present on the raw request; it mirrors the engine's own `collapseAliasToUrn` and what legacy SDKs do when a monitor lacks `ALIAS_SPECS` support. The wrapper can be deleted once pulumi-go-provider forwards spec aliases.

Closes https://github.com/pulumi/pulumi-hcl/issues/543

🤖 Generated with [Claude Code](https://claude.com/claude-code)
