### PR TITLE
Run `pulumi install` for attached providers instead of stub SDKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,7 @@ jobs:
             go-test-
       - uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7
         with:
-          # TODO: move back to "dev" once a dev release carries
-          # https://github.com/pulumi/pulumi/pull/24604, which `pulumi install`
-          # needs for the attached providers in tests/putest.
-          pulumi-version: "pr#24604"
+          pulumi-version: "dev"
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       - uses: opentofu/setup-opentofu@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,10 @@ jobs:
             go-test-
       - uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7
         with:
-          pulumi-version: "dev"
+          # TODO: move back to "dev" once a dev release carries
+          # https://github.com/pulumi/pulumi/pull/24604, which `pulumi install`
+          # needs for the attached providers in tests/putest.
+          pulumi-version: "pr#24604"
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       - uses: opentofu/setup-opentofu@v2

--- a/tests/putest/testdata/cases/l2_ignore_changes_forcenew_block_removed/0/main.tf
+++ b/tests/putest/testdata/cases/l2_ignore_changes_forcenew_block_removed/0/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    fnblock = { source = "pulumi/fnblock" }
+  }
+}
+
 # Stage 0: create with a `settings` block. `mode` is ForceNew, and it is listed
 # in ignore_changes. `verbose` is an ordinary in-place attribute.
 resource "fnblock_resource" "r" {

--- a/tests/putest/testdata/cases/l2_ignore_changes_forcenew_block_removed/1/main.tf
+++ b/tests/putest/testdata/cases/l2_ignore_changes_forcenew_block_removed/1/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    fnblock = { source = "pulumi/fnblock" }
+  }
+}
+
 # Stage 1: remove the whole `settings` block. ignore_changes can no longer
 # reset the ForceNew `mode` (its index is gone), so the resource is REPLACED
 # and `settings` reports the replacement's empty list, matching OpenTofu. The

--- a/tests/putest/testdata/cases/l2_null_aliases/main.tf
+++ b/tests/putest/testdata/cases/l2_null_aliases/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    simple = { source = "pulumi/simple" }
+  }
+}
+
 resource "simple_resource" "res" {
   pulumi {
     aliases = tolist(null)

--- a/tests/putest/testdata/cases/l2_omitted_nested_block/main.tf
+++ b/tests/putest/testdata/cases/l2_omitted_nested_block/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    blocky = { source = "pulumi/blocky" }
+  }
+}
+
 # `rule` (MaxItems=1) is an optional nested block, left out here: it reads as
 # `[]`, matching OpenTofu. The plugin path reads null (https://github.com/pulumi/pulumi-hcl/issues/508).
 resource "blocky_thing" "t" {

--- a/tests/putest/testdata/cases/l2_optional_computed_block_unset/main.tf
+++ b/tests/putest/testdata/cases/l2_optional_computed_block_unset/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    optcomp = { source = "pulumi/optcomp" }
+  }
+}
+
 # `identity` is an Optional+Computed MaxItems=1 nested block the provider
 # leaves unset; `identity_set` is its TypeSet twin. Matching OpenTofu, the
 # list variant reads null and the set variant stays an empty set. The plugin

--- a/tests/putest/testdata/cases/l2_pf_max_items_one_attr/main.tf
+++ b/tests/putest/testdata/cases/l2_pf_max_items_one_attr/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    pfx = { source = "pulumi/pfx" }
+  }
+}
+
 resource "pfx_flat" "this" {
   settings = [{ enabled = true }]
 }

--- a/tests/putest/testdata/cases/l2_pf_max_items_one_attr_output/main.tf
+++ b/tests/putest/testdata/cases/l2_pf_max_items_one_attr_output/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    pfx = { source = "pulumi/pfx" }
+  }
+}
+
 resource "pfx_flat" "this" {
   settings = [{ enabled = true }]
 }

--- a/tests/putest/testdata/cases/l2_renamed_data_source_inputs/main.tf
+++ b/tests/putest/testdata/cases/l2_renamed_data_source_inputs/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    renamed = { source = "pulumi/renamed" }
+  }
+}
+
 data "renamed_lookup" "d" {
   query = "lambda"
 

--- a/tests/putest/testdata/cases/l2_renamed_data_source_nested_outputs/main.tf
+++ b/tests/putest/testdata/cases/l2_renamed_data_source_nested_outputs/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    renamed = { source = "pulumi/renamed" }
+  }
+}
+
 data "renamed_lookup" "d" {
   query = "lambda"
 }

--- a/tests/putest/testdata/cases/l2_renamed_data_source_outputs/main.tf
+++ b/tests/putest/testdata/cases/l2_renamed_data_source_outputs/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    renamed = { source = "pulumi/renamed" }
+  }
+}
+
 data "renamed_lookup" "d" {
   query = "lambda"
 }

--- a/tests/putest/testdata/cases/l2_renamed_outputs/main.tf
+++ b/tests/putest/testdata/cases/l2_renamed_outputs/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    renamed = { source = "pulumi/renamed" }
+  }
+}
+
 resource "renamed_thing" "r" {
   function_name = "alpha"
 

--- a/tests/putest/testdata/cases/l2_renamed_provider_config/main.tf
+++ b/tests/putest/testdata/cases/l2_renamed_provider_config/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    renamed = { source = "pulumi/renamed" }
+  }
+}
+
 provider "renamed" {
   endpoint = "https://example.test/api"
 

--- a/tests/putest/testdata/cases/l2_set_block_equality/main.tf
+++ b/tests/putest/testdata/cases/l2_set_block_equality/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    blocky = { source = "pulumi/blocky" }
+  }
+}
+
 # `filter` is a repeating TypeSet nested block: a cty set, so `== toset(...)`
 # of the same elements is true in either order, matching OpenTofu. The plugin
 # path materializes an ordered tuple and yields false (https://github.com/pulumi/pulumi-hcl/issues/509).

--- a/tests/putest/testdata/cases/l2_single_segment_token/main.tf
+++ b/tests/putest/testdata/cases/l2_single_segment_token/main.tf
@@ -1,3 +1,9 @@
+terraform {
+  required_providers {
+    single = { source = "pulumi/single" }
+  }
+}
+
 data "single" "ds" {
   query     = "hi"
   tag_value = "v"

--- a/tests/putest/testdata/cases/l2_union_discriminator_sensitive/main.tf
+++ b/tests/putest/testdata/cases/l2_union_discriminator_sensitive/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     union = {
-      source = "union"
+      source = "pulumi/union"
     }
   }
 }

--- a/tests/putest/testdata/cases/l2_union_discriminator_unknown/main.tf
+++ b/tests/putest/testdata/cases/l2_union_discriminator_unknown/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     union = {
-      source = "union"
+      source = "pulumi/union"
     }
   }
 }

--- a/tests/testutil/pulexec/run.go
+++ b/tests/testutil/pulexec/run.go
@@ -111,9 +111,9 @@ type Driver struct {
 	pt        *pulumitest.PulumiTest
 	dir       string
 	providers []Provider
-	// install is set when reattach providers are present: their SDKs are
-	// written by the real `pulumi install` flow, run once per stage.
-	install bool
+	// debugProviders is the PULUMI_DEBUG_PROVIDERS value for the attached
+	// providers, served once for the commands the harness runs itself.
+	debugProviders string
 	// extraEnv holds the same env pairs opttest.Env configures on the
 	// workspace, for commands the harness must run itself (`pulumi install`,
 	// which pulumitest runs without the workspace env).
@@ -189,7 +189,7 @@ backend:
 		opts = append(opts, opttest.AttachProvider(
 			p.Name,
 			func(ctx context.Context, pt providers.PulumiTest) (providers.Port, error) {
-				handle, err := startProvider(ctx, p.Start)
+				handle, err := startProvider(ctx, p.Start, nil)
 				if err != nil {
 					return 0, err
 				}
@@ -205,7 +205,6 @@ backend:
 		pt:        pt,
 		dir:       dir,
 		providers: provs,
-		install:   len(reattach) > 0,
 		extraEnv:  extraEnv,
 	}
 }
@@ -316,47 +315,50 @@ func (d *Driver) writeFiles(t *testing.T, programFiles map[string]string) {
 		require.NoError(t, os.WriteFile(fullPath, []byte(content), 0o600))
 		d.lastProgramFiles = append(d.lastProgramFiles, path)
 	}
-	d.writeStubSDKs(t)
-	if d.install {
-		// Reattach providers go through the real parameterization flow: the
-		// language host reports them as terraform-provider PackageSpecs and
-		// `pulumi install` runs the plugin (which reattaches to the in-process
-		// TF provider) to generate their SDK descriptors. pulumitest's Install
-		// runs without the workspace env, so run the command directly.
-		cmd := exec.Command("pulumi", "install")
-		cmd.Dir = d.dir
-		// Go child processes resolve duplicate env entries last-wins, so
-		// appending overrides the test process env.
-		cmd.Env = append(os.Environ(), d.extraEnv...)
-		out, err := cmd.CombinedOutput()
-		require.NoErrorf(t, err, "pulumi install failed: %s", out)
-	}
+	// Providers go through the real install flow. The language host reports
+	// a reattach provider as a terraform-provider PackageSpec, and `pulumi
+	// install` runs the plugin (which reattaches to the in-process TF
+	// provider) to generate its SDK descriptor. An attached provider is
+	// declared with `source = "pulumi/<name>"` and counts as installed.
+	// pulumitest's Install runs without the workspace env, so run the
+	// command directly.
+	cmd := exec.Command("pulumi", "install")
+	cmd.Dir = d.dir
+	// Go child processes resolve duplicate env entries last-wins, so
+	// appending overrides the test process env.
+	cmd.Env = append(os.Environ(), d.extraEnv...)
+	cmd.Env = append(cmd.Env, d.attachedProvidersEnv(t))
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "pulumi install failed: %s", out)
 }
 
-// writeStubSDKs materializes a minimal sdks/<provider>/hcl.sdk.json for each
-// attached provider. In production this file is written by `pulumi install`
-// (via GeneratePackage), but the harness uses AttachProvider, so the
-// terraform-provider plugin that `pulumi install` would normally invoke is
-// never run. The descriptor is intentionally unparameterized — AttachProvider
-// short-circuits plugin lookup to the in-process gRPC server.
-func (d *Driver) writeStubSDKs(t *testing.T) {
+// attachedProvidersEnv returns the PULUMI_DEBUG_PROVIDERS env pair that points
+// the CLI at the attached providers. pulumitest attaches them only around its
+// own operations, so the commands the harness runs itself get provider
+// servers of their own, started on first use and kept for the test.
+func (d *Driver) attachedProvidersEnv(t *testing.T) string {
 	t.Helper()
-	for _, p := range d.providers {
-		if p.Start == nil {
-			// Reattach providers get real SDKs from `pulumi install`.
-			continue
+	if d.debugProviders == "" {
+		cancel := make(chan bool)
+		t.Cleanup(func() { close(cancel) })
+		ports := map[providers.ProviderName]providers.Port{}
+		for _, p := range d.providers {
+			if p.Start == nil {
+				continue
+			}
+			handle, err := startProvider(t.Context(), p.Start, cancel)
+			require.NoError(t, err)
+			ports[providers.ProviderName(p.Name)] = providers.Port(handle.Port)
 		}
-		sdkDir := filepath.Join(d.dir, "sdks", p.Name)
-		require.NoError(t, os.MkdirAll(sdkDir, 0o755))
-		desc := fmt.Appendf(nil, `{"name":%q,"kind":"resource"}`+"\n", p.Name)
-		require.NoError(t, os.WriteFile(
-			filepath.Join(sdkDir, "hcl.sdk.json"), desc, 0o600,
-		))
+		d.debugProviders = providers.GetDebugProvidersEnv(ports)
 	}
+	return "PULUMI_DEBUG_PROVIDERS=" + d.debugProviders
 }
 
+// startProvider serves start's provider until cancel closes; a nil cancel
+// serves for the life of the process.
 func startProvider(
-	ctx context.Context, start func(context.Context) (pulumirpc.ResourceProviderServer, error),
+	ctx context.Context, start func(context.Context) (pulumirpc.ResourceProviderServer, error), cancel chan bool,
 ) (*rpcutil.ServeHandle, error) {
 	// Fail fast on providers that cannot start at all; the router then builds
 	// one instance server per engine connection.
@@ -365,6 +367,7 @@ func startProvider(
 	}
 
 	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: cancel,
 		Init: func(srv *grpc.Server) error {
 			pulumirpc.RegisterResourceProviderServer(srv, newConnRoutedProvider(start))
 			return nil


### PR DESCRIPTION
The pulexec driver wrote a stub `sdks/<name>/hcl.sdk.json` for each attached provider, so the HCL language host treated the provider as an installed Pulumi package without a real `pulumi install`. The stub emulated an install result that the CLI could not produce: `pulumi install` failed on a root program that requires an attached provider.

This PR removes the stubs. The driver runs `pulumi install` before every stage for every provider, with `PULUMI_DEBUG_PROVIDERS` set so the CLI counts an attached provider as installed. Each putest case declares its provider with `source = "pulumi/<name>"`, which is what a program that uses a native Pulumi provider writes.

This needs https://github.com/pulumi/pulumi/pull/24604. Without it, every putest case fails in `pulumi install`:

```
installing packages: expected "simple" to have an executable named "pulumi-resource-simple" or a PulumiPlugin file
```

CI installs the `dev` CLI, which carries the fix.
