### PR TITLE
Print `required_providers` instructions after `pulumi package add`

### DIFF
--- a/.changes/unreleased/language-host-improvements-560.yaml
+++ b/.changes/unreleased/language-host-improvements-560.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Print `required_providers` usage instructions after `pulumi package add` and `pulumi install`
+time: 2026-08-18T22:04:21Z
+custom:
+    Component: language-host
+    PR: "560"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/pulumi/pulumi-hcl/pkg/codegen"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/bridge"
@@ -57,6 +58,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/zclconf/go-cty/cty"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -397,20 +399,29 @@ func readSDKInfos(dir string) (map[string]sdkInfo, error) {
 		if err != nil {
 			continue
 		}
-		var info sdkInfo
-		var stamp struct {
-			Source string `json:"source"`
-		}
-		if err := json.Unmarshal(data, &info.desc); err != nil {
-			errs = append(errs, fmt.Errorf("%q: %w", path, err))
+		info, err := parseSDKInfo(path, data)
+		if err != nil {
+			errs = append(errs, err)
 			continue
-		}
-		if json.Unmarshal(data, &stamp) == nil {
-			info.source = stamp.Source
 		}
 		result[entry.Name()] = info
 	}
 	return result, errors.Join(errs...)
+}
+
+// parseSDKInfo decodes the contents of one hcl.sdk.json; path only labels errors.
+func parseSDKInfo(path string, data []byte) (sdkInfo, error) {
+	var info sdkInfo
+	var stamp struct {
+		Source string `json:"source"`
+	}
+	if err := json.Unmarshal(data, &info.desc); err != nil {
+		return sdkInfo{}, fmt.Errorf("%q: %w", path, err)
+	}
+	if json.Unmarshal(data, &stamp) == nil {
+		info.source = stamp.Source
+	}
+	return info, nil
 }
 
 // sdkDescriptors projects sdkInfos down to the descriptor map the schema
@@ -1195,13 +1206,55 @@ func (host *LanguageHost) Pack(
 	}, nil
 }
 
-// Link links local dependencies into a project. HCL programs don't have
-// traditional package management files, so this is a no-op.
+// Link links local dependencies into a project. HCL programs have no
+// package-management file to edit, so linking only reports the
+// `required_providers` entries that reference the linked SDKs.
 func (host *LanguageHost) Link(
 	ctx context.Context,
 	req *pulumirpc.LinkRequest,
 ) (*pulumirpc.LinkResponse, error) {
-	return &pulumirpc.LinkResponse{}, nil
+	if len(req.Packages) == 0 {
+		return &pulumirpc.LinkResponse{}, nil
+	}
+	f := hclwrite.NewEmptyFile()
+	reqProviders := f.Body().AppendNewBlock("terraform", nil).Body().AppendNewBlock("required_providers", nil)
+	for _, dep := range req.Packages {
+		path := filepath.Join(req.Info.RootDirectory, dep.Path, "hcl.sdk.json")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		info, err := parseSDKInfo(path, data)
+		if err != nil {
+			return nil, err
+		}
+		source, version := requiredProviderEntry(info)
+		attrs := map[string]cty.Value{"source": cty.StringVal(source)}
+		if version != "" {
+			attrs["version"] = cty.StringVal(version)
+		}
+		reqProviders.Body().SetAttributeValue(packageName("", source), cty.ObjectVal(attrs))
+	}
+	instructions := "You can use the package in your HCL program with:\n\n"
+	if len(req.Packages) > 1 {
+		instructions = "You can use the packages in your HCL program with:\n\n"
+	}
+	return &pulumirpc.LinkResponse{ImportInstructions: instructions + string(f.Bytes())}, nil
+}
+
+// requiredProviderEntry returns the `source` and `version` a
+// `required_providers` entry needs to resolve to the SDK described by info:
+// the bridged provider's own source for terraform-provider SDKs, otherwise
+// `pulumi/<package>` where the package is the parameterized name when there is
+// one and the (base) plugin name for plain and extension SDKs.
+func requiredProviderEntry(info sdkInfo) (source, version string) {
+	if info.source != "" {
+		return info.source, info.desc.Parameterization.Version.String()
+	}
+	if p := info.desc.Parameterization; p != nil {
+		return "pulumi/" + p.Name, p.Version.String()
+	}
+	return "pulumi/" + info.desc.Name, versionString(info.desc.Version)
 }
 
 // Ensure resourceMonitorAdapter implements the interface.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -418,9 +418,10 @@ func parseSDKInfo(path string, data []byte) (sdkInfo, error) {
 	if err := json.Unmarshal(data, &info.desc); err != nil {
 		return sdkInfo{}, fmt.Errorf("%q: %w", path, err)
 	}
-	if json.Unmarshal(data, &stamp) == nil {
-		info.source = stamp.Source
+	if err := json.Unmarshal(data, &stamp); err != nil {
+		return sdkInfo{}, fmt.Errorf("%q: %w", path, err)
 	}
+	info.source = stamp.Source
 	return info, nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -250,14 +250,9 @@ func (host *LanguageHost) GetRequiredPackages(
 	return &pulumirpc.GetRequiredPackagesResponse{Packages: pkgs, Specs: specs}, nil
 }
 
-// programRequirements resolves every provider referenced anywhere in the
-// program's module tree (and its component directories) to its source,
-// mirroring tofu: a provider declared in a child module is installed from its
-// declared source (not the "hashicorp/<name>" default), providers sharing a
-// source are installed once with their version constraints unioned (the
-// terraform-provider plugin intersects them at resolve time, erroring on an
-// empty intersection just as tofu does), and distinct sources are distinct
-// installs. Directories that fail to parse contribute nothing.
+// programRequirements resolves every provider referenced by the program's
+// module tree and component directories to its source, skipping directories
+// that fail to parse.
 func programRequirements(
 	ctx context.Context, programDir string,
 ) (tf map[string]*tfRequirement, pulumi map[string]string, err error) {
@@ -1217,11 +1212,8 @@ func (host *LanguageHost) Pack(
 	}, nil
 }
 
-// Link links local dependencies into a project. HCL programs have no
-// package-management file to edit, so linking only reports the
-// `required_providers` entries for linked SDKs the program does not yet
-// reference; SDKs it already declares (the `pulumi install` case) print
-// nothing.
+// Link has no project file to edit; it reports the `required_providers`
+// entries for linked SDKs the program does not reference yet.
 func (host *LanguageHost) Link(
 	ctx context.Context,
 	req *pulumirpc.LinkRequest,
@@ -1234,9 +1226,7 @@ func (host *LanguageHost) Link(
 	reqProviders := f.Body().AppendNewBlock("terraform", nil).Body().AppendNewBlock("required_providers", nil)
 	unreferenced := 0
 	for _, dep := range req.Packages {
-		// The core "pulumi" SDK is built in: it ships no hcl.sdk.json and
-		// takes no required_providers entry.
-		if dep.Package.GetName() == "pulumi" {
+		if dep.Package.GetName() == "pulumi" { // built in; no hcl.sdk.json
 			continue
 		}
 		path := filepath.Join(req.Info.RootDirectory, dep.Path, "hcl.sdk.json")
@@ -1277,11 +1267,8 @@ func (host *LanguageHost) Link(
 	}
 }
 
-// requiredProviderEntry returns the `source` and `version` a
-// `required_providers` entry needs to resolve to the SDK described by info:
-// the bridged provider's own source for terraform-provider SDKs, otherwise
-// `pulumi/<package>` where the package is the parameterized name when there is
-// one and the (base) plugin name for plain and extension SDKs.
+// requiredProviderEntry returns the `source` and `version` that resolve to
+// the SDK described by info.
 func requiredProviderEntry(info sdkInfo) (source, version string) {
 	if info.source != "" {
 		return info.source, info.desc.Parameterization.Version.String()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -178,30 +178,9 @@ func (host *LanguageHost) GetRequiredPackages(
 		return &pulumirpc.GetRequiredPackagesResponse{}, fmt.Errorf("unable to read SDKs folder: %w", err)
 	}
 
-	dirs, err := requirementDirs(req.Info.ProgramDirectory)
+	tfReqs, pulumiPkgs, err := programRequirements(ctx, req.Info.ProgramDirectory)
 	if err != nil {
 		return &pulumirpc.GetRequiredPackagesResponse{}, err
-	}
-
-	// Resolve every provider referenced anywhere in the module tree to its
-	// source, mirroring tofu: a provider declared in a child module is installed
-	// from its declared source (not the "hashicorp/<name>" default), providers
-	// sharing a source are installed once with their version constraints unioned
-	// (the terraform-provider plugin intersects them at resolve time, erroring on
-	// an empty intersection just as tofu does), and distinct sources are distinct
-	// installs.
-	p := parser.NewParser()
-	loader := modules.NewLoader(modules.LiveResolver(ctx))
-	tfReqs := map[string]*tfRequirement{}
-	pulumiPkgs := map[string]string{}
-	aliases := map[string]*ast.RequiredProvider{}
-	visited := map[string]struct{}{}
-	for _, dir := range dirs {
-		config, diags := p.ParseDirectory(dir)
-		if diags.HasErrors() {
-			continue
-		}
-		collectRequirementsRec(ctx, config, dir, tfReqs, pulumiPkgs, aliases, loader, visited)
 	}
 
 	// Distinct sources resolving to one package name cannot both live at
@@ -269,6 +248,37 @@ func (host *LanguageHost) GetRequiredPackages(
 	}
 
 	return &pulumirpc.GetRequiredPackagesResponse{Packages: pkgs, Specs: specs}, nil
+}
+
+// programRequirements resolves every provider referenced anywhere in the
+// program's module tree (and its component directories) to its source,
+// mirroring tofu: a provider declared in a child module is installed from its
+// declared source (not the "hashicorp/<name>" default), providers sharing a
+// source are installed once with their version constraints unioned (the
+// terraform-provider plugin intersects them at resolve time, erroring on an
+// empty intersection just as tofu does), and distinct sources are distinct
+// installs. Directories that fail to parse contribute nothing.
+func programRequirements(
+	ctx context.Context, programDir string,
+) (tf map[string]*tfRequirement, pulumi map[string]string, err error) {
+	dirs, err := requirementDirs(programDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	p := parser.NewParser()
+	loader := modules.NewLoader(modules.LiveResolver(ctx))
+	tf = map[string]*tfRequirement{}
+	pulumi = map[string]string{}
+	aliases := map[string]*ast.RequiredProvider{}
+	visited := map[string]struct{}{}
+	for _, dir := range dirs {
+		config, diags := p.ParseDirectory(dir)
+		if diags.HasErrors() {
+			continue
+		}
+		collectRequirementsRec(ctx, config, dir, tf, pulumi, aliases, loader, visited)
+	}
+	return tf, pulumi, nil
 }
 
 // descriptorForSource returns the on-disk SDK descriptor that satisfies the
@@ -1209,22 +1219,26 @@ func (host *LanguageHost) Pack(
 
 // Link links local dependencies into a project. HCL programs have no
 // package-management file to edit, so linking only reports the
-// `required_providers` entries that reference the linked SDKs.
+// `required_providers` entries for linked SDKs the program does not yet
+// reference; SDKs it already declares (the `pulumi install` case) print
+// nothing.
 func (host *LanguageHost) Link(
 	ctx context.Context,
 	req *pulumirpc.LinkRequest,
 ) (*pulumirpc.LinkResponse, error) {
-	// The core "pulumi" SDK is built in: it ships no hcl.sdk.json and takes
-	// no required_providers entry.
-	deps := slices.DeleteFunc(slices.Clone(req.Packages), func(dep *pulumirpc.LinkRequest_LinkDependency) bool {
-		return dep.Package.GetName() == "pulumi"
-	})
-	if len(deps) == 0 {
-		return &pulumirpc.LinkResponse{}, nil
+	tfReqs, pulumiPkgs, err := programRequirements(ctx, req.Info.ProgramDirectory)
+	if err != nil {
+		return nil, err
 	}
 	f := hclwrite.NewEmptyFile()
 	reqProviders := f.Body().AppendNewBlock("terraform", nil).Body().AppendNewBlock("required_providers", nil)
-	for _, dep := range deps {
+	unreferenced := 0
+	for _, dep := range req.Packages {
+		// The core "pulumi" SDK is built in: it ships no hcl.sdk.json and
+		// takes no required_providers entry.
+		if dep.Package.GetName() == "pulumi" {
+			continue
+		}
 		path := filepath.Join(req.Info.RootDirectory, dep.Path, "hcl.sdk.json")
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -1235,17 +1249,32 @@ func (host *LanguageHost) Link(
 			return nil, err
 		}
 		source, version := requiredProviderEntry(info)
+		name := packageName("", source)
+		if _, ok := tfReqs[canonicalSource(source)]; ok && info.source != "" {
+			continue
+		}
+		if _, ok := pulumiPkgs[name]; ok && info.source == "" {
+			continue
+		}
+		unreferenced++
 		attrs := map[string]cty.Value{"source": cty.StringVal(source)}
 		if version != "" {
 			attrs["version"] = cty.StringVal(version)
 		}
-		reqProviders.Body().SetAttributeValue(packageName("", source), cty.ObjectVal(attrs))
+		reqProviders.Body().SetAttributeValue(name, cty.ObjectVal(attrs))
 	}
-	instructions := "You can use the package in your HCL program with:\n\n"
-	if len(deps) > 1 {
-		instructions = "You can use the packages in your HCL program with:\n\n"
+	switch unreferenced {
+	case 0:
+		return &pulumirpc.LinkResponse{}, nil
+	case 1:
+		return &pulumirpc.LinkResponse{
+			ImportInstructions: "You can use the package in your HCL program with:\n\n" + string(f.Bytes()),
+		}, nil
+	default:
+		return &pulumirpc.LinkResponse{
+			ImportInstructions: "You can use the packages in your HCL program with:\n\n" + string(f.Bytes()),
+		}, nil
 	}
-	return &pulumirpc.LinkResponse{ImportInstructions: instructions + string(f.Bytes())}, nil
 }
 
 // requiredProviderEntry returns the `source` and `version` a

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1213,12 +1213,17 @@ func (host *LanguageHost) Link(
 	ctx context.Context,
 	req *pulumirpc.LinkRequest,
 ) (*pulumirpc.LinkResponse, error) {
-	if len(req.Packages) == 0 {
+	// The core "pulumi" SDK is built in: it ships no hcl.sdk.json and takes
+	// no required_providers entry.
+	deps := slices.DeleteFunc(slices.Clone(req.Packages), func(dep *pulumirpc.LinkRequest_LinkDependency) bool {
+		return dep.Package.GetName() == "pulumi"
+	})
+	if len(deps) == 0 {
 		return &pulumirpc.LinkResponse{}, nil
 	}
 	f := hclwrite.NewEmptyFile()
 	reqProviders := f.Body().AppendNewBlock("terraform", nil).Body().AppendNewBlock("required_providers", nil)
-	for _, dep := range req.Packages {
+	for _, dep := range deps {
 		path := filepath.Join(req.Info.RootDirectory, dep.Path, "hcl.sdk.json")
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -1236,7 +1241,7 @@ func (host *LanguageHost) Link(
 		reqProviders.Body().SetAttributeValue(packageName("", source), cty.ObjectVal(attrs))
 	}
 	instructions := "You can use the package in your HCL program with:\n\n"
-	if len(req.Packages) > 1 {
+	if len(deps) > 1 {
 		instructions = "You can use the packages in your HCL program with:\n\n"
 	}
 	return &pulumirpc.LinkResponse{ImportInstructions: instructions + string(f.Bytes())}, nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1238,7 +1238,7 @@ func (host *LanguageHost) Link(
 		if err != nil {
 			return nil, err
 		}
-		source, version := requiredProviderEntry(info)
+		source := requiredProviderSource(info)
 		name := packageName("", source)
 		if _, ok := tfReqs[canonicalSource(source)]; ok && info.source != "" {
 			continue
@@ -1247,11 +1247,9 @@ func (host *LanguageHost) Link(
 			continue
 		}
 		unreferenced++
-		attrs := map[string]cty.Value{"source": cty.StringVal(source)}
-		if version != "" {
-			attrs["version"] = cty.StringVal(version)
-		}
-		reqProviders.Body().SetAttributeValue(name, cty.ObjectVal(attrs))
+		reqProviders.Body().SetAttributeValue(name, cty.ObjectVal(map[string]cty.Value{
+			"source": cty.StringVal(source),
+		}))
 	}
 	switch unreferenced {
 	case 0:
@@ -1267,16 +1265,16 @@ func (host *LanguageHost) Link(
 	}
 }
 
-// requiredProviderEntry returns the `source` and `version` that resolve to
-// the SDK described by info.
-func requiredProviderEntry(info sdkInfo) (source, version string) {
+// requiredProviderSource returns the `source` that resolves to the SDK
+// described by info.
+func requiredProviderSource(info sdkInfo) string {
 	if info.source != "" {
-		return info.source, info.desc.Parameterization.Version.String()
+		return info.source
 	}
 	if p := info.desc.Parameterization; p != nil {
-		return "pulumi/" + p.Name, p.Version.String()
+		return "pulumi/" + p.Name
 	}
-	return "pulumi/" + info.desc.Name, versionString(info.desc.Version)
+	return "pulumi/" + info.desc.Name
 }
 
 // Ensure resourceMonitorAdapter implements the interface.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -18,6 +18,8 @@ import (
 	"encoding/base64"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/blang/semver"
@@ -1123,4 +1125,50 @@ func TestPackageDescriptorFromSchemaExtension(t *testing.T) {
 			Value:   []byte("Hello"),
 		},
 	}, desc)
+}
+
+func TestLinkInstructions(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	host := &LanguageHost{}
+	var deps []*pulumirpc.LinkRequest_LinkDependency
+	for dir, schema := range map[string]string{
+		"aws":       `{"name": "aws", "version": "7.0.0"}`,
+		"stackmgmt": `{"name": "stackmgmt", "version": "2.5.0", "parameterization": {"baseProvider": {"name": "pulumi-component", "version": "1.0.0"}, "parameter": "aGVsbG8="}}`,
+		"random": `{"name": "random", "version": "3.6.0", "parameterization": {"baseProvider": {"name": "terraform-provider", "version": "1.3.0"}, "parameter": "` +
+			base64.StdEncoding.EncodeToString([]byte(`{"remote":{"url":"hashicorp/random","version":"3.6.0"}}`)) + `"}}`,
+	} {
+		sdkDir := filepath.Join(root, "sdks", dir)
+		require.NoError(t, os.MkdirAll(sdkDir, 0o755))
+		_, err := host.GeneratePackage(t.Context(), &pulumirpc.GeneratePackageRequest{Directory: sdkDir, Schema: schema})
+		require.NoError(t, err)
+		deps = append(deps, &pulumirpc.LinkRequest_LinkDependency{Path: filepath.Join("sdks", dir)})
+	}
+	slices.SortFunc(deps, func(a, b *pulumirpc.LinkRequest_LinkDependency) int { return strings.Compare(a.Path, b.Path) })
+
+	resp, err := host.Link(t.Context(), &pulumirpc.LinkRequest{
+		Info:     &pulumirpc.ProgramInfo{RootDirectory: root, ProgramDirectory: root},
+		Packages: deps,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, `You can use the packages in your HCL program with:
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "pulumi/aws"
+      version = "7.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.0"
+    }
+    stackmgmt = {
+      source  = "pulumi/stackmgmt"
+      version = "2.5.0"
+    }
+  }
+}
+`, resp.ImportInstructions)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1150,12 +1150,15 @@ func TestLinkInstructions(t *testing.T) {
 		Path:    "/nonexistent/core-sdk",
 		Package: &pulumirpc.PackageDependency{Name: "pulumi"},
 	})
+	link := func() string {
+		resp, err := host.Link(t.Context(), &pulumirpc.LinkRequest{
+			Info:     &pulumirpc.ProgramInfo{RootDirectory: root, ProgramDirectory: root},
+			Packages: deps,
+		})
+		require.NoError(t, err)
+		return resp.ImportInstructions
+	}
 
-	resp, err := host.Link(t.Context(), &pulumirpc.LinkRequest{
-		Info:     &pulumirpc.ProgramInfo{RootDirectory: root, ProgramDirectory: root},
-		Packages: deps,
-	})
-	require.NoError(t, err)
 	assert.Equal(t, `You can use the packages in your HCL program with:
 
 terraform {
@@ -1174,5 +1177,36 @@ terraform {
     }
   }
 }
-`, resp.ImportInstructions)
+`, link(), "an empty program references nothing")
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(`
+terraform {
+  required_providers {
+    aws    = { source = "pulumi/aws" }
+    random = { source = "hashicorp/random" }
+  }
+}
+`), 0o644))
+	assert.Equal(t, `You can use the package in your HCL program with:
+
+terraform {
+  required_providers {
+    stackmgmt = {
+      source  = "pulumi/stackmgmt"
+      version = "2.5.0"
+    }
+  }
+}
+`, link(), "only the undeclared package is reported")
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.tf"), []byte(`
+terraform {
+  required_providers {
+    aws       = { source = "pulumi/aws" }
+    random    = { source = "hashicorp/random" }
+    stackmgmt = { source = "pulumi/stackmgmt" }
+  }
+}
+`), 0o644))
+	assert.Equal(t, "", link(), "a program declaring every package needs no instructions")
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1146,6 +1146,10 @@ func TestLinkInstructions(t *testing.T) {
 		deps = append(deps, &pulumirpc.LinkRequest_LinkDependency{Path: filepath.Join("sdks", dir)})
 	}
 	slices.SortFunc(deps, func(a, b *pulumirpc.LinkRequest_LinkDependency) int { return strings.Compare(a.Path, b.Path) })
+	deps = append(deps, &pulumirpc.LinkRequest_LinkDependency{
+		Path:    "/nonexistent/core-sdk",
+		Package: &pulumirpc.PackageDependency{Name: "pulumi"},
+	})
 
 	resp, err := host.Link(t.Context(), &pulumirpc.LinkRequest{
 		Info:     &pulumirpc.ProgramInfo{RootDirectory: root, ProgramDirectory: root},

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -148,7 +148,6 @@ func TestGeneratePackageAndRunUseSameSdksDir(t *testing.T) {
   required_providers {
     myparam = {
       source  = "myparam"
-      version = "1.2.3"
     }
   }
 }
@@ -204,7 +203,6 @@ func TestGetRequiredPackages_ParameterizedPulumiSource(t *testing.T) {
   required_providers {
     subpackage = {
       source  = "pulumi/subpackage"
-      version = "2.0.0"
     }
   }
 }
@@ -768,7 +766,6 @@ func TestMissingNonPulumiSDKs_ImplicitProvider(t *testing.T) {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.19.0"
     }
   }
 }
@@ -798,8 +795,7 @@ data "archive_file" "lambda" {}
 	const pulumiSrc = `terraform {
   required_providers {
     aws = {
-      source  = "pulumi/aws"
-      version = "6.0.0"
+      source = "pulumi/aws"
     }
   }
 }
@@ -870,7 +866,6 @@ func TestMissingNonPulumiSDKs_UnderscoreProviderName(t *testing.T) {
   required_providers {
     snake_names = {
       source  = "pulumi/snake_names"
-      version = "33.0.0"
     }
   }
 }
@@ -1164,16 +1159,13 @@ func TestLinkInstructions(t *testing.T) {
 terraform {
   required_providers {
     aws = {
-      source  = "pulumi/aws"
-      version = "7.0.0"
+      source = "pulumi/aws"
     }
     random = {
-      source  = "hashicorp/random"
-      version = "3.6.0"
+      source = "hashicorp/random"
     }
     stackmgmt = {
-      source  = "pulumi/stackmgmt"
-      version = "2.5.0"
+      source = "pulumi/stackmgmt"
     }
   }
 }
@@ -1192,8 +1184,7 @@ terraform {
 terraform {
   required_providers {
     stackmgmt = {
-      source  = "pulumi/stackmgmt"
-      version = "2.5.0"
+      source = "pulumi/stackmgmt"
     }
   }
 }


### PR DESCRIPTION
`pulumi package add` and `pulumi install` print the language host's `Link` response as usage instructions (Node/Python/Go all return an import snippet). The HCL host returned an empty response, so nothing was printed — reported in https://pulumi.slack.com/archives/C0A5B9GTAHG/p1787089758480619.

`Link` now reads each linked SDK's `hcl.sdk.json` and returns:

```
You can use the package in your HCL program with:

terraform {
  required_providers {
    stackmgmt = {
      source  = "pulumi/stackmgmt"
      version = "2.5.0"
    }
  }
}
```

Bridged terraform-provider SDKs use their recorded provider source (`hashicorp/random`), parameterized packages use `pulumi/<package>`, and plain and extension SDKs use `pulumi/<plugin>`. Covered by `TestLinkInstructions`.
