### PR TITLE
Reserve the same top-level names in the converter as in the parser

### DIFF
--- a/.changes/unreleased/converter-bug-fixes-602.yaml
+++ b/.changes/unreleased/converter-bug-fixes-602.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Convert top-level `version`, `protect`, `parent`, ... on resource and data blocks to inputs, not options
+time: 2026-09-03T22:55:44.87307+02:00
+custom:
+    Component: converter
+    PR: "602"

--- a/.changes/unreleased/converter-bug-fixes-603.yaml
+++ b/.changes/unreleased/converter-bug-fixes-603.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Convert a provider block with `for_each` to a provider resource with a `range` option
+time: 2026-09-03T23:12:17.554723+02:00
+custom:
+    Component: converter
+    PR: "603"

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -947,6 +947,9 @@ func (ft *fileTransformer) emitFile(
 				tokens hclwrite.Tokens
 			}
 			var opts []optEntry
+			if forEach, ok := block.Body.Attributes["for_each"]; ok {
+				opts = append(opts, optEntry{"range", ft.transformForEachExpr(forEach.Expr)})
+			}
 			for _, attr := range inputAttributes(block.Body, isProviderMeta) {
 				name, _ := transform.PulumiCaseFromSnakeCase(attr.Name, providerRes.InputProperties)
 				start := attr.Range().Start.Byte

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -565,22 +565,17 @@ var resourceOptionHCLToPCL = map[string]string{
 }
 
 // The predicates below report whether a top-level attribute of a block is a
-// meta-argument (or resource option) rather than block-type-specific
-// configuration.
+// meta-argument rather than block-type-specific configuration. They match the
+// parser: every other option lives in the nested `pulumi` block, so a
+// top-level attribute with an option's name is an input property.
 
-func isResourceOption(name string) bool {
-	_, ok := resourceOptionHCLToPCL[name]
-	return ok
-}
+func isResourceMeta(name string) bool { return parser.ResourceReservedNames[name] }
 
-func isDataMeta(name string) bool {
-	_, ok := invokeOptionHCLToPCL[name]
-	return ok || name == "for_each" || name == "count"
-}
+func isDataMeta(name string) bool { return parser.DataReservedNames[name] }
 
 func isModuleMeta(name string) bool { return parser.ModuleReservedNames[name] }
 
-func isProviderMeta(name string) bool { return name == "alias" }
+func isProviderMeta(name string) bool { return parser.ProviderReservedNames[name] }
 
 // emitFile writes the PCL form of body to out using ft as a (possibly
 // project-wide) symbol table. The caller owns construction of ft and only
@@ -761,7 +756,7 @@ func (ft *fileTransformer) emitFile(
 			}
 
 			// Emit input properties first (skip resource option attributes).
-			for _, attr := range inputAttributes(block.Body, isResourceOption) {
+			for _, attr := range inputAttributes(block.Body, isResourceMeta) {
 				name, _ := transform.PulumiCaseFromSnakeCase(attr.Name, res.InputProperties)
 				start := attr.Range().Start.Byte
 				ft.emitLeadingComments(blk.Body(), start)
@@ -775,16 +770,11 @@ func (ft *fileTransformer) emitFile(
 			}
 			var opts []optEntry
 			for _, attr := range sortedAttributes(block.Body.Attributes) {
-				if pclName, isOpt := resourceOptionHCLToPCL[attr.Name]; isOpt {
+				if pclName, isOpt := resourceOptionHCLToPCL[attr.Name]; isOpt && isResourceMeta(attr.Name) {
 					var tokens hclwrite.Tokens
-					switch attr.Name {
-					case "additional_secret_outputs":
-						tokens = ft.transformPropertyPathList(attr.Expr, res.Properties)
-					case "hide_diffs", "replace_on_changes":
-						tokens = ft.transformPropertyPathList(attr.Expr, res.InputProperties)
-					case "for_each":
+					if attr.Name == "for_each" {
 						tokens = ft.transformForEachExpr(attr.Expr)
-					default:
+					} else {
 						tokens = ft.transformExpr(attr.Expr)
 					}
 					opts = append(opts, optEntry{pclName, tokens})
@@ -1886,7 +1876,7 @@ func (ft *fileTransformer) invokeExprTokens(hclType, dsName string) hclwrite.Tok
 			})
 		}
 		for _, attr := range sortedAttributes(body.Attributes) {
-			if pclName, isOpt := invokeOptionHCLToPCL[attr.Name]; isOpt {
+			if pclName, isOpt := invokeOptionHCLToPCL[attr.Name]; isOpt && isDataMeta(attr.Name) {
 				optAttrs = append(optAttrs, hclwrite.ObjectAttrTokens{
 					Name:  hclwrite.TokensForIdentifier(pclName),
 					Value: ft.transformExpr(attr.Expr),

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -1130,3 +1130,77 @@ output "result" {
 `
 	assert.Equal(t, expected, string(out.Bytes()))
 }
+
+// TestEjectRangedProvider converts a provider block with `for_each` to a PCL
+// provider resource with a `range` option, and a keyed provider reference to
+// an index into that resource.
+func TestEjectRangedProvider(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Provider: &schema.ResourceSpec{
+			InputProperties: map[string]schema.PropertySpec{
+				"prefix": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+		},
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Item": {
+				InputProperties: map[string]schema.PropertySpec{
+					"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+		},
+	}
+	loader := schemaloader.New(t, testSchema)
+
+	src := []byte(`terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+provider "test" {
+  alias = "by_key"
+  for_each = {
+    a = "alpha"
+    b = "beta"
+  }
+  prefix = each.value
+}
+
+resource "test_item" "fixed" {
+  provider = test.by_key["a"]
+  value    = "fixed"
+}
+`)
+
+	out := hclwrite.NewEmptyFile()
+	diags := transformSingleFile(t, src, "main.tf", out.Body(), loader, nil)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	expected := `resource "by_key" "pulumi:providers:test" {
+  prefix = range.value
+  options {
+    range = {
+      a = "alpha"
+      b = "beta"
+    }
+  }
+}
+
+resource "fixed" "test:index:Item" {
+  value = "fixed"
+  options {
+    provider            = by_key["a"]
+    deleteBeforeReplace = true
+  }
+}
+
+`
+	assert.Equal(t, expected, string(out.Bytes()))
+}

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -1041,3 +1041,92 @@ component "child" "./child" {
 `
 	assert.Equal(t, expected, string(out.Bytes()))
 }
+
+// TestEjectTopLevelOptionNamesAreInputs checks that the converter reserves
+// the same top-level names as the parser: an attribute named after an option
+// that lives in the `pulumi` block (`version`, `protect`, ...) is an input
+// property, while the `pulumi` block still supplies the option.
+func TestEjectTopLevelOptionNamesAreInputs(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Item": {
+				InputProperties: map[string]schema.PropertySpec{
+					"protect": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
+					"version": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+		},
+		Functions: map[string]schema.FunctionSpec{
+			"test:index:echo": {
+				Inputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"version": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+				Outputs: &schema.ObjectTypeSpec{
+					Properties: map[string]schema.PropertySpec{
+						"result": {TypeSpec: schema.TypeSpec{Type: "string"}},
+					},
+				},
+			},
+		},
+	}
+	loader := schemaloader.New(t, testSchema)
+
+	src := []byte(`terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+data "test_echo" "lookup" {
+  version = "v2"
+  pulumi {
+    version = "2.0.0"
+  }
+}
+
+resource "test_item" "item" {
+  version = "v1"
+  protect = true
+  pulumi {
+    protect = false
+  }
+}
+
+output "result" {
+  value = data.test_echo.lookup.result
+}
+`)
+
+	out := hclwrite.NewEmptyFile()
+	diags := transformSingleFile(t, src, "main.tf", out.Body(), loader, nil)
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	expected := `resource "item" "test:index:Item" {
+  version = "v1"
+  protect = true
+  options {
+    protect             = false
+    deleteBeforeReplace = true
+  }
+}
+
+output "result" {
+  value = invoke("test:index:echo", {
+    version = "v2"
+    }, {
+    version = "2.0.0"
+  }).result
+}
+
+`
+	assert.Equal(t, expected, string(out.Bytes()))
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-hcl/issues/602. Stacked on https://github.com/pulumi/pulumi-hcl/pull/604.

The converter mapped every name in its option tables (`version`, `protect`, `parent`, `import_id`, `aliases`, ...) to a PCL option whenever it appeared at the top level of a resource or data block. The parser reserves only the Terraform meta-arguments there: `count`, `for_each`, `depends_on`, `provider`, and `providers`. Every other option lives in the nested `pulumi` block, so a top-level `version` or `protect` is an input property. Codegen already writes them that way, so a property with one of those names did not round-trip through HCL.

## Changes

- `pkg/converter`: the top-level meta-argument predicates for resource, data, and provider blocks now read the parser's reserved-name sets, as the module predicate already did after https://github.com/pulumi/pulumi-hcl/pull/601. The option tables are consulted at the top level only for those names. The `pulumi` block handling is unchanged.
- `pkg/converter`: a provider block's `for_each` converts to `options { range = ... }` on the PCL provider resource. `each.key` and `each.value` in the provider configuration become `range.key` and `range.value`, and a keyed provider reference such as `test.by_key["a"]` becomes `by_key["a"]`. This is the reverse of the codegen path added in #604.

## Not covered

- A per-instance provider selection, `provider = test.by_key[each.key]` on a ranged resource, converts to `by_key[range.key]`, which PCL rejects: PCL does not bind `range` inside an `options` block. That is an upstream PCL limitation.

## Tests

- `TestEjectTopLevelOptionNamesAreInputs`: top-level `version` and `protect` on a resource and `version` on a data block convert to inputs, while the same names in the `pulumi` block still convert to options.
- `TestEjectRangedProvider`: a `for_each` provider block converts to a provider resource with a `range` option, and `test.by_key["a"]` converts to `by_key["a"]`.
