### PR TITLE
Add a tfcompat case for a terraform_data import

### DIFF
--- a/tests/tfcompat/l2_terraform_data_import_test.go
+++ b/tests/tfcompat/l2_terraform_data_import_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+// terraform_data is a built-in resource that supports import, so an import
+// block can adopt an existing id and then apply the configured input.
+func TestL2TerraformDataImport(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_terraform_data_import", tfcompat.Case{})
+}

--- a/tests/tfcompat/testdata/cases/l2_terraform_data_import/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_terraform_data_import/main.tf
@@ -1,0 +1,16 @@
+resource "terraform_data" "a" {
+  input = "from-config"
+}
+
+import {
+  to = terraform_data.a
+  id = "existing-id"
+}
+
+output "id" {
+  value = terraform_data.a.id
+}
+
+output "out" {
+  value = terraform_data.a.output
+}


### PR DESCRIPTION
Lock in that we correctly import the built-in `terraform_data` resource.