### PR TITLE
Type a conditional over non-unifying branches as a union in a module schema

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-605.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-605.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: "Type a conditional whose branches do not unify, such as `var.create ? res[0] : data.res[0]`, as a union in a module's generated schema instead of failing schema generation"
+time: 2026-09-04T10:58:33Z
+custom:
+    Component: runtime
+    PR: "605"

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -147,6 +147,10 @@ type PropertySpec struct {
 
 	// Ref is a reference to another type definition.
 	Ref string `json:"$ref,omitempty"`
+
+	// OneOf lists the alternatives of a union type: the value is of exactly one
+	// of them.
+	OneOf []*PropertySpec `json:"oneOf,omitempty"`
 }
 
 // GenerateModuleSchema generates a Pulumi schema from an HCL module
@@ -197,7 +201,7 @@ func GenerateModuleSchema(
 			return nil, fmt.Errorf("processing output %q: %w", o.Name, err)
 		}
 		schema.OutputProperties[o.Name] = prop
-		if !val.Range().CouldBeNull() {
+		if !couldBeNull(val) {
 			schema.RequiredOutputs = append(schema.RequiredOutputs, o.Name)
 		}
 	}
@@ -465,7 +469,8 @@ func seedModuleTypes(
 // inferOutputType evaluates an output's value expression against the type scope
 // and returns the resulting unknown value, whose type and nullability describe
 // the output. An output with no value, or one that cannot be evaluated against
-// the scope, is an error. The value is unmarked so its range can be read.
+// the scope, is an error. The value keeps only its union marks, so its range
+// can be read.
 func inferOutputType(evaluator *eval.Evaluator, o *ast.Output) (cty.Value, error) {
 	if o.Value == nil {
 		return cty.NilVal, fmt.Errorf("output has no value expression")
@@ -474,8 +479,7 @@ func inferOutputType(evaluator *eval.Evaluator, o *ast.Output) (cty.Value, error
 	if diags.HasErrors() {
 		return cty.NilVal, fmt.Errorf("%s", diags.Error())
 	}
-	unmarked, _ := val.UnmarkDeep()
-	return unmarked, nil
+	return keepUnions(val), nil
 }
 
 // variableToPropertySpec converts an HCL variable to a PropertySpec.
@@ -553,10 +557,22 @@ func outputToPropertySpec(o *ast.Output, val cty.Value) (*PropertySpec, error) {
 }
 
 // ctyValueToPropertySpec converts an inferred unknown value to a PropertySpec.
-// For object types it reads each attribute's nullability from the value's
-// refinements to populate Required; collections fall back to ctyTypeToPropertySpec,
-// where nested object fields' requiredness rides on optional-attribute metadata.
+// A union value becomes a OneOf over its members. For object types it reads
+// each attribute's nullability from the value's refinements to populate
+// Required; collections fall back to ctyTypeToPropertySpec, where nested object
+// fields' requiredness rides on optional-attribute metadata.
 func ctyValueToPropertySpec(v cty.Value) (*PropertySpec, error) {
+	if members, ok := unionMembers(v); ok {
+		oneOf := make([]*PropertySpec, len(members))
+		for i, m := range members {
+			spec, err := ctyValueToPropertySpec(m)
+			if err != nil {
+				return nil, err
+			}
+			oneOf[i] = spec
+		}
+		return &PropertySpec{OneOf: oneOf}, nil
+	}
 	t := v.Type()
 	if !t.IsObjectType() {
 		return ctyTypeToPropertySpec(t)
@@ -570,7 +586,7 @@ func ctyValueToPropertySpec(v cty.Value) (*PropertySpec, error) {
 			return nil, err
 		}
 		props[name] = propSpec
-		if !attr.Range().CouldBeNull() {
+		if !couldBeNull(attr) {
 			required = append(required, name)
 		}
 	}
@@ -724,6 +740,9 @@ func convertPropertyNames(v property.Value, spec *PropertySpec, toPulumi bool) p
 	if spec == nil || v.IsNull() || v.IsComputed() {
 		return v
 	}
+	if len(spec.OneOf) > 0 {
+		spec = mergeSpecs(spec.OneOf)
+	}
 	switch {
 	case len(spec.Properties) > 0 && v.IsMap():
 		obj := v.AsMap()
@@ -755,6 +774,43 @@ func convertPropertyNames(v property.Value, spec *PropertySpec, toPulumi bool) p
 	default:
 		return v
 	}
+}
+
+// mergeSpecs folds the alternatives of a union into one spec that renames every
+// field any alternative declares. A field's Pulumi name depends only on its HCL
+// name, so renaming against the merged spec renames a value of any alternative
+// correctly; the merged spec describes no single alternative's type.
+func mergeSpecs(specs []*PropertySpec) *PropertySpec {
+	merged := &PropertySpec{}
+	byName := map[string][]*PropertySpec{}
+	var items, additional []*PropertySpec
+	for _, spec := range specs {
+		if len(spec.OneOf) > 0 {
+			spec = mergeSpecs(spec.OneOf)
+		}
+		for name, field := range spec.Properties {
+			byName[name] = append(byName[name], field)
+		}
+		if spec.Items != nil {
+			items = append(items, spec.Items)
+		}
+		if spec.AdditionalProperties != nil {
+			additional = append(additional, spec.AdditionalProperties)
+		}
+	}
+	if len(byName) > 0 {
+		merged.Properties = make(map[string]*PropertySpec, len(byName))
+		for name, fields := range byName {
+			merged.Properties[name] = mergeSpecs(fields)
+		}
+	}
+	if len(items) > 0 {
+		merged.Items = mergeSpecs(items)
+	}
+	if len(additional) > 0 {
+		merged.AdditionalProperties = mergeSpecs(additional)
+	}
+	return merged
 }
 
 // ToPulumiPackageSchema converts the module schema to a full Pulumi package
@@ -919,6 +975,12 @@ func (s *ModuleSchema) schemaType(
 	prop *PropertySpec, typeName string, types map[string]pulumischema.ComplexTypeSpec,
 ) pulumischema.TypeSpec {
 	switch {
+	case len(prop.OneOf) > 0:
+		oneOf := make([]pulumischema.TypeSpec, len(prop.OneOf))
+		for i, member := range prop.OneOf {
+			oneOf[i] = s.schemaType(member, fmt.Sprintf("%s%d", typeName, i), types)
+		}
+		return pulumischema.TypeSpec{OneOf: oneOf}
 	case prop.Properties != nil:
 		token := fmt.Sprintf("%s:%s:%s", s.PackageName, s.Module, typeName)
 		fields := make(map[string]pulumischema.PropertySpec, len(prop.Properties))

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -378,24 +378,26 @@ output "missing" {
 // so output typing that depends on the mapping (e.g. MaxItemsOne block shape)
 // can be tested without a live provider.
 type mappingResolver struct {
-	resources map[string]*pulumiSchema.Resource
-	mappings  map[string]*bridge.BodyMapping
+	resources          map[string]*pulumiSchema.Resource
+	mappings           map[string]*bridge.BodyMapping
+	dataSources        map[string]*pulumiSchema.Function
+	dataSourceMappings map[string]*bridge.BodyMapping
 }
 
 func (s mappingResolver) ResolveResource(_ context.Context, tfType string) (*pulumiSchema.Resource, error) {
 	return s.resources[tfType], nil
 }
 
-func (mappingResolver) ResolveFunction(_ context.Context, _ string) (*pulumiSchema.Function, error) {
-	return nil, nil
+func (s mappingResolver) ResolveFunction(_ context.Context, tfType string) (*pulumiSchema.Function, error) {
+	return s.dataSources[tfType], nil
 }
 
 func (s mappingResolver) ResourceBodyMapping(_ context.Context, tfType string) *bridge.BodyMapping {
 	return s.mappings[tfType]
 }
 
-func (mappingResolver) DataSourceBodyMapping(_ context.Context, _ string) *bridge.BodyMapping {
-	return nil
+func (s mappingResolver) DataSourceBodyMapping(_ context.Context, tfType string) *bridge.BodyMapping {
+	return s.dataSourceMappings[tfType]
 }
 
 func (mappingResolver) ProviderFunctions(
@@ -1030,4 +1032,137 @@ func TestPackageSchema(t *testing.T) {
 		_, err := PackageSchema(nil, []*ModuleSchema{makeComponent("user-data"), makeComponent("userdata")})
 		require.EqualError(t, err, `modules "user-data" and "userdata" both map to Go package "userdata"`)
 	})
+}
+
+// TestConditionalResourceDataSourceOutputIsTyped covers the "create or adopt"
+// idiom: a conditional selects between a counted resource and its matching data
+// source, whose reference types differ (here in the `timeouts` operations and in
+// a resource-only attribute). At runtime only one branch ever holds a value, so
+// an attribute read through the local must type from the selected object.
+func TestConditionalResourceDataSourceOutputIsTyped(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+variable "create" {
+  type = bool
+}
+
+resource "pfx_res" "this" {
+  count = var.create ? 1 : 0
+}
+
+data "pfx_res" "this" {
+  count = var.create ? 0 : 1
+}
+
+locals {
+  selected = var.create ? pfx_res.this[0] : data.pfx_res.this[0]
+}
+
+output "selected_id" {
+  value = local.selected.id
+}
+
+output "selected_attr" {
+  value = local.selected.attr
+}
+
+output "selected" {
+  value = local.selected
+}
+
+output "wrapped" {
+  value = { inner = local.selected }
+}
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	resolver := mappingResolver{
+		resources: map[string]*pulumiSchema.Resource{
+			"pfx_res": {Properties: []*pulumiSchema.Property{{Name: "attr", Type: pulumiSchema.StringType}}},
+		},
+		mappings: map[string]*bridge.BodyMapping{
+			"pfx_res": {Timeouts: []string{"create", "read", "update", "delete"}},
+		},
+		dataSources: map[string]*pulumiSchema.Function{
+			"pfx_res": {ReturnType: &pulumiSchema.ObjectType{Properties: []*pulumiSchema.Property{
+				{Name: "id", Type: pulumiSchema.StringType},
+			}}},
+		},
+		dataSourceMappings: map[string]*bridge.BodyMapping{
+			"pfx_res": {Timeouts: []string{"read"}},
+		},
+	}
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+
+	// The synthetic `id` and `timeouts` of a resource reference are optional, so
+	// only the declared required property is required; a data source's `id` is a
+	// declared property.
+	resource := &PropertySpec{Type: TypeObject, Properties: map[string]*PropertySpec{
+		"attr": {Type: TypeString},
+		"id":   {Type: TypeString},
+		"timeouts": {Type: TypeObject, Properties: map[string]*PropertySpec{
+			"create": {Type: TypeString},
+			"delete": {Type: TypeString},
+			"read":   {Type: TypeString},
+			"update": {Type: TypeString},
+		}},
+	}, Required: []string{"attr"}}
+	dataSource := &PropertySpec{Type: TypeObject, Properties: map[string]*PropertySpec{
+		"id": {Type: TypeString},
+		"timeouts": {Type: TypeObject, Properties: map[string]*PropertySpec{
+			"read": {Type: TypeString},
+		}},
+	}, Required: []string{"id"}}
+	selected := &PropertySpec{OneOf: []*PropertySpec{resource, dataSource}}
+	assert.Equal(t, map[string]*PropertySpec{
+		"selected_id":   {Type: TypeString},
+		"selected_attr": {Type: TypeString},
+		"selected":      selected,
+		"wrapped": {Type: TypeObject, Properties: map[string]*PropertySpec{
+			"inner": selected,
+		}, Required: []string{"inner"}},
+	}, moduleSchema.OutputProperties)
+	assert.Equal(t, []string{"selected", "selected_attr", "wrapped"}, moduleSchema.RequiredOutputs)
+
+	spec := moduleSchema.ToPulumiPackageSchema()
+	assert.Equal(t, pulumiSchema.TypeSpec{OneOf: []pulumiSchema.TypeSpec{
+		{Ref: "#/types/pkg:index:Selected0"},
+		{Ref: "#/types/pkg:index:Selected1"},
+	}}, spec.Resources["pkg:index:pkg"].Properties["selected"].TypeSpec)
+	assert.Equal(t, []string{"attr", "id", "timeouts"}, slices.Sorted(maps.Keys(spec.Types["pkg:index:Selected0"].Properties)))
+	assert.Equal(t, []string{"id", "timeouts"}, slices.Sorted(maps.Keys(spec.Types["pkg:index:Selected1"].Properties)))
+	assert.Equal(t, pulumiSchema.TypeSpec{OneOf: []pulumiSchema.TypeSpec{
+		{Ref: "#/types/pkg:index:WrappedInner0"},
+		{Ref: "#/types/pkg:index:WrappedInner1"},
+	}}, spec.Types["pkg:index:Wrapped"].Properties["inner"].TypeSpec)
+}
+
+// TestConditionalUnifiedObjectsOutputIsMap shows that a conditional over objects
+// whose attribute types unify keeps HCL's own result: the branches become a map,
+// as they do at runtime, rather than a union.
+func TestConditionalUnifiedObjectsOutputIsMap(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+variable "flag" {
+  type = bool
+}
+
+output "disjoint" {
+  value = var.flag ? { a = "x" } : { b = 1 }
+}
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, nil, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]*PropertySpec{
+		"disjoint": {Type: TypeObject, AdditionalProperties: &PropertySpec{Type: TypeString}},
+	}, moduleSchema.OutputProperties)
 }

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -767,6 +767,44 @@ func TestBoundaryNameConversion(t *testing.T) {
 	})))
 }
 
+// TestUnionBoundaryNameConversion shows that a union output's fields are
+// renamed whichever member the value is, including a field only one member
+// declares and a nested object inside a member.
+func TestUnionBoundaryNameConversion(t *testing.T) {
+	t.Parallel()
+
+	s := &ModuleSchema{
+		OutputProperties: map[string]*PropertySpec{
+			"union_out": {OneOf: []*PropertySpec{
+				{Type: TypeObject, Properties: map[string]*PropertySpec{
+					"shared_field": {Type: TypeString},
+					"only_first": {Type: TypeObject, Properties: map[string]*PropertySpec{
+						"nested_field": {Type: TypeString},
+					}},
+				}},
+				{Type: TypeObject, Properties: map[string]*PropertySpec{
+					"shared_field": {Type: TypeString},
+					"only_second":  {Type: TypeString},
+				}},
+			}},
+		},
+	}
+	propMap := func(m map[string]any) property.Map {
+		return resource.FromResourcePropertyMap(resource.NewPropertyMapFromMap(m))
+	}
+
+	assert.Equal(t, propMap(map[string]any{
+		"unionOut": map[string]any{"sharedField": "a", "onlyFirst": map[string]any{"nestedField": "b"}},
+	}), s.OutputsToPulumi(propMap(map[string]any{
+		"union_out": map[string]any{"shared_field": "a", "only_first": map[string]any{"nested_field": "b"}},
+	})))
+	assert.Equal(t, propMap(map[string]any{
+		"unionOut": map[string]any{"sharedField": "c", "onlySecond": "d"},
+	}), s.OutputsToPulumi(propMap(map[string]any{
+		"union_out": map[string]any{"shared_field": "c", "only_second": "d"},
+	})))
+}
+
 // TestAnyTypedVariableIsAny reproduces
 // https://github.com/pulumi/pulumi-hcl/issues/515: a module input declared
 // `type = any` (or with no type constraint) must surface in the Pulumi schema
@@ -1165,4 +1203,70 @@ output "disjoint" {
 	assert.Equal(t, map[string]*PropertySpec{
 		"disjoint": {Type: TypeObject, AdditionalProperties: &PropertySpec{Type: TypeString}},
 	}, moduleSchema.OutputProperties)
+}
+
+// TestConditionalUnionOutsideTraversal shows the two ways a union leaves the
+// walker's precise handling: an attribute no member has is HCL's own error, and
+// a union that flows through a function call degrades to any.
+func TestConditionalUnionOutsideTraversal(t *testing.T) {
+	t.Parallel()
+
+	// A list attribute against a string attribute cannot unify, so the
+	// conditional is a union rather than HCL's map.
+	resolver := mappingResolver{
+		resources: map[string]*pulumiSchema.Resource{
+			"pfx_res": {Properties: []*pulumiSchema.Property{
+				{Name: "attr", Type: &pulumiSchema.ArrayType{ElementType: pulumiSchema.StringType}},
+			}},
+		},
+		dataSources: map[string]*pulumiSchema.Function{
+			"pfx_res": {ReturnType: &pulumiSchema.ObjectType{Properties: []*pulumiSchema.Property{
+				{Name: "id", Type: pulumiSchema.StringType},
+			}}},
+		},
+	}
+	const prelude = `
+variable "create" {
+  type = bool
+}
+
+resource "pfx_res" "this" {
+  count = var.create ? 1 : 0
+}
+
+data "pfx_res" "this" {
+  count = var.create ? 0 : 1
+}
+
+locals {
+  selected = var.create ? pfx_res.this[0] : data.pfx_res.this[0]
+}
+`
+	generate := func(t *testing.T, src string) (*ModuleSchema, error) {
+		config, diags := parser.NewParser().ParseSource("main.tf", []byte(prelude+src))
+		require.False(t, diags.HasErrors(), diags.Error())
+		return GenerateModuleSchema(
+			t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	}
+
+	t.Run("attribute of no member", func(t *testing.T) {
+		t.Parallel()
+		_, err := generate(t, `
+output "missing" {
+  value = local.selected.missing
+}
+`)
+		require.EqualError(t, err, `typing output "missing": main.tf:19,25-33: Unsupported attribute; This object does not have an attribute named "missing".`)
+	})
+
+	t.Run("through a function call", func(t *testing.T) {
+		t.Parallel()
+		moduleSchema, err := generate(t, `
+output "merged" {
+  value = merge(local.selected, {})
+}
+`)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]*PropertySpec{"merged": {Type: TypeAny}}, moduleSchema.OutputProperties)
+	})
 }

--- a/pkg/hcl/schema/typeexpr.go
+++ b/pkg/hcl/schema/typeexpr.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/transform"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // rangedRefMark marks the unknown list or map a counted or for_each resource,
@@ -38,13 +39,24 @@ func markRangedRef(val cty.Value, ranged bool) cty.Value {
 }
 
 // typeExpr evaluates expr against ctx for its type, the way HCL would, except
-// that traversals are applied one step at a time so an object indexed out of
-// a ranged reference regains the null refinements of its type. Every other
-// expression is delegated to HCL.
+// that a conditional whose branches do not unify types as the union of its
+// branches, traversals into a union type against each member, and traversals
+// are applied one step at a time so an object indexed out of a ranged
+// reference regains the null refinements of its type. Every other expression
+// is delegated to HCL; a union that reaches such an expression is stripped from
+// the result, since HCL evaluated it as a plain dynamic unknown.
 func typeExpr(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	switch e := expr.(type) {
 	case *hclsyntax.ParenthesesExpr:
 		return typeExpr(e.Expression, ctx)
+
+	case *hclsyntax.ConditionalExpr:
+		trueVal, trueDiags := typeExpr(e.TrueResult, ctx)
+		falseVal, falseDiags := typeExpr(e.FalseResult, ctx)
+		if trueDiags.HasErrors() || falseDiags.HasErrors() || !branchesDisagree(trueVal, falseVal) {
+			break
+		}
+		return unionVal([]cty.Value{trueVal, falseVal}), nil
 
 	case *hclsyntax.ScopeTraversalExpr:
 		root, diags := e.Traversal[:1].TraverseAbs(ctx)
@@ -69,31 +81,118 @@ func typeExpr(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnos
 		if keyDiags.HasErrors() {
 			return key, keyDiags
 		}
+		if _, isUnion := unionMembers(key); isUnion {
+			break
+		}
 		return traverse(collection, hcl.Traversal{hcl.TraverseIndex{Key: key, SrcRange: e.SrcRange}})
+
+	case *hclsyntax.TupleConsExpr:
+		elems := make([]cty.Value, len(e.Exprs))
+		for i, elemExpr := range e.Exprs {
+			elem, diags := typeExpr(elemExpr, ctx)
+			if diags.HasErrors() {
+				return elem, diags
+			}
+			elems[i] = elem
+		}
+		return cty.TupleVal(elems), nil
+
+	case *hclsyntax.ObjectConsExpr:
+		attrs := make(map[string]cty.Value, len(e.Items))
+		for _, item := range e.Items {
+			key, diags := item.KeyExpr.Value(ctx)
+			if diags.HasErrors() || key.IsMarked() || key.IsNull() || !key.IsKnown() {
+				attrs = nil
+				break
+			}
+			key, err := convert.Convert(key, cty.String)
+			if err != nil {
+				attrs = nil
+				break
+			}
+			val, diags := typeExpr(item.ValueExpr, ctx)
+			if diags.HasErrors() {
+				return val, diags
+			}
+			attrs[key.AsString()] = val
+		}
+		if attrs != nil {
+			return cty.ObjectVal(attrs), nil
+		}
 	}
 
-	return expr.Value(ctx)
+	val, diags := expr.Value(ctx)
+	return stripUnions(val), diags
 }
 
-// traverse applies traversal to val one step at a time. A ranged reference
-// yields an unrefined unknown when indexed; when that instance is an object it
-// is rebuilt with the refinements its type implies, as a direct reference to
-// the same object carries, so attributes reached through the index keep their
-// nullability. The instance sheds the ranged-reference mark, since it is no
-// longer a collection of instances.
+// branchesDisagree reports whether HCL would reject a conditional over the two
+// branch values: either is a union, or their types do not unify. A dynamic
+// branch never disagrees, matching HCL, which adopts the other branch's type.
+func branchesDisagree(trueVal, falseVal cty.Value) bool {
+	if _, ok := unionMembers(trueVal); ok {
+		return true
+	}
+	if _, ok := unionMembers(falseVal); ok {
+		return true
+	}
+	trueTy, falseTy := trueVal.Type(), falseVal.Type()
+	if trueTy == cty.DynamicPseudoType || falseTy == cty.DynamicPseudoType {
+		return false
+	}
+	unified, _ := convert.UnifyUnsafe([]cty.Type{trueTy, falseTy})
+	return unified == cty.NilType
+}
+
+// traverse applies traversal to val one step at a time. A step into a union
+// applies to each member; members the step rejects are dropped, since the
+// runtime rejects the step only when it selects such a member. When every
+// member rejects the step, its diagnostics are reported.
 func traverse(val cty.Value, traversal hcl.Traversal) (cty.Value, hcl.Diagnostics) {
 	for _, step := range traversal {
-		collection := val
-		var diags hcl.Diagnostics
-		val, diags = hcl.Traversal{step}.TraverseRel(collection)
-		if diags.HasErrors() {
-			return val, diags
+		members, isUnion := unionMembers(val)
+		if !isUnion {
+			var diags hcl.Diagnostics
+			val, diags = traverseStep(val, step)
+			if diags.HasErrors() {
+				return val, diags
+			}
+			continue
 		}
-		if _, isIndex := step.(hcl.TraverseIndex); isIndex && collection.HasMark(rangedRefMark{}) && val.Type().IsObjectType() {
-			_, marks := val.Unmark()
-			delete(marks, rangedRefMark{})
-			val = transform.RefinedUnknown(val.Type(), false).WithMarks(marks)
+		var survivors []cty.Value
+		var firstDiags hcl.Diagnostics
+		for _, m := range members {
+			stepped, diags := traverseStep(m, step)
+			if diags.HasErrors() {
+				if firstDiags == nil {
+					firstDiags = diags
+				}
+				continue
+			}
+			survivors = append(survivors, stepped)
 		}
+		if len(survivors) == 0 {
+			return cty.DynamicVal, firstDiags
+		}
+		val = unionVal(survivors)
 	}
 	return val, nil
+}
+
+// traverseStep applies one traversal step to val. A ranged reference yields an
+// unrefined unknown when indexed; when that instance is an object it is rebuilt
+// with the refinements its type implies, as a direct reference to the same
+// object carries, so attributes reached through the index keep their
+// nullability. The instance sheds the ranged-reference mark, since it is no
+// longer a collection of instances.
+func traverseStep(val cty.Value, step hcl.Traverser) (cty.Value, hcl.Diagnostics) {
+	stepped, diags := hcl.Traversal{step}.TraverseRel(val)
+	if diags.HasErrors() {
+		return stepped, diags
+	}
+	if _, isIndex := step.(hcl.TraverseIndex); isIndex && val.HasMark(rangedRefMark{}) && stepped.Type().IsObjectType() {
+		_, marks := stepped.Unmark()
+		delete(marks, rangedRefMark{})
+		stepped = transform.RefinedUnknown(stepped.Type(), false).WithMarks(marks)
+	}
+	return stepped, nil
 }

--- a/pkg/hcl/schema/union.go
+++ b/pkg/hcl/schema/union.go
@@ -1,0 +1,117 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"slices"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// unionMark marks a dynamic unknown that stands for one of several typed
+// values. cty has no union type, so a conditional whose branch types do not
+// unify is typed as the union of its branches: at runtime only the selected
+// branch is ever evaluated, so the result is one of the branch values, not a
+// unification of them. Members are never unions themselves and no member is
+// dynamic (a dynamic member makes the whole value dynamic).
+type unionMark struct {
+	members []cty.Value
+}
+
+// unionMembers returns the members of a union value, and false for any other
+// value.
+func unionMembers(v cty.Value) ([]cty.Value, bool) {
+	_, marks := v.Unmark()
+	for m := range marks {
+		if u, ok := m.(*unionMark); ok {
+			return u.members, true
+		}
+	}
+	return nil, false
+}
+
+// unionVal returns the value standing for any of members: the member itself
+// when they collapse to one distinct type, a dynamic unknown when any member is
+// dynamic, and otherwise a union of the distinct member types. Nested unions
+// are flattened. Members keep only their union marks, since the members ride
+// inside a mark where a later unmark cannot reach them.
+func unionVal(members []cty.Value) cty.Value {
+	var flat []cty.Value
+	for _, m := range members {
+		if nested, ok := unionMembers(m); ok {
+			flat = append(flat, nested...)
+			continue
+		}
+		if m.Type() == cty.DynamicPseudoType {
+			return cty.DynamicVal
+		}
+		m = keepUnions(m)
+		if !containsType(flat, m.Type()) {
+			flat = append(flat, m)
+		}
+	}
+	if len(flat) == 1 {
+		return flat[0]
+	}
+	return cty.DynamicVal.Mark(&unionMark{members: flat})
+}
+
+func containsType(vals []cty.Value, t cty.Type) bool {
+	return slices.ContainsFunc(vals, func(v cty.Value) bool { return v.Type().Equals(t) })
+}
+
+// couldBeNull reports whether v, or any member of a union v, could be null.
+func couldBeNull(v cty.Value) bool {
+	if members, ok := unionMembers(v); ok {
+		return slices.ContainsFunc(members, couldBeNull)
+	}
+	return v.Range().CouldBeNull()
+}
+
+// stripUnions removes every union mark from v's value tree. A union that flowed
+// through an operation the typing walker does not model carries stale members,
+// so the value degrades to what HCL computed for it (a dynamic unknown).
+func stripUnions(v cty.Value) cty.Value {
+	unmarked, pvms := v.UnmarkDeepWithPaths()
+	return unmarked.MarkWithPaths(filterMarks(pvms, func(m any) bool {
+		_, isUnion := m.(*unionMark)
+		return !isUnion
+	}))
+}
+
+// keepUnions removes every mark from v's value tree except union marks.
+func keepUnions(v cty.Value) cty.Value {
+	unmarked, pvms := v.UnmarkDeepWithPaths()
+	return unmarked.MarkWithPaths(filterMarks(pvms, func(m any) bool {
+		_, isUnion := m.(*unionMark)
+		return isUnion
+	}))
+}
+
+func filterMarks(pvms []cty.PathValueMarks, keep func(any) bool) []cty.PathValueMarks {
+	var out []cty.PathValueMarks
+	for _, pvm := range pvms {
+		kept := cty.ValueMarks{}
+		for m := range pvm.Marks {
+			if keep(m) {
+				kept[m] = struct{}{}
+			}
+		}
+		if len(kept) > 0 {
+			out = append(out, cty.PathValueMarks{Path: pvm.Path, Marks: kept})
+		}
+	}
+	return out
+}

--- a/tests/mlctest/conditional_union_test.go
+++ b/tests/mlctest/conditional_union_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mlctest_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/mlctest"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A component selects between a counted resource and its data source with a
+// conditional whose branches do not unify (https://github.com/pulumi/pulumi-hcl/issues/605).
+// The schema types the selected object as a union of the two branches, and
+// the program reads the data source's attributes through it.
+func TestConditionalUnion(t *testing.T) {
+	t.Parallel()
+	mlctest.RunCase(t, "conditional_union", mlctest.Case{
+		Providers: []mlctest.Provider{
+			{Name: "timeoutable", Factory: providers.TimeoutableProvider},
+		},
+		ExpectedOutputs: map[string]string{
+			"selected_id":     "timeoutable-data-id",
+			"selected_result": "read",
+		},
+	})
+}

--- a/tests/mlctest/testdata/cases/conditional_union/Main.yaml
+++ b/tests/mlctest/testdata/cases/conditional_union/Main.yaml
@@ -1,0 +1,8 @@
+resources:
+  a:
+    type: adopt:index:Module
+    properties:
+      create: false
+outputs:
+  selected_id: ${a.selectedId}
+  selected_result: ${a.selectedResult}

--- a/tests/mlctest/testdata/cases/conditional_union/adopt/PulumiPlugin.yaml
+++ b/tests/mlctest/testdata/cases/conditional_union/adopt/PulumiPlugin.yaml
@@ -1,0 +1,2 @@
+name: adopt
+runtime: hcl

--- a/tests/mlctest/testdata/cases/conditional_union/adopt/main.tf
+++ b/tests/mlctest/testdata/cases/conditional_union/adopt/main.tf
@@ -1,0 +1,31 @@
+# The "create or adopt" idiom: a conditional selects between a counted
+# resource and its matching data source. The two declare different timeout
+# operations, so their `timeouts` attribute types do not unify.
+variable "create" {
+  type = bool
+}
+
+resource "timeoutable_resource" "this" {
+  count     = var.create ? 1 : 0
+  input_one = "hello"
+}
+
+data "timeoutable_data" "this" {
+  count = var.create ? 0 : 1
+}
+
+locals {
+  selected = var.create ? timeoutable_resource.this[0] : data.timeoutable_data.this[0]
+}
+
+output "selected" {
+  value = local.selected
+}
+
+output "selected_id" {
+  value = local.selected.id
+}
+
+output "selected_result" {
+  value = local.selected.result
+}

--- a/tests/mlctest/testdata/cases/conditional_union/schema.json
+++ b/tests/mlctest/testdata/cases/conditional_union/schema.json
@@ -1,0 +1,110 @@
+{
+  "name": "adopt",
+  "version": "0.0.0-dev",
+  "config": {},
+  "types": {
+    "adopt:index:Selected0": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "inputOne": {
+          "type": "string"
+        },
+        "resourceId": {
+          "type": "string"
+        },
+        "result": {
+          "type": "string"
+        },
+        "timeouts": {
+          "$ref": "#/types/adopt:index:Selected0Timeouts"
+        }
+      },
+      "type": "object",
+      "required": [
+        "resourceId",
+        "result"
+      ]
+    },
+    "adopt:index:Selected0Timeouts": {
+      "properties": {
+        "create": {
+          "type": "string"
+        },
+        "default": {
+          "type": "string"
+        },
+        "delete": {
+          "type": "string"
+        },
+        "update": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "adopt:index:Selected1": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "result": {
+          "type": "string"
+        },
+        "timeouts": {
+          "$ref": "#/types/adopt:index:Selected1Timeouts"
+        }
+      },
+      "type": "object",
+      "required": [
+        "id",
+        "result"
+      ]
+    },
+    "adopt:index:Selected1Timeouts": {
+      "properties": {
+        "read": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "resources": {
+    "adopt:index:Module": {
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "selected": {
+          "oneOf": [
+            {
+              "$ref": "#/types/adopt:index:Selected0"
+            },
+            {
+              "$ref": "#/types/adopt:index:Selected1"
+            }
+          ]
+        },
+        "selectedId": {
+          "type": "string"
+        },
+        "selectedResult": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "selected",
+        "selectedResult"
+      ],
+      "inputProperties": {
+        "create": {
+          "type": "boolean"
+        }
+      },
+      "isComponent": true
+    }
+  }
+}

--- a/tests/tfcompat/l1_conditional_object_inconsistent_test.go
+++ b/tests/tfcompat/l1_conditional_object_inconsistent_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+func TestL1ConditionalObjectInconsistent(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_conditional_object_inconsistent", tfcompat.Case{
+		Stages: []tfcompat.Stage{{ExpectErr: "Inconsistent conditional result types"}},
+	})
+}

--- a/tests/tfcompat/l1_conditional_object_missing_attr_test.go
+++ b/tests/tfcompat/l1_conditional_object_missing_attr_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+func TestL1ConditionalObjectMissingAttr(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_conditional_object_missing_attr", tfcompat.Case{
+		Stages: []tfcompat.Stage{{ExpectErr: "Missing map element"}},
+	})
+}

--- a/tests/tfcompat/l1_conditional_object_test.go
+++ b/tests/tfcompat/l1_conditional_object_test.go
@@ -1,0 +1,26 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+)
+
+func TestL1ConditionalObject(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l1_conditional_object", tfcompat.Case{})
+}

--- a/tests/tfcompat/l2_conditional_resource_data_missing_attr_test.go
+++ b/tests/tfcompat/l2_conditional_resource_data_missing_attr_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+func TestL2ConditionalResourceDataMissingAttr(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_conditional_resource_data_missing_attr", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "timeoutable", Factory: providers.TimeoutableProvider},
+		},
+		Stages: []tfcompat.Stage{{ExpectErr: "Unsupported attribute"}},
+	})
+}

--- a/tests/tfcompat/l2_conditional_resource_data_test.go
+++ b/tests/tfcompat/l2_conditional_resource_data_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfcompat_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+func TestL2ConditionalResourceData(t *testing.T) {
+	t.Parallel()
+	tfcompat.RunCase(t, "l2_conditional_resource_data", tfcompat.Case{
+		Providers: []tfcompat.Provider{
+			{Name: "timeoutable", Factory: providers.TimeoutableProvider},
+		},
+	})
+}

--- a/tests/tfcompat/testdata/cases/l1_conditional_object/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_conditional_object/main.tf
@@ -1,0 +1,54 @@
+# A conditional whose branches are objects with different attribute sets
+# unifies to a map when the attribute types unify, and to the unified
+# object type when the attribute names match.
+variable "flag" {
+  type    = bool
+  default = true
+}
+
+locals {
+  disjoint = var.flag ? { a = "x" } : { b = "y" }
+  superset = var.flag ? { a = "x" } : { a = "y", b = "z" }
+  mixed    = !var.flag ? { a = "x" } : { b = 1 }
+  nested   = var.flag ? { shared = "s", inner = { p = "1" } } : { shared = "t", inner = { q = "2" } }
+}
+
+output "disjoint" {
+  value = local.disjoint
+}
+
+output "disjoint_a" {
+  value = local.disjoint.a
+}
+
+output "superset" {
+  value = local.superset
+}
+
+output "mixed" {
+  value = local.mixed
+}
+
+output "mixed_b" {
+  value = local.mixed.b
+}
+
+output "nested" {
+  value = local.nested
+}
+
+output "nested_inner" {
+  value = local.nested.inner
+}
+
+output "lookup_missing" {
+  value = lookup(local.disjoint, "b", "dflt")
+}
+
+output "can_missing" {
+  value = can(local.disjoint.b)
+}
+
+output "try_missing" {
+  value = try(local.disjoint.b, "fallback")
+}

--- a/tests/tfcompat/testdata/cases/l1_conditional_object_inconsistent/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_conditional_object_inconsistent/main.tf
@@ -1,0 +1,14 @@
+# Branch objects whose attribute types do not unify are an error, even
+# though only one branch is selected.
+variable "flag" {
+  type    = bool
+  default = true
+}
+
+locals {
+  inconsistent = var.flag ? { a = "x" } : { b = ["y"] }
+}
+
+output "inconsistent" {
+  value = local.inconsistent
+}

--- a/tests/tfcompat/testdata/cases/l1_conditional_object_missing_attr/main.tf
+++ b/tests/tfcompat/testdata/cases/l1_conditional_object_missing_attr/main.tf
@@ -1,0 +1,14 @@
+# The branches unify to a map, so an attribute that only the unselected
+# branch declares is a missing map element, not an unsupported attribute.
+variable "flag" {
+  type    = bool
+  default = true
+}
+
+locals {
+  disjoint = var.flag ? { a = "x" } : { b = "y" }
+}
+
+output "disjoint_b" {
+  value = local.disjoint.b
+}

--- a/tests/tfcompat/testdata/cases/l2_conditional_resource_data/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_conditional_resource_data/main.tf
@@ -1,0 +1,32 @@
+# The "create or adopt" idiom: a conditional selects between a counted
+# resource and its matching data source. The two declare different timeout
+# operations, so their `timeouts` attribute types differ.
+variable "create" {
+  type    = bool
+  default = false
+}
+
+resource "timeoutable_resource" "this" {
+  count     = var.create ? 1 : 0
+  input_one = "hello"
+}
+
+data "timeoutable_data" "this" {
+  count = var.create ? 0 : 1
+}
+
+locals {
+  selected = var.create ? timeoutable_resource.this[0] : data.timeoutable_data.this[0]
+}
+
+output "selected_id" {
+  value = local.selected.id
+}
+
+output "selected_result" {
+  value = local.selected.result
+}
+
+output "selected_timeouts" {
+  value = local.selected.timeouts
+}

--- a/tests/tfcompat/testdata/cases/l2_conditional_resource_data_missing_attr/main.tf
+++ b/tests/tfcompat/testdata/cases/l2_conditional_resource_data_missing_attr/main.tf
@@ -1,0 +1,23 @@
+# The selected branch is the data source, so an attribute that only the
+# resource declares is unsupported.
+variable "create" {
+  type    = bool
+  default = false
+}
+
+resource "timeoutable_resource" "this" {
+  count     = var.create ? 1 : 0
+  input_one = "hello"
+}
+
+data "timeoutable_data" "this" {
+  count = var.create ? 0 : 1
+}
+
+locals {
+  selected = var.create ? timeoutable_resource.this[0] : data.timeoutable_data.this[0]
+}
+
+output "selected_input_one" {
+  value = local.selected.input_one
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-hcl/issues/605

`var.create ? res[0] : data.res[0]` failed schema generation because the generator typed both branches and HCL could not unify the two object types. At runtime the unselected branch is dynamic, so HCL never unifies them and the result is the selected object.

The generator now types a conditional whose branches do not unify as a union of the branches. A traversal into a union applies to each member, so `selected.id` still types as a string. The schema emits the union as `oneOf` over named member types. A union that reaches an expression the walker does not model degrades to `any`. tfcompat cases lock in the runtime semantics against OpenTofu.