### PR TITLE
Update CODEOWNERS for renamed GitHub teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pulumi/platform
+* @pulumi/iac-core


### PR DESCRIPTION
The GitHub team `@pulumi/platform` no longer exists. The GitHub teams API returns 404 for that slug, so GitHub requests no reviews from it. This change maps `@pulumi/platform` to `@pulumi/iac-core`. The source of truth is `teams.yaml` in `pulumi/team-management`, at commit 525c7378, "Realign teams to the Aug 17 reorg".
