### PR TITLE
Install and run Pulumi components added from a git source

### DIFF
--- a/.changes/unreleased/language-host-bug-fixes-566.yaml
+++ b/.changes/unreleased/language-host-bug-fixes-566.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Install and run Pulumi components added from a git source (`packages:` in `Pulumi.yaml`)
+time: 2026-08-21T08:55:47Z
+custom:
+    Component: language-host
+    PR: "566"

--- a/pkg/hcl/packages/packages.go
+++ b/pkg/hcl/packages/packages.go
@@ -341,8 +341,8 @@ func resolvePackage(ctx context.Context, loader schema.ReferenceLoader, descript
 }
 
 // ParameterizationAwareLoader wraps a schema.ReferenceLoader and enriches load
-// requests for parameterized packages with the correct base provider name and
-// parameterization.
+// requests for packages with a local SDK descriptor: the base provider name and
+// parameterization, or for plain packages the version and download URL.
 type ParameterizationAwareLoader struct {
 	inner   schema.ReferenceLoader
 	aliases map[string]workspace.PackageDescriptor
@@ -360,7 +360,7 @@ func (l *ParameterizationAwareLoader) enrich(descriptor *schema.PackageDescripto
 		return descriptor
 	}
 	desc, ok := l.aliases[descriptor.Name]
-	if !ok || desc.Parameterization == nil {
+	if !ok {
 		return descriptor
 	}
 	// Base version may be nil for auto-derived TF-style entries (we let the
@@ -370,6 +370,20 @@ func (l *ParameterizationAwareLoader) enrich(descriptor *schema.PackageDescripto
 	if desc.Version != nil {
 		v := *desc.Version
 		baseVersion = &v
+	}
+	if desc.Parameterization == nil {
+		if desc.ExtensionParameterization != nil {
+			return descriptor
+		}
+		// A git-sourced plugin is found only by its download URL and version.
+		enriched := *descriptor
+		if enriched.Version == nil {
+			enriched.Version = baseVersion
+		}
+		if enriched.DownloadURL == "" {
+			enriched.DownloadURL = desc.PluginDownloadURL
+		}
+		return &enriched
 	}
 	pkgName := desc.Name
 	if pkgName == "" {

--- a/pkg/hcl/packages/packages_test.go
+++ b/pkg/hcl/packages/packages_test.go
@@ -15,10 +15,13 @@
 package packages
 
 import (
+	"context"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/pulumi/pulumi-hcl/tests/testutil/schemaloader"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/stretchr/testify/require"
 )
 
@@ -428,4 +431,37 @@ func TestResolveFunction(t *testing.T) {
 			require.Equal(t, tt.wantToken, actualToken)
 		})
 	}
+}
+
+type recordingLoader struct {
+	schema.ReferenceLoader
+	got *schema.PackageDescriptor
+}
+
+func (r *recordingLoader) LoadPackageReferenceV2(
+	_ context.Context, d *schema.PackageDescriptor,
+) (schema.PackageReference, error) {
+	r.got = d
+	return nil, nil
+}
+
+func TestParameterizationAwareLoader_PlainPackageVersionAndURL(t *testing.T) {
+	t.Parallel()
+
+	v := semver.MustParse("0.0.0-x52a8a71555d964542b308da197755c64dbe63352")
+	inner := &recordingLoader{}
+	loader := NewParameterizationAwareLoader(inner, map[string]workspace.PackageDescriptor{
+		"tls-self-signed-cert": {PluginDescriptor: workspace.PluginDescriptor{
+			Name:              "tls-self-signed-cert",
+			Version:           &v,
+			PluginDownloadURL: "git://github.com/pulumi/component-test-providers/test-provider",
+		}},
+	})
+	_, err := loader.LoadPackageReferenceV2(t.Context(), &schema.PackageDescriptor{Name: "tls-self-signed-cert"})
+	require.NoError(t, err)
+	require.Equal(t, &schema.PackageDescriptor{
+		Name:        "tls-self-signed-cert",
+		Version:     &v,
+		DownloadURL: "git://github.com/pulumi/component-test-providers/test-provider",
+	}, inner.got)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -210,6 +210,7 @@ func (host *LanguageHost) GetRequiredPackages(
 			Name:             info.Name,
 			Version:          versionString(info.Version),
 			Kind:             "resource",
+			Server:           info.PluginDownloadURL,
 			Parameterization: parameterizationProto(info.Parameterization),
 			Extension:        parameterizationProto(info.ExtensionParameterization),
 		})
@@ -231,13 +232,10 @@ func (host *LanguageHost) GetRequiredPackages(
 	}
 
 	for _, name := range sortedKeys(pulumiPkgs) {
-		// A local SDK descriptor written by `pulumi package add` carries the
-		// parameterization a required_providers entry alone lacks; prefer it.
-		// A terraform-provider descriptor is not this package — it serves a
-		// non-Pulumi source that happens to share the name (e.g. a root on
-		// pulumi/aws with a child module on hashicorp/aws).
-		if info, ok := sdks[name]; ok && info.desc.Name != bridgePackageName {
-			emitPkg(name, info.desc)
+		// The SDK descriptor carries the parameterization and download URL
+		// a required_providers entry alone lacks.
+		if dir, desc, ok := descriptorForPulumiPackage(name, sdks); ok {
+			emitPkg(dir, desc)
 			continue
 		}
 		pkgs = append(pkgs, &pulumirpc.PackageDependency{
@@ -430,12 +428,40 @@ func parseSDKInfo(path string, data []byte) (sdkInfo, error) {
 	return info, nil
 }
 
+// sdkPackageName returns the package an SDK serves: the name of the schema
+// it was generated from.
+func sdkPackageName(desc workspace.PackageDescriptor) string {
+	if desc.Parameterization != nil {
+		return desc.Parameterization.Name
+	}
+	if desc.ExtensionParameterization != nil {
+		return desc.ExtensionParameterization.Name
+	}
+	return desc.Name
+}
+
+// descriptorForPulumiPackage returns the SDK descriptor serving a Pulumi
+// package and its sdks/ directory. The directory may be namespace-prefixed
+// (sdks/<namespace>-<name>), so match on the descriptor. A terraform-provider
+// descriptor serves a non-Pulumi source that happens to share the name.
+func descriptorForPulumiPackage(
+	name string, sdks map[string]sdkInfo,
+) (string, workspace.PackageDescriptor, bool) {
+	for _, dir := range sortedKeys(sdks) {
+		desc := sdks[dir].desc
+		if desc.Name != bridgePackageName && sdkPackageName(desc) == name {
+			return dir, desc, true
+		}
+	}
+	return "", workspace.PackageDescriptor{}, false
+}
+
 // sdkDescriptors projects sdkInfos down to the descriptor map the schema
-// loader and run engine consume.
+// loader and run engine consume, keyed by package name.
 func sdkDescriptors(infos map[string]sdkInfo) map[string]workspace.PackageDescriptor {
 	descs := make(map[string]workspace.PackageDescriptor, len(infos))
-	for name, info := range infos {
-		descs[name] = info.desc
+	for _, info := range infos {
+		descs[sdkPackageName(info.desc)] = info.desc
 	}
 	return descs
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -234,6 +234,69 @@ resource "subpackage_hello_world" "example" {}
 	}, resp.Packages[0])
 }
 
+// TestGetRequiredPackages_GitComponent reproduces
+// https://github.com/pulumi/pulumi-hcl/issues/566: a git-sourced component
+// lives in sdks/<namespace>-<name> and is found only by its download URL.
+func TestGetRequiredPackages_GitComponent(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	sdkDir := filepath.Join(projectDir, "sdks", "pulumi-tls-self-signed-cert")
+	require.NoError(t, os.MkdirAll(sdkDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sdkDir, "hcl.sdk.json"), []byte(`{
+		"Name": "tls-self-signed-cert",
+		"Kind": "resource",
+		"Version": "0.0.0-x52a8a71555d964542b308da197755c64dbe63352",
+		"PluginDownloadURL": "git://github.com/pulumi/component-test-providers/test-provider"
+	}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "main.tf"), []byte(`terraform {
+  required_providers {
+    tls-self-signed-cert = {
+      source = "pulumi/tls-self-signed-cert"
+    }
+  }
+}
+
+resource "tls-self-signed-cert_self_signed_certificate" "cert" {
+  dns_name = "example.com"
+}
+`), 0o600))
+
+	resp := getRequiredPackages(t, projectDir)
+	assert.Empty(t, resp.Specs)
+	assert.Equal(t, []*pulumirpc.PackageDependency{{
+		Name:    "tls-self-signed-cert",
+		Version: "0.0.0-x52a8a71555d964542b308da197755c64dbe63352",
+		Kind:    "resource",
+		Server:  "git://github.com/pulumi/component-test-providers/test-provider",
+	}}, resp.Packages)
+}
+
+func TestSDKDescriptors_KeyedByPackageName(t *testing.T) {
+	t.Parallel()
+
+	plain := workspace.PackageDescriptor{
+		PluginDescriptor: workspace.PluginDescriptor{Name: "tls-self-signed-cert"},
+	}
+	parameterized := workspace.PackageDescriptor{
+		PluginDescriptor: workspace.PluginDescriptor{Name: "terraform-provider"},
+		Parameterization: &workspace.Parameterization{Name: "random"},
+	}
+	extension := workspace.PackageDescriptor{
+		PluginDescriptor:          workspace.PluginDescriptor{Name: "extbase"},
+		ExtensionParameterization: &workspace.Parameterization{Name: "myext"},
+	}
+	assert.Equal(t, map[string]workspace.PackageDescriptor{
+		"tls-self-signed-cert": plain,
+		"random":               parameterized,
+		"myext":                extension,
+	}, sdkDescriptors(map[string]sdkInfo{
+		"pulumi-tls-self-signed-cert": {desc: plain},
+		"random":                      {desc: parameterized},
+		"myext":                       {desc: extension},
+	}))
+}
+
 // TestGetRequiredPackages_TransitiveModuleSource reproduces
 // https://github.com/pulumi/pulumi-hcl/issues/184: a provider declared in
 // a child module's required_providers with a non-hashicorp source must be

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -113,6 +113,28 @@ func TestSmokeInstallConverges(t *testing.T) {
 	})
 }
 
+// TestSmokeGitComponent reproduces https://github.com/pulumi/pulumi-hcl/issues/566:
+// a Pulumi component installed from a git source (Pulumi.yaml `packages:`).
+// Hits GitHub and the public Pulumi registry.
+func TestSmokeGitComponent(t *testing.T) {
+	t.Parallel()
+
+	home := seedPluginCache(t, "github.com_pulumi_component-test-providers.git_test-provider", "tls")
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		NoParallel:     true,
+		Dir:            filepath.Join("testdata", "git-component"),
+		PulumiHomeDir:  home,
+		PrepareProject: prepareWithPulumiInstall(home),
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			pem, ok := stack.Outputs["pem"].(string)
+			require.True(t, ok, "pem output must be a string, got %T (%v)",
+				stack.Outputs["pem"], stack.Outputs["pem"])
+			require.True(t, strings.HasPrefix(pem, "-----BEGIN CERTIFICATE-----"),
+				"pem output should be a PEM certificate, got %q", pem)
+		},
+	})
+}
+
 // TestSmokeInLanguageModule proves a plain HCL module (no component or package block) can
 // be served as a Multi-Language Component: `pulumi package add ../randommodule` generates
 // a local SDK, the consuming HCL program instantiates the component as

--- a/tests/smoke/testdata/git-component/Pulumi.yaml
+++ b/tests/smoke/testdata/git-component/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: smoke-test-git-component
+runtime: hcl
+packages:
+  tls-self-signed-cert: github.com/pulumi/component-test-providers/test-provider@52a8a71555d964542b308da197755c64dbe63352

--- a/tests/smoke/testdata/git-component/main.tf
+++ b/tests/smoke/testdata/git-component/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    tls-self-signed-cert = {
+      source = "pulumi/tls-self-signed-cert"
+    }
+  }
+}
+
+resource "tls-self-signed-cert_self_signed_certificate" "cert" {
+  dns_name                    = "example.com"
+  validity_period_hours       = 24
+  local_validity_period_hours = 12
+  subject = {
+    common_name  = "example.com"
+    organization = "Pulumi"
+  }
+}
+
+output "pem" {
+  value = tls-self-signed-cert_self_signed_certificate.cert.pem
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-hcl/issues/566

A component package added with `pulumi package add github.com/<org>/<repo>@<ref>` is a plugin the CLI finds only through its `git://` download URL, and the CLI writes its SDK to `sdks/<namespace>-<name>`. Three seams in the language host assumed a registry package named after its SDK directory:

1. `GetRequiredPackages` never set `Server` from the descriptor's `PluginDownloadURL`, so `pulumi install` fell back to get.pulumi.com (`403 … pulumi-resource-random-abstracted-v1.0.5`).
2. The run-time schema load passed `{Name}` only; the engine then looked the plugin up on GitHub by name (`GetSchema executing: package=random-abstracted, version=` → 404 → `resolving resource type …: not found`).
3. SDK descriptors were matched (`GetRequiredPackages`) and keyed (`sdkDescriptors`, consumed by the resolver, loader and package registration) by directory name, so `sdks/pulumi-tls-self-signed-cert` was never found under `tls-self-signed-cert`.

Changes:
- `emitPkg` sets `Server: info.PluginDownloadURL`.
- `ParameterizationAwareLoader.enrich` fills `Version` + `DownloadURL` for plain packages with a local SDK descriptor.
- `sdkPackageName` / `descriptorForPulumiPackage`: SDKs are identified by the schema name they were generated from (parameterization name, extension name, or plugin name) rather than their directory.

The `source` to use is what `pulumi package add` prints, `pulumi/<name>` (e.g. `pulumi/tls-self-signed-cert`); the namespace-prefixed directory name is not a package name.

Tests: `TestSmokeGitComponent` installs and deploys `github.com/pulumi/component-test-providers/test-provider` (fails on master with the CLI's by-name lookup error; passes here), plus unit tests for each seam.

https://claude.ai/code/session_01XGr51NcUUcd92rDFUvu8sd