### PR TITLE
Preserve spec-form aliases on components

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-543.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-543.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Preserve spec-form `aliases` (such as `noParent`) on components, so re-parenting an aliased component no longer recreates it
+time: 2026-08-25T10:17:19Z
+custom:
+    Component: runtime
+    PR: "543"

--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -146,8 +146,6 @@ var expectedFailures = map[string]string{
 		" is reserved as the namespace for resource method calls in HCL",
 	"l2-config-default-from-invoke": "HCL codegen does not support a config variable whose" +
 		" default is sourced from an invoke result",
-	"provider-alias-component": "component aliases are not propagated to children, so re-parenting" +
-		" an aliased component recreates it (https://github.com/pulumi/pulumi-hcl/issues/543)",
 }
 
 // expectedEjectFailures lists tests whose eject (HCL→PCL conversion) step is

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/opentofu/registry-address/v2 v2.0.0-20250611143131-d0a99bd8acdd
 	github.com/opentofu/svchost v0.0.0-20250610175836-86c9e5e3d8c8
 	github.com/pulumi/providertest v0.7.0
-	github.com/pulumi/pulumi-go-provider v1.5.0
+	github.com/pulumi/pulumi-go-provider v1.6.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.134.1-0.20260720151533-5ffabd1227c9
 	github.com/pulumi/pulumi/pkg/v3 v3.259.0
 	github.com/pulumi/pulumi/sdk/v3 v3.259.0

--- a/go.sum
+++ b/go.sum
@@ -3978,8 +3978,8 @@ github.com/pulumi/providertest v0.7.0 h1:nXydemrnkJfil6sd8AtvO81gJOTzYc1wFfgtco4
 github.com/pulumi/providertest v0.7.0/go.mod h1:R7nigJF1sE3yUtNQSozNSfsUl/gK4xIDW0Mxmacl6IY=
 github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3 v3.113.0 h1:Qy/YYw4RqrD4/V2i+MVIHvhia8mX/He0Llm5asyUyGc=
 github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3 v3.113.0/go.mod h1:TgM6TXBsmKCVr9chv/6lMRRifdMtoA1fcEbX7oHK7VA=
-github.com/pulumi/pulumi-go-provider v1.5.0 h1:xsqbkdrbSWGKp4KcdKJJfzD0MuqDDR8X0PAc8FOdAF8=
-github.com/pulumi/pulumi-go-provider v1.5.0/go.mod h1:Aa9+QSfufi0VMM/dJLLqFf7M6CWThMV8/slOcoD3JVU=
+github.com/pulumi/pulumi-go-provider v1.6.0 h1:jT5r6HsCRbulgeX1eE9AxJreL9O2EQyMTKq6J7Mrw7Y=
+github.com/pulumi/pulumi-go-provider v1.6.0/go.mod h1:hkD/7N45XlFOp6tBFZGtCQQZHV/F521aYB7bFbVx8Cg=
 github.com/pulumi/pulumi-java v1.36.2 h1:umQmOa00zJimiGdXBwfmtHIQPnfcEEuPjlgTN3kqshU=
 github.com/pulumi/pulumi-java v1.36.2/go.mod h1:4lGHRUvb7dl5CpqQ9VNcNKovuxt+TiK1uH8ooZV//7s=
 github.com/pulumi/pulumi-terraform-bridge/v3 v3.134.1-0.20260720151533-5ffabd1227c9 h1:RORmCOW9K/RFqF8TwStNXr7vciQc9KXA6KWgERoljk4=

--- a/pkg/server/module_resource.go
+++ b/pkg/server/module_resource.go
@@ -391,7 +391,7 @@ func (m *moduleProvider) newConstructMonitor(
 		componentType:           string(req.Urn.Type()),
 		componentName:           string(req.Urn.Name()),
 		componentInputs:         componentInputs,
-		aliases:                 aliasURNsToProto(req.Aliases),
+		aliases:                 aliasesToProto(req.Aliases),
 		protect:                 req.Protect,
 		dependencies:            urnsToStrings(req.Dependencies),
 		providers:               providersToProto(req.Providers),
@@ -525,13 +525,28 @@ func wrapModuleOutputs(outputs property.Map) property.Map {
 	})
 }
 
-func aliasURNsToProto(urns []resource.URN) []*pulumirpc.Alias {
-	if len(urns) == 0 {
+func aliasesToProto(aliases []resource.Alias) []*pulumirpc.Alias {
+	if len(aliases) == 0 {
 		return nil
 	}
-	out := make([]*pulumirpc.Alias, len(urns))
-	for i, u := range urns {
-		out[i] = &pulumirpc.Alias{Alias: &pulumirpc.Alias_Urn{Urn: string(u)}}
+	out := make([]*pulumirpc.Alias, len(aliases))
+	for i, a := range aliases {
+		if a.URN != "" {
+			out[i] = &pulumirpc.Alias{Alias: &pulumirpc.Alias_Urn{Urn: string(a.URN)}}
+			continue
+		}
+		spec := &pulumirpc.Alias_Spec{
+			Name:    a.Name,
+			Type:    a.Type,
+			Stack:   a.Stack,
+			Project: a.Project,
+		}
+		if a.NoParent {
+			spec.Parent = &pulumirpc.Alias_Spec_NoParent{NoParent: true}
+		} else if a.Parent != "" {
+			spec.Parent = &pulumirpc.Alias_Spec_ParentUrn{ParentUrn: string(a.Parent)}
+		}
+		out[i] = &pulumirpc.Alias{Alias: &pulumirpc.Alias_Spec_{Spec: spec}}
 	}
 	return out
 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-hcl/issues/543.

pulumi-go-provider v1.6.0 ([pulumi/pulumi-go-provider#574](https://github.com/pulumi/pulumi-go-provider/pull/574)) changes `ConstructRequest.Aliases` from `[]resource.URN` to `[]resource.Alias`, so spec-form aliases (name, type, project, stack, parent, `noParent`) are no longer silently dropped before they reach the language host. This PR upgrades to v1.6.0 and forwards the full alias on the component's own registration by replacing `aliasURNsToProto` with `aliasesToProto`, mirroring the run-side conversion in `server.go`.

No child-alias propagation is needed: once the component itself matches its old resource via the alias, the engine's step generator multiplies parent aliases onto children (`generateAliases`/`inheritedChildAlias`), so the component's children are preserved as well.

Un-parks the `provider-alias-component` conformance test, which passes both runs.