### PR TITLE
Type a conditional over non-unifying branches as a union

### DIFF
--- a/.changes/unreleased/runtime-bug-fixes-605.yaml
+++ b/.changes/unreleased/runtime-bug-fixes-605.yaml
@@ -1,0 +1,6 @@
+kind: bug-fixes
+body: Type a conditional whose branches do not unify, such as a resource against its data source, as a union instead of failing schema generation
+time: 2026-09-10T12:08:43Z
+custom:
+    Component: runtime
+    PR: "605"

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -197,7 +197,7 @@ func GenerateModuleSchema(
 			return nil, fmt.Errorf("processing output %q: %w", o.Name, err)
 		}
 		schema.OutputProperties[o.Name] = prop
-		if !val.Range().CouldBeNull() {
+		if outputRequired(val) {
 			schema.RequiredOutputs = append(schema.RequiredOutputs, o.Name)
 		}
 	}
@@ -465,7 +465,9 @@ func seedModuleTypes(
 // inferOutputType evaluates an output's value expression against the type scope
 // and returns the resulting unknown value, whose type and nullability describe
 // the output. An output with no value, or one that cannot be evaluated against
-// the scope, is an error. The value is unmarked so its range can be read.
+// the scope, is an error. A union is returned as it is, so a parent module that
+// reads the output keeps its members; any other value is unmarked so its range
+// can be read.
 func inferOutputType(evaluator *eval.Evaluator, o *ast.Output) (cty.Value, error) {
 	if o.Value == nil {
 		return cty.NilVal, fmt.Errorf("output has no value expression")
@@ -473,6 +475,9 @@ func inferOutputType(evaluator *eval.Evaluator, o *ast.Output) (cty.Value, error
 	val, diags := typeExpr(o.Value, evaluator.Context().HCLContext())
 	if diags.HasErrors() {
 		return cty.NilVal, fmt.Errorf("%s", diags.Error())
+	}
+	if _, ok := asUnion(val); ok {
+		return val, nil
 	}
 	unmarked, _ := val.UnmarkDeep()
 	return unmarked, nil
@@ -556,7 +561,9 @@ func outputToPropertySpec(o *ast.Output, val cty.Value) (*PropertySpec, error) {
 // For object types it reads each attribute's nullability from the value's
 // refinements to populate Required; collections fall back to ctyTypeToPropertySpec,
 // where nested object fields' requiredness rides on optional-attribute metadata.
+// A union is of DynamicPseudoType, so it maps to the any type.
 func ctyValueToPropertySpec(v cty.Value) (*PropertySpec, error) {
+	v, _ = v.UnmarkDeep()
 	t := v.Type()
 	if !t.IsObjectType() {
 		return ctyTypeToPropertySpec(t)

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -473,6 +473,91 @@ output "evaluated" {
 	assert.Equal(t, []string{"either", "evaluated", "nested", "pruned", "same_type", "shared"}, moduleSchema.RequiredOutputs)
 }
 
+// TestConditionalUnionSharedAttributesKeepShape shows that an attribute both
+// union members declare with one structured type, such as an object type from
+// another package or a collection of such objects, types as that structure
+// through the union, with the nullability its schema declares.
+func TestConditionalUnionSharedAttributesKeepShape(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+variable "c" {
+  type = bool
+}
+
+resource "kind_a" "a" {}
+resource "kind_b" "b" {}
+
+locals {
+  either = var.c ? kind_a.a : kind_b.b
+}
+
+output "endpoint" {
+  value = local.either.endpoint
+}
+
+output "host" {
+  value = local.either.endpoint.host
+}
+
+output "port" {
+  value = local.either.endpoint.port
+}
+
+output "endpoints" {
+  value = local.either.endpoints
+}
+
+output "by_name" {
+  value = local.either.by_name
+}
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	endpoint := &pulumiSchema.ObjectType{
+		Token: "other:index:Endpoint",
+		Properties: []*pulumiSchema.Property{
+			{Name: "host", Type: pulumiSchema.StringType},
+			{Name: "port", Type: &pulumiSchema.OptionalType{ElementType: pulumiSchema.IntType}},
+		},
+	}
+	shared := []*pulumiSchema.Property{
+		{Name: "endpoint", Type: endpoint},
+		{Name: "endpoints", Type: &pulumiSchema.ArrayType{ElementType: endpoint}},
+		{Name: "by_name", Type: &pulumiSchema.MapType{ElementType: endpoint}},
+	}
+	resolver := stubResolver{resources: map[string]*pulumiSchema.Resource{
+		"kind_a": {Properties: append([]*pulumiSchema.Property{
+			{Name: "zones", Type: &pulumiSchema.ArrayType{ElementType: pulumiSchema.StringType}},
+		}, shared...)},
+		"kind_b": {Properties: append([]*pulumiSchema.Property{
+			{Name: "tags", Type: &pulumiSchema.MapType{ElementType: pulumiSchema.StringType}},
+		}, shared...)},
+	}}
+
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+
+	endpointSpec := &PropertySpec{
+		Type: TypeObject,
+		Properties: map[string]*PropertySpec{
+			"host": {Type: TypeString},
+			"port": {Type: TypeNumber},
+		},
+		Required: []string{"host"},
+	}
+	assert.Equal(t, map[string]*PropertySpec{
+		"endpoint":  endpointSpec,
+		"host":      {Type: TypeString},
+		"port":      {Type: TypeNumber},
+		"endpoints": {Type: TypeArray, Items: endpointSpec},
+		"by_name":   {Type: TypeObject, AdditionalProperties: endpointSpec},
+	}, moduleSchema.OutputProperties)
+	assert.Equal(t, []string{"by_name", "endpoint", "endpoints", "host"}, moduleSchema.RequiredOutputs)
+}
+
 // TestConditionalUnionCrossesModuleBoundary shows that a child module output
 // typed as a union keeps its members through a module.<name>.<output>
 // reference, so the parent can still step into it.

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -374,6 +374,198 @@ output "missing" {
 	require.EqualError(t, err, `typing output "missing": main.tf:7,26-34: Unsupported attribute; This object does not have an attribute named "missing".`)
 }
 
+// TestConditionalUnionOutputsAreTyped shows how a conditional over branches
+// whose types do not unify is typed: as a union, whose members a traversal
+// steps into one by one before the results unify again. Results of one type
+// unify to it; results of different types stay a union; a member the step does
+// not apply to is pruned.
+func TestConditionalUnionOutputsAreTyped(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+variable "c" {
+  type = bool
+}
+
+resource "kind_a" "a" {}
+resource "kind_a" "a2" {}
+resource "kind_b" "b" {}
+
+locals {
+  either = var.c ? kind_a.a : kind_b.b
+}
+
+output "either" {
+  value = local.either
+}
+
+output "shared" {
+  value = local.either.name
+}
+
+output "indexed" {
+  value = (var.c ? kind_a.a.zones : kind_b.b.tags)[0]
+}
+
+output "nested" {
+  value = local.either.nested
+}
+
+output "pruned" {
+  value = local.either.zones
+}
+
+output "nullable_member" {
+  value = (var.c ? null : local.either).name
+}
+
+output "nullable_union" {
+  value = var.c ? null : local.either
+}
+
+output "same_type" {
+  value = (var.c ? kind_a.a : kind_a.a2).name
+}
+
+output "evaluated" {
+  value = upper(local.either)
+}
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	resolver := stubResolver{resources: map[string]*pulumiSchema.Resource{
+		"kind_a": {
+			Properties: []*pulumiSchema.Property{
+				{Name: "name", Type: pulumiSchema.StringType},
+				{Name: "zones", Type: &pulumiSchema.ArrayType{ElementType: pulumiSchema.StringType}},
+				{Name: "nested", Type: &pulumiSchema.ObjectType{
+					Properties: []*pulumiSchema.Property{{Name: "x", Type: pulumiSchema.StringType}},
+				}},
+			},
+		},
+		"kind_b": {
+			Properties: []*pulumiSchema.Property{
+				{Name: "name", Type: pulumiSchema.StringType},
+				{Name: "tags", Type: &pulumiSchema.MapType{ElementType: pulumiSchema.StringType}},
+				{Name: "nested", Type: &pulumiSchema.ObjectType{
+					Properties: []*pulumiSchema.Property{{Name: "y", Type: pulumiSchema.StringType}},
+				}},
+			},
+		},
+	}}
+
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]*PropertySpec{
+		"either":          {Type: TypeAny},
+		"shared":          {Type: TypeString},
+		"indexed":         {Type: TypeString},
+		"nested":          {Type: TypeAny},
+		"pruned":          {Type: TypeArray, Items: &PropertySpec{Type: TypeString}},
+		"nullable_member": {Type: TypeString},
+		"nullable_union":  {Type: TypeAny},
+		"same_type":       {Type: TypeString},
+		"evaluated":       {Type: TypeString},
+	}, moduleSchema.OutputProperties)
+	assert.Equal(t, []string{"either", "evaluated", "nested", "pruned", "same_type", "shared"}, moduleSchema.RequiredOutputs)
+}
+
+// TestConditionalUnionCrossesModuleBoundary shows that a child module output
+// typed as a union keeps its members through a module.<name>.<output>
+// reference, so the parent can still step into it.
+func TestConditionalUnionCrossesModuleBoundary(t *testing.T) {
+	t.Parallel()
+
+	child, childDiags := parser.NewParser().ParseSource("child.tf", []byte(`
+variable "c" {
+  type = bool
+}
+
+resource "kind_a" "a" {}
+resource "kind_b" "b" {}
+
+output "either" {
+  value = var.c ? kind_a.a : kind_b.b
+}
+`))
+	require.False(t, childDiags.HasErrors(), childDiags.Error())
+
+	const parent = `
+module "child" {
+  source = "./child"
+  c      = true
+}
+
+output "either" {
+  value = module.child.either
+}
+
+output "name" {
+  value = module.child.either.name
+}
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(parent))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	binder := &Binder{
+		Resources: stubResolver{resources: map[string]*pulumiSchema.Resource{
+			"kind_a": {Properties: []*pulumiSchema.Property{
+				{Name: "name", Type: pulumiSchema.StringType},
+				{Name: "zones", Type: &pulumiSchema.ArrayType{ElementType: pulumiSchema.StringType}},
+			}},
+			"kind_b": {Properties: []*pulumiSchema.Property{
+				{Name: "name", Type: pulumiSchema.StringType},
+				{Name: "tags", Type: &pulumiSchema.MapType{ElementType: pulumiSchema.StringType}},
+			}},
+		}},
+		Modules:   stubModuleLoader{configs: map[string]*ast.Config{"./child": child}},
+		ModuleDir: ".",
+	}
+	moduleSchema, err := GenerateModuleSchema(
+		t.Context(), config, binder, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]*PropertySpec{
+		"either": {Type: TypeAny},
+		"name":   {Type: TypeString},
+	}, moduleSchema.OutputProperties)
+	assert.Equal(t, []string{"either", "name"}, moduleSchema.RequiredOutputs)
+}
+
+// TestConditionalUnionMissingAttributeIsError shows that an attribute no union
+// member has is an error, as it is for a plain reference.
+func TestConditionalUnionMissingAttributeIsError(t *testing.T) {
+	t.Parallel()
+
+	const src = `
+variable "c" {
+  type = bool
+}
+
+resource "kind_a" "a" {}
+resource "kind_b" "b" {}
+
+output "missing" {
+  value = (var.c ? kind_a.a : kind_b.b).missing
+}
+`
+	config, diags := parser.NewParser().ParseSource("main.tf", []byte(src))
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	resolver := stubResolver{resources: map[string]*pulumiSchema.Resource{
+		"kind_a": {Properties: []*pulumiSchema.Property{
+			{Name: "zones", Type: &pulumiSchema.ArrayType{ElementType: pulumiSchema.StringType}},
+		}},
+		"kind_b": {Properties: []*pulumiSchema.Property{{Name: "name", Type: pulumiSchema.StringType}}},
+	}}
+	_, err := GenerateModuleSchema(
+		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
+	require.EqualError(t, err, `typing output "missing": main.tf:10,40-48: Unsupported attribute; This object does not have an attribute named "missing"., and 1 other diagnostic(s)`)
+}
+
 // mappingResolver resolves resources and their bridge body mappings by TF type,
 // so output typing that depends on the mapping (e.g. MaxItemsOne block shape)
 // can be tested without a live provider.

--- a/pkg/hcl/schema/typeexpr.go
+++ b/pkg/hcl/schema/typeexpr.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi-hcl/pkg/hcl/transform"
 	"github.com/zclconf/go-cty/cty"
+	ctyconvert "github.com/zclconf/go-cty/cty/convert"
 )
 
 // rangedRefMark marks the unknown list or map a counted or for_each resource,
@@ -37,10 +38,144 @@ func markRangedRef(val cty.Value, ranged bool) cty.Value {
 	return val
 }
 
+// union marks the unknown value of DynamicPseudoType that a conditional
+// yields when its branch types do not unify. Its members are the branch values.
+// A traversal step applies to every member that supports it and unifies the
+// results, so an attribute the members share types as that attribute. A union
+// that reaches an output types as any. A union that reaches an expression HCL evaluates (a
+// function call, a for expression, ...) degrades to a plain DynamicVal.
+type union struct {
+	members []cty.Value
+}
+
+// asUnion returns the union val carries, if any.
+func asUnion(val cty.Value) (*union, bool) {
+	if val.Type() != cty.DynamicPseudoType {
+		return nil, false
+	}
+	for m := range val.Marks() {
+		if u, ok := m.(*union); ok {
+			return u, true
+		}
+	}
+	return nil, false
+}
+
+// dropUnions strips union marks from val and every value nested in it. HCL
+// re-applies the marks of an argument to the value it computes from it, so a
+// union mark on such a value no longer describes it.
+func dropUnions(val cty.Value) cty.Value {
+	unmarked, pvm := val.UnmarkDeepWithPaths()
+	for _, p := range pvm {
+		for m := range p.Marks {
+			if _, ok := m.(*union); ok {
+				delete(p.Marks, m)
+			}
+		}
+	}
+	return unmarked.MarkWithPaths(pvm)
+}
+
+// unify returns the value that stands for a value that is one of members.
+// Members of one type unify to an unknown of that type, not null when no
+// member can be null; members of one object type unify attribute by attribute,
+// so each attribute keeps the refinements of its members. A null of unknown
+// type only makes the result nullable. Members of different types form a
+// union, unless convert is set and UnifyUnsafe finds a type every member
+// converts to, which is what HCL does for the branches of a conditional. Only
+// marks every member carries survive.
+func unify(members []cty.Value, convert bool) cty.Value {
+	var flat []cty.Value
+	for _, m := range members {
+		if u, ok := asUnion(m); ok {
+			flat = append(flat, u.members...)
+		} else {
+			flat = append(flat, m)
+		}
+	}
+
+	nullable := false
+	var typed []cty.Value
+	marks := cty.NewValueMarks()
+	for i, m := range flat {
+		unmarked, ms := m.Unmark()
+		if i == 0 {
+			marks = ms
+		} else {
+			for mark := range marks {
+				if _, ok := ms[mark]; !ok {
+					delete(marks, mark)
+				}
+			}
+		}
+		if unmarked.Range().CouldBeNull() {
+			nullable = true
+		}
+		if unmarked.IsNull() && unmarked.Type() == cty.DynamicPseudoType {
+			continue
+		}
+		typed = append(typed, unmarked)
+	}
+	if len(typed) == 0 {
+		return cty.NullVal(cty.DynamicPseudoType)
+	}
+
+	ty := typed[0].Type()
+	same := true
+	types := make([]cty.Type, len(typed))
+	for i, m := range typed {
+		types[i] = m.Type()
+		same = same && ty.Equals(types[i])
+	}
+	switch {
+	case same && ty.IsObjectType() && !nullable:
+		attrs := make(map[string]cty.Value, len(ty.AttributeTypes()))
+		for name := range ty.AttributeTypes() {
+			attr := make([]cty.Value, len(typed))
+			for i, m := range typed {
+				attr[i] = m.GetAttr(name)
+			}
+			attrs[name] = unify(attr, convert)
+		}
+		return cty.ObjectVal(attrs).WithMarks(marks)
+	case same:
+	case convert:
+		if ty, _ = ctyconvert.UnifyUnsafe(types); ty != cty.NilType {
+			break
+		}
+		fallthrough
+	default:
+		return cty.DynamicVal.Mark(&union{members: flat})
+	}
+	val := cty.UnknownVal(ty)
+	if !nullable {
+		val = val.RefineNotNull()
+	}
+	return val.WithMarks(marks)
+}
+
+// outputRequired reports whether the value inferred for an output is never
+// null: for a union, whether no member can be null.
+func outputRequired(val cty.Value) bool {
+	if u, ok := asUnion(val); ok {
+		for _, m := range u.members {
+			m, _ := m.Unmark()
+			if m.Range().CouldBeNull() {
+				return false
+			}
+		}
+		return true
+	}
+	val, _ = val.UnmarkDeep()
+	return !val.Range().CouldBeNull()
+}
+
 // typeExpr evaluates expr against ctx for its type, the way HCL would, except
 // that traversals are applied one step at a time so an object indexed out of
-// a ranged reference regains the null refinements of its type. Every other
-// expression is delegated to HCL.
+// a ranged reference regains the null refinements of its type, and that a
+// conditional whose branch types do not unify yields a union instead of an
+// error. Every other expression is delegated to HCL, which degrades a union
+// among its inputs to a plain DynamicVal.
 func typeExpr(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	switch e := expr.(type) {
 	case *hclsyntax.ParenthesesExpr:
@@ -70,30 +205,95 @@ func typeExpr(expr hcl.Expression, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnos
 			return key, keyDiags
 		}
 		return traverse(collection, hcl.Traversal{hcl.TraverseIndex{Key: key, SrcRange: e.SrcRange}})
+
+	case *hclsyntax.ConditionalExpr:
+		return typeConditional(e, ctx)
 	}
 
-	return expr.Value(ctx)
+	val, diags := expr.Value(ctx)
+	return dropUnions(val), diags
 }
 
-// traverse applies traversal to val one step at a time. A ranged reference
-// yields an unrefined unknown when indexed; when that instance is an object it
-// is rebuilt with the refinements its type implies, as a direct reference to
-// the same object carries, so attributes reached through the index keep their
-// nullability. The instance sheds the ranged-reference mark, since it is no
-// longer a collection of instances.
+// typeConditional types a conditional. A known condition selects its branch. An
+// unknown condition unifies both branches. A condition HCL would reject (null,
+// or not convertible to bool) is delegated to HCL for its diagnostic.
+func typeConditional(e *hclsyntax.ConditionalExpr, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
+	cond, diags := typeExpr(e.Condition, ctx)
+	if diags.HasErrors() {
+		return cond, diags
+	}
+	cond, _ = cond.Unmark()
+	if cond.IsKnown() {
+		b, err := ctyconvert.Convert(cond, cty.Bool)
+		if err != nil || b.IsNull() {
+			return e.Value(ctx)
+		}
+		if b.True() {
+			return typeExpr(e.TrueResult, ctx)
+		}
+		return typeExpr(e.FalseResult, ctx)
+	}
+	trueVal, diags := typeExpr(e.TrueResult, ctx)
+	if diags.HasErrors() {
+		return trueVal, diags
+	}
+	falseVal, diags := typeExpr(e.FalseResult, ctx)
+	if diags.HasErrors() {
+		return falseVal, diags
+	}
+	return unify([]cty.Value{trueVal, falseVal}, true), nil
+}
+
+// traverse applies traversal to val one step at a time.
 func traverse(val cty.Value, traversal hcl.Traversal) (cty.Value, hcl.Diagnostics) {
 	for _, step := range traversal {
-		collection := val
 		var diags hcl.Diagnostics
-		val, diags = hcl.Traversal{step}.TraverseRel(collection)
+		val, diags = traverseStep(val, step)
 		if diags.HasErrors() {
 			return val, diags
 		}
-		if _, isIndex := step.(hcl.TraverseIndex); isIndex && collection.HasMark(rangedRefMark{}) && val.Type().IsObjectType() {
-			_, marks := val.Unmark()
-			delete(marks, rangedRefMark{})
-			val = transform.RefinedUnknown(val.Type(), false).WithMarks(marks)
-		}
 	}
 	return val, nil
+}
+
+// traverseStep applies one traversal step to val. A step into a union applies
+// to every member and the results unify. A null member is kept as it is. A
+// member the step does not apply to is pruned, since a type-correct program
+// only takes the step on members that support it; the step is an error only
+// when no member supports it. A ranged reference yields an unrefined unknown when indexed; when that
+// instance is an object it is rebuilt with the refinements its type implies,
+// as a direct reference to the same object carries, so attributes reached
+// through the index keep their nullability. The instance sheds the
+// ranged-reference mark, since it is no longer a collection of instances.
+func traverseStep(val cty.Value, step hcl.Traverser) (cty.Value, hcl.Diagnostics) {
+	if u, ok := asUnion(val); ok {
+		var results []cty.Value
+		var failed hcl.Diagnostics
+		for _, m := range u.members {
+			if m.IsNull() {
+				results = append(results, m)
+				continue
+			}
+			next, diags := traverseStep(m, step)
+			if diags.HasErrors() {
+				failed = append(failed, diags...)
+				continue
+			}
+			results = append(results, next)
+		}
+		if len(results) == 0 {
+			return cty.DynamicVal, failed
+		}
+		return unify(results, false), nil
+	}
+	next, diags := hcl.Traversal{step}.TraverseRel(val)
+	if diags.HasErrors() {
+		return next, diags
+	}
+	if _, isIndex := step.(hcl.TraverseIndex); isIndex && val.HasMark(rangedRefMark{}) && next.Type().IsObjectType() {
+		_, marks := next.Unmark()
+		delete(marks, rangedRefMark{})
+		next = transform.RefinedUnknown(next.Type(), false).WithMarks(marks)
+	}
+	return next, nil
 }

--- a/tests/mlctest/conditional_union_test.go
+++ b/tests/mlctest/conditional_union_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mlctest_test
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi-hcl/tests/testutil/mlctest"
+	"github.com/pulumi/pulumi-hcl/tests/testutil/tfcompat/providers"
+)
+
+// A component selects between a resource and its data source, whose reference
+// types do not unify (their `timeouts` objects differ). The conditional types
+// as a union: an attribute both members share types as that attribute, and
+// the union itself types as any.
+func TestConditionalUnion(t *testing.T) {
+	t.Parallel()
+	mlctest.RunCase(t, "conditional_union", mlctest.Case{
+		Providers: []mlctest.Provider{
+			{Name: "timeoutable", Factory: providers.TimeoutableProvider},
+		},
+		ExpectedOutputs: map[string]string{
+			"result": "hello-done",
+			"thing":  `{"id":"timeoutable-id","input_one":"hello","resource_id":"timeoutable-id","result":"hello-done"}`,
+		},
+	})
+}

--- a/tests/mlctest/testdata/cases/conditional_union/Main.yaml
+++ b/tests/mlctest/testdata/cases/conditional_union/Main.yaml
@@ -1,0 +1,8 @@
+resources:
+  a:
+    type: adopter:index:Module
+    properties:
+      create: true
+outputs:
+  result: ${a.result}
+  thing: ${a.thing}

--- a/tests/mlctest/testdata/cases/conditional_union/adopter/PulumiPlugin.yaml
+++ b/tests/mlctest/testdata/cases/conditional_union/adopter/PulumiPlugin.yaml
@@ -1,0 +1,2 @@
+name: adopter
+runtime: hcl

--- a/tests/mlctest/testdata/cases/conditional_union/adopter/main.tf
+++ b/tests/mlctest/testdata/cases/conditional_union/adopter/main.tf
@@ -1,0 +1,24 @@
+variable "create" {
+  type = bool
+}
+
+resource "timeoutable_resource" "this" {
+  count     = var.create ? 1 : 0
+  input_one = "hello"
+}
+
+data "timeoutable_data" "this" {
+  count = var.create ? 0 : 1
+}
+
+locals {
+  thing = var.create ? timeoutable_resource.this[0] : data.timeoutable_data.this[0]
+}
+
+output "result" {
+  value = local.thing.result
+}
+
+output "thing" {
+  value = local.thing
+}

--- a/tests/mlctest/testdata/cases/conditional_union/schema.json
+++ b/tests/mlctest/testdata/cases/conditional_union/schema.json
@@ -1,0 +1,31 @@
+{
+  "name": "adopter",
+  "version": "0.0.0-dev",
+  "config": {},
+  "resources": {
+    "adopter:index:Module": {
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "result": {
+          "type": "string"
+        },
+        "thing": {
+          "$ref": "pulumi.json#/Any"
+        }
+      },
+      "type": "object",
+      "required": [
+        "result",
+        "thing"
+      ],
+      "inputProperties": {
+        "create": {
+          "type": "boolean"
+        }
+      },
+      "isComponent": true
+    }
+  }
+}


### PR DESCRIPTION
Schema generation types an output by evaluating its expression against typed unknowns. HCL rejects a conditional whose branch types do not unify, so a module that selects between a resource and its data source (`var.create ? res.this[0] : data.res.this[0]`) failed to generate a schema at all. The `timeouts` attribute the issue names is only the first mismatch HCL reports: the two reference types have different attribute sets and mixed attribute types, so they never unify.

The type walker now handles conditionals itself. When the branch types do not unify, the result is a union: an unknown of `DynamicPseudoType` that carries its member values. A traversal step applies to every member that supports it and prunes the rest, since a type-correct program only takes a step on members that support it; the step is an error only when no member supports it. The results unify when they are of one type (`local.thing.result` is a `string`) and stay a union otherwise. A union that reaches an output types as `any`, and is required when no member can be null. A union that reaches an expression HCL evaluates, such as a function call, degrades to a plain `DynamicVal`.

Where HCL can unify the branches, the walker keeps HCL's result, so a module types the way Terraform evaluates it. Branches of one object type unify attribute by attribute, so each attribute keeps the nullability of its members.

The new `conditional_union` mlctest case is the shape from the issue: a resource and its data source with different `timeouts`, selected by a `count` toggle. It pins the schema (`result` as `string`, `thing` as `any`) and runs the program. A follow-up will emit union types in the schema instead of `any`.

Fixes https://github.com/pulumi/pulumi-hcl/issues/605
