### PR TITLE
Detect module cycles while inlining instead of recursing forever

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-574.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-574.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Error on `module` cycles instead of hanging
+time: 2026-08-24T09:57:26Z
+custom:
+    Component: runtime
+    PR: "574"

--- a/pkg/hcl/graph/graph.go
+++ b/pkg/hcl/graph/graph.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"maps"
 	"math/big"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -586,7 +587,11 @@ func BuildFromConfig(config *ast.Config, moduleLoader ModuleLoader, workDir stri
 	if err := checkRemovedStillExists(g.removed, root, config); err != nil {
 		return nil, err
 	}
-	rootScope := &moduleScope{config: config}
+	rootDir, err := filepath.Abs(workDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving working directory: %w", err)
+	}
+	rootScope := &moduleScope{config: config, sourcePath: rootDir}
 	g.scopes[root] = rootScope
 
 	contract.AssertNoErrorf(errors.Join(
@@ -868,6 +873,9 @@ type moduleScope struct {
 	parent     *moduleScope
 	mod        *ast.Module
 	parentPath modulepath.Path
+	// sourcePath is the module's resolved source directory, used to detect
+	// module cycles while inlining.
+	sourcePath string
 }
 
 // inheritedProviderDeps returns an edge to the nearest ancestor's default
@@ -1667,6 +1675,22 @@ func (g *Graph) inlineModule(
 		return fmt.Errorf("loading module %s: %w", name, err)
 	}
 
+	// Module expansion is static — count/for_each do not gate inlining — so a
+	// source directory that is already being expanded on the ancestor chain
+	// can only recurse forever. The same directory as a sibling is fine.
+	for s := parent; s != nil; s = s.parent {
+		if s.sourcePath != loaded.SourcePath {
+			continue
+		}
+		chain := []string{loaded.SourcePath}
+		for a := parent; a != nil; a = a.parent {
+			chain = append(chain, a.sourcePath)
+		}
+		slices.Reverse(chain)
+		return fmt.Errorf("module %q source %q creates a module cycle: %s",
+			name, mod.Source, strings.Join(chain, " -> "))
+	}
+
 	path := parentPath.Append(modulepath.NewStep(name))
 	// Rewrite child-declared removed addresses to root-relative before
 	// validating, so the child's own declarations are checked against its
@@ -1686,6 +1710,7 @@ func (g *Graph) inlineModule(
 		parent:     parent,
 		mod:        mod,
 		parentPath: parentPath,
+		sourcePath: loaded.SourcePath,
 	}
 	g.scopes[path] = scope
 	modInfo := &ModuleInfo{

--- a/pkg/hcl/graph/graph_test.go
+++ b/pkg/hcl/graph/graph_test.go
@@ -87,6 +87,99 @@ output "instance_id" {
 	}
 }
 
+// TestBuildFromConfigSelfModuleCycle: a module whose source resolves back to
+// the root directory must fail with a cycle error instead of recursing forever.
+func TestBuildFromConfigSelfModuleCycle(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+module "self" {
+  source = "./."
+}
+`)
+	config, diags := parser.NewParser().ParseSource("main.tf", src)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	loader := fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./.": {Config: config, SourcePath: "/proj"},
+	}}
+
+	_, err := BuildFromConfig(config, loader, "/proj")
+	require.EqualError(t, err,
+		`inlining module self: module "self" source "./." creates a module cycle: /proj -> /proj`)
+}
+
+// TestBuildFromConfigIndirectModuleCycle: a cycle through an intermediate
+// module (a -> b -> a) must fail, while the same module reused as a sibling
+// stays legal (covered by the a-under-root and a-under-b duplication here
+// erroring only on the ancestor repeat).
+func TestBuildFromConfigIndirectModuleCycle(t *testing.T) {
+	t.Parallel()
+	rootSrc := []byte(`
+module "a" {
+  source = "./a"
+}
+`)
+	aSrc := []byte(`
+module "b" {
+  source = "./b"
+}
+`)
+	bSrc := []byte(`
+module "a" {
+  source = "./a"
+}
+`)
+	p := parser.NewParser()
+	root, diags := p.ParseSource("main.tf", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+	a, diags := p.ParseSource("a.tf", aSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+	b, diags := p.ParseSource("b.tf", bSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	loader := fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./a": {Config: a, SourcePath: "/proj/a"},
+		"./b": {Config: b, SourcePath: "/proj/b"},
+	}}
+
+	_, err := BuildFromConfig(root, loader, "/proj")
+	require.EqualError(t, err,
+		`inlining module a: inlining nested module b: inlining nested module a: `+
+			`module "a" source "./a" creates a module cycle: /proj -> /proj/a -> /proj/b -> /proj/a`)
+}
+
+// TestBuildFromConfigSiblingModuleReuse: the same module included twice as
+// siblings is not a cycle and must build.
+func TestBuildFromConfigSiblingModuleReuse(t *testing.T) {
+	t.Parallel()
+	rootSrc := []byte(`
+module "x" {
+  source = "./child"
+}
+
+module "y" {
+  source = "./child"
+}
+`)
+	childSrc := []byte(`
+resource "simple_resource" "r" {
+  input_one = "a"
+}
+`)
+	p := parser.NewParser()
+	root, diags := p.ParseSource("main.tf", rootSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+	child, diags := p.ParseSource("child.tf", childSrc)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	loader := fakeModuleLoader{modules: map[string]*LoadedModule{
+		"./child": {Config: child, SourcePath: "/proj/child"},
+	}}
+
+	_, err := BuildFromConfig(root, loader, "/proj")
+	require.NoError(t, err)
+}
+
 func TestVariableValidationResourceRefSplitsNode(t *testing.T) {
 	t.Parallel()
 	// gate's validation references a resource, so the rules move to a

--- a/pkg/hcl/modules/loader.go
+++ b/pkg/hcl/modules/loader.go
@@ -60,9 +60,8 @@ var fetchMu sync.Mutex
 type Loader struct {
 	mu sync.Mutex
 
-	parser    *parser.Parser
-	cache     map[string]*LoadedModule
-	callStack []string
+	parser *parser.Parser
+	cache  map[string]*LoadedModule
 
 	resolve ResolverFunc
 	// resolved caches successful package resolutions, so one package resolves
@@ -177,19 +176,9 @@ func (l *Loader) LoadModule(ctx context.Context, source, versionConstraint, call
 		return nil, fmt.Errorf("resolving module source %q: %w", source, err)
 	}
 
-	if slices.Contains(l.callStack, resolvedPath) {
-		return nil, classified(ErrInvalid, fmt.Errorf("module cycle detected: %s",
-			strings.Join(append(l.callStack, resolvedPath), " -> ")))
-	}
-
 	if cached, ok := l.cache[resolvedPath]; ok {
 		return cached, nil
 	}
-
-	l.callStack = append(l.callStack, resolvedPath)
-	defer func() {
-		l.callStack = l.callStack[:len(l.callStack)-1]
-	}()
 
 	config, diags := l.parser.ParseDirectory(resolvedPath)
 	if diags.HasErrors() {
@@ -531,11 +520,6 @@ func isRegistrySource(source string) bool {
 func hashSource(source string) string {
 	h := sha256.Sum256([]byte(source))
 	return hex.EncodeToString(h[:8])
-}
-
-// GetCallStack returns the current module call stack (for debugging/error messages).
-func (l *Loader) GetCallStack() []string {
-	return append([]string{}, l.callStack...)
 }
 
 // ComponentTypeName derives a component type name from a module's name,


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-hcl/issues/574

A module whose `source` resolves back to a module already being expanded (directly via `source = "./."` or through a longer chain) made `graph.(*Graph).inlineModule` recurse without bound: `pulumi preview` hung with unbounded memory growth and never produced a diagnostic.

Module expansion is static — `count`/`for_each` gate instances, not inclusion — so a source directory repeating on the ancestor chain can only recurse forever; there is no terminating case to preserve. Each `moduleScope` now records its resolved source directory (the root scope gets the canonicalized working directory, which is what catches `source = "./."`), and `inlineModule` errors on an ancestor repeat with the full chain:

```
inlining module a: inlining nested module b: inlining nested module a: module "a" source "./a" creates a module cycle: /proj -> /proj/a -> /proj/b -> /proj/a
```

Only the ancestor chain is checked, so the same module used twice as siblings (or in a diamond) still builds — covered by a test.

Also removes the loader's dead `callStack` cycle guard: `LoadModule` never recurses within itself (the graph drives recursion through separate top-level calls after the deferred pop), so the guard could never fire and falsely read as existing cycle protection.

For comparison, `tofu init` on the same configuration also recurses but dies on filesystem path-length limits; failing with an explicit diagnostic at the first repeat is an error-quality improvement, not a semantic divergence.
