### PR TITLE
Refine an instance indexed out of a ranged reference when typing a module

### DIFF
--- a/.changes/unreleased/runtime-improvements-609.yaml
+++ b/.changes/unreleased/runtime-improvements-609.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Type an instance indexed out of a `count` or `for_each` reference with the same required attributes as a direct reference in a module's generated schema
+time: 2026-09-04T10:56:18Z
+custom:
+    Component: runtime
+    PR: "609"

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -324,12 +324,11 @@ func seedProviderFunctions(
 // failure is returned. Each local binds the value it evaluated to, preserving
 // the nullability refinements references through the local read later.
 func seedLocalTypes(scope *eval.Context, config *ast.Config) error {
-	evaluator := eval.NewEvaluator(scope)
 	remaining := maps.Clone(config.Locals)
 	for len(remaining) > 0 {
 		progress := false
 		for name, l := range remaining {
-			val, diags := evaluator.Evaluate(l.Value)
+			val, diags := typeExpr(l.Value, scope.HCLContext())
 			if diags.HasErrors() {
 				continue
 			}
@@ -339,7 +338,7 @@ func seedLocalTypes(scope *eval.Context, config *ast.Config) error {
 		}
 		if !progress {
 			for _, name := range slices.Sorted(maps.Keys(remaining)) {
-				_, diags := evaluator.Evaluate(remaining[name].Value)
+				_, diags := typeExpr(remaining[name].Value, scope.HCLContext())
 				return fmt.Errorf("typing local %q: %s", name, diags.Error())
 			}
 		}
@@ -469,7 +468,7 @@ func inferOutputType(evaluator *eval.Evaluator, o *ast.Output) (cty.Value, error
 	if o.Value == nil {
 		return cty.NilVal, fmt.Errorf("output has no value expression")
 	}
-	val, diags := evaluator.Evaluate(o.Value)
+	val, diags := typeExpr(o.Value, evaluator.Context().HCLContext())
 	if diags.HasErrors() {
 		return cty.NilVal, fmt.Errorf("%s", diags.Error())
 	}

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -382,8 +382,9 @@ func seedResourceTypes(
 			return fmt.Errorf("resolving resource %q: no schema for type %q", key, res.Type)
 		}
 		mapping := resolver.ResourceBodyMapping(ctx, res.Type)
+		ranged := res.Count != nil || res.ForEach != nil
 		ty := rangedType(transform.ResourceReferenceType(schemaRes, mapping), res.Count != nil, res.ForEach != nil)
-		scope.SetResource(key, urn.URN(""), transform.RefinedUnknown(ty, false))
+		scope.SetResource(key, urn.URN(""), markRangedRef(transform.RefinedUnknown(ty, false), ranged))
 	}
 
 	for _, key := range slices.Sorted(maps.Keys(config.DataSources)) {
@@ -396,8 +397,9 @@ func seedResourceTypes(
 			return fmt.Errorf("resolving data source %q: no schema for type %q", key, ds.Type)
 		}
 		mapping := resolver.DataSourceBodyMapping(ctx, ds.Type)
+		ranged := ds.Count != nil || ds.ForEach != nil
 		ty := rangedType(transform.DataSourceReferenceType(fn, mapping), ds.Count != nil, ds.ForEach != nil)
-		scope.SetDataSource(key, transform.RefinedUnknown(ty, false))
+		scope.SetDataSource(key, markRangedRef(transform.RefinedUnknown(ty, false), ranged))
 	}
 	return nil
 }
@@ -449,9 +451,9 @@ func seedModuleTypes(
 		var val cty.Value
 		switch {
 		case call.Count != nil:
-			val = cty.UnknownVal(cty.List(obj.Type())).RefineNotNull()
+			val = cty.UnknownVal(cty.List(obj.Type())).RefineNotNull().Mark(rangedRefMark{})
 		case call.ForEach != nil:
-			val = cty.UnknownVal(cty.Map(obj.Type())).RefineNotNull()
+			val = cty.UnknownVal(cty.Map(obj.Type())).RefineNotNull().Mark(rangedRefMark{})
 		default:
 			val = obj
 		}

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -315,6 +315,40 @@ output "parenthesized_length" {
 	}, moduleSchema.RequiredOutputs)
 }
 
+// TestIndexedVariableElementStaysNullable shows that only a ranged reference
+// refines the instance an index yields: a list variable may hold null
+// elements, so an element indexed out of it stays nullable, as do its
+// attributes.
+func TestIndexedVariableElementStaysNullable(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+variable "l" {
+  type     = list(object({ a = string }))
+  nullable = false
+}
+
+output "first" {
+  value = var.l[0]
+}
+
+output "first_a" {
+  value = var.l[0].a
+}
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, nil, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]*PropertySpec{
+		"first":   {Type: TypeObject, Properties: map[string]*PropertySpec{"a": {Type: TypeString}}},
+		"first_a": {Type: TypeString},
+	}, moduleSchema.OutputProperties)
+	assert.Equal(t, []string{"l"}, moduleSchema.RequiredOutputs)
+}
+
 // TestUnsupportedAttributeIsError shows that a reference to an attribute the
 // resolved schema lacks fails typing with HCL's own diagnostic.
 func TestUnsupportedAttributeIsError(t *testing.T) {

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -255,6 +255,10 @@ resource "random_pet" "keyed" {
   length   = 2
 }
 
+variable "i" {
+  type = number
+}
+
 output "counted_id" {
   value = random_pet.counted[0].id
 }
@@ -274,6 +278,14 @@ output "counted_instance" {
 output "keyed_instance" {
   value = random_pet.keyed["a"]
 }
+
+output "indexed_by_var" {
+  value = random_pet.counted[var.i]
+}
+
+output "parenthesized_length" {
+  value = (random_pet.keyed)["a"].length
+}
 `
 	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
 	require.False(t, diags.HasErrors(), diags.Error())
@@ -290,13 +302,42 @@ output "keyed_instance" {
 		"length": {Type: TypeNumber},
 	}, Required: []string{"length"}}
 	assert.Equal(t, map[string]*PropertySpec{
-		"counted_id":       {Type: TypeString},
-		"keyed_id":         {Type: TypeString},
-		"all_counted":      {Type: TypeArray, Items: elem},
-		"counted_instance": elem,
-		"keyed_instance":   elem,
+		"counted_id":           {Type: TypeString},
+		"keyed_id":             {Type: TypeString},
+		"all_counted":          {Type: TypeArray, Items: elem},
+		"counted_instance":     elem,
+		"keyed_instance":       elem,
+		"indexed_by_var":       elem,
+		"parenthesized_length": {Type: TypeNumber},
 	}, moduleSchema.OutputProperties)
-	assert.Equal(t, []string{"all_counted", "counted_instance", "keyed_instance"}, moduleSchema.RequiredOutputs)
+	assert.Equal(t, []string{
+		"all_counted", "counted_instance", "indexed_by_var", "keyed_instance", "parenthesized_length",
+	}, moduleSchema.RequiredOutputs)
+}
+
+// TestUnsupportedAttributeIsError shows that a reference to an attribute the
+// resolved schema lacks fails typing with HCL's own diagnostic.
+func TestUnsupportedAttributeIsError(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+resource "random_pet" "name" {
+  length = 2
+}
+
+output "missing" {
+  value = random_pet.name.missing
+}
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	resolver := stubResolver{resources: map[string]*pulumiSchema.Resource{
+		"random_pet": {Properties: []*pulumiSchema.Property{{Name: "length", Type: pulumiSchema.IntType}}},
+	}}
+	_, err := GenerateModuleSchema(
+		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.EqualError(t, err, `typing output "missing": main.tf:7,26-34: Unsupported attribute; This object does not have an attribute named "missing".`)
 }
 
 // mappingResolver resolves resources and their bridge body mappings by TF type,

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -266,6 +266,14 @@ output "all_counted" {
 output "keyed_id" {
   value = random_pet.keyed["a"].id
 }
+
+output "counted_instance" {
+  value = random_pet.counted[0]
+}
+
+output "keyed_instance" {
+  value = random_pet.keyed["a"]
+}
 `
 	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
 	require.False(t, diags.HasErrors(), diags.Error())
@@ -282,10 +290,13 @@ output "keyed_id" {
 		"length": {Type: TypeNumber},
 	}, Required: []string{"length"}}
 	assert.Equal(t, map[string]*PropertySpec{
-		"counted_id":  {Type: TypeString},
-		"keyed_id":    {Type: TypeString},
-		"all_counted": {Type: TypeArray, Items: elem},
+		"counted_id":       {Type: TypeString},
+		"keyed_id":         {Type: TypeString},
+		"all_counted":      {Type: TypeArray, Items: elem},
+		"counted_instance": elem,
+		"keyed_instance":   elem,
 	}, moduleSchema.OutputProperties)
+	assert.Equal(t, []string{"all_counted", "counted_instance", "keyed_instance"}, moduleSchema.RequiredOutputs)
 }
 
 // mappingResolver resolves resources and their bridge body mappings by TF type,

--- a/pkg/hcl/schema/typeexpr.go
+++ b/pkg/hcl/schema/typeexpr.go
@@ -1,0 +1,80 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pulumi/pulumi-hcl/pkg/hcl/transform"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// typeExpr evaluates expr against ctx for its type, the way HCL would, except
+// that traversals are applied one step at a time so an object indexed out of
+// an unknown collection regains the null refinements of its type. Every other
+// expression is delegated to HCL.
+func typeExpr(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+	switch e := expr.(type) {
+	case *hclsyntax.ParenthesesExpr:
+		return typeExpr(e.Expression, ctx)
+
+	case *hclsyntax.ScopeTraversalExpr:
+		root, diags := e.Traversal[:1].TraverseAbs(ctx)
+		if diags.HasErrors() {
+			return root, diags
+		}
+		return traverse(root, e.Traversal[1:])
+
+	case *hclsyntax.RelativeTraversalExpr:
+		source, diags := typeExpr(e.Source, ctx)
+		if diags.HasErrors() {
+			return source, diags
+		}
+		return traverse(source, e.Traversal)
+
+	case *hclsyntax.IndexExpr:
+		collection, diags := typeExpr(e.Collection, ctx)
+		if diags.HasErrors() {
+			return collection, diags
+		}
+		key, keyDiags := e.Key.Value(ctx)
+		if keyDiags.HasErrors() {
+			return key, keyDiags
+		}
+		return traverse(collection, hcl.Traversal{hcl.TraverseIndex{Key: key, SrcRange: e.SrcRange}})
+	}
+
+	return expr.Value(ctx)
+}
+
+// traverse applies traversal to val one step at a time. An unknown collection,
+// such as a counted or for_each reference, yields an unrefined unknown when
+// indexed; when that element is an object it is rebuilt with the refinements
+// its type implies, as a direct reference to the same object carries, so
+// attributes reached through the index keep their nullability.
+func traverse(val cty.Value, traversal hcl.Traversal) (cty.Value, hcl.Diagnostics) {
+	for _, step := range traversal {
+		collection := val
+		var diags hcl.Diagnostics
+		val, diags = hcl.Traversal{step}.TraverseRel(collection)
+		if diags.HasErrors() {
+			return val, diags
+		}
+		if _, isIndex := step.(hcl.TraverseIndex); isIndex && !collection.IsKnown() && val.Type().IsObjectType() {
+			val = transform.RefinedUnknown(val.Type(), false).WithSameMarks(val)
+		}
+	}
+	return val, nil
+}

--- a/pkg/hcl/schema/typeexpr.go
+++ b/pkg/hcl/schema/typeexpr.go
@@ -21,9 +21,25 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// rangedRefMark marks the unknown list or map a counted or for_each resource,
+// data source, or module reference is seeded as. An index into such a
+// collection resolves to an instance or errors, so the instance is never null
+// and its attributes carry the refinements of a direct reference. A collection
+// from anywhere else, such as a variable, may hold null elements and is left
+// alone.
+type rangedRefMark struct{}
+
+// markRangedRef marks val as a ranged reference when ranged is true.
+func markRangedRef(val cty.Value, ranged bool) cty.Value {
+	if ranged {
+		return val.Mark(rangedRefMark{})
+	}
+	return val
+}
+
 // typeExpr evaluates expr against ctx for its type, the way HCL would, except
 // that traversals are applied one step at a time so an object indexed out of
-// an unknown collection regains the null refinements of its type. Every other
+// a ranged reference regains the null refinements of its type. Every other
 // expression is delegated to HCL.
 func typeExpr(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	switch e := expr.(type) {
@@ -59,11 +75,12 @@ func typeExpr(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnos
 	return expr.Value(ctx)
 }
 
-// traverse applies traversal to val one step at a time. An unknown collection,
-// such as a counted or for_each reference, yields an unrefined unknown when
-// indexed; when that element is an object it is rebuilt with the refinements
-// its type implies, as a direct reference to the same object carries, so
-// attributes reached through the index keep their nullability.
+// traverse applies traversal to val one step at a time. A ranged reference
+// yields an unrefined unknown when indexed; when that instance is an object it
+// is rebuilt with the refinements its type implies, as a direct reference to
+// the same object carries, so attributes reached through the index keep their
+// nullability. The instance sheds the ranged-reference mark, since it is no
+// longer a collection of instances.
 func traverse(val cty.Value, traversal hcl.Traversal) (cty.Value, hcl.Diagnostics) {
 	for _, step := range traversal {
 		collection := val
@@ -72,8 +89,10 @@ func traverse(val cty.Value, traversal hcl.Traversal) (cty.Value, hcl.Diagnostic
 		if diags.HasErrors() {
 			return val, diags
 		}
-		if _, isIndex := step.(hcl.TraverseIndex); isIndex && !collection.IsKnown() && val.Type().IsObjectType() {
-			val = transform.RefinedUnknown(val.Type(), false).WithSameMarks(val)
+		if _, isIndex := step.(hcl.TraverseIndex); isIndex && collection.HasMark(rangedRefMark{}) && val.Type().IsObjectType() {
+			_, marks := val.Unmark()
+			delete(marks, rangedRefMark{})
+			val = transform.RefinedUnknown(val.Type(), false).WithMarks(marks)
 		}
 	}
 	return val, nil


### PR DESCRIPTION
## Summary

A direct resource, data source, or module reference is seeded as a known object whose attributes carry the null refinements the provider schema implies. A `count` or `for_each` reference is seeded as an unknown list or map, and an index into it yields an unrefined unknown object, so nothing read through `res[0]` was marked required in a module's generated schema. The same resource's whole-list output did mark those attributes required, so the schema was inconsistent with itself.

Locals and outputs are now typed through a traversal-aware step that applies each traversal step itself. When an index into an unknown collection yields an object, the object is rebuilt with the refinements its type implies, the same way a direct reference is seeded. Every other expression is still delegated to HCL.

This is the base for the union typing fix for https://github.com/pulumi/pulumi-hcl/issues/605, which builds on the same typing step.

## Testing

`TestRangedResourceOutputsAreTyped` now also outputs the indexed instances themselves and asserts the required outputs and their required attributes.