### PR TITLE
Emit a union output as a oneOf of its member types

### DIFF
--- a/.changes/unreleased/runtime-improvements-622.yaml
+++ b/.changes/unreleased/runtime-improvements-622.yaml
@@ -1,0 +1,6 @@
+kind: Improvements
+body: Type a component output that is a union, such as a conditional between a resource and its data source, as a `oneOf` of its member types instead of `any`
+time: 2026-09-10T12:42:20Z
+custom:
+    Component: runtime
+    PR: "622"

--- a/pkg/hcl/schema/generator.go
+++ b/pkg/hcl/schema/generator.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	gotoken "go/token"
 	"maps"
+	"reflect"
 	"slices"
 	"sort"
 	"strings"
@@ -147,6 +148,10 @@ type PropertySpec struct {
 
 	// Ref is a reference to another type definition.
 	Ref string `json:"$ref,omitempty"`
+
+	// OneOf lists the member types of a union; the property holds a value of
+	// one of them.
+	OneOf []*PropertySpec `json:"oneOf,omitempty"`
 }
 
 // GenerateModuleSchema generates a Pulumi schema from an HCL module
@@ -558,11 +563,14 @@ func outputToPropertySpec(o *ast.Output, val cty.Value) (*PropertySpec, error) {
 }
 
 // ctyValueToPropertySpec converts an inferred unknown value to a PropertySpec.
-// For object types it reads each attribute's nullability from the value's
-// refinements to populate Required; collections fall back to ctyTypeToPropertySpec,
-// where nested object fields' requiredness rides on optional-attribute metadata.
-// A union is of DynamicPseudoType, so it maps to the any type.
+// A union is one of its members' specs. For object types it reads each
+// attribute's nullability from the value's refinements to populate Required;
+// collections fall back to ctyTypeToPropertySpec, where nested object fields'
+// requiredness rides on optional-attribute metadata.
 func ctyValueToPropertySpec(v cty.Value) (*PropertySpec, error) {
+	if u, ok := asUnion(v); ok {
+		return unionPropertySpec(u)
+	}
 	v, _ = v.UnmarkDeep()
 	t := v.Type()
 	if !t.IsObjectType() {
@@ -583,6 +591,30 @@ func ctyValueToPropertySpec(v cty.Value) (*PropertySpec, error) {
 	}
 	sort.Strings(required)
 	return &PropertySpec{Type: TypeObject, Properties: props, Required: required}, nil
+}
+
+// unionPropertySpec converts a union to a property that is one of its members'
+// specs. A null member only affects nullability, so it contributes no spec.
+// Members whose specs coincide, such as a list and a set of one element type,
+// collapse into one, and a union left with one spec is that spec.
+func unionPropertySpec(u *union) (*PropertySpec, error) {
+	var members []*PropertySpec
+	for _, m := range u.members {
+		if m.IsNull() {
+			continue
+		}
+		spec, err := ctyValueToPropertySpec(m)
+		if err != nil {
+			return nil, err
+		}
+		if !slices.ContainsFunc(members, func(seen *PropertySpec) bool { return reflect.DeepEqual(seen, spec) }) {
+			members = append(members, spec)
+		}
+	}
+	if len(members) == 1 {
+		return members[0], nil
+	}
+	return &PropertySpec{OneOf: members}, nil
 }
 
 // ctyTypeToPropertySpec converts a cty.Type to a PropertySpec.
@@ -724,14 +756,17 @@ func (s *ModuleSchema) OutputsToPulumi(outputs property.Map) property.Map {
 // convertPropertyNames recursively renames object-field names in v according to
 // spec, which describes v's type. Object fields (spec.Properties, snake_case)
 // are renamed between snake_case and camelCase; the dynamic keys of a map
-// (spec.AdditionalProperties) are user data and left unchanged. toPulumi selects
-// the direction: snake_case→camelCase when true, the reverse when false. A
-// value's secret flag and dependencies are preserved across the rename.
+// (spec.AdditionalProperties) are user data and left unchanged. A union renames
+// by the member v belongs to. toPulumi selects the direction:
+// snake_case→camelCase when true, the reverse when false. A value's secret flag
+// and dependencies are preserved across the rename.
 func convertPropertyNames(v property.Value, spec *PropertySpec, toPulumi bool) property.Value {
 	if spec == nil || v.IsNull() || v.IsComputed() {
 		return v
 	}
 	switch {
+	case len(spec.OneOf) > 0:
+		return convertPropertyNames(v, unionMember(v, spec.OneOf, toPulumi), toPulumi)
 	case len(spec.Properties) > 0 && v.IsMap():
 		obj := v.AsMap()
 		out := make(map[string]property.Value, obj.Len())
@@ -762,6 +797,41 @@ func convertPropertyNames(v property.Value, spec *PropertySpec, toPulumi bool) p
 	default:
 		return v
 	}
+}
+
+// unionMember picks the member of a union that v belongs to, for renaming its
+// object fields: the object member whose fields cover the most keys of v, or
+// else the first array or map member of v's kind. Keys of v are in the
+// direction's source case, as in convertPropertyNames. Nil when no member fits.
+func unionMember(v property.Value, members []*PropertySpec, toPulumi bool) *PropertySpec {
+	var best, fallback *PropertySpec
+	bestScore := 0
+	for _, m := range members {
+		switch {
+		case len(m.Properties) > 0 && v.IsMap():
+			score := 0
+			for snake := range m.Properties {
+				key := snake
+				if !toPulumi {
+					key = pulumiCase(snake)
+				}
+				if _, ok := v.AsMap().GetOk(key); ok {
+					score++
+				}
+			}
+			if score > bestScore {
+				best, bestScore = m, score
+			}
+		case (m.AdditionalProperties != nil && v.IsMap()) || (m.Items != nil && v.IsArray()):
+			if fallback == nil {
+				fallback = m
+			}
+		}
+	}
+	if best != nil {
+		return best
+	}
+	return fallback
 }
 
 // ToPulumiPackageSchema converts the module schema to a full Pulumi package
@@ -921,11 +991,18 @@ func (s *ModuleSchema) schemaProperty(
 // schemaType converts a PropertySpec to a Pulumi TypeSpec. An object type is
 // registered as a named type (keyed by a token derived from typeName) in types
 // and referenced via `$ref`; the dynamic keys of a map are not named, so its
-// value type recurses without registering field names.
+// value type recurses without registering field names. A union is a `oneOf`
+// of its members, named by their position.
 func (s *ModuleSchema) schemaType(
 	prop *PropertySpec, typeName string, types map[string]pulumischema.ComplexTypeSpec,
 ) pulumischema.TypeSpec {
 	switch {
+	case len(prop.OneOf) > 0:
+		oneOf := make([]pulumischema.TypeSpec, len(prop.OneOf))
+		for i, member := range prop.OneOf {
+			oneOf[i] = s.schemaType(member, fmt.Sprintf("%s%d", typeName, i), types)
+		}
+		return pulumischema.TypeSpec{OneOf: oneOf}
 	case prop.Properties != nil:
 		token := fmt.Sprintf("%s:%s:%s", s.PackageName, s.Module, typeName)
 		fields := make(map[string]pulumischema.PropertySpec, len(prop.Properties))

--- a/pkg/hcl/schema/generator_test.go
+++ b/pkg/hcl/schema/generator_test.go
@@ -69,6 +69,7 @@ func TestGenerateModuleSchemaGolden(t *testing.T) {
 		{name: "sensitive", pkgName: "sensitive", version: "0.0.0-dev", componentName: "sensitive", module: "index"},
 		{name: "required", pkgName: "required", version: "0.0.0-dev", componentName: "required", module: "index"},
 		{name: "inference", pkgName: "inference", version: "0.0.0-dev", componentName: "inference", module: "index"},
+		{name: "union", pkgName: "union", version: "0.0.0-dev", componentName: "union", module: "index"},
 	}
 
 	for _, tc := range cases {
@@ -377,8 +378,8 @@ output "missing" {
 // TestConditionalUnionOutputsAreTyped shows how a conditional over branches
 // whose types do not unify is typed: as a union, whose members a traversal
 // steps into one by one before the results unify again. Results of one type
-// unify to it; results of different types stay a union; a member the step does
-// not apply to is pruned.
+// unify to it; results of different types stay a union, which is one of its
+// members' specs; a member the step does not apply to is pruned.
 func TestConditionalUnionOutputsAreTyped(t *testing.T) {
 	t.Parallel()
 
@@ -459,14 +460,40 @@ output "evaluated" {
 		t.Context(), config, &Binder{Resources: resolver}, componentToken("pkg", "index", "pkg"), semver.MustParse("0.0.0-dev"))
 	require.NoError(t, err)
 
+	nestedX := &PropertySpec{
+		Type: TypeObject, Properties: map[string]*PropertySpec{"x": {Type: TypeString}}, Required: []string{"x"},
+	}
+	nestedY := &PropertySpec{
+		Type: TypeObject, Properties: map[string]*PropertySpec{"y": {Type: TypeString}}, Required: []string{"y"},
+	}
+	kindA := &PropertySpec{
+		Type: TypeObject,
+		Properties: map[string]*PropertySpec{
+			"id":     {Type: TypeString},
+			"name":   {Type: TypeString},
+			"zones":  {Type: TypeArray, Items: &PropertySpec{Type: TypeString}},
+			"nested": nestedX,
+		},
+		Required: []string{"name", "nested", "zones"},
+	}
+	kindB := &PropertySpec{
+		Type: TypeObject,
+		Properties: map[string]*PropertySpec{
+			"id":     {Type: TypeString},
+			"name":   {Type: TypeString},
+			"tags":   {Type: TypeObject, AdditionalProperties: &PropertySpec{Type: TypeString}},
+			"nested": nestedY,
+		},
+		Required: []string{"name", "nested", "tags"},
+	}
 	assert.Equal(t, map[string]*PropertySpec{
-		"either":          {Type: TypeAny},
+		"either":          {OneOf: []*PropertySpec{kindA, kindB}},
 		"shared":          {Type: TypeString},
 		"indexed":         {Type: TypeString},
-		"nested":          {Type: TypeAny},
+		"nested":          {OneOf: []*PropertySpec{nestedX, nestedY}},
 		"pruned":          {Type: TypeArray, Items: &PropertySpec{Type: TypeString}},
 		"nullable_member": {Type: TypeString},
-		"nullable_union":  {Type: TypeAny},
+		"nullable_union":  {OneOf: []*PropertySpec{kindA, kindB}},
 		"same_type":       {Type: TypeString},
 		"evaluated":       {Type: TypeString},
 	}, moduleSchema.OutputProperties)
@@ -614,8 +641,27 @@ output "name" {
 	require.NoError(t, err)
 
 	assert.Equal(t, map[string]*PropertySpec{
-		"either": {Type: TypeAny},
-		"name":   {Type: TypeString},
+		"either": {OneOf: []*PropertySpec{
+			{
+				Type: TypeObject,
+				Properties: map[string]*PropertySpec{
+					"id":    {Type: TypeString},
+					"name":  {Type: TypeString},
+					"zones": {Type: TypeArray, Items: &PropertySpec{Type: TypeString}},
+				},
+				Required: []string{"name", "zones"},
+			},
+			{
+				Type: TypeObject,
+				Properties: map[string]*PropertySpec{
+					"id":   {Type: TypeString},
+					"name": {Type: TypeString},
+					"tags": {Type: TypeObject, AdditionalProperties: &PropertySpec{Type: TypeString}},
+				},
+				Required: []string{"name", "tags"},
+			},
+		}},
+		"name": {Type: TypeString},
 	}, moduleSchema.OutputProperties)
 	assert.Equal(t, []string{"either", "name"}, moduleSchema.RequiredOutputs)
 }
@@ -998,7 +1044,8 @@ output "z" {
 
 // TestBoundaryNameConversion shows that the Construct boundary renames object
 // field names (snake_case ↔ camelCase) at every depth in both directions, while
-// leaving the dynamic keys of a map untouched.
+// leaving the dynamic keys of a map untouched, and through the member of a
+// union a value belongs to.
 func TestBoundaryNameConversion(t *testing.T) {
 	t.Parallel()
 
@@ -1014,6 +1061,19 @@ func TestBoundaryNameConversion(t *testing.T) {
 				"field_two": {Type: TypeString},
 			}},
 			"map_out": {Type: TypeObject, AdditionalProperties: &PropertySpec{Type: TypeString}},
+			"union_out": {OneOf: []*PropertySpec{
+				{Type: TypeObject, Properties: map[string]*PropertySpec{
+					"field_three": {Type: TypeString},
+					"only_here":   {Type: TypeString},
+				}},
+				{Type: TypeObject, Properties: map[string]*PropertySpec{
+					"field_three": {Type: TypeString},
+					"only_there":  {Type: TypeString},
+				}},
+				{Type: TypeArray, Items: &PropertySpec{Type: TypeObject, Properties: map[string]*PropertySpec{
+					"field_four": {Type: TypeString},
+				}}},
+			}},
 		},
 	}
 
@@ -1039,6 +1099,20 @@ func TestBoundaryNameConversion(t *testing.T) {
 	}), s.OutputsToPulumi(propMap(map[string]any{
 		"object_out": map[string]any{"field_two": "c"},
 		"map_out":    map[string]any{"user_key": "d"},
+	})))
+
+	// A union output renames by the member the value belongs to: the object
+	// member whose fields cover the most of the value's keys, or the member of
+	// the value's kind.
+	assert.Equal(t, propMap(map[string]any{
+		"unionOut": map[string]any{"fieldThree": "e", "onlyThere": "f"},
+	}), s.OutputsToPulumi(propMap(map[string]any{
+		"union_out": map[string]any{"field_three": "e", "only_there": "f"},
+	})))
+	assert.Equal(t, propMap(map[string]any{
+		"unionOut": []any{map[string]any{"fieldFour": "g"}},
+	}), s.OutputsToPulumi(propMap(map[string]any{
+		"union_out": []any{map[string]any{"field_four": "g"}},
 	})))
 }
 

--- a/pkg/hcl/schema/testdata/union/main.tf
+++ b/pkg/hcl/schema/testdata/union/main.tf
@@ -1,0 +1,19 @@
+variable "flag" {
+  type = bool
+}
+
+locals {
+  either = var.flag ? { name = "a", zones = ["x"] } : { name = 1, nested = { deep = true } }
+}
+
+output "either" {
+  value = local.either
+}
+
+output "name" {
+  value = local.either.name
+}
+
+output "nested" {
+  value = local.either.nested
+}

--- a/pkg/hcl/schema/testdata/union/schema.json
+++ b/pkg/hcl/schema/testdata/union/schema.json
@@ -1,0 +1,106 @@
+{
+  "name": "union",
+  "version": "0.0.0-dev",
+  "config": {},
+  "types": {
+    "union:index:Either0": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "zones": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "zones"
+      ]
+    },
+    "union:index:Either1": {
+      "properties": {
+        "name": {
+          "type": "number"
+        },
+        "nested": {
+          "$ref": "#/types/union:index:Either1Nested"
+        }
+      },
+      "type": "object",
+      "required": [
+        "name",
+        "nested"
+      ]
+    },
+    "union:index:Either1Nested": {
+      "properties": {
+        "deep": {
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "required": [
+        "deep"
+      ]
+    },
+    "union:index:Nested": {
+      "properties": {
+        "deep": {
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "required": [
+        "deep"
+      ]
+    }
+  },
+  "resources": {
+    "union:index:union": {
+      "properties": {
+        "either": {
+          "oneOf": [
+            {
+              "$ref": "#/types/union:index:Either0"
+            },
+            {
+              "$ref": "#/types/union:index:Either1"
+            }
+          ]
+        },
+        "flag": {
+          "type": "boolean"
+        },
+        "name": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "nested": {
+          "$ref": "#/types/union:index:Nested"
+        }
+      },
+      "type": "object",
+      "required": [
+        "either",
+        "name",
+        "nested"
+      ],
+      "inputProperties": {
+        "flag": {
+          "type": "boolean"
+        }
+      },
+      "isComponent": true
+    }
+  }
+}

--- a/tests/mlctest/conditional_union_test.go
+++ b/tests/mlctest/conditional_union_test.go
@@ -24,7 +24,8 @@ import (
 // A component selects between a resource and its data source, whose reference
 // types do not unify (their `timeouts` objects differ). The conditional types
 // as a union: an attribute both members share types as that attribute, and
-// the union itself types as any.
+// the union itself is a `oneOf` of the two object types, whose output value
+// renames its fields by the member it belongs to.
 func TestConditionalUnion(t *testing.T) {
 	t.Parallel()
 	mlctest.RunCase(t, "conditional_union", mlctest.Case{
@@ -33,7 +34,7 @@ func TestConditionalUnion(t *testing.T) {
 		},
 		ExpectedOutputs: map[string]string{
 			"result": "hello-done",
-			"thing":  `{"id":"timeoutable-id","input_one":"hello","resource_id":"timeoutable-id","result":"hello-done"}`,
+			"thing":  `{"id":"timeoutable-id","inputOne":"hello","resourceId":"timeoutable-id","result":"hello-done"}`,
 		},
 	})
 }

--- a/tests/mlctest/testdata/cases/conditional_union/schema.json
+++ b/tests/mlctest/testdata/cases/conditional_union/schema.json
@@ -2,6 +2,75 @@
   "name": "adopter",
   "version": "0.0.0-dev",
   "config": {},
+  "types": {
+    "adopter:index:Thing0": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "inputOne": {
+          "type": "string"
+        },
+        "resourceId": {
+          "type": "string"
+        },
+        "result": {
+          "type": "string"
+        },
+        "timeouts": {
+          "$ref": "#/types/adopter:index:Thing0Timeouts"
+        }
+      },
+      "type": "object",
+      "required": [
+        "resourceId",
+        "result"
+      ]
+    },
+    "adopter:index:Thing0Timeouts": {
+      "properties": {
+        "create": {
+          "type": "string"
+        },
+        "default": {
+          "type": "string"
+        },
+        "delete": {
+          "type": "string"
+        },
+        "update": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "adopter:index:Thing1": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "result": {
+          "type": "string"
+        },
+        "timeouts": {
+          "$ref": "#/types/adopter:index:Thing1Timeouts"
+        }
+      },
+      "type": "object",
+      "required": [
+        "id",
+        "result"
+      ]
+    },
+    "adopter:index:Thing1Timeouts": {
+      "properties": {
+        "read": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
   "resources": {
     "adopter:index:Module": {
       "properties": {
@@ -12,7 +81,14 @@
           "type": "string"
         },
         "thing": {
-          "$ref": "pulumi.json#/Any"
+          "oneOf": [
+            {
+              "$ref": "#/types/adopter:index:Thing0"
+            },
+            {
+              "$ref": "#/types/adopter:index:Thing1"
+            }
+          ]
         }
       },
       "type": "object",


### PR DESCRIPTION
A component output whose inferred value is a union (https://github.com/pulumi/pulumi-hcl/pull/621) was typed as `any`. It is now a `oneOf` of its members' types. Each member converts the way a plain output does, so an object member becomes a named type with its own required list, and members whose specs coincide, such as a list and a set of one element type, collapse into one. A null member only affects nullability, so it contributes no member. Member types are named by their position under the output's type name (`Thing0`, `Thing1`).

At the Construct boundary, a union output renames its object fields by the member the value belongs to: the object member whose fields cover the most of the value's keys, or else the first member of the value's kind.

The `conditional_union` mlctest golden now types `thing` as a `oneOf` of the resource and data-source object types, and its output value arrives with camelCase fields. A new `union` golden case covers a union of literal objects, a union of primitives reached through it, and an attribute only one member has.
