### PR TITLE
Round-trip inputs named after HCL meta-arguments through the `_` block

### DIFF
--- a/.changes/unreleased/codegen-bug-fixes-600.yaml
+++ b/.changes/unreleased/codegen-bug-fixes-600.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Write inputs named after a meta-argument (`count`, `lifecycle`, `source`, ...) in the `_` escaping block
+time: 2026-09-03T15:02:27.578483+02:00
+custom:
+    Component: codegen
+    PR: "600"

--- a/.changes/unreleased/converter-bug-fixes-600.yaml
+++ b/.changes/unreleased/converter-bug-fixes-600.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Read inputs from the `_` escaping block
+time: 2026-09-03T15:02:27.619376+02:00
+custom:
+    Component: converter
+    PR: "600"

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -2974,3 +2974,83 @@ resource "test_resource" "r" {
 		property.NewSegment("settings"), property.NewSegment(0), property.NewSegment("token"),
 	)}, r.HideDiffs)
 }
+
+// TestEscapedArguments converts PCL whose inputs are named after HCL
+// meta-arguments. The codegen must write those inputs in a `_` escaping block
+// so the runtime passes them through as inputs instead of expanding the
+// resource or misreading the argument.
+func TestEscapedArguments(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Item": {
+				InputProperties: map[string]schema.PropertySpec{
+					"count":     {TypeSpec: schema.TypeSpec{Type: "integer"}},
+					"lifecycle": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"value":     {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+		},
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"provider": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+
+	componentPCL := `config "source" "string" {}
+
+resource "inner" "test:index:Item" {
+    value = source
+}
+`
+	parentPCL := `resource "escaped" "test:index:Item" {
+    count = 3
+    lifecycle = "not-a-block"
+}
+
+component "mod" "./mod" {
+    source = "escaped-source"
+}
+
+output result {
+    value = invoke("test:index:echo", { provider = "escaped-provider" }).result
+}
+`
+	mock := testConvertedPCLWithComponent(t, parentPCL, map[string]string{
+		"./mod": componentPCL,
+	}, nil, testSchema)
+
+	inputs := map[string]property.Map{}
+	for _, r := range mock.RegisteredResources {
+		if r.Type == "test:index:Item" {
+			inputs[r.Name] = r.Inputs
+		}
+	}
+	assert.Equal(t, map[string]property.Map{
+		"escaped": property.NewMap(map[string]property.Value{
+			"count":     property.New(3.0),
+			"lifecycle": property.New("not-a-block"),
+		}),
+		"mod-inner": property.NewMap(map[string]property.Value{
+			"value": property.New("escaped-source"),
+		}),
+	}, inputs)
+
+	require.Len(t, mock.InvokedFunctions, 1)
+	assert.Equal(t, property.NewMap(map[string]property.Value{
+		"provider": property.New("escaped-provider"),
+	}), mock.InvokedFunctions[0].Args)
+}

--- a/cmd/pulumi-language-hcl/language_test.go
+++ b/cmd/pulumi-language-hcl/language_test.go
@@ -152,10 +152,6 @@ var expectedFailures = map[string]string{
 	"l2-reserved-names": "whole objects in stack outputs must keep their wire-format (camelCase) keys," +
 		" but the runtime emits the TF-renamed snake_case keys: expected 'elementType', got 'element_type'" +
 		" (asserted since v3.260.0, https://github.com/pulumi/pulumi-hcl/issues/589)",
-	"l2-resource-const": "upstream fixture names a property `count`, which HCL reserves as the resource" +
-		" `count` meta-argument; codegen does not emit and the converter does not read the `_` escaping" +
-		" block: Unsupported attribute; This value does not have any attributes" +
-		" (asserted since v3.261.0, https://github.com/pulumi/pulumi-hcl/issues/600)",
 	"l2-provider-call-explicit": "upstream fixture declares `provider \"call\"`, which" +
 		" is reserved as the namespace for resource method calls in HCL",
 	"l2-config-default-from-invoke": "HCL codegen does not support a config variable whose" +

--- a/cmd/pulumi-language-hcl/testdata/TestEscapedArguments/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/TestEscapedArguments/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+data "test_echo" "invoke_0" {
+  _ {
+    provider = "escaped-provider"
+  }
+}
+
+resource "test_item" "escaped" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  _ {
+    count     = 3
+    lifecycle = "not-a-block"
+  }
+}
+module "mod" {
+  source = "./mod"
+  _ {
+    source = "escaped-source"
+  }
+}
+output "result" {
+  value = data.test_echo.invoke_0.result
+}

--- a/cmd/pulumi-language-hcl/testdata/TestEscapedArguments/mod/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/TestEscapedArguments/mod/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+resource "test_item" "inner" {
+  pulumi {
+    name ="${pulumi.module.name}-inner"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = var.source
+}
+variable "source" {
+  type = string
+}

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-const/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-const/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-const
+runtime: pcl

--- a/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-const/main.pp
+++ b/cmd/pulumi-language-hcl/testdata/eject-pcl/l2-resource-const/main.pp
@@ -1,0 +1,25 @@
+resource "first" "constant:index:Resource" {
+  kind  = "Constant"
+  flag  = true
+  count = 3
+  ratio = 1.5
+}
+
+// Every property has a constant value in the schema, one per constant kind; reading them must
+// bind without type errors.
+output "kind" {
+  value = first.kind
+}
+
+output "flag" {
+  value = first.flag
+}
+
+output "count" {
+  value = first.count
+}
+
+output "ratio" {
+  value = first.ratio
+}
+

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-const/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-const/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-const
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/projects/l2-resource-const/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/projects/l2-resource-const/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    constant = {
+      source  = "pulumi/constant"
+      version = "43.0.0"
+    }
+  }
+}
+
+resource "constant_resource" "first" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  kind = "Constant"
+  flag = true
+  _ {
+    count = 3
+  }
+  ratio = 1.5
+}
+// Every property has a constant value in the schema, one per constant kind; reading them must
+// bind without type errors.
+output "kind" {
+  value = constant_resource.first.kind
+}
+output "flag" {
+  value = constant_resource.first.flag
+}
+output "count" {
+  value = constant_resource.first.count
+}
+output "ratio" {
+  value = constant_resource.first.ratio
+}

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-const/Pulumi.yaml
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-const/Pulumi.yaml
@@ -1,0 +1,2 @@
+name: l2-resource-const
+runtime: hcl

--- a/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-const/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/round-tripped-project/l2-resource-const/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    constant = {
+      source  = "pulumi/constant"
+      version = "43.0.0"
+    }
+  }
+}
+
+resource "constant_resource" "first" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  kind = "Constant"
+  flag = true
+  _ {
+    count = 3
+  }
+  ratio = 1.5
+}
+// Every property has a constant value in the schema, one per constant kind; reading them must
+// bind without type errors.
+output "kind" {
+  value = constant_resource.first.kind
+}
+output "flag" {
+  value = constant_resource.first.flag
+}
+output "count" {
+  value = constant_resource.first.count
+}
+output "ratio" {
+  value = constant_resource.first.ratio
+}

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/comments"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/eval"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/packages"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/transform"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
@@ -1066,11 +1067,12 @@ func (g *generator) genInvokeDataSource(body *hclwrite.Body, ds spilledDataSourc
 					}
 				}
 				hclName := transform.SnakeCaseFromPulumiCase(keyName)
+				target := inputBody(block.Body(), hclName, parser.DataReservedNames)
 				if objType, ok := transform.AsHCLBlockType(propType); ok {
-					d := g.genBlocks(block.Body(), hclName, item.Value, objType)
+					d := g.genBlocks(target, hclName, item.Value, objType)
 					diags = append(diags, d...)
 				} else {
-					d := g.genExpression(block.Body(), hclName, item.Value, propType)
+					d := g.genExpression(target, hclName, item.Value, propType)
 					diags = append(diags, d...)
 				}
 			}
@@ -1152,24 +1154,47 @@ func (g *generator) genResource(body *hclwrite.Body, r *pcl.Resource) hcl.Diagno
 	d = g.genResourceOptions(block.Body(), r)
 	diags = append(diags, d...)
 
+	d = g.genInputs(block.Body(), r, parser.ResourceReservedNames)
+	return append(diags, d...)
+}
+
+// genInputs writes r's input properties to body. An input whose HCL name is
+// in reserved goes in the block's `_` escaping block instead, so the runtime
+// reads it as a property rather than as a meta-argument.
+func (g *generator) genInputs(body *hclwrite.Body, r *pcl.Resource, reserved map[string]bool) hcl.Diagnostics {
 	var inputs []*schema.Property
 	if r.Schema != nil {
 		inputs = r.Schema.InputProperties
 	}
 
+	var diags hcl.Diagnostics
 	for _, attr := range r.Inputs {
 		inputType := findPropertyType(inputs, attr.Name)
 		hclName := transform.SnakeCaseFromPulumiCase(attr.Name)
-		g.emitLeadingComments(block.Body(), attr.SyntaxNode())
+		target := inputBody(body, hclName, reserved)
+		g.emitLeadingComments(target, attr.SyntaxNode())
 		if objType, ok := transform.AsHCLBlockType(inputType); ok {
-			d := g.genBlocks(block.Body(), hclName, attr.Value, objType)
+			d := g.genBlocks(target, hclName, attr.Value, objType)
 			diags = append(diags, d...)
 		} else {
-			d := g.genAttributeWithTrailing(block.Body(), hclName, attr.Value, inputType, attr.SyntaxNode())
+			d := g.genAttributeWithTrailing(target, hclName, attr.Value, inputType, attr.SyntaxNode())
 			diags = append(diags, d...)
 		}
 	}
 	return diags
+}
+
+// inputBody returns the body an argument named name is written to: body
+// itself, or its `_` escaping block when name is one of the block type's
+// reserved meta-argument names.
+func inputBody(body *hclwrite.Body, name string, reserved map[string]bool) *hclwrite.Body {
+	if !reserved[name] {
+		return body
+	}
+	if escape := body.FirstMatchingBlock("_", nil); escape != nil {
+		return escape.Body()
+	}
+	return body.AppendNewBlock("_", nil).Body()
 }
 
 // genProvider emits a `provider "<pkg>" { ... }` block for a PCL provider
@@ -1226,23 +1251,8 @@ func (g *generator) genProvider(body *hclwrite.Body, r *pcl.Resource) hcl.Diagno
 		}
 	}
 
-	var inputs []*schema.Property
-	if r.Schema != nil {
-		inputs = r.Schema.InputProperties
-	}
-	for _, attr := range r.Inputs {
-		inputType := findPropertyType(inputs, attr.Name)
-		hclName := transform.SnakeCaseFromPulumiCase(attr.Name)
-		g.emitLeadingComments(block.Body(), attr.SyntaxNode())
-		if objType, ok := transform.AsHCLBlockType(inputType); ok {
-			d := g.genBlocks(block.Body(), hclName, attr.Value, objType)
-			diags = append(diags, d...)
-		} else {
-			d := g.genAttributeWithTrailing(block.Body(), hclName, attr.Value, inputType, attr.SyntaxNode())
-			diags = append(diags, d...)
-		}
-	}
-	return diags
+	d := g.genInputs(block.Body(), r, parser.ProviderReservedNames)
+	return append(diags, d...)
 }
 
 // genResourceOptions generates HCL meta-arguments for a resource's options.
@@ -1995,8 +2005,9 @@ func (g *generator) genModule(body *hclwrite.Body, c *pcl.Component) hcl.Diagnos
 	}
 
 	for _, attr := range c.Inputs {
-		g.emitLeadingComments(block.Body(), attr.SyntaxNode())
-		d := g.genAttributeWithTrailing(block.Body(), attr.Name, attr.Value, schema.AnyType, attr.SyntaxNode())
+		target := inputBody(block.Body(), attr.Name, parser.ModuleReservedNames)
+		g.emitLeadingComments(target, attr.SyntaxNode())
+		d := g.genAttributeWithTrailing(target, attr.Name, attr.Value, schema.AnyType, attr.SyntaxNode())
 		diags = append(diags, d...)
 	}
 	return diags

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/comments"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/packages"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/transform"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -563,6 +564,24 @@ var resourceOptionHCLToPCL = map[string]string{
 	"version":                   "version",
 }
 
+// The predicates below report whether a top-level attribute of a block is a
+// meta-argument (or resource option) rather than block-type-specific
+// configuration.
+
+func isResourceOption(name string) bool {
+	_, ok := resourceOptionHCLToPCL[name]
+	return ok
+}
+
+func isDataMeta(name string) bool {
+	_, ok := invokeOptionHCLToPCL[name]
+	return ok || name == "for_each" || name == "count"
+}
+
+func isModuleMeta(name string) bool { return parser.ModuleReservedNames[name] }
+
+func isProviderMeta(name string) bool { return name == "alias" }
+
 // emitFile writes the PCL form of body to out using ft as a (possibly
 // project-wide) symbol table. The caller owns construction of ft and only
 // per-file context (src, filename, body, paramInfos) flows through here.
@@ -684,19 +703,15 @@ func (ft *fileTransformer) emitFile(
 				blk.Body().SetAttributeRaw("__logicalName", hclwrite.TokensForValue(cty.StringVal(logicalName)))
 			}
 			var rangeExpr, providersExpr hclsyntax.Expression
-			for _, attr := range sortedAttributes(block.Body.Attributes) {
+			for _, attr := range block.Body.Attributes {
 				switch attr.Name {
-				case "source":
-					continue
 				case "count", "for_each":
 					rangeExpr = attr.Expr
-					continue
 				case "providers":
 					providersExpr = attr.Expr
-					continue
-				case "depends_on", "version":
-					continue
 				}
+			}
+			for _, attr := range inputAttributes(block.Body, isModuleMeta) {
 				start := attr.Range().Start.Byte
 				ft.emitLeadingComments(blk.Body(), start)
 				blk.Body().SetAttributeRaw(attr.Name, ft.withTrailing(ft.transformExpr(attr.Expr), start))
@@ -746,10 +761,7 @@ func (ft *fileTransformer) emitFile(
 			}
 
 			// Emit input properties first (skip resource option attributes).
-			for _, attr := range sortedAttributes(block.Body.Attributes) {
-				if _, isOpt := resourceOptionHCLToPCL[attr.Name]; isOpt {
-					continue
-				}
+			for _, attr := range inputAttributes(block.Body, isResourceOption) {
 				name, _ := transform.PulumiCaseFromSnakeCase(attr.Name, res.InputProperties)
 				start := attr.Range().Start.Byte
 				ft.emitLeadingComments(blk.Body(), start)
@@ -812,6 +824,18 @@ func (ft *fileTransformer) emitFile(
 				case "dynamic":
 					d := ft.convertDynamicBlock(blk.Body(), subBlock, res.InputProperties)
 					resultDiags = append(resultDiags, d...)
+				case "_":
+					// Blocks in the escaping block are input properties
+					// whatever their names; the runtime still expands a
+					// dynamic block written there.
+					for _, escaped := range subBlock.Body.Blocks {
+						if escaped.Type == "dynamic" {
+							d := ft.convertDynamicBlock(blk.Body(), escaped, res.InputProperties)
+							resultDiags = append(resultDiags, d...)
+						} else {
+							propertyBlocks = append(propertyBlocks, escaped)
+						}
+					}
 				case "lifecycle":
 					for _, attr := range sortedAttributes(subBlock.Body.Attributes) {
 						switch attr.Name {
@@ -933,10 +957,7 @@ func (ft *fileTransformer) emitFile(
 				tokens hclwrite.Tokens
 			}
 			var opts []optEntry
-			for _, attr := range sortedAttributes(block.Body.Attributes) {
-				if attr.Name == "alias" {
-					continue
-				}
+			for _, attr := range inputAttributes(block.Body, isProviderMeta) {
 				name, _ := transform.PulumiCaseFromSnakeCase(attr.Name, providerRes.InputProperties)
 				start := attr.Range().Start.Byte
 				ft.emitLeadingComments(blk.Body(), start)
@@ -1008,11 +1029,33 @@ func (ft *fileTransformer) emitFile(
 
 // sortedAttributes returns attributes sorted by source position.
 func sortedAttributes(attrs hclsyntax.Attributes) []*hclsyntax.Attribute {
-	result := slices.Collect(maps.Values(attrs))
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].NameRange.Start.Byte < result[j].NameRange.Start.Byte
+	return sortAttributes(slices.Collect(maps.Values(attrs)))
+}
+
+// sortAttributes sorts attrs by source position.
+func sortAttributes(attrs []*hclsyntax.Attribute) []*hclsyntax.Attribute {
+	sort.Slice(attrs, func(i, j int) bool {
+		return attrs[i].NameRange.Start.Byte < attrs[j].NameRange.Start.Byte
 	})
-	return result
+	return attrs
+}
+
+// inputAttributes returns body's block-type-specific attributes in source
+// order: the top-level attributes for which isMeta is false, plus every
+// attribute of the `_` escaping block, whatever its name.
+func inputAttributes(body *hclsyntax.Body, isMeta func(name string) bool) []*hclsyntax.Attribute {
+	var result []*hclsyntax.Attribute
+	for _, attr := range body.Attributes {
+		if !isMeta(attr.Name) {
+			result = append(result, attr)
+		}
+	}
+	for _, block := range body.Blocks {
+		if block.Type == "_" {
+			result = slices.AppendSeq(result, maps.Values(block.Body.Attributes))
+		}
+	}
+	return sortAttributes(result)
 }
 
 // convertHCLTypeExpr converts an HCL type constraint expression to a PCL type string.
@@ -1835,38 +1878,40 @@ func (ft *fileTransformer) invokeExprTokens(hclType, dsName string) hclwrite.Tok
 
 	var argAttrs, optAttrs []hclwrite.ObjectAttrTokens
 	if body, ok := ft.dataBlocks[dataReference{hclType, dsName}]; ok {
+		for _, attr := range inputAttributes(body, isDataMeta) {
+			name, _ := transform.PulumiCaseFromSnakeCase(attr.Name, inputProps)
+			argAttrs = append(argAttrs, hclwrite.ObjectAttrTokens{
+				Name:  hclwrite.TokensForIdentifier(name),
+				Value: ft.transformExpr(attr.Expr),
+			})
+		}
 		for _, attr := range sortedAttributes(body.Attributes) {
-			if attr.Name == "for_each" || attr.Name == "count" {
-				continue
-			}
 			if pclName, isOpt := invokeOptionHCLToPCL[attr.Name]; isOpt {
 				optAttrs = append(optAttrs, hclwrite.ObjectAttrTokens{
 					Name:  hclwrite.TokensForIdentifier(pclName),
 					Value: ft.transformExpr(attr.Expr),
 				})
-			} else {
-				name, _ := transform.PulumiCaseFromSnakeCase(attr.Name, inputProps)
-				argAttrs = append(argAttrs, hclwrite.ObjectAttrTokens{
-					Name:  hclwrite.TokensForIdentifier(name),
-					Value: ft.transformExpr(attr.Expr),
-				})
 			}
 		}
 		// Pulumi-specific invoke options live in a nested `pulumi` block; the
-		// remaining blocks are array-of-object input properties.
+		// remaining blocks, including those in the `_` escaping block, are
+		// array-of-object input properties.
 		var inputBlocks []*hclsyntax.Block
 		for _, b := range body.Blocks {
-			if b.Type != "pulumi" {
-				inputBlocks = append(inputBlocks, b)
-				continue
-			}
-			for _, attr := range sortedAttributes(b.Body.Attributes) {
-				if pclName, isOpt := invokeOptionHCLToPCL[attr.Name]; isOpt {
-					optAttrs = append(optAttrs, hclwrite.ObjectAttrTokens{
-						Name:  hclwrite.TokensForIdentifier(pclName),
-						Value: ft.transformExpr(attr.Expr),
-					})
+			switch b.Type {
+			case "_":
+				inputBlocks = append(inputBlocks, b.Body.Blocks...)
+			case "pulumi":
+				for _, attr := range sortedAttributes(b.Body.Attributes) {
+					if pclName, isOpt := invokeOptionHCLToPCL[attr.Name]; isOpt {
+						optAttrs = append(optAttrs, hclwrite.ObjectAttrTokens{
+							Name:  hclwrite.TokensForIdentifier(pclName),
+							Value: ft.transformExpr(attr.Expr),
+						})
+					}
 				}
+			default:
+				inputBlocks = append(inputBlocks, b)
 			}
 		}
 		argAttrs = append(argAttrs, ft.blocksToObjectAttrs(inputBlocks, inputProps)...)

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -949,3 +949,95 @@ func TestEjectMultiFileHCL(t *testing.T) {
 		"providers.pp": "",
 	}, pclFiles)
 }
+
+// TestEjectEscapedArguments feeds in the `_` escaping blocks the codegen emits
+// for arguments whose names collide with meta-arguments: the escaped
+// arguments convert to inputs, while the top-level meta-arguments of the same
+// names still convert to options.
+func TestEjectEscapedArguments(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Item": {
+				InputProperties: map[string]schema.PropertySpec{
+					"count":    {TypeSpec: schema.TypeSpec{Type: "integer"}},
+					"provider": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					"value":    {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+		},
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"provider": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+	loader := schemaloader.New(t, testSchema)
+
+	src := []byte(`terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+data "test_echo" "lookup" {
+  _ {
+    provider = "escaped"
+  }
+}
+
+resource "test_item" "escaped" {
+  count = 2
+  value = data.test_echo.lookup.result
+  _ {
+    count    = 3
+    provider = "literal"
+  }
+}
+
+module "child" {
+  source = "./child"
+  _ {
+    source = "escaped"
+  }
+}
+`)
+
+	out := hclwrite.NewEmptyFile()
+	diags := transformSingleFile(t, src, "main.tf", out.Body(), loader, nil)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	expected := `resource "escaped" "test:index:Item" {
+  value = invoke("test:index:echo", {
+    provider = "escaped"
+  }).result
+  count    = 3
+  provider = "literal"
+  options {
+    range               = 2
+    deleteBeforeReplace = true
+  }
+}
+
+component "child" "./child" {
+  source = "escaped"
+}
+
+`
+	assert.Equal(t, expected, string(out.Bytes()))
+}

--- a/pkg/hcl/parser/schema.go
+++ b/pkg/hcl/parser/schema.go
@@ -386,3 +386,27 @@ var importSchema = &hcl.BodySchema{
 		{Name: "for_each"},
 	},
 }
+
+// reservedNames returns the argument and block names s claims, so an argument
+// with one of those names must be written in the `_` escaping block to be
+// read as block-type-specific configuration.
+func reservedNames(s *hcl.BodySchema) map[string]bool {
+	names := make(map[string]bool, len(s.Attributes)+len(s.Blocks))
+	for _, attr := range s.Attributes {
+		names[attr.Name] = true
+	}
+	for _, block := range s.Blocks {
+		names[block.Type] = true
+	}
+	return names
+}
+
+// The argument and block names each block type reserves for meta-arguments.
+// An argument with one of these names is read as block-type-specific
+// configuration only inside the block's `_` escaping block.
+var (
+	ResourceReservedNames = reservedNames(resourceSchema)
+	DataReservedNames     = reservedNames(dataBlockSchema)
+	ProviderReservedNames = reservedNames(providerSchema)
+	ModuleReservedNames   = reservedNames(moduleSchema)
+)


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-hcl/issues/600.

A Pulumi property whose HCL name collides with a meta-argument (`count`, `for_each`, `lifecycle`, `source`, ...) could not be written in HCL in a way that survives conversion. `pulumi convert --language hcl` emitted `count = 3` at the top level, the runtime read it as the `count` meta-argument, and the converter could not read the `_` escaping block that the parser already accepts.

## Changes

- `pkg/hcl/parser`: export the reserved argument and block names of each block type (`ResourceReservedNames`, `DataReservedNames`, `ProviderReservedNames`, `ModuleReservedNames`), derived from the body schemas the parser uses. This is the single source of truth for what needs escaping.
- `pkg/codegen`: write an input whose HCL name is reserved to the block's `_` escaping block. Applies to resources, providers, data sources (hoisted invokes), and modules (components). The block-name collisions (a property named `lifecycle`, `timeouts`, ...) are covered too, since HCL rejects an attribute named after a schema block type.
- `pkg/converter`: read the attributes and nested blocks of a `_` block back as inputs for the same four block types, keeping source order with the top-level inputs.
- `l2-resource-const` leaves `expectedFailures`; snapshots accepted.

## Tests

- `TestEscapedArguments` (language host): PCL with a resource input named `count` and `lifecycle`, a component input named `source`, and an invoke input named `provider` runs end to end and registers one resource with the escaped inputs.
- `TestEjectEscapedArguments` (converter): HCL with `_` blocks on a resource, a data block, and a module converts back to PCL inputs while the top-level `count` still becomes `options.range`.
- `TestLanguage/l2-resource-const` conformance test, including the eject round trip.
