### PR TITLE
Emit `for_each` on provider blocks from a PCL provider range

### DIFF
--- a/.changes/unreleased/codegen-bug-fixes-604.yaml
+++ b/.changes/unreleased/codegen-bug-fixes-604.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Emit `for_each` on a provider block from a provider resource with a `range` option
+time: 2026-09-03T23:11:39.48699+02:00
+custom:
+    Component: codegen
+    PR: "604"

--- a/cmd/pulumi-language-hcl/hcl_test.go
+++ b/cmd/pulumi-language-hcl/hcl_test.go
@@ -3054,3 +3054,75 @@ output result {
 		"provider": property.New("escaped-provider"),
 	}), mock.InvokedFunctions[0].Args)
 }
+
+// TestRangedProvider converts a PCL provider resource with a `range` option.
+// The provider block must carry `for_each`, and resources that select an
+// instance by key must resolve to that instance. PCL does not bind `range`
+// inside an options block, so the keys are literals.
+func TestRangedProvider(t *testing.T) {
+	t.Parallel()
+
+	testSchema := schema.PackageSpec{
+		Name:    "test",
+		Version: "1.0.0",
+		Provider: &schema.ResourceSpec{
+			InputProperties: map[string]schema.PropertySpec{
+				"prefix": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+		},
+		Resources: map[string]schema.ResourceSpec{
+			"test:index:Item": {
+				InputProperties: map[string]schema.PropertySpec{
+					"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				},
+			},
+		},
+	}
+
+	pclSource := `resource "byKey" "pulumi:providers:test" {
+    options {
+        range = {
+            a = "alpha"
+            b = "beta"
+        }
+    }
+    prefix = range.value
+}
+
+resource "fixed" "test:index:Item" {
+    options {
+        provider = byKey["a"]
+    }
+    value = "fixed"
+}
+
+resource "other" "test:index:Item" {
+    options {
+        provider = byKey["b"]
+    }
+    value = "other"
+}
+`
+	mock := testConvertedPCL(t, pclSource, testSchema)
+
+	providers := map[string]property.Map{}
+	providerURNs := map[string]string{}
+	itemProviders := map[string]string{}
+	for _, r := range mock.RegisteredResources {
+		switch r.Type {
+		case "pulumi:providers:test":
+			providers[r.Name] = r.Inputs
+			providerURNs[r.Name] = fmt.Sprintf("urn:pulumi:test::project::pulumi:providers:test::%s::%s-id", r.Name, r.Name)
+		case "test:index:Item":
+			itemProviders[r.Name] = r.Provider
+		}
+	}
+	assert.Equal(t, map[string]property.Map{
+		`byKey["a"]`: property.NewMap(map[string]property.Value{"prefix": property.New("alpha")}),
+		`byKey["b"]`: property.NewMap(map[string]property.Value{"prefix": property.New("beta")}),
+	}, providers)
+	assert.Equal(t, map[string]string{
+		"fixed": providerURNs[`byKey["a"]`],
+		"other": providerURNs[`byKey["b"]`],
+	}, itemProviders)
+}

--- a/cmd/pulumi-language-hcl/testdata/TestRangedProvider/main.tf
+++ b/cmd/pulumi-language-hcl/testdata/TestRangedProvider/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_providers {
+    test = {
+      source  = "pulumi/test"
+      version = "1.0.0"
+    }
+  }
+}
+
+provider "test" {
+  alias = "byKey"
+  for_each = {
+    "a" = "alpha"
+    "b" = "beta"
+  }
+  prefix = each.value
+}
+resource "test_item" "fixed" {
+  provider = test.byKey["a"]
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = "fixed"
+}
+resource "test_item" "other" {
+  provider = test.byKey["b"]
+  lifecycle {
+    create_before_destroy = true
+  }
+  value = "other"
+}

--- a/pkg/codegen/generate.go
+++ b/pkg/codegen/generate.go
@@ -1214,10 +1214,15 @@ func (g *generator) genProvider(body *hclwrite.Body, r *pcl.Resource) hcl.Diagno
 	var diags hcl.Diagnostics
 
 	// Pulumi-specific options go in a nested `pulumi { }` block so they cannot
-	// collide with the provider's own configuration attributes. `alias` is a
-	// Terraform-standard meta-argument and stays at the top level.
+	// collide with the provider's own configuration attributes. `alias` and
+	// `for_each` are Terraform-standard meta-arguments and stay at the top
+	// level.
 	opts := r.Options
 	if opts != nil {
+		if opts.Range != nil {
+			d := g.genProviderRange(block.Body(), opts.Range)
+			diags = append(diags, d...)
+		}
 		var pulumiBlockBody *hclwrite.Body
 		pulumiBody := func() *hclwrite.Body {
 			if pulumiBlockBody == nil {
@@ -1485,21 +1490,46 @@ func (g *generator) genRange(body *hclwrite.Body, rangeExpr model.Expression) (i
 		return instanceNamingIndex, nil
 
 	default:
-		exprTokens, d := g.exprTokens(rangeExpr, schema.AnyType)
-		if d.HasErrors() {
-			return instanceNamingNone, d
-		}
-		var tokens hclwrite.Tokens
-		switch rangeType.(type) {
-		case *model.ListType, *model.TupleType:
-			tokens = wrapListAsMapForEach(exprTokens)
-		default:
-			tokens = exprTokens
-		}
-		body.SetAttributeRaw("for_each", tokens)
-		g.currentRangeKind = rangeKindForEach
-		return instanceNamingKey, nil
+		return instanceNamingKey, g.genForEach(body, rangeExpr, rangeType)
 	}
+}
+
+// genForEach emits a collection-valued PCL range option as a `for_each`
+// meta-argument. A list range becomes a map keyed by the stringified index so
+// `range.key` keeps indexing it.
+func (g *generator) genForEach(body *hclwrite.Body, rangeExpr model.Expression, rangeType model.Type) hcl.Diagnostics {
+	exprTokens, d := g.exprTokens(rangeExpr, schema.AnyType)
+	if d.HasErrors() {
+		return d
+	}
+	var tokens hclwrite.Tokens
+	switch rangeType.(type) {
+	case *model.ListType, *model.TupleType:
+		tokens = wrapListAsMapForEach(exprTokens)
+	default:
+		tokens = exprTokens
+	}
+	body.SetAttributeRaw("for_each", tokens)
+	g.currentRangeKind = rangeKindForEach
+	return nil
+}
+
+// genProviderRange emits a provider resource's range option. A provider block
+// accepts `for_each` only: an integer or boolean range has no `count`
+// equivalent there, so it is a diagnostic.
+func (g *generator) genProviderRange(body *hclwrite.Body, rangeExpr model.Expression) hcl.Diagnostics {
+	rangeType := model.ResolveOutputs(rangeExpr.Type())
+	if model.InputType(model.BoolType).ConversionFrom(rangeType) == model.SafeConversion ||
+		model.InputType(model.NumberType).ConversionFrom(rangeType) == model.SafeConversion {
+		return hcl.Diagnostics{{
+			Severity: hcl.DiagError,
+			Summary:  "unsupported provider range",
+			Detail: "a provider block accepts only a collection-valued range (`for_each`); " +
+				"a boolean or integer range has no `count` equivalent on a provider",
+			Subject: rangeExpr.SyntaxNode().Range().Ptr(),
+		}}
+	}
+	return g.genForEach(body, rangeExpr, rangeType)
 }
 
 // pinnedNameTokens builds the `pulumi { name = ... }` template that pins a


### PR DESCRIPTION
A PCL provider resource may carry a `range` option, and the runtime already expands a provider block with `for_each` into one instance per key. Codegen ignored the option, so `pulumi convert --language hcl` produced a single unranged `provider` block and the program silently changed meaning.

## Changes

- `pkg/codegen`: the provider emitter writes a collection-valued range as `for_each` on the provider block. The `for_each` emission is shared with the resource path (`genForEach`), so a list range becomes a map keyed by the stringified index and `range.key` / `range.value` inside the provider configuration become `each.key` / `each.value`.
- A boolean or integer range on a provider is a diagnostic. A provider block has no `count` meta-argument.

## Notes

- A resource selects an instance with a literal key, `provider = byKey["a"]`, which already converts through the index-expression path to `test.byKey["a"]`. PCL does not bind `range` inside an `options` block, so a per-instance selection such as `provider = byKey[range.key]` cannot be written in PCL.
- Provider instances keep the runtime's `alias["key"]` names. The provider `pulumi` block has no `name` argument to pin them the way ranged resources are pinned.

## Tests

- `TestRangedProvider`: a provider resource with a map range converts to a `for_each` provider block, registers one provider per key with the per-key configuration, and two resources that select `byKey["a"]` and `byKey["b"]` resolve to the matching provider instance.
