### PR TITLE
Record the state's schema version on imported resources

### DIFF
--- a/.changes/unreleased/converter-bug-fixes-596.yaml
+++ b/.changes/unreleased/converter-bug-fixes-596.yaml
@@ -1,0 +1,7 @@
+kind: bug-fixes
+body: Record the schema version imported Terraform state was written at, so a provider
+    upgrades that state only when it is behind the schema version the provider serves
+time: 2026-09-01T14:35:00Z
+custom:
+    Component: converter
+    PR: "596"

--- a/pkg/converter/convert_state.go
+++ b/pkg/converter/convert_state.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi-hcl/vendored/addrs"
 	"github.com/pulumi/pulumi-hcl/vendored/statefile"
 	"github.com/pulumi/pulumi-hcl/vendored/states"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/reservedkeys"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/convert"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -539,6 +540,15 @@ func translateInstanceValues(
 	}
 	if idProp == nil {
 		outs["id"] = resource.NewStringProperty(id)
+	}
+	// The state's own schema version travels with the values in the metadata
+	// the bridge keeps its Terraform state under, so the provider runs its
+	// state upgraders over them exactly as Terraform would. Without it the
+	// values read as version 0 and the whole upgrade chain runs over state
+	// that is already current.
+	if current.SchemaVersion != 0 {
+		outs[reservedkeys.Meta] = resource.NewStringProperty(
+			fmt.Sprintf(`{"schema_version":"%d"}`, current.SchemaVersion))
 	}
 	return outs, ins, nil
 }

--- a/pkg/converter/convert_state_test.go
+++ b/pkg/converter/convert_state_test.go
@@ -593,6 +593,8 @@ func TestConvertTFState_ValueFallbacks(t *testing.T) {
 	// they carry their own schema version, and the provider upgrades them.
 	drifted := byID["old-schema"].Outputs.AsMap()
 	assert.Equal(t, property.New("hello"), drifted["inputOne"])
+	assert.Equal(t, property.New(`{"schema_version":"5"}`), drifted["__meta"],
+		"the state's version travels with its values")
 
 	// Flatmap attributes have no translation at all.
 	assert.Nil(t, byID["flatmap"].Outputs, "pre-0.12 state imports by id only")
@@ -603,9 +605,8 @@ func TestConvertTFState_ValueFallbacks(t *testing.T) {
 }
 
 // A resource whose provider declares a schema version imports its values like
-// any other: the version the mapping reports cannot be trusted to match, since
-// a mapping records no version for a provider plugin built before it carried
-// them.
+// any other, and records the version those values are at, so the provider
+// upgrades them only if they are behind the schema it now serves.
 func TestConvertTFState_VersionedResource(t *testing.T) {
 	t.Parallel()
 
@@ -642,6 +643,7 @@ func TestConvertTFState_VersionedResource(t *testing.T) {
 
 	outs := resp.Resources[0].Outputs.AsMap()
 	assert.Equal(t, property.New("hello"), outs["inputOne"])
+	assert.Equal(t, property.New(`{"schema_version":"1"}`), outs["__meta"])
 }
 
 // TestConvertTFState_ModuleResources pins the module import shape: a component

--- a/tests/testutil/tfcompat/providers/upgrader.go
+++ b/tests/testutil/tfcompat/providers/upgrader.go
@@ -1,0 +1,73 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// UpgraderProvider exposes a resource at schema version 2 whose state
+// upgraders rewrite `note`, and whose read cannot recover it — the API returns
+// a placeholder, as it does for a value a provider only ever writes.
+//
+// Both properties are load-bearing for the state import. The read means an
+// import that carries no values cannot recover `note`, and the upgraders mean
+// an import that carries values but loses the state's schema version has them
+// rewritten on the first operation, since state at an unrecorded version reads
+// as version 0 and runs the whole upgrade chain.
+func UpgraderProvider() *schema.Provider {
+	upgrade := func(to string) schema.StateUpgradeFunc {
+		return func(_ context.Context, state map[string]any, _ any) (map[string]any, error) {
+			state["note"] = to
+			return state, nil
+		}
+	}
+	priorType := cty.Object(map[string]cty.Type{"id": cty.String, "note": cty.String})
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"upgrader_resource": {
+				SchemaVersion: 2,
+				StateUpgraders: []schema.StateUpgrader{
+					{Version: 0, Type: priorType, Upgrade: upgrade("upgraded-from-v0")},
+					{Version: 1, Type: priorType, Upgrade: upgrade("upgraded-from-v1")},
+				},
+				Schema: map[string]*schema.Schema{
+					"note": {Type: schema.TypeString, Required: true},
+				},
+				Importer: &schema.ResourceImporter{
+					StateContext: schema.ImportStatePassthroughContext,
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("only")
+					return nil
+				},
+				ReadContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					return diag.FromErr(d.Set("note", "unrecoverable-by-read"))
+				},
+				UpdateContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+					return nil
+				},
+				DeleteContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("")
+					return nil
+				},
+			},
+		},
+	}
+}

--- a/tests/tfcompat/l2_state_upgrader_import_test.go
+++ b/tests/tfcompat/l2_state_upgrader_import_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// The resource is at schema version 2, its read cannot recover `note`, and its
+// state upgraders rewrite `note` whenever they run. Adopting its state is
+// therefore only a no-op if the import carries both the instance's values and
+// the version those values are at: an id-only import reads the placeholder
+// back, and an import that drops the version runs the upgrade chain from 0.
+func TestL2StateUpgraderImport(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_state_upgrader_import", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "upgrader", Factory: providers.UpgraderProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l2_state_upgrader_import/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_state_upgrader_import/main.tf
@@ -1,0 +1,3 @@
+resource "upgrader_resource" "a" {
+  note = "written-once"
+}


### PR DESCRIPTION
This PR writes `{"schema_version":"N"}` into `__meta`, taking N from the state
file.

Refs #594.
