### PR TITLE
Add mlctest, a harness for HCL components consumed from YAML

### DIFF
--- a/tests/mlctest/native_test.go
+++ b/tests/mlctest/native_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mlctest_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/mlctest"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+)
+
+// A local HCL component declares a native Pulumi provider with
+// `source = "pulumi/echo"`; `pulumi install` resolves the attached provider
+// and the component's resource is created through it. `pulumi install`
+// writes no SDK descriptor for a Pulumi package that is not parameterized,
+// so the runtime resolves the provider by name and its default provider
+// carries no version.
+func TestNative(t *testing.T) {
+	t.Parallel()
+	mlctest.RunCase(t, "native", mlctest.Case{
+		Providers: []mlctest.Provider{
+			{Name: "echo", Native: providers.EchoProvider},
+		},
+		ExpectedOutputs: map[string]string{
+			"greeting": "hello world",
+		},
+		AssertState: func(t *testing.T, resources []apitype.ResourceV3) {
+			type res struct{ Type, URN, Parent string }
+			got := make([]res, len(resources))
+			for i, r := range resources {
+				got[i] = res{string(r.Type), string(r.URN), string(r.Parent)}
+			}
+			const stack = "urn:pulumi:test::tfcompat::pulumi:pulumi:Stack::tfcompat-test"
+			const module = "urn:pulumi:test::tfcompat::greeter:index:Module::g"
+			assert.Equal(t, []res{
+				{"pulumi:pulumi:Stack", stack, ""},
+				{"pulumi:providers:greeter", "urn:pulumi:test::tfcompat::pulumi:providers:greeter::default_0_0_0_dev", ""},
+				{"greeter:index:Module", module, stack},
+				{"pulumi:providers:echo", "urn:pulumi:test::tfcompat::pulumi:providers:echo::default", ""},
+				{
+					"echo:index:Thing",
+					"urn:pulumi:test::tfcompat::greeter:index:Module$echo:index:Thing::g-hello",
+					module,
+				},
+			}, got)
+		},
+	})
+}

--- a/tests/mlctest/simple_test.go
+++ b/tests/mlctest/simple_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mlctest_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/mlctest"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfexec"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/assert"
+)
+
+// A YAML program passes a variable to a local HCL component and reads its
+// output; the component's resource is a child of the component.
+func TestSimple(t *testing.T) {
+	t.Parallel()
+	mlctest.RunCase(t, "simple", mlctest.Case{
+		Providers: []mlctest.Provider{
+			{Name: "simple", Factory: providers.SimpleProvider},
+		},
+		ExpectedOutputs: map[string]string{
+			"result": "hello-true",
+		},
+		AssertState: func(t *testing.T, resources []apitype.ResourceV3) {
+			type res struct{ Type, URN, Parent string }
+			got := make([]res, len(resources))
+			for i, r := range resources {
+				got[i] = res{string(r.Type), string(r.URN), string(r.Parent)}
+			}
+			const stack = "urn:pulumi:test::tfcompat::pulumi:pulumi:Stack::tfcompat-test"
+			const module = "urn:pulumi:test::tfcompat::wrapper:index:Module::w"
+			assert.Equal(t, []res{
+				{"pulumi:pulumi:Stack", stack, ""},
+				{"pulumi:providers:wrapper", "urn:pulumi:test::tfcompat::pulumi:providers:wrapper::default_0_0_0_dev", ""},
+				{"wrapper:index:Module", module, stack},
+				{"pulumi:providers:simple", "urn:pulumi:test::tfcompat::pulumi:providers:simple::default_0_0_0", ""},
+				{
+					"simple:index/resource:Resource",
+					"urn:pulumi:test::tfcompat::wrapper:index:Module$simple:index/resource:Resource::w-res",
+					module,
+				},
+			}, got)
+		},
+		AssertOps: func(t *testing.T, ops []tfexec.Op) {
+			assert.Equal(t, []tfexec.Op{{
+				Kind: tfexec.OpCreate,
+				Type: "simple_resource",
+				Inputs: map[string]any{
+					"for_each": "", "input_one": "hello", "input_two": true,
+					"prefix_result": "", "result": "", "version": "",
+				},
+				Outputs: map[string]any{
+					"for_each": "", "input_one": "hello", "input_two": true,
+					"prefix_result": "-hello", "result": "hello-true", "version": "",
+				},
+			}}, ops)
+		},
+	})
+}

--- a/tests/mlctest/testdata/cases/native/Main.yaml
+++ b/tests/mlctest/testdata/cases/native/Main.yaml
@@ -1,0 +1,7 @@
+resources:
+  g:
+    type: greeter:index:Module
+    properties:
+      name: world
+outputs:
+  greeting: ${g.greeting}

--- a/tests/mlctest/testdata/cases/native/greeter/PulumiPlugin.yaml
+++ b/tests/mlctest/testdata/cases/native/greeter/PulumiPlugin.yaml
@@ -1,0 +1,2 @@
+name: greeter
+runtime: hcl

--- a/tests/mlctest/testdata/cases/native/greeter/main.tf
+++ b/tests/mlctest/testdata/cases/native/greeter/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    echo = {
+      source = "pulumi/echo"
+    }
+  }
+}
+
+variable "name" {
+  type = string
+}
+
+resource "echo_thing" "hello" {
+  text = "hello ${var.name}"
+}
+
+output "greeting" {
+  value = echo_thing.hello.out
+}

--- a/tests/mlctest/testdata/cases/native/schema.json
+++ b/tests/mlctest/testdata/cases/native/schema.json
@@ -1,0 +1,27 @@
+{
+  "name": "greeter",
+  "version": "0.0.0-dev",
+  "config": {},
+  "resources": {
+    "greeter:index:Module": {
+      "properties": {
+        "greeting": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "greeting"
+      ],
+      "inputProperties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "isComponent": true
+    }
+  }
+}

--- a/tests/mlctest/testdata/cases/simple/Main.yaml
+++ b/tests/mlctest/testdata/cases/simple/Main.yaml
@@ -1,0 +1,7 @@
+resources:
+  w:
+    type: wrapper:index:Module
+    properties:
+      input: hello
+outputs:
+  result: ${w.result}

--- a/tests/mlctest/testdata/cases/simple/schema.json
+++ b/tests/mlctest/testdata/cases/simple/schema.json
@@ -1,0 +1,27 @@
+{
+  "name": "wrapper",
+  "version": "0.0.0-dev",
+  "config": {},
+  "resources": {
+    "wrapper:index:Module": {
+      "properties": {
+        "input": {
+          "type": "string"
+        },
+        "result": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "required": [
+        "result"
+      ],
+      "inputProperties": {
+        "input": {
+          "type": "string"
+        }
+      },
+      "isComponent": true
+    }
+  }
+}

--- a/tests/mlctest/testdata/cases/simple/wrapper/PulumiPlugin.yaml
+++ b/tests/mlctest/testdata/cases/simple/wrapper/PulumiPlugin.yaml
@@ -1,0 +1,2 @@
+name: wrapper
+runtime: hcl

--- a/tests/mlctest/testdata/cases/simple/wrapper/main.tf
+++ b/tests/mlctest/testdata/cases/simple/wrapper/main.tf
@@ -1,0 +1,12 @@
+variable "input" {
+  type = string
+}
+
+resource "simple_resource" "res" {
+  input_one = var.input
+  input_two = true
+}
+
+output "result" {
+  value = simple_resource.res.result
+}

--- a/tests/testutil/mlctest/mlctest.go
+++ b/tests/testutil/mlctest/mlctest.go
@@ -1,0 +1,170 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mlctest is the component half of putest: it runs a YAML program
+// that consumes one local HCL component directory, pins the component's
+// package schema against a golden file, and asserts on stack outputs,
+// exported Pulumi state, and recorded provider operations.
+package mlctest
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	gp "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-hcl/tests/testutil"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/pulexec"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfexec"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Provider describes an in-memory provider the component's resources use.
+// Exactly one of Factory, PFFactory, and Native must be set.
+type Provider struct {
+	Name string
+	// Factory builds an SDKv2 (helper/schema) Terraform provider.
+	Factory func() *schema.Provider
+	// PFFactory builds a terraform-plugin-framework provider.
+	PFFactory func() pfprovider.Provider
+	// Native builds a native pulumi-go-provider.
+	Native func() gp.Provider
+}
+
+// Case is the test description passed to RunCase.
+type Case struct {
+	Providers []Provider
+	// Config is set as stack config.
+	Config map[string]string
+	// ExpectedOutputs, if non-nil, must equal the stack outputs exactly.
+	// Non-string outputs appear in their compact-JSON form (see
+	// pulexec.Result).
+	ExpectedOutputs map[string]string
+	// AssertState, if set, runs against the exported resources after the
+	// apply.
+	AssertState func(t *testing.T, resources []apitype.ResourceV3)
+	// AssertOps, if set, runs against the recorded provider operations after
+	// the apply.
+	AssertOps func(t *testing.T, ops []tfexec.Op)
+}
+
+// RunCase resolves testdata/cases/<caseName>/ relative to the calling test
+// file and runs it. The case directory holds Main.yaml, the golden
+// schema.json, and exactly one subdirectory: the HCL component, whose name is
+// the package name the YAML program refers to.
+func RunCase(t *testing.T, caseName string, c Case) {
+	t.Helper()
+
+	_, callerFile, _, _ := runtime.Caller(1)
+	caseDir := filepath.Join(filepath.Dir(callerFile), "testdata", "cases", caseName)
+	files, err := testutil.LoadCaseDir(caseDir)
+	require.NoError(t, err)
+	delete(files, "schema.json")
+
+	pkgs := map[string]struct{}{}
+	for path := range files {
+		if dir, _, nested := strings.Cut(path, string(filepath.Separator)); nested {
+			pkgs[dir] = struct{}{}
+		}
+	}
+	require.Lenf(t, pkgs, 1, "case %s must hold exactly one component directory", caseName)
+	var pkg string
+	for dir := range pkgs {
+		pkg = dir
+	}
+	_, hasMain := files["Main.yaml"]
+	require.Truef(t, hasMain, "case %s has no Main.yaml", caseName)
+
+	rec := &tfexec.Recorder{}
+	driver := pulexec.NewYAMLDriver(t, pkg, providers(t, rec, c.Providers), c.Config)
+
+	schema, err := driver.PackageSchema(t, files, pkg)
+	require.NoError(t, err, "pulumi package get-schema failed")
+	assertGolden(t, filepath.Join(caseDir, "schema.json"), schema)
+
+	_, err = driver.Preview(t, files)
+	require.NoError(t, err, "pulumi preview failed")
+	res, err := driver.TryApply(t, files)
+	require.NoError(t, err, "pulumi up failed")
+
+	changes, err := driver.Preview(t, files)
+	require.NoError(t, err, "second pulumi preview failed")
+	for op := range changes {
+		require.Equalf(t, apitype.OpSame, op, "second preview is not a no-op: %v", changes)
+	}
+
+	if c.ExpectedOutputs != nil {
+		require.Equal(t, c.ExpectedOutputs, res.Outputs)
+	}
+	if c.AssertState != nil {
+		c.AssertState(t, res.Resources)
+	}
+	if c.AssertOps != nil {
+		c.AssertOps(t, rec.Ops())
+	}
+}
+
+// providers builds the in-process pulexec form of each Provider, with every
+// provider operation recorded into rec. SDKv2 providers record at the
+// helper/schema CRUD boundary, plugin-framework providers at the tfprotov6
+// boundary; native providers are not recorded.
+func providers(t *testing.T, rec *tfexec.Recorder, provs []Provider) []pulexec.Provider {
+	t.Helper()
+	out := make([]pulexec.Provider, len(provs))
+	for i, prov := range provs {
+		switch {
+		case prov.Factory != nil && prov.PFFactory == nil && prov.Native == nil:
+			factory := prov.Factory
+			out[i] = pulexec.SDKv2ProviderDynamic(t, prov.Name,
+				func() *schema.Provider { return tfexec.Wrap(factory(), rec) })
+		case prov.PFFactory != nil && prov.Factory == nil && prov.Native == nil:
+			out[i] = pulexec.PFProviderDynamic(t, prov.Name, prov.PFFactory, rec)
+		case prov.Native != nil && prov.Factory == nil && prov.PFFactory == nil:
+			out[i] = pulexec.NativeProvider(prov.Name, "0.0.1", prov.Native())
+		default:
+			t.Fatalf("provider %q: exactly one of Factory, PFFactory, or Native must be set", prov.Name)
+		}
+	}
+	return out
+}
+
+// assertGolden compares got against the JSON golden file at path, with both
+// sides re-indented so formatting differences do not fail the test. If
+// PULUMI_ACCEPT is truthy, it writes the golden file instead.
+func assertGolden(t *testing.T, path string, got []byte) {
+	t.Helper()
+
+	indent := func(raw []byte) string {
+		var buf bytes.Buffer
+		require.NoError(t, json.Indent(&buf, bytes.TrimSpace(raw), "", "  "))
+		return buf.String() + "\n"
+	}
+
+	if cmdutil.IsTruthy(os.Getenv("PULUMI_ACCEPT")) {
+		require.NoError(t, os.WriteFile(path, []byte(indent(got)), 0o644)) //nolint:gosec // golden file
+		return
+	}
+	want, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err, "golden file %s not found; run with PULUMI_ACCEPT=1 to generate", path)
+	assert.Equal(t, indent(want), indent(got))
+}

--- a/tests/testutil/pulexec/run.go
+++ b/tests/testutil/pulexec/run.go
@@ -15,6 +15,7 @@
 package pulexec
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -128,9 +129,36 @@ type Driver struct {
 // any stack config. Call Driver.Apply once per stage.
 func NewDriver(t *testing.T, provs []Provider, config map[string]string) *Driver {
 	t.Helper()
+	return newDriver(t, provs, config, "hcl", "")
+}
+
+// NewYAMLDriver builds a project whose root program is YAML and whose
+// packages entry points at the local HCL component directory pkgDir. The
+// engine launches that component through the language host's RunPlugin RPC,
+// so the component provider also runs in the test process. `pulumi install`
+// runs before each stage and writes the SDK descriptors the component needs.
+func NewYAMLDriver(t *testing.T, pkgDir string, provs []Provider, config map[string]string) *Driver {
+	t.Helper()
+	return newDriver(t, provs, config, "yaml", pkgDir)
+}
+
+// newDriver builds the project with the given Pulumi.yaml runtime and the
+// local component directory the project consumes, if any.
+func newDriver(
+	t *testing.T, provs []Provider, config map[string]string, runtime, componentDir string,
+) *Driver {
+	t.Helper()
 
 	hostPort := serveLanguageHost(t)
 	dir := t.TempDir()
+
+	extraProject := ""
+	if componentDir != "" {
+		// TODO[https://github.com/pulumi/pulumi/pull/24596]: a plugin started
+		// inside the component resolves a relative package path against its
+		// own working directory, so the path is absolute.
+		extraProject = fmt.Sprintf("packages:\n  %s: %s\n", componentDir, filepath.Join(dir, componentDir))
+	}
 
 	reattach := map[string]*goplugin.ReattachConfig{}
 	for _, p := range provs {
@@ -149,10 +177,11 @@ func NewDriver(t *testing.T, provs []Provider, config map[string]string) *Driver
 	// The project name is used as the default namespace for user config. It
 	// must not collide with any attached provider name, or user config like
 	// "<project>:foo" would be misrouted to the provider.
-	pulumiYAML := `name: tfcompat
-runtime: hcl
+	pulumiYAML := fmt.Sprintf(`name: tfcompat
+runtime: %s
 backend:
-  url: file://` + filepath.Join(dir, "state") + "\n"
+  url: file://%s
+%s`, runtime, filepath.Join(dir, "state"), extraProject)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte(pulumiYAML), 0o600))
 
 	env := [][2]string{
@@ -410,6 +439,41 @@ func converterShim(t *testing.T, port int) string {
 	return dir
 }
 
+// workspaceEnv returns the process env overlaid with the stack workspace's
+// env vars, for commands the harness must run itself rather than through
+// pulumitest.
+func (d *Driver) workspaceEnv(t *testing.T) []string {
+	t.Helper()
+	stack := d.pt.CurrentStack()
+	require.NotNil(t, stack, "driver has no stack")
+	// Go child processes resolve duplicate env entries last-wins, so
+	// appending overrides the test process env.
+	env := os.Environ()
+	for k, v := range stack.Workspace().GetEnvVars() {
+		env = append(env, k+"="+v)
+	}
+	return env
+}
+
+// PackageSchema writes programFiles and returns the package schema of the
+// local package directory dir, as `pulumi package get-schema ./<dir>` prints
+// it on stdout. Its stderr goes to the test log.
+func (d *Driver) PackageSchema(t *testing.T, programFiles map[string]string, dir string) ([]byte, error) {
+	t.Helper()
+	d.writeFiles(t, programFiles)
+
+	cmd := exec.Command("pulumi", "package", "get-schema", "./"+dir)
+	cmd.Dir = d.dir
+	cmd.Env = append(d.workspaceEnv(t), d.attachedProvidersEnv(t))
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if stderr.Len() > 0 {
+		t.Logf("pulumi package get-schema stderr:\n%s", stderr.String())
+	}
+	return out, err
+}
+
 // Import writes programFiles and runs `pulumi import --from hcl` with the
 // given converter arguments. The converter is served in-process behind a PATH
 // shim, and the CLI's mapper resolves mappings through the providers the
@@ -433,13 +497,10 @@ func (d *Driver) Import(t *testing.T, programFiles map[string]string, converterA
 	}, converterArgs...)
 	cmd := exec.Command("pulumi", args...)
 	cmd.Dir = d.dir
-	env := os.Environ()
+	env := d.workspaceEnv(t)
 	envPath := os.Getenv("PATH")
-	for k, v := range stack.Workspace().GetEnvVars() {
-		env = append(env, k+"="+v)
-		if k == "PATH" {
-			envPath = v
-		}
+	if p, ok := stack.Workspace().GetEnvVars()["PATH"]; ok {
+		envPath = p
 	}
 	shimDir := converterShim(t, d.serveConverter(t))
 	env = append(env, "PATH="+shimDir+string(os.PathListSeparator)+envPath)

--- a/tests/testutil/tfcompat/providers/echo.go
+++ b/tests/testutil/tfcompat/providers/echo.go
@@ -1,0 +1,53 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"encoding/json"
+
+	gp "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+// EchoProvider is a native Pulumi provider whose `echo:index:Thing` resource
+// copies its `text` input into its `out` output.
+func EchoProvider() gp.Provider {
+	return gp.Provider{
+		GetSchema: func(context.Context, gp.GetSchemaRequest) (gp.GetSchemaResponse, error) {
+			str := schema.PropertySpec{TypeSpec: schema.TypeSpec{Type: "string"}}
+			spec := schema.PackageSpec{
+				Name:    "echo",
+				Version: "0.0.1",
+				Resources: map[string]schema.ResourceSpec{
+					"echo:index:Thing": {
+						InputProperties: map[string]schema.PropertySpec{"text": str},
+						RequiredInputs:  []string{"text"},
+						ObjectTypeSpec: schema.ObjectTypeSpec{
+							Properties: map[string]schema.PropertySpec{"text": str, "out": str},
+							Required:   []string{"text", "out"},
+						},
+					},
+				},
+			}
+			raw, err := json.Marshal(spec)
+			return gp.GetSchemaResponse{Schema: string(raw)}, err
+		},
+		Create: func(_ context.Context, req gp.CreateRequest) (gp.CreateResponse, error) {
+			out := req.Properties.Get("text")
+			return gp.CreateResponse{ID: "id-0", Properties: req.Properties.Set("out", out)}, nil
+		},
+	}
+}


### PR DESCRIPTION
Adds `tests/mlctest`, a putest-style harness for HCL multi-language components. A case is:

- `Main.yaml`: the YAML program.
- One component directory (`PulumiPlugin.yaml` with `runtime: hcl` plus `*.tf`); its name is the package name.
- `schema.json`: the golden package schema, written with `PULUMI_ACCEPT=1`.
- `Providers`: in-memory providers. A Terraform provider (`Factory`, `PFFactory`) is served in-process over go-plugin and reached through the real terraform-provider plugin, as in tfcompat. A native provider (`Native`) is attached to the engine and the component declares it with `source = "pulumi/<name>"`.
- `ExpectedOutputs`, `AssertState`, `AssertOps`.

Every case also checks that `preview` and `up` succeed and that a second `preview` reports only `same`.

All pulumi-hcl code runs in the test process. The engine reaches the in-process language host through `PULUMI_DEBUG_LANGUAGES` and launches the component through its `RunPlugin` RPC, so no binary is built.

Two cases:

- `simple` wraps the bridged `simple_resource` in a component and pins the output, the state (the child resource parented to the component), the recorded create, and the schema.
- `native` wraps a resource of a native pulumi-go-provider and pins the output, the state, and the schema.

The `packages:` entry uses an absolute path. A plugin that starts inside the component resolves a relative path against its own working directory until https://github.com/pulumi/pulumi/pull/24596 (merged) ships in the plugins that link it.
