### PR TITLE
Pin terraform-provider 1.4.0; bump the bridge to v3.138.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       # terraform_remote_state lowers to the pulumi-terraform getLocalReference
       # invoke; the tfcompat harness disables plugin acquisition, so pre-install it.
       - run: pulumi plugin install resource terraform 6.1.0
-      - run: pulumi plugin install resource terraform-provider 1.3.0 # renovate: github-releases pulumi/pulumi-terraform-provider
+      - run: pulumi plugin install resource terraform-provider 1.4.0 # renovate: github-releases pulumi/pulumi-terraform-provider
       - run: pulumi plugin install resource local 0.1.6
       - run: make bin/pulumi-language-hcl bin/pulumi-converter-hcl bin/pulumi-resource-hcl
       - run: echo "$PWD/bin" >> "$GITHUB_PATH"

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/opentofu/svchost v0.0.0-20250610175836-86c9e5e3d8c8
 	github.com/pulumi/providertest v0.7.0
 	github.com/pulumi/pulumi-go-provider v1.6.0
-	github.com/pulumi/pulumi-terraform-bridge/v3 v3.134.1-0.20260720151533-5ffabd1227c9
+	github.com/pulumi/pulumi-terraform-bridge/v3 v3.138.0
 	github.com/pulumi/pulumi/pkg/v3 v3.259.0
 	github.com/pulumi/pulumi/sdk/v3 v3.259.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -3982,8 +3982,8 @@ github.com/pulumi/pulumi-go-provider v1.6.0 h1:jT5r6HsCRbulgeX1eE9AxJreL9O2EQyMT
 github.com/pulumi/pulumi-go-provider v1.6.0/go.mod h1:hkD/7N45XlFOp6tBFZGtCQQZHV/F521aYB7bFbVx8Cg=
 github.com/pulumi/pulumi-java v1.36.2 h1:umQmOa00zJimiGdXBwfmtHIQPnfcEEuPjlgTN3kqshU=
 github.com/pulumi/pulumi-java v1.36.2/go.mod h1:4lGHRUvb7dl5CpqQ9VNcNKovuxt+TiK1uH8ooZV//7s=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.134.1-0.20260720151533-5ffabd1227c9 h1:RORmCOW9K/RFqF8TwStNXr7vciQc9KXA6KWgERoljk4=
-github.com/pulumi/pulumi-terraform-bridge/v3 v3.134.1-0.20260720151533-5ffabd1227c9/go.mod h1:rGCYEDTzafKts3L76JC5GOMwcIBawTCBiqH7TozBKX8=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.138.0 h1:ojG1RXQdqgiyo36HMYUbYdwfvrBnwX64VjO1UK/uvW8=
+github.com/pulumi/pulumi-terraform-bridge/v3 v3.138.0/go.mod h1:Tc7Pj3RiiNevnF59CpmBxNB2JuGZ/lVyFgTsvQeUAz8=
 github.com/pulumi/pulumi-yaml v1.38.4 h1:97WoAChelE2xwqSBE+CMvb4nKjw2JQGWgpcD9zI3pwU=
 github.com/pulumi/pulumi-yaml v1.38.4/go.mod h1:JHpOVO8/wXEGgFt6ScQHYl3prJf0RLytFu2zs7B7Cp0=
 github.com/pulumi/pulumi/pkg/v3 v3.259.0 h1:Zf4wiLmgdhTAyq5dtTVnNY26BjtGrJ85ZQYut2qG6xM=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -165,7 +165,7 @@ const bridgePackageName = "terraform-provider"
 // plugin cache, so a stale install keeps serving long-fixed schema bugs
 // (https://github.com/pulumi/pulumi-hcl/issues/204). Renovate bumps it on
 // each release (see renovate.json5).
-const bridgePackageVersion = "1.3.0" // renovate: github-releases pulumi/pulumi-terraform-provider
+const bridgePackageVersion = "1.4.0" // renovate: github-releases pulumi/pulumi-terraform-provider
 
 // terraformProviderVersionOption is the Pulumi.yaml runtime option that
 // overrides bridgePackageVersion:
@@ -173,7 +173,7 @@ const bridgePackageVersion = "1.3.0" // renovate: github-releases pulumi/pulumi-
 //	runtime:
 //	  name: hcl
 //	  options:
-//	    terraformProviderVersion: 1.3.0
+//	    terraformProviderVersion: ${VERSION}
 const terraformProviderVersionOption = "terraformProviderVersion"
 
 // bridgeVersion returns the terraform-provider release install specs resolve

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1257,7 +1257,8 @@ func TestLinkInstructions(t *testing.T) {
 	for dir, schema := range map[string]string{
 		"aws":       `{"name": "aws", "version": "7.0.0"}`,
 		"stackmgmt": `{"name": "stackmgmt", "version": "2.5.0", "parameterization": {"baseProvider": {"name": "pulumi-component", "version": "1.0.0"}, "parameter": "aGVsbG8="}}`,
-		"random": `{"name": "random", "version": "3.6.0", "parameterization": {"baseProvider": {"name": "terraform-provider", "version": "1.3.0"}, "parameter": "` +
+		"random": `{"name": "random", "version": "3.6.0", "parameterization": {"baseProvider": {"name": "` +
+			bridgePackageName + `", "version": "` + bridgePackageVersion + `"}, "parameter": "` +
 			base64.StdEncoding.EncodeToString([]byte(`{"remote":{"url":"hashicorp/random","version":"3.6.0"}}`)) + `"}}`,
 	} {
 		sdkDir := filepath.Join(root, "sdks", dir)


### PR DESCRIPTION
Both releases carry the declared-timeouts GetMapping payload from https://github.com/pulumi/pulumi-terraform-bridge/pull/3590, which https://github.com/pulumi/pulumi-hcl/pull/439 consumes — split out so the version churn merges independently and #439 rebases down to the feature.

- `bridgePackageVersion` (install-spec pin) and the CI plugin install → `1.4.0`; the runtime-option doc example now says `${VERSION}` so it can't go stale.
- `pulumi-terraform-bridge` → `v3.138.0` (first release with `resourceTimeouts`/`dataSourceTimeouts` in the provider-schema section).
- `TestLinkInstructions` interpolates `bridgePackageName`/`bridgePackageVersion` into its fixture instead of hard-coding the version, so renovate bumps no longer drift past it.


