### PR TITLE
Report an unmapped block or attribute as a diagnostic instead of panicking

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-561.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-561.yaml
@@ -1,0 +1,5 @@
+kind: bug-fixes
+body: Return a diagnostic instead of panicking when a provider's mapping names a block or attribute its schema lacks
+time: 2026-08-19T11:30:00Z
+custom:
+    Component: runtime

--- a/.changes/unreleased/runtime-bug-fixes-561.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-561.yaml
@@ -3,3 +3,4 @@ body: Return a diagnostic instead of panicking when a provider's mapping names a
 time: 2026-08-19T11:30:00Z
 custom:
     Component: runtime
+    PR: "564"

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/archive"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
@@ -167,8 +166,10 @@ func evalBlockWithSchema(config hcl.Body, props []*schema.Property, mapping *bri
 	attrExprs := make(map[string]hcl.Expression, len(body.Attributes))
 	resourceInputs := make(map[string]cty.Value, len(body.Attributes)+len(body.Blocks))
 	for name, attr := range body.Attributes {
-		_, prop := resolvePulumiProperty(name, props, mapping)
-		contract.Assertf(prop != nil, "unable to find schema for validated property")
+		puName, prop := resolvePulumiProperty(name, props, mapping)
+		if prop == nil {
+			return cty.Value{}, nil, append(diags, unmappedProperty(name, puName, props, attr.Range))
+		}
 
 		out, attrDiag := eval(resource.PropertyKey(prop.Name), attr.Expr, nil)
 		diags = diags.Extend(attrDiag)
@@ -194,8 +195,10 @@ func evalBlockWithSchema(config hcl.Body, props []*schema.Property, mapping *bri
 			continue
 		}
 
-		_, prop := resolvePulumiProperty(name, props, mapping)
-		contract.Assertf(prop != nil, "unable to find schema for validated property")
+		puName, prop := resolvePulumiProperty(name, props, mapping)
+		if prop == nil {
+			return cty.Value{}, nil, append(diags, unmappedProperty(name, puName, props, block.DefRange))
+		}
 
 		blockProps, isList := blockPropertiesOf(prop.Type)
 		var nestedMapping *bridge.BodyMapping
@@ -497,6 +500,25 @@ func appendBlockListValues(resourceInputs map[string]cty.Value, key string, valu
 
 // tooManySingularBlocks reports more than one block (static or dynamically
 // expanded) for a MaxItems=1 field.
+// unmappedProperty reports a TF name the provider's mapping admitted into the
+// body but its Pulumi schema has no property for — a self-inconsistent
+// provider package (e.g. a bridged nested type whose name two resources share
+// with different shapes), which the engine cannot evaluate against.
+func unmappedProperty(tfName, puName string, props []*schema.Property, rng hcl.Range) *hcl.Diagnostic {
+	names := make([]string, len(props))
+	for i, p := range props {
+		names[i] = p.Name
+	}
+	return &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  fmt.Sprintf("Provider schema has no property for %q", tfName),
+		Detail: fmt.Sprintf("The provider's mapping names %q as %q, but its schema defines only: %s. "+
+			"The provider's schema and mapping disagree; this is a provider bug.",
+			tfName, puName, strings.Join(names, ", ")),
+		Subject: rng.Ptr(),
+	}
+}
+
 func tooManySingularBlocks(name string, rng hcl.Range) *hcl.Diagnostic {
 	return &hcl.Diagnostic{
 		Severity: hcl.DiagError,

--- a/pkg/hcl/transform/transform.go
+++ b/pkg/hcl/transform/transform.go
@@ -498,8 +498,6 @@ func appendBlockListValues(resourceInputs map[string]cty.Value, key string, valu
 	resourceInputs[key] = blockListValue(values)
 }
 
-// tooManySingularBlocks reports more than one block (static or dynamically
-// expanded) for a MaxItems=1 field.
 // unmappedProperty reports a TF name the provider's mapping admitted into the
 // body but its Pulumi schema has no property for — a self-inconsistent
 // provider package (e.g. a bridged nested type whose name two resources share
@@ -519,6 +517,8 @@ func unmappedProperty(tfName, puName string, props []*schema.Property, rng hcl.R
 	}
 }
 
+// tooManySingularBlocks reports more than one block (static or dynamically
+// expanded) for a MaxItems=1 field.
 func tooManySingularBlocks(name string, rng hcl.Range) *hcl.Diagnostic {
 	return &hcl.Diagnostic{
 		Severity: hcl.DiagError,

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -608,10 +608,12 @@ func TestUnmappedProperty(t *testing.T) {
 		}},
 	}
 	mapping := &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
-		"settings": {TFName: "settings", PulumiName: "settings", TFBlock: true, MaxItemsOne: true,
+		"settings": {
+			TFName: "settings", PulumiName: "settings", TFBlock: true, MaxItemsOne: true,
 			Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
 				"inner_block": {TFName: "inner_block", PulumiName: "innerBlock", TFBlock: true, MaxItemsOne: true},
-			}}},
+			}},
+		},
 	}}
 
 	src := `

--- a/pkg/hcl/transform/transform_test.go
+++ b/pkg/hcl/transform/transform_test.go
@@ -588,6 +588,54 @@ resource "fake" "f" {
 	}
 }
 
+// A TF name the mapping admits but the Pulumi schema has no property for (a
+// provider whose schema and mapping disagree) is a diagnostic, not a panic.
+func TestUnmappedProperty(t *testing.T) {
+	t.Parallel()
+
+	r := &schema.Resource{
+		Token: "fake:index:F",
+		InputProperties: []*schema.Property{{
+			Name: "settings",
+			Type: &schema.ObjectType{
+				Properties: []*schema.Property{{
+					Name: "innerBlocks",
+					Type: &schema.ArrayType{ElementType: &schema.ObjectType{
+						Properties: []*schema.Property{{Name: "attr", Type: schema.StringType}},
+					}},
+				}},
+			},
+		}},
+	}
+	mapping := &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+		"settings": {TFName: "settings", PulumiName: "settings", TFBlock: true, MaxItemsOne: true,
+			Nested: &bridge.BodyMapping{Fields: map[string]*bridge.FieldMapping{
+				"inner_block": {TFName: "inner_block", PulumiName: "innerBlock", TFBlock: true, MaxItemsOne: true},
+			}}},
+	}}
+
+	src := `
+resource "fake" "f" {
+  settings {
+    inner_block { attr = "a" }
+  }
+}`
+	file, diags := hclsyntax.ParseConfig([]byte(src), "test.hcl", hcl.Pos{Line: 1, Column: 1})
+	require.False(t, diags.HasErrors(), diags.Error())
+	resourceBody := file.Body.(*hclsyntax.Body).Blocks[0].Body
+
+	evalFn := func(_ resource.PropertyKey, expr hcl.Expression, extraVars map[string]cty.Value) (cty.Value, hcl.Diagnostics) {
+		return expr.Value(&hcl.EvalContext{Variables: extraVars})
+	}
+
+	_, _, diags = EvalResourceWithSchema(resourceBody, r, mapping, evalFn)
+	require.Len(t, diags, 1)
+	assert.Equal(t, `Provider schema has no property for "inner_block"`, diags[0].Summary)
+	assert.Equal(t, `The provider's mapping names "inner_block" as "innerBlock", but its schema defines only: innerBlocks. `+
+		`The provider's schema and mapping disagree; this is a provider bug.`, diags[0].Detail)
+	assert.Equal(t, 4, diags[0].Subject.Start.Line)
+}
+
 func TestCtyToPropertyValue_Primitives(t *testing.T) {
 	t.Parallel()
 

--- a/tests/testutil/tfcompat/providers/typeclash.go
+++ b/tests/testutil/tfcompat/providers/typeclash.go
@@ -1,0 +1,93 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TypeClashProvider has two resources whose nested object types the bridge
+// names identically: `typeclash_res.block[].nested_block[]` and
+// `typeclash_res_block.nested_block[]` both become `ResBlockNestedBlock`. The
+// two declarations disagree on their `inner_block` MaxItems, so the single
+// Pulumi type the bridge keeps for the name does not match one resource's TF
+// shape.
+func TypeClashProvider() *schema.Provider {
+	// nestedBlock is the shared-named block; its inner_block is MaxItems=1
+	// under typeclash_res and unbounded under typeclash_res_block.
+	nestedBlock := func(innerMaxItems int) *schema.Schema {
+		return &schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"inner_block": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: innerMaxItems,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"attr": {Type: schema.TypeString, Required: true},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	summarize := func(d *schema.ResourceData, path string) diag.Diagnostics {
+		d.SetId(path)
+		return diag.FromErr(d.Set("summary", fmt.Sprintf("%v", d.Get(path))))
+	}
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"typeclash_res": {
+				Schema: map[string]*schema.Schema{
+					"block": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name":         {Type: schema.TypeString, Required: true},
+								"nested_block": nestedBlock(1),
+							},
+						},
+					},
+					"summary": {Type: schema.TypeString, Computed: true},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					return summarize(d, "block")
+				},
+				ReadContext:   func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+			},
+			"typeclash_res_block": {
+				Schema: map[string]*schema.Schema{
+					"nested_block": nestedBlock(0),
+					"summary":      {Type: schema.TypeString, Computed: true},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					return summarize(d, "nested_block")
+				},
+				ReadContext:   func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+			},
+		},
+	}
+}

--- a/tests/tfcompat/l2_block_type_clash_test.go
+++ b/tests/tfcompat/l2_block_type_clash_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// TestL2BlockTypeClash exercises a MaxItems=1 nested block whose bridged
+// Pulumi type name is shared with (and overwritten by) an unbounded block of
+// another resource, so the schema's property is the plural list while the
+// mapping still flattens the singular block.
+func TestL2BlockTypeClash(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_block_type_clash", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "typeclash", Factory: providers.TypeClashProvider},
+		},
+	})
+}

--- a/tests/tfcompat/l2_block_type_clash_test.go
+++ b/tests/tfcompat/l2_block_type_clash_test.go
@@ -27,6 +27,9 @@ import (
 // mapping still flattens the singular block.
 func TestL2BlockTypeClash(t *testing.T) {
 	t.Parallel()
+	t.Skip("TODO[https://github.com/pulumi/pulumi-terraform-bridge/issues/3583]: " +
+		"tfgen overwrites the shared nested type with the unbounded declaration, " +
+		"so the Pulumi schema has no property for the flattened block")
 	tfcompat.RunCase(t, "l2_block_type_clash", tfcompat.Case{
 		Providers: []tfcompat.Provider{
 			{Name: "typeclash", Factory: providers.TypeClashProvider},

--- a/tests/tfcompat/testdata/cases/l2_block_type_clash/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_block_type_clash/main.tf
@@ -1,0 +1,29 @@
+resource "typeclash_res" "r" {
+  block {
+    name = "a"
+    nested_block {
+      inner_block {
+        attr = "x"
+      }
+    }
+  }
+}
+
+resource "typeclash_res_block" "b" {
+  nested_block {
+    inner_block {
+      attr = "y"
+    }
+    inner_block {
+      attr = "z"
+    }
+  }
+}
+
+output "res" {
+  value = typeclash_res.r.summary
+}
+
+output "res_block" {
+  value = typeclash_res_block.b.summary
+}


### PR DESCRIPTION
## Summary

- Replace the two `contract.Assertf(prop != nil, "unable to find schema for validated property")` calls in `evalBlockWithSchema` with an error diagnostic anchored at the offending block/attribute, naming the TF name, the Pulumi name the mapping expects, and the properties the schema actually has.
- Add `TestUnmappedProperty` (unit) and the `l2_block_type_clash` tfcompat case with `providers.TypeClashProvider`. The tfcompat case is skipped pending the bridge fix.

Fixes https://github.com/pulumi/pulumi-hcl/issues/561

## Root cause

tfgen gathers nested types per resource "module" (`aws:index/wafv2WebAcl`, `aws:index/wafv2WebAclRule`) and then writes them into `spec.Types[tok]` without checking for an existing definition, so `aws_wafv2_web_acl.rule[].statement` and the resource `aws_wafv2_web_acl_rule.statement[]` — both `Wafv2WebAclRuleStatement` — collide and the later one (unbounded blocks, pluralized `geoMatchStatements`) wins. The provider's `terraform` mapping still says `geo_match_statement` is MaxItemsOne → `geoMatchStatement`. `inputBodyFromProperties` admitted the block via the mapping, `resolvePulumiProperty` found no property, the assert fired. Filed upstream as https://github.com/pulumi/pulumi-terraform-bridge/issues/3583.

Such a provider package is self-inconsistent (a TS user would hit the mirror failure inside the bridge), so the runtime can't make the program work; it now fails with:

```
main.tf:5,7-18: Provider schema has no property for "inner_block"; The provider's mapping names "inner_block" as "innerBlock", but its schema defines only: innerBlocks. The provider's schema and mapping disagree; this is a provider bug.
```

## Testing

- `go test ./pkg/hcl/transform/ -count=1`
- `TestL2BlockTypeClash` demonstrated: panic before the change, the diagnostic above after (then skipped with the bridge issue).