### PR TITLE
Order a moved resource after the init of its prior module

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-586.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-586.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Fix an intermittent replace of a resource that a `moved` block moves out of a module
+time: 2026-09-04T09:32:59Z
+custom:
+    Component: runtime
+    PR: "586"

--- a/pkg/hcl/run/cells.go
+++ b/pkg/hcl/run/cells.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/graph"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/modulepath"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -293,7 +294,22 @@ func (e *Engine) wireCell(g *graph.Graph, node *graph.Node, mi *moduleInstance) 
 	if !ok {
 		return fmt.Errorf("no graph node for %q", node.Key.String())
 	}
-	return b.CompleteBefore(blockNode)
+	if err := b.CompleteBefore(blockNode); err != nil {
+		return err
+	}
+
+	// A moved block's target registers after the init of each module it moved
+	// out of, so its alias can name that module's component as its prior
+	// parent. An edge that would close a cycle — the module's own inputs read
+	// the moved-out resource — is skipped: the program still runs, at the cost
+	// of that alias. Wired after every mandatory edge of this cell, so the
+	// cycle surfaces on this optional edge and not on one wired later.
+	for _, init := range e.movedFromModuleInits(node) {
+		if err := b.DependOn(init); err != nil {
+			logging.V(5).Infof("moved: cannot order %s after prior module init: %v", node.Key, err)
+		}
+	}
+	return nil
 }
 
 // cellEvalState resolves the evaluation context, parent URN, and module

--- a/pkg/hcl/run/run.go
+++ b/pkg/hcl/run/run.go
@@ -2408,6 +2408,70 @@ func (e *Engine) resolveMovedAliases(
 	return aliases
 }
 
+// movedFromModuleInits returns the init nodes of the still-configured modules
+// that `moved` blocks name as prior homes of the block's resource, following
+// chained moves. The resource's cell is ordered after those inits so that
+// resolveMovedAliases finds the prior module's component already registered
+// when it resolves the prior parent URN (priorComponentURN); without that
+// ordering the alias silently degrades whenever the resource wins the race.
+//
+// The walk is the static shadow of resolveMovedAliases's chain walk: instance
+// keys are ignored, so it over-approximates to every instance of the named
+// modules, which only adds ordering.
+func (e *Engine) movedFromModuleInits(node *graph.Node) []pdag.Node {
+	res := node.Resource
+	if res == nil {
+		return nil
+	}
+	resPath := modulepath.Root()
+	if node.ModuleInfo != nil {
+		resPath = node.ModuleInfo.Path
+	}
+	type addr struct {
+		path      modulepath.Path
+		typ, name string
+	}
+	start := addr{resPath, res.Type, res.Name}
+	work := []addr{start}
+	seen := map[addr]bool{start: true}
+	needInit := map[modulepath.Path]bool{}
+	for len(work) > 0 {
+		cur := work[0]
+		work = work[1:]
+		for _, scope := range ancestorPaths(cur.path) {
+			for _, moved := range e.graph.MovedBlocks(scope) {
+				to, ok := ast.ParseTargetAddr(moved.To)
+				if !ok || to.Type == "" { // skip whole-module-call moves
+					continue
+				}
+				if scope.Join(to.Module).Config() != cur.path || to.Type != cur.typ || to.Name != cur.name {
+					continue
+				}
+				from, ok := ast.ParseTargetAddr(moved.From)
+				if !ok || from.Type == "" {
+					continue
+				}
+				prior := addr{scope.Join(from.Module).Config(), from.Type, from.Name}
+				if seen[prior] {
+					continue
+				}
+				seen[prior] = true
+				work = append(work, prior)
+				if prior.path != resPath && !prior.path.IsRoot() {
+					needInit[prior.path] = true
+				}
+			}
+		}
+	}
+	var inits []pdag.Node
+	for path := range needInit {
+		if init, ok := e.graph.KeyNode(graph.NodeKey{Module: path, ID: "__init__"}); ok {
+			inits = append(inits, init)
+		}
+	}
+	return inits
+}
+
 // oldModulePaths applies the whole-module-call `moved` blocks that rename a
 // module enclosing (or equal to) path, following chained renames, and returns
 // every prior module path the object lived at, nearest rename first. It

--- a/pkg/hcl/run/run_internal_test.go
+++ b/pkg/hcl/run/run_internal_test.go
@@ -15,12 +15,18 @@
 package run
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/ast"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/bridge"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/eval"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/graph"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/modulepath"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/parser"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v3/util/pdag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/stretchr/testify/assert"
@@ -428,4 +434,93 @@ func TestTranslateSecretOutputName(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestMovedFromModuleInits pins the ordering that keeps a moved-out resource's
+// alias intact: the resource's cell must wait for the init of every
+// still-configured module a chain of moved blocks names as a prior home, or
+// resolveMovedAliases races processModuleInit for the prior module's component
+// URN and silently drops the alias when it wins (#586).
+func TestMovedFromModuleInits(t *testing.T) {
+	t.Parallel()
+
+	parse := func(name, src string) *ast.Config {
+		config, diags := parser.NewParser().ParseSource(name, []byte(src))
+		require.False(t, diags.HasErrors(), diags.Error())
+		return config
+	}
+
+	child := parse("mod.hcl", `resource "simple_resource" "kept" { input_one = "k" }`)
+	root := parse("root.hcl", `
+module "b" { source = "./mod" }
+module "c" { source = "./mod" }
+
+resource "simple_resource" "r" { input_one = "x" }
+
+# Chained move: module.c.r -> module.b.moved_r -> simple_resource.r, composed
+# with the module.a -> module.b call rename from the flaky case. The resource
+# must wait for both prior modules' inits; the whole-call rename adds none.
+moved {
+  from = module.a
+  to   = module.b
+}
+
+moved {
+  from = module.c.simple_resource.r
+  to   = module.b.simple_resource.moved_r
+}
+
+moved {
+  from = module.b.simple_resource.moved_r
+  to   = simple_resource.r
+}
+`)
+
+	g, err := graph.BuildFromConfig(root, fakeModuleLoader{modules: map[string]*graph.LoadedModule{
+		"./mod": {Config: child, SourcePath: "./mod"},
+	}}, ".")
+	require.NoError(t, err)
+	require.Empty(t, g.Validate())
+
+	var resNode *graph.Node
+	for _, node := range g.ExpandableNodes() {
+		if node.ModuleInfo == nil && node.Type == graph.NodeTypeResource {
+			resNode = node
+		}
+	}
+	require.NotNil(t, resNode, "no root resource node")
+
+	initNode := func(name string) pdag.Node {
+		init, ok := g.KeyNode(graph.NodeKey{
+			Module: modulepath.Root().Append(modulepath.NewStep(name)),
+			ID:     "__init__",
+		})
+		require.True(t, ok, "no init node for module.%s", name)
+		return init
+	}
+
+	e := &Engine{graph: g}
+	assert.ElementsMatch(t, []pdag.Node{initNode("b"), initNode("c")}, e.movedFromModuleInits(resNode))
+
+	// The kept resource inside the module is no moved target: no ordering.
+	var childNode *graph.Node
+	for _, node := range g.ExpandableNodes() {
+		if node.ModuleInfo != nil && node.Type == graph.NodeTypeResource {
+			childNode = node
+		}
+	}
+	require.NotNil(t, childNode, "no child resource node")
+	assert.Empty(t, e.movedFromModuleInits(childNode))
+}
+
+type fakeModuleLoader struct {
+	modules map[string]*graph.LoadedModule
+}
+
+func (f fakeModuleLoader) LoadModule(source, _, _ string) (*graph.LoadedModule, error) {
+	m, ok := f.modules[source]
+	if !ok {
+		return nil, fmt.Errorf("no module %q", source)
+	}
+	return m, nil
 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-hcl/issues/586.

## Root cause

A resource that a `moved` block moves out of a module aliases its old address with the prior module's component as its parent. `resolveMovedAliases` read that component's URN from `e.moduleInstances`, which `processModuleInit` fills concurrently. No graph edge ordered a root resource against a module init it does not reference. When the resource registered first, `priorParentSpec` found no component and silently dropped the alias, so the apply created the resource anew and deleted the original.

A forced `time.Sleep` at the top of `processModuleInit` reproduced the CI failure from the issue byte for byte, and also broke `TestL2Moved/consolidate` — the plain move-out case carried the same latent race.

## Fix

`movedFromModuleInits` walks the moved chain statically, as `resolveMovedAliases` does at runtime, without instance keys. It returns the init nodes of every still-configured module the chain names as a prior home. `wireCell` orders the resource's expansion cell after those inits.

An edge that would close a cycle — the module's own inputs read the moved-out resource — is skipped with a V5 log, so the program still runs at the cost of that alias. That config drops the alias deterministically today as well; a follow-up can remove the drop by deriving the prior component URN from config instead of the live registration. The optional edges are wired after the cell's mandatory edges, so the cycle surfaces on a skippable edge and not on a mandatory one.

## Testing

- `TestMovedFromModuleInits` pins the chain walk: both prior modules of a chained move, whole-call renames contributing no edge, non-targets receiving none.
- With the forced init delay in place, `module_call_rename_out`, `consolidate`, and `module_to_module` all pass with the fix and fail without it.
- All `TestL2Moved*` tfcompat tests and the `run`/`graph` unit suites pass.