### PR TITLE
Import Terraform resources that have no `id` attribute

### DIFF
--- a/.changes/unreleased/converter-bug-fixes-0.yaml
+++ b/.changes/unreleased/converter-bug-fixes-0.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Import resources with no Terraform `id` under the ID the bridge computes for them, instead of skipping them
+time: 2026-08-24T16:02:48.966283+02:00
+custom:
+    Component: converter
+    PR: "0"

--- a/.changes/unreleased/converter-bug-fixes-579.yaml
+++ b/.changes/unreleased/converter-bug-fixes-579.yaml
@@ -3,4 +3,4 @@ body: Import resources with no Terraform `id` under the ID the bridge computes f
 time: 2026-08-24T16:02:48.966283+02:00
 custom:
     Component: converter
-    PR: "0"
+    PR: "579"

--- a/pkg/converter/convert_state.go
+++ b/pkg/converter/convert_state.go
@@ -304,11 +304,6 @@ func convertTFState(
 			}
 			id, ok := idAttr(current)
 			if !ok {
-				// The bridge hands ID-less TF resources this sentinel
-				// (tfbridge/tokens/fixups.go, missingIDComputeID), so the
-				// import agrees with whatever the next up computes. Pulumi IDs
-				// need not be unique; an empty one means "deleted", so the
-				// engine rejects it.
 				id = missingID
 			}
 			var outs, ins resource.PropertyMap

--- a/pkg/converter/convert_state.go
+++ b/pkg/converter/convert_state.go
@@ -304,9 +304,12 @@ func convertTFState(
 			}
 			id, ok := idAttr(current)
 			if !ok {
-				warn("Skipped resource without id", fmt.Sprintf(
-					"an instance of %s has no string `id` attribute to import by", res.Addr))
-				continue
+				// The bridge hands ID-less TF resources this sentinel
+				// (tfbridge/tokens/fixups.go, missingIDComputeID), so the
+				// import agrees with whatever the next up computes. Pulumi IDs
+				// need not be unique; an empty one means "deleted", so the
+				// engine rejects it.
+				id = missingID
 			}
 			var outs, ins resource.PropertyMap
 			var err error
@@ -639,6 +642,10 @@ func resourceSchema(
 	}
 	return res, nil
 }
+
+// missingID is the ID the bridge computes for a TF resource that has no usable
+// string `id` of its own.
+const missingID = "missing ID"
 
 // idAttr extracts the `id` attribute verbatim.
 func idAttr(src *states.ResourceInstanceObjectSrc) (string, bool) {

--- a/pkg/converter/convert_state_test.go
+++ b/pkg/converter/convert_state_test.go
@@ -244,7 +244,28 @@ func TestConvertTFState_SkipsUnimportable(t *testing.T) {
 				"mode": "managed", "type": "unknown_widget", "name": "g",
 				"provider": "provider[\"registry.terraform.io/acme/unknown\"]",
 				"instances": [ { "attributes": { "id": "widget-1" } } ]
-			},
+			}
+		]
+	}`)
+
+	resp := convertTFState(t.Context(), exampleInfoSource(t), exampleLoader(t), nil, nil, state)
+
+	// The data source skips silently; the other two each warn.
+	assert.Empty(t, resp.Resources)
+	assert.Len(t, resp.Diagnostics, 2)
+	for _, d := range resp.Diagnostics {
+		assert.Equal(t, hcl.DiagWarning, d.Severity)
+	}
+}
+
+// TestConvertTFState_MissingID pins the ID a resource with no `id` attribute
+// imports under: the sentinel the bridge computes for it, not an empty ID,
+// which the engine reads as a deleted resource.
+func TestConvertTFState_MissingID(t *testing.T) {
+	t.Parallel()
+
+	state := parseState(t, `{
+		"resources": [
 			{
 				"mode": "managed", "type": "example_resource", "name": "no_id",
 				"provider": "provider[\"registry.terraform.io/acme/example\"]",
@@ -255,12 +276,10 @@ func TestConvertTFState_SkipsUnimportable(t *testing.T) {
 
 	resp := convertTFState(t.Context(), exampleInfoSource(t), exampleLoader(t), nil, nil, state)
 
-	// The data source skips silently; the other three each warn.
-	assert.Empty(t, resp.Resources)
-	assert.Len(t, resp.Diagnostics, 3)
-	for _, d := range resp.Diagnostics {
-		assert.Equal(t, hcl.DiagWarning, d.Severity)
-	}
+	require.Empty(t, resp.Diagnostics)
+	require.Len(t, resp.Resources, 1)
+	assert.Equal(t, "missing ID", resp.Resources[0].ID)
+	assert.Equal(t, property.New("hello"), resp.Resources[0].Inputs.AsMap()["inputOne"])
 }
 
 func TestConvertTFState_CountAndForEach(t *testing.T) {

--- a/tests/testutil/tfcompat/harness.go
+++ b/tests/testutil/tfcompat/harness.go
@@ -123,8 +123,10 @@ type Case struct {
 	// here.
 	Config map[string]string
 
-	// AssertState, if set, runs after `pulumi up`. Use for assertions on
-	// resource fields that aren't reachable via stack outputs (e.g. Protect).
+	// AssertState, if set, runs after `pulumi up` — both the case's own and
+	// the one the state-import check runs, so it holds of imported state too.
+	// Use for assertions on resource fields that aren't reachable via stack
+	// outputs (e.g. Protect).
 	AssertState func(t *testing.T, resources []apitype.ResourceV3)
 
 	// OrderDeterministic, if true, compares provider operations in arrival

--- a/tests/testutil/tfcompat/importcheck.go
+++ b/tests/testutil/tfcompat/importcheck.go
@@ -53,11 +53,6 @@ func runImportCheck(
 		if c.SkipImport != "" {
 			t.Skipf("state check skipped: %s", c.SkipImport)
 		}
-		for _, p := range c.Providers {
-			if p.PFFactory != nil {
-				t.Skip("TODO[github.com/pulumi/pulumi-hcl#167]: state-import check does not support plugin-framework providers yet")
-			}
-		}
 		statePath := filepath.Join(tfStateDir, "terraform.tfstate")
 		require.FileExists(t, statePath)
 
@@ -83,6 +78,12 @@ func runImportCheck(
 		require.NoErrorf(t, err, "up after import failed:\n%s", res.Output)
 		assertNoMutatingOps(t, "up", rec)
 		assertNoDestructiveOps(t, "up", res.Changes)
+
+		// The case's state assertions hold of imported state too: whatever the
+		// providers compute on a create, the import has to reproduce.
+		if c.AssertState != nil {
+			c.AssertState(t, res.Resources)
+		}
 
 		// TF state records no module inputs, so an imported component carries
 		// none and the up above records them. Nothing may remain after that.

--- a/tests/testutil/tfcompat/providers/pf.go
+++ b/tests/testutil/tfcompat/providers/pf.go
@@ -66,6 +66,7 @@ func (p *pfxProvider) Resources(context.Context) []func() resource.Resource {
 		func() resource.Resource { return &pfxObj{} },
 		func() resource.Resource { return &pfxMatrix{} },
 		func() resource.Resource { return &pfxFlat{} },
+		func() resource.Resource { return &pfxAnon{} },
 	}
 }
 
@@ -599,3 +600,49 @@ func (r *pfxMatrix) Update(ctx context.Context, req resource.UpdateRequest, resp
 }
 
 func (r *pfxMatrix) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {}
+
+// pfxAnon declares no `id` attribute at all — legal for a plugin-framework
+// resource, and the shape the bridge answers with its "missing ID" sentinel
+// because there is no ID property to project. Its state carries no `id` for
+// an import to key on either.
+type pfxAnon struct{}
+
+var _ resource.Resource = (*pfxAnon)(nil)
+
+type pfxAnonModel struct {
+	Name types.String `tfsdk:"name"`
+}
+
+func (r *pfxAnon) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_anon"
+}
+
+func (r *pfxAnon) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"name": rschema.StringAttribute{Required: true},
+		},
+	}
+}
+
+func (r *pfxAnon) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan pfxAnonModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *pfxAnon) Read(_ context.Context, _ resource.ReadRequest, _ *resource.ReadResponse) {}
+
+func (r *pfxAnon) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan pfxAnonModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *pfxAnon) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {}

--- a/tests/tfcompat/l2_import_missing_id_test.go
+++ b/tests/tfcompat/l2_import_missing_id_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+)
+
+// pfx_anon declares no `id` attribute, so its Terraform state carries nothing
+// for an import to key on and the bridge falls back to a sentinel ID. The
+// import must invent the same one: AssertState runs over both the created and
+// the imported state, so the two IDs are pinned against each other rather than
+// against the literal alone.
+func TestL2ImportMissingID(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_import_missing_id", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "pfx", PFFactory: providers.PFXProvider},
+		},
+		AssertState: func(t *testing.T, resources []apitype.ResourceV3) {
+			for _, r := range resources {
+				if r.Type == "pfx:index/anon:Anon" {
+					assert.Equal(t, "missing ID", string(r.ID))
+					return
+				}
+			}
+			t.Error("no pfx:index/anon:Anon resource in state")
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_import_missing_id/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_import_missing_id/main.tf
@@ -1,0 +1,7 @@
+resource "pfx_anon" "a" {
+  name = "alpha"
+}
+
+output "name" {
+  value = pfx_anon.a.name
+}


### PR DESCRIPTION
Rather than skipping ID-less resources during HCL import, we can give them the ID `missing ID`, as we do in [the bridge](https://github.com/pulumi/pulumi-terraform-bridge/blob/da6fef6821f5e68512ff87042f8d0b71d2be3ff6/pkg/tfbridge/tokens/fixups.go#L393-L419).

🤖 Generated with [Claude Code](https://claude.com/claude-code)