### PR TITLE
Import Terraform state values regardless of the mapped schema version

### DIFF
--- a/.changes/unreleased/converter-bug-fixes-595.yaml
+++ b/.changes/unreleased/converter-bug-fixes-595.yaml
@@ -1,0 +1,8 @@
+kind: bug-fixes
+body: Import a resource's values from Terraform state even when its provider declares
+    a schema version, instead of falling back to an id-only import that resource types
+    supporting no import cannot serve
+time: 2026-09-01T14:20:00Z
+custom:
+    Component: converter
+    PR: "595"

--- a/pkg/converter/convert_state.go
+++ b/pkg/converter/convert_state.go
@@ -499,16 +499,8 @@ func translateInstanceValues(
 	if info.P == nil {
 		return nil, nil, errors.New("the mapping carries no provider schema")
 	}
-	shimRes, ok := info.P.ResourcesMap().GetOk(tfType)
-	if !ok {
+	if _, ok := info.P.ResourcesMap().GetOk(tfType); !ok {
 		return nil, nil, fmt.Errorf("provider schema has no resource %q", tfType)
-	}
-	// Without a live provider there is no UpgradeResourceState, so
-	// version-drifted attributes cannot be translated.
-	if int(current.SchemaVersion) != shimRes.SchemaVersion() {
-		return nil, nil, fmt.Errorf(
-			"state attributes have schema version %d but the provider maps version %d",
-			current.SchemaVersion, shimRes.SchemaVersion())
 	}
 	res, err := resourceSchema(ctx, loader, token)
 	if err != nil {

--- a/pkg/converter/convert_state_test.go
+++ b/pkg/converter/convert_state_test.go
@@ -572,7 +572,7 @@ func TestConvertTFState_ValueFallbacks(t *testing.T) {
 			{
 				"mode": "managed", "type": "example_resource", "name": "drifted",
 				"provider": "provider[\"registry.terraform.io/acme/example\"]",
-				"instances": [ { "schema_version": 5, "attributes": { "id": "old-schema" } } ]
+				"instances": [ { "schema_version": 5, "attributes": { "id": "old-schema", "input_one": "hello" } } ]
 			},
 			{
 				"mode": "managed", "type": "example_resource", "name": "legacy",
@@ -584,14 +584,64 @@ func TestConvertTFState_ValueFallbacks(t *testing.T) {
 
 	resp := convertTFState(t.Context(), exampleInfoSource(t), exampleLoader(t), nil, nil, state)
 	require.Len(t, resp.Resources, 2)
+	byID := map[string]plugin.ResourceImport{}
 	for _, r := range resp.Resources {
-		assert.Nil(t, r.Outputs, "%s should import by id only", r.ID)
-		assert.Nil(t, r.Inputs)
+		byID[r.ID] = r
 	}
-	require.Len(t, resp.Diagnostics, 2)
-	for _, d := range resp.Diagnostics {
-		assert.Equal(t, "Importing without values", d.Summary)
-	}
+
+	// Attributes at a version the provider does not map are still imported:
+	// they carry their own schema version, and the provider upgrades them.
+	drifted := byID["old-schema"].Outputs.AsMap()
+	assert.Equal(t, property.New("hello"), drifted["inputOne"])
+
+	// Flatmap attributes have no translation at all.
+	assert.Nil(t, byID["flatmap"].Outputs, "pre-0.12 state imports by id only")
+	assert.Nil(t, byID["flatmap"].Inputs)
+
+	require.Len(t, resp.Diagnostics, 1)
+	assert.Equal(t, "Importing without values", resp.Diagnostics[0].Summary)
+}
+
+// A resource whose provider declares a schema version imports its values like
+// any other: the version the mapping reports cannot be trusted to match, since
+// a mapping records no version for a provider plugin built before it carried
+// them.
+func TestConvertTFState_VersionedResource(t *testing.T) {
+	t.Parallel()
+
+	info := roundtrip(t, tfbridge.ProviderInfo{
+		P: shimv2.NewProvider(&sdkschema.Provider{
+			ResourcesMap: map[string]*sdkschema.Resource{
+				"example_resource": {
+					SchemaVersion: 1,
+					Schema: map[string]*sdkschema.Schema{
+						"input_one": {Type: sdkschema.TypeString, Optional: true},
+					},
+				},
+			},
+		}),
+		Name: "example",
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"example_resource": {Tok: "example:index/resource:Resource"},
+		},
+	})
+	state := parseState(t, `{
+		"resources": [
+			{
+				"mode": "managed", "type": "example_resource", "name": "b",
+				"provider": "provider[\"registry.terraform.io/acme/example\"]",
+				"instances": [ { "schema_version": 1, "attributes": { "id": "res-1", "input_one": "hello" } } ]
+			}
+		]
+	}`)
+
+	src := fakeInfoSource{infos: map[string]*tfbridge.ProviderInfo{"example": info}}
+	resp := convertTFState(t.Context(), src, exampleLoader(t), nil, nil, state)
+	assert.Empty(t, resp.Diagnostics)
+	require.Len(t, resp.Resources, 1)
+
+	outs := resp.Resources[0].Outputs.AsMap()
+	assert.Equal(t, property.New("hello"), outs["inputOne"])
 }
 
 // TestConvertTFState_ModuleResources pins the module import shape: a component

--- a/tests/testutil/tfcompat/providers/versioned.go
+++ b/tests/testutil/tfcompat/providers/versioned.go
@@ -1,0 +1,51 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// VersionedProvider exposes a resource that declares a non-zero schema
+// version and supports no import, like tls_private_key (version 1) or
+// aws_instance (version 2). Its state instances carry that same version, so an
+// importer that only trusts version-0 state has to fall back to importing by
+// id — which this resource cannot do.
+func VersionedProvider() *schema.Provider {
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"versioned_resource": {
+				SchemaVersion: 1,
+				Schema: map[string]*schema.Schema{
+					"algorithm": {Type: schema.TypeString, Required: true, ForceNew: true},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("key-" + d.Get("algorithm").(string))
+					return nil
+				},
+				ReadContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+					return nil
+				},
+				DeleteContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("")
+					return nil
+				},
+			},
+		},
+	}
+}

--- a/tests/tfcompat/l2_versioned_resource_import_test.go
+++ b/tests/tfcompat/l2_versioned_resource_import_test.go
@@ -24,8 +24,7 @@ import (
 // The resource declares schema version 1 and supports no import, like
 // tls_private_key. Its state instance is at the version the provider declares,
 // so importing it must supply the instance's values rather than fall back to
-// an id-only import the resource cannot serve. Fails today:
-// https://github.com/pulumi/pulumi-hcl/issues/594.
+// an id-only import the resource cannot serve.
 func TestL2VersionedResourceImport(t *testing.T) {
 	t.Parallel()
 	tfcompat.RunCase(t, "l2_versioned_resource_import", tfcompat.Case{

--- a/tests/tfcompat/l2_versioned_resource_import_test.go
+++ b/tests/tfcompat/l2_versioned_resource_import_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// The resource declares schema version 1 and supports no import, like
+// tls_private_key. Its state instance is at the version the provider declares,
+// so importing it must supply the instance's values rather than fall back to
+// an id-only import the resource cannot serve. Fails today:
+// https://github.com/pulumi/pulumi-hcl/issues/594.
+func TestL2VersionedResourceImport(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_versioned_resource_import", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "versioned", Factory: providers.VersionedProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_versioned_resource_import/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_versioned_resource_import/main.tf
@@ -1,0 +1,3 @@
+resource "versioned_resource" "a" {
+  algorithm = "RSA"
+}


### PR DESCRIPTION
`pulumi import --from hcl` refused to translate an instance's attributes unless
the state's schema version matched the version the mapping reports for that
resource. A mapping carries no schema version for a provider plugin built
before it recorded them, so the comparison ran against a constant zero and
every resource whose provider declares a version

This PR changes our logic to unconditionally do a value import. This should be fine:

We source the resource schemas from providers with versions set from the state, so they should match.

Fixes #594.
