### PR TITLE
Align nested body mappings with bound schemas

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-562.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-562.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Stop panicking when nested provider schema projections differ
+time: 2026-08-19T14:22:12Z
+custom:
+    Component: runtime
+    PR: "562"

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opentofu/registry-address/v2 v2.0.0-20250611143131-d0a99bd8acdd
 	github.com/opentofu/svchost v0.0.0-20250610175836-86c9e5e3d8c8
+	github.com/pulumi/inflector v0.2.1
 	github.com/pulumi/providertest v0.7.0
 	github.com/pulumi/pulumi-go-provider v1.5.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.134.1-0.20260720151533-5ffabd1227c9
@@ -255,7 +256,6 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/pulumi-labs/pulumi-hcl v0.3.1 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
-	github.com/pulumi/inflector v0.2.1 // indirect
 	github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3 v3.109.1-0.20260729130442-aef193ab2411 // indirect
 	github.com/pulumi/pulumi-java v1.34.0 // indirect
 	github.com/pulumi/pulumi-yaml v1.37.1-0.20260709082604-efc7b02d80e5 // indirect

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -1648,6 +1648,8 @@ func (e *Engine) registerResourceInstanceInContext(
 	hclCtx := evalCtx.HCLContext()
 
 	resourceMapping := e.resolver.ResourceBodyMapping(ctx, res.Type)
+	allResourceProperties := append(slices.Clone(resSchema.InputProperties), resSchema.Properties...)
+	resourceMapping = transform.AlignBodyMapping(resourceMapping, allResourceProperties)
 	// terraform_data's attributes are dynamically typed, so their cty types
 	// (e.g. set-ness) survive the Pulumi property round-trip only via the
 	// evaluated values captured here; see wrapTerraformDataInputs.

--- a/pkg/hcl/run/run_internal_test.go
+++ b/pkg/hcl/run/run_internal_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/bridge"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/eval"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/transform"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
@@ -252,6 +253,54 @@ func TestTranslateAttrPathTraversal(t *testing.T) {
 			assert.Equal(t, tt.want, string(text))
 		})
 	}
+}
+
+func TestTranslateAttrPathTraversalAlignedProjection(t *testing.T) {
+	t.Parallel()
+
+	geo := &schema.ObjectType{Properties: []*schema.Property{{
+		Name: "countryCodes", Type: &schema.ArrayType{ElementType: schema.StringType},
+	}}}
+	statement := &schema.ObjectType{Properties: []*schema.Property{{
+		Name: "geoMatchStatements", Type: &schema.ArrayType{ElementType: geo},
+	}}}
+	rule := &schema.ObjectType{Properties: []*schema.Property{{Name: "statement", Type: statement}}}
+	props := []*schema.Property{{Name: "rules", Type: &schema.ArrayType{ElementType: rule}}}
+	mapping := &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+		"rule": {
+			TFName: "rule", PulumiName: "rules", TFBlock: true,
+			Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+				"statement": {
+					TFName: "statement", PulumiName: "statement", TFBlock: true, MaxItemsOne: true,
+					Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+						"geo_match_statement": {
+							TFName: "geo_match_statement", PulumiName: "geoMatchStatement",
+							TFBlock: true, MaxItemsOne: true,
+							Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+								"country_codes": {TFName: "country_codes", PulumiName: "countryCodes"},
+							}},
+						},
+					}},
+				},
+			}},
+		},
+	}}
+	mapping = transform.AlignBodyMapping(mapping, props)
+
+	traversal := hcl.Traversal{
+		hcl.TraverseAttr{Name: "rule"},
+		hcl.TraverseIndex{Key: cty.NumberIntVal(0)},
+		hcl.TraverseAttr{Name: "statement"},
+		hcl.TraverseIndex{Key: cty.NumberIntVal(0)},
+		hcl.TraverseAttr{Name: "geo_match_statement"},
+		hcl.TraverseIndex{Key: cty.NumberIntVal(0)},
+		hcl.TraverseAttr{Name: "country_codes"},
+	}
+	glob, err := translateAttrPathTraversal(traversal, mapping, props)
+	require.NoError(t, err)
+	text, err := glob.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "rules[0].statement.geoMatchStatements[0].countryCodes", string(text))
 }
 
 // TestIgnoreChangesApplies covers the OpenTofu-style existence check that

--- a/pkg/hcl/transform/mapping_alignment.go
+++ b/pkg/hcl/transform/mapping_alignment.go
@@ -1,0 +1,121 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transform
+
+import (
+	"github.com/pulumi/inflector"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/bridge"
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+// AlignBodyMapping returns a copy of mapping reconciled with the bound Pulumi
+// schema. The raw provider mapping remains authoritative for HCL names and
+// block classification, while the bound schema supplies the Pulumi property
+// names and wire shapes that the engine accepts.
+func AlignBodyMapping(mapping *bridge.BodyMapping, props []*schema.Property) *bridge.BodyMapping {
+	if mapping == nil {
+		return nil
+	}
+
+	aligned := &bridge.BodyMapping{Fields: make(map[string]*bridge.FieldMapping, len(mapping.Fields))}
+	for tfName, field := range mapping.Fields {
+		if field == nil {
+			continue
+		}
+
+		fieldCopy := *field
+		if prop := propertyForField(tfName, field, props); prop != nil {
+			fieldCopy.PulumiName = prop.Name
+			if field.TFBlock {
+				if repeated, ok := repeatedBlockShape(prop.Type); ok {
+					fieldCopy.MaxItemsOne = !repeated
+				}
+			}
+			fieldCopy.Nested = AlignBodyMapping(field.Nested, nestedPropertiesOf(prop.Type))
+		} else {
+			// Keep unmatched fields so HCL validation can recognize the original
+			// provider field and evaluation can report a source-ranged diagnostic.
+			fieldCopy.Nested = AlignBodyMapping(field.Nested, nil)
+		}
+		aligned.Fields[tfName] = &fieldCopy
+	}
+	return aligned
+}
+
+func propertyForField(
+	tfName string, field *bridge.FieldMapping, props []*schema.Property,
+) *schema.Property {
+	for _, prop := range props {
+		if prop.Name == field.PulumiName && fieldShapeCompatible(field, prop) {
+			return prop
+		}
+	}
+
+	if _, prop := camelCaseFromSnakeCase(tfName, props); prop != nil && fieldShapeCompatible(field, prop) {
+		return prop
+	}
+
+	// Some dynamically-bound schemas retain a collection where the raw
+	// mapping projects MaxItemsOne to a scalar (or vice versa). In that case
+	// the generated Pulumi name differs only by singular/plural inflection.
+	variants := map[string]struct{}{
+		inflector.Pluralize(field.PulumiName):   {},
+		inflector.Singularize(field.PulumiName): {},
+	}
+	var match *schema.Property
+	for _, prop := range props {
+		if _, ok := variants[prop.Name]; !ok {
+			continue
+		}
+		if !fieldShapeCompatible(field, prop) {
+			continue
+		}
+		if match != nil {
+			return nil
+		}
+		match = prop
+	}
+	return match
+}
+
+func fieldShapeCompatible(field *bridge.FieldMapping, prop *schema.Property) bool {
+	if !field.TFBlock {
+		return true
+	}
+	_, ok := repeatedBlockShape(prop.Type)
+	return ok
+}
+
+func repeatedBlockShape(typ schema.Type) (repeated bool, ok bool) {
+	if _, ok := AsHCLBlockType(typ); ok {
+		return true, true
+	}
+	_, ok = codegen.UnwrapType(typ).(*schema.ObjectType)
+	return false, ok
+}
+
+func nestedPropertiesOf(typ schema.Type) []*schema.Property {
+	switch typ := codegen.UnwrapType(typ).(type) {
+	case *schema.ObjectType:
+		return typ.Properties
+	case *schema.ArrayType:
+		return nestedPropertiesOf(typ.ElementType)
+	case *schema.MapType:
+		return nestedPropertiesOf(typ.ElementType)
+	default:
+		return nil
+	}
+}

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
@@ -57,6 +56,7 @@ func EvalFunctionWithSchema(config hcl.Body, r *schema.Function, mapping *bridge
 	if r.Inputs != nil {
 		props = r.Inputs.Properties
 	}
+	mapping = AlignBodyMapping(mapping, props)
 	functionInputs, attrExprs, diags := evalBlockWithSchema(config, props, mapping, eval)
 	if diags.HasErrors() {
 		return property.Map{}, diags
@@ -76,6 +76,7 @@ func EvalFunctionWithSchema(config hcl.Body, r *schema.Function, mapping *bridge
 // mark. Paths are in the assembled inputs' namespace — snake-cased Pulumi
 // names with MaxItemsOne blocks already flattened — and sorted.
 func EvalResourceWithSchema(config hcl.Body, r *schema.Resource, mapping *bridge.BodyMapping, eval EvalFunc) (property.Map, []cty.Path, hcl.Diagnostics) {
+	mapping = AlignBodyMapping(mapping, r.InputProperties)
 	resourceInputs, attrExprs, diags := evalBlockWithSchema(config, r.InputProperties, mapping, eval)
 	if diags.HasErrors() {
 		return property.Map{}, nil, diags
@@ -168,7 +169,10 @@ func evalBlockWithSchema(config hcl.Body, props []*schema.Property, mapping *bri
 	resourceInputs := make(map[string]cty.Value, len(body.Attributes)+len(body.Blocks))
 	for name, attr := range body.Attributes {
 		_, prop := resolvePulumiProperty(name, props, mapping)
-		contract.Assertf(prop != nil, "unable to find schema for validated property")
+		if prop == nil {
+			diags = append(diags, invalidSchemaMapping("attribute", name, attr.NameRange))
+			return cty.Value{}, nil, diags
+		}
 
 		out, attrDiag := eval(resource.PropertyKey(prop.Name), attr.Expr, nil)
 		diags = diags.Extend(attrDiag)
@@ -195,7 +199,10 @@ func evalBlockWithSchema(config hcl.Body, props []*schema.Property, mapping *bri
 		}
 
 		_, prop := resolvePulumiProperty(name, props, mapping)
-		contract.Assertf(prop != nil, "unable to find schema for validated property")
+		if prop == nil {
+			diags = append(diags, invalidSchemaMapping("block", name, block.TypeRange))
+			return cty.Value{}, nil, diags
+		}
 
 		blockProps, isList := blockPropertiesOf(prop.Type)
 		var nestedMapping *bridge.BodyMapping
@@ -228,6 +235,16 @@ func evalBlockWithSchema(config hcl.Body, props []*schema.Property, mapping *bri
 	}
 
 	return cty.ObjectVal(resourceInputs), attrExprs, diags
+}
+
+func invalidSchemaMapping(kind, name string, subject hcl.Range) *hcl.Diagnostic {
+	return &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "Invalid schema mapping",
+		Detail: fmt.Sprintf("The provider mapping accepts the %s %q, but the bound Pulumi schema has no "+
+			"corresponding property.", kind, name),
+		Subject: subject.Ptr(),
+	}
 }
 
 // blockPropertiesOf returns the inner-block property list and whether the
@@ -1208,6 +1225,7 @@ func ResourceOutputToCty(
 			&schema.Property{Name: "pluginDownloadURL", Type: schema.StringType},
 		)
 	}
+	mapping = AlignBodyMapping(mapping, properties)
 	return propertyObjectToCtyMap("", pv, properties, mapping, dryRun)
 }
 
@@ -1224,6 +1242,7 @@ func ResourceReferenceType(r *schema.Resource, mapping *bridge.BodyMapping) cty.
 			&schema.Property{Name: "pluginDownloadURL", Type: schema.StringType},
 		)
 	}
+	mapping = AlignBodyMapping(mapping, properties)
 	return ctyObjectType(properties, map[string]cty.Type{"id": cty.String}, mapping)
 }
 
@@ -1235,12 +1254,14 @@ func DataSourceReferenceType(fn *schema.Function, mapping *bridge.BodyMapping) c
 	if !ok {
 		return cty.DynamicPseudoType
 	}
+	mapping = AlignBodyMapping(mapping, obj.Properties)
 	return ctyObjectType(obj.Properties, nil, mapping)
 }
 
 // FunctionOutputToCty mirrors ResourceOutputToCty for invoke return values.
 func FunctionOutputToCty(pv property.Map, r *schema.Function, mapping *bridge.BodyMapping, dryRun bool) (cty.Value, error) {
 	if obj, ok := r.ReturnType.(*schema.ObjectType); ok {
+		mapping = AlignBodyMapping(mapping, obj.Properties)
 		o, err := propertyObjectToCtyMap("", pv, obj.Properties, mapping, dryRun)
 		return cty.ObjectVal(o), err
 	}

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -588,6 +588,197 @@ resource "fake" "f" {
 	}
 }
 
+func projectionMismatchSchema() *schema.Resource {
+	geo := &schema.ObjectType{Properties: []*schema.Property{
+		{Name: "countryCodes", Type: &schema.ArrayType{ElementType: schema.StringType}},
+	}}
+	statement := &schema.ObjectType{Properties: []*schema.Property{
+		{Name: "geoMatchStatements", Type: &schema.ArrayType{ElementType: geo}},
+	}}
+	rule := &schema.ObjectType{Properties: []*schema.Property{
+		{Name: "statement", Type: statement},
+	}}
+	return &schema.Resource{
+		Token: "test:index:WebAcl",
+		InputProperties: []*schema.Property{
+			{Name: "rules", Type: &schema.ArrayType{ElementType: rule}},
+		},
+		Properties: []*schema.Property{
+			{Name: "rules", Type: &schema.ArrayType{ElementType: rule}},
+		},
+	}
+}
+
+func projectionMismatchMapping() *bridge.BodyMapping {
+	return &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+		"rule": {
+			TFName:     "rule",
+			PulumiName: "rules",
+			TFBlock:    true,
+			Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+				"statement": {
+					TFName:      "statement",
+					PulumiName:  "statement",
+					TFBlock:     true,
+					MaxItemsOne: true,
+					Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+						"geo_match_statement": {
+							TFName:      "geo_match_statement",
+							PulumiName:  "geoMatchStatement",
+							TFBlock:     true,
+							MaxItemsOne: true,
+							Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+								"country_codes": {
+									TFName:     "country_codes",
+									PulumiName: "countryCodes",
+								},
+							}},
+						},
+					}},
+				},
+			}},
+		},
+	}}
+}
+
+func projectionMismatchExpectedInputs() property.Map {
+	return property.NewMap(map[string]property.Value{
+		"rules": property.New([]property.Value{
+			property.New(property.NewMap(map[string]property.Value{
+				"statement": property.New(property.NewMap(map[string]property.Value{
+					"geoMatchStatements": property.New([]property.Value{
+						property.New(property.NewMap(map[string]property.Value{
+							"countryCodes": property.New([]property.Value{property.New("GB")}),
+						})),
+					}),
+				})),
+			})),
+		}),
+	})
+}
+
+// The raw provider mapping can flatten a nested MaxItemsOne block even when
+// the bound Pulumi schema retains it as a plural collection. Both static and
+// dynamic HCL blocks must follow the bound schema without losing their values.
+func TestEvalResourceAlignsNestedSchemaProjection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "static block",
+			src: `resource "fake" "f" {
+  rule {
+    statement {
+      geo_match_statement {
+        country_codes = ["GB"]
+      }
+    }
+  }
+}`,
+		},
+		{
+			name: "dynamic block",
+			src: `resource "fake" "f" {
+  rule {
+    statement {
+      dynamic "geo_match_statement" {
+        for_each = ["GB"]
+        content {
+          country_codes = [geo_match_statement.value]
+        }
+      }
+    }
+  }
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			file, diags := hclsyntax.ParseConfig([]byte(tt.src), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+			require.False(t, diags.HasErrors(), diags.Error())
+			resourceBody := file.Body.(*hclsyntax.Body).Blocks[0].Body
+			evalFn := func(
+				_ resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value,
+			) (cty.Value, hcl.Diagnostics) {
+				return expr.Value(&hcl.EvalContext{Variables: extraVars})
+			}
+
+			inputs, _, diags := EvalResourceWithSchema(
+				resourceBody, projectionMismatchSchema(), projectionMismatchMapping(), evalFn)
+			require.False(t, diags.HasErrors(), "unexpected diags: %v", diags)
+			assert.Equal(t, projectionMismatchExpectedInputs(), inputs)
+		})
+	}
+}
+
+func TestNestedSchemaProjectionOutputAndReferenceShape(t *testing.T) {
+	t.Parallel()
+
+	res := projectionMismatchSchema()
+	mapping := projectionMismatchMapping()
+	outputs, err := ResourceOutputToCty(projectionMismatchExpectedInputs(), res, mapping, false)
+	require.NoError(t, err)
+
+	rules := outputs["rule"]
+	require.True(t, rules.Type().IsListType())
+	rule := rules.Index(cty.NumberIntVal(0))
+	statements := rule.GetAttr("statement")
+	require.True(t, statements.Type().IsTupleType() || statements.Type().IsListType())
+	statement := statements.Index(cty.NumberIntVal(0))
+	geoStatements := statement.GetAttr("geo_match_statement")
+	require.True(t, geoStatements.Type().IsListType())
+	geo := geoStatements.Index(cty.NumberIntVal(0))
+	assert.Equal(t, "GB", geo.GetAttr("country_codes").Index(cty.NumberIntVal(0)).AsString())
+
+	referenceType := ResourceReferenceType(res, mapping)
+	ruleType := referenceType.AttributeType("rule").ElementType()
+	statementType := ruleType.AttributeType("statement").ElementType()
+	geoType := statementType.AttributeType("geo_match_statement")
+	assert.True(t, geoType.IsListType())
+	assert.Equal(t, cty.String, geoType.ElementType().AttributeType("country_codes").ElementType())
+}
+
+func TestUnmatchedBodyMappingReturnsDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	file, diags := hclsyntax.ParseConfig([]byte(`resource "fake" "f" {
+  missing_block {}
+}`), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	require.False(t, diags.HasErrors(), diags.Error())
+	resourceBody := file.Body.(*hclsyntax.Body).Blocks[0].Body
+	res := &schema.Resource{
+		Token: "test:index:F",
+		InputProperties: []*schema.Property{{
+			Name: "name",
+			Type: &schema.OptionalType{ElementType: schema.StringType},
+		}},
+	}
+	mapping := &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+		"missing_block": {
+			TFName:     "missing_block",
+			PulumiName: "missingBlock",
+			TFBlock:    true,
+		},
+	}}
+
+	_, _, diags = EvalResourceWithSchema(resourceBody, res, mapping,
+		func(_ resource.PropertyKey, expr hcl.Expression, _ map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
+			return expr.Value(nil)
+		})
+	require.True(t, diags.HasErrors())
+	require.Len(t, diags, 1)
+	assert.Equal(t, "Invalid schema mapping", diags[0].Summary)
+	assert.Contains(t, diags[0].Detail, `block "missing_block"`)
+	require.NotNil(t, diags[0].Subject)
+	assert.Equal(t, 2, diags[0].Subject.Start.Line)
+}
+
 func TestCtyToPropertyValue_Primitives(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- reconcile raw provider body mappings with bound Pulumi property names and block cardinality
- preserve original HCL names across inputs, dynamic blocks, outputs, references, and lifecycle paths
- return source-ranged diagnostics for unresolved mappings instead of panicking

Fixes #561.

## Root cause

The parameterized AWS schema binds `geo_match_statement` as the plural array property `geoMatchStatements`, while the raw provider mapping projects its `MaxItemsOne` shape to singular `geoMatchStatement`. HCL body validation accepted the raw block name, but property resolution asserted when the mapped singular name was absent from the bound schema.

## Testing

- `make build`
- `go test ./pkg/hcl/transform/... -count=1`
- `go test ./pkg/hcl/run/... -count=1`
- `PATH="$PWD/bin:$PATH" go test ./pkg/hcl/... -count=1`
- AWS 6.59 WAFv2 repro: `pulumi preview --refresh=false --non-interactive --diff` succeeds and retains `geoMatchStatements[0].countryCodes`
- changelog fragment: `.changes/unreleased/runtime-bug-fixes-562.yaml`